### PR TITLE
Factor old conda locator out of conda service

### DIFF
--- a/src/client/common/installer/condaInstaller.ts
+++ b/src/client/common/installer/condaInstaller.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import { ICondaService, ICondaServiceDeprecated } from '../../interpreter/contracts';
+import { ICondaService, ICondaLocatorService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { ExecutionInfo, IConfigurationService } from '../types';
 import { isResource } from '../utils/misc';
@@ -96,7 +96,7 @@ export class CondaInstaller extends ModuleInstaller {
      * Is the provided interprter a conda environment
      */
     private async isCurrentEnvironmentACondaEnvironment(resource?: InterpreterUri): Promise<boolean> {
-        const condaService = this.serviceContainer.get<ICondaServiceDeprecated>(ICondaServiceDeprecated);
+        const condaService = this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService);
         const pythonPath = isResource(resource)
             ? this.serviceContainer.get<IConfigurationService>(IConfigurationService).getSettings(resource).pythonPath
             : resource.path;

--- a/src/client/common/installer/condaInstaller.ts
+++ b/src/client/common/installer/condaInstaller.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import { ICondaService } from '../../interpreter/contracts';
+import { ICondaService, ICondaServiceDeprecated } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { ExecutionInfo, IConfigurationService } from '../types';
 import { isResource } from '../utils/misc';
@@ -96,7 +96,7 @@ export class CondaInstaller extends ModuleInstaller {
      * Is the provided interprter a conda environment
      */
     private async isCurrentEnvironmentACondaEnvironment(resource?: InterpreterUri): Promise<boolean> {
-        const condaService = this.serviceContainer.get<ICondaService>(ICondaService);
+        const condaService = this.serviceContainer.get<ICondaServiceDeprecated>(ICondaServiceDeprecated);
         const pythonPath = isResource(resource)
             ? this.serviceContainer.get<IConfigurationService>(IConfigurationService).getSettings(resource).pythonPath
             : resource.path;

--- a/src/client/common/installer/condaInstaller.ts
+++ b/src/client/common/installer/condaInstaller.ts
@@ -67,7 +67,8 @@ export class CondaInstaller extends ModuleInstaller {
         const pythonPath = isResource(resource)
             ? this.serviceContainer.get<IConfigurationService>(IConfigurationService).getSettings(resource).pythonPath
             : resource.path;
-        const info = await condaService.getCondaEnvironment(pythonPath);
+        const condaLocatorService = this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService);
+        const info = await condaLocatorService.getCondaEnvironment(pythonPath);
         const args = [isUpgrade ? 'update' : 'install'];
 
         // Temporarily ensure tensorboard is installed from the conda-forge

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -5,7 +5,7 @@ import { gte } from 'semver';
 
 import { Uri } from 'vscode';
 import { IEnvironmentActivationService } from '../../interpreter/activation/types';
-import { IComponentAdapter, ICondaService } from '../../interpreter/contracts';
+import { IComponentAdapter, ICondaLocatorService, ICondaService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { CondaEnvironmentInfo } from '../../pythonEnvironments/discovery/locators/services/conda';
 import { inDiscoveryExperiment } from '../experiments/helpers';
@@ -114,7 +114,7 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
             : this.processServiceFactory.create(resource);
         const [condaVersion, condaEnvironment, condaFile, procService] = await Promise.all([
             this.condaService.getCondaVersion(),
-            this.condaService.getCondaEnvironment(pythonPath),
+            this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService).getCondaEnvironment(pythonPath),
             this.condaService.getCondaFile(),
             processServicePromise,
         ]);

--- a/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
@@ -7,10 +7,11 @@ import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { Uri } from 'vscode';
 
-import { ICondaService } from '../../../interpreter/contracts';
+import { ICondaLocatorService, ICondaService } from '../../../interpreter/contracts';
 import { IPlatformService } from '../../platform/types';
 import { IConfigurationService } from '../../types';
 import { ITerminalActivationCommandProvider, TerminalShellType } from '../types';
+import { IServiceContainer } from '../../../ioc/types';
 
 // Version number of conda that requires we call activate with 'conda activate' instead of just 'activate'
 const CondaRequiredMajor = 4;
@@ -26,6 +27,7 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
         @inject(ICondaService) private readonly condaService: ICondaService,
         @inject(IPlatformService) private platform: IPlatformService,
         @inject(IConfigurationService) private configService: IConfigurationService,
+        @inject(IServiceContainer) private serviceContainer: IServiceContainer,
     ) {}
 
     /**
@@ -54,7 +56,8 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
         pythonPath: string,
         targetShell: TerminalShellType,
     ): Promise<string[] | undefined> {
-        const envInfo = await this.condaService.getCondaEnvironment(pythonPath);
+        const condaLocatorService = this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService);
+        const envInfo = await condaLocatorService.getCondaEnvironment(pythonPath);
         if (!envInfo) {
             return;
         }

--- a/src/client/common/terminal/helper.ts
+++ b/src/client/common/terminal/helper.ts
@@ -3,7 +3,7 @@
 
 import { inject, injectable, multiInject, named } from 'inversify';
 import { Terminal, Uri } from 'vscode';
-import { ICondaService, IInterpreterService } from '../../interpreter/contracts';
+import { ICondaServiceDeprecated, IInterpreterService } from '../../interpreter/contracts';
 import { EnvironmentType, PythonEnvironment } from '../../pythonEnvironments/info';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
@@ -28,7 +28,7 @@ export class TerminalHelper implements ITerminalHelper {
     constructor(
         @inject(IPlatformService) private readonly platform: IPlatformService,
         @inject(ITerminalManager) private readonly terminalManager: ITerminalManager,
-        @inject(ICondaService) private readonly condaService: ICondaService,
+        @inject(ICondaServiceDeprecated) private readonly condaService: ICondaServiceDeprecated,
         @inject(IInterpreterService) readonly interpreterService: IInterpreterService,
         @inject(IConfigurationService) private readonly configurationService: IConfigurationService,
         @inject(ITerminalActivationCommandProvider)

--- a/src/client/common/terminal/helper.ts
+++ b/src/client/common/terminal/helper.ts
@@ -3,7 +3,7 @@
 
 import { inject, injectable, multiInject, named } from 'inversify';
 import { Terminal, Uri } from 'vscode';
-import { ICondaServiceDeprecated, IInterpreterService } from '../../interpreter/contracts';
+import { ICondaLocatorService, IInterpreterService } from '../../interpreter/contracts';
 import { EnvironmentType, PythonEnvironment } from '../../pythonEnvironments/info';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
@@ -28,7 +28,7 @@ export class TerminalHelper implements ITerminalHelper {
     constructor(
         @inject(IPlatformService) private readonly platform: IPlatformService,
         @inject(ITerminalManager) private readonly terminalManager: ITerminalManager,
-        @inject(ICondaServiceDeprecated) private readonly condaService: ICondaServiceDeprecated,
+        @inject(ICondaLocatorService) private readonly condaService: ICondaLocatorService,
         @inject(IInterpreterService) readonly interpreterService: IInterpreterService,
         @inject(IConfigurationService) private readonly configurationService: IConfigurationService,
         @inject(ITerminalActivationCommandProvider)

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -94,7 +94,6 @@ export const ICondaLocatorService = Symbol('ICondaLocatorService');
 export interface ICondaLocatorService {
     readonly condaEnvironmentsFile: string | undefined;
     getCondaFile(): Promise<string>;
-    isCondaAvailable(): Promise<boolean>;
     getCondaVersion(): Promise<SemVer | undefined>;
     getCondaInfo(): Promise<CondaInfo | undefined>;
     getCondaEnvironments(ignoreCache: boolean): Promise<CondaEnvironmentInfo[] | undefined>;

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -79,6 +79,20 @@ export interface IInterpreterLocatorService extends Disposable {
 export const ICondaService = Symbol('ICondaService');
 
 export interface ICondaService {
+    getCondaFile(): Promise<string>;
+    isCondaAvailable(): Promise<boolean>;
+    getCondaVersion(): Promise<SemVer | undefined>;
+    getCondaInfo(): Promise<CondaInfo | undefined>;
+    getCondaFileFromInterpreter(interpreterPath?: string, envName?: string): Promise<string | undefined>;
+    isCondaEnvironment(interpreterPath: string): Promise<boolean>;
+    getCondaEnvironment(interpreterPath: string): Promise<CondaEnvironmentInfo | undefined>;
+}
+
+export const ICondaServiceDeprecated = Symbol('ICondaServiceDeprecated');
+/**
+ * @deprecated
+ */
+export interface ICondaServiceDeprecated {
     readonly condaEnvironmentsFile: string | undefined;
     getCondaFile(): Promise<string>;
     isCondaAvailable(): Promise<boolean>;

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -78,7 +78,7 @@ export interface IInterpreterLocatorService extends Disposable {
 
 export const ICondaService = Symbol('ICondaService');
 /**
- * Interface carries the properties which are not available via the discovery component.
+ * Interface carries the properties which are not available via the discovery component interface.
  */
 export interface ICondaService {
     getCondaFile(): Promise<string>;
@@ -89,12 +89,11 @@ export interface ICondaService {
 
 export const ICondaLocatorService = Symbol('ICondaLocatorService');
 /**
- * @deprecated Use the new discovery component when in experiment, only use this otherwise.
+ * @deprecated Use the new discovery component when in experiment, use this otherwise.
  */
 export interface ICondaLocatorService {
     readonly condaEnvironmentsFile: string | undefined;
     getCondaFile(): Promise<string>;
-    getCondaVersion(): Promise<SemVer | undefined>;
     getCondaInfo(): Promise<CondaInfo | undefined>;
     getCondaEnvironments(ignoreCache: boolean): Promise<CondaEnvironmentInfo[] | undefined>;
     getInterpreterPath(condaEnvironmentPath: string): string;

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -77,7 +77,9 @@ export interface IInterpreterLocatorService extends Disposable {
 }
 
 export const ICondaService = Symbol('ICondaService');
-
+/**
+ * Interface carries the properties which are not available via the discovery component.
+ */
 export interface ICondaService {
     getCondaFile(): Promise<string>;
     isCondaAvailable(): Promise<boolean>;
@@ -97,7 +99,6 @@ export interface ICondaLocatorService {
     getCondaInfo(): Promise<CondaInfo | undefined>;
     getCondaEnvironments(ignoreCache: boolean): Promise<CondaEnvironmentInfo[] | undefined>;
     getInterpreterPath(condaEnvironmentPath: string): string;
-    getCondaFileFromInterpreter(interpreterPath?: string, envName?: string): Promise<string | undefined>;
     isCondaEnvironment(interpreterPath: string): Promise<boolean>;
     getCondaEnvironment(interpreterPath: string): Promise<CondaEnvironmentInfo | undefined>;
 }

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -84,7 +84,6 @@ export interface ICondaService {
     getCondaVersion(): Promise<SemVer | undefined>;
     getCondaInfo(): Promise<CondaInfo | undefined>;
     getCondaFileFromInterpreter(interpreterPath?: string, envName?: string): Promise<string | undefined>;
-    isCondaEnvironment(interpreterPath: string): Promise<boolean>;
     getCondaEnvironment(interpreterPath: string): Promise<CondaEnvironmentInfo | undefined>;
 }
 

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -87,11 +87,11 @@ export interface ICondaService {
     getCondaEnvironment(interpreterPath: string): Promise<CondaEnvironmentInfo | undefined>;
 }
 
-export const ICondaServiceDeprecated = Symbol('ICondaServiceDeprecated');
+export const ICondaLocatorService = Symbol('ICondaLocatorService');
 /**
  * @deprecated
  */
-export interface ICondaServiceDeprecated {
+export interface ICondaLocatorService {
     readonly condaEnvironmentsFile: string | undefined;
     getCondaFile(): Promise<string>;
     isCondaAvailable(): Promise<boolean>;

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -82,14 +82,12 @@ export interface ICondaService {
     getCondaFile(): Promise<string>;
     isCondaAvailable(): Promise<boolean>;
     getCondaVersion(): Promise<SemVer | undefined>;
-    getCondaInfo(): Promise<CondaInfo | undefined>;
     getCondaFileFromInterpreter(interpreterPath?: string, envName?: string): Promise<string | undefined>;
-    getCondaEnvironment(interpreterPath: string): Promise<CondaEnvironmentInfo | undefined>;
 }
 
 export const ICondaLocatorService = Symbol('ICondaLocatorService');
 /**
- * @deprecated
+ * @deprecated Use the new discovery component when in experiment, only use this otherwise.
  */
 export interface ICondaLocatorService {
     readonly condaEnvironmentsFile: string | undefined;

--- a/src/client/pythonEnvironments/discovery/locators/services/condaEnvFileService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaEnvFileService.ts
@@ -13,7 +13,7 @@ import * as path from 'path';
 import { Uri } from 'vscode';
 import { traceError } from '../../../../common/logger';
 import { IFileSystem } from '../../../../common/platform/types';
-import { ICondaServiceDeprecated, IInterpreterHelper } from '../../../../interpreter/contracts';
+import { ICondaLocatorService, IInterpreterHelper } from '../../../../interpreter/contracts';
 import { IServiceContainer } from '../../../../ioc/types';
 import { EnvironmentType, PythonEnvironment } from '../../../info';
 import { CacheableLocatorService } from './cacheableLocatorService';
@@ -26,7 +26,7 @@ import { AnacondaCompanyName } from './conda';
 export class CondaEnvFileService extends CacheableLocatorService {
     constructor(
         @inject(IInterpreterHelper) private helperService: IInterpreterHelper,
-        @inject(ICondaServiceDeprecated) private condaService: ICondaServiceDeprecated,
+        @inject(ICondaLocatorService) private condaService: ICondaLocatorService,
         @inject(IFileSystem) private fileSystem: IFileSystem,
         @inject(IServiceContainer) serviceContainer: IServiceContainer,
     ) {

--- a/src/client/pythonEnvironments/discovery/locators/services/condaEnvFileService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaEnvFileService.ts
@@ -13,7 +13,7 @@ import * as path from 'path';
 import { Uri } from 'vscode';
 import { traceError } from '../../../../common/logger';
 import { IFileSystem } from '../../../../common/platform/types';
-import { ICondaService, IInterpreterHelper } from '../../../../interpreter/contracts';
+import { ICondaServiceDeprecated, IInterpreterHelper } from '../../../../interpreter/contracts';
 import { IServiceContainer } from '../../../../ioc/types';
 import { EnvironmentType, PythonEnvironment } from '../../../info';
 import { CacheableLocatorService } from './cacheableLocatorService';
@@ -26,7 +26,7 @@ import { AnacondaCompanyName } from './conda';
 export class CondaEnvFileService extends CacheableLocatorService {
     constructor(
         @inject(IInterpreterHelper) private helperService: IInterpreterHelper,
-        @inject(ICondaService) private condaService: ICondaService,
+        @inject(ICondaServiceDeprecated) private condaService: ICondaServiceDeprecated,
         @inject(IFileSystem) private fileSystem: IFileSystem,
         @inject(IServiceContainer) serviceContainer: IServiceContainer,
     ) {

--- a/src/client/pythonEnvironments/discovery/locators/services/condaEnvService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaEnvService.ts
@@ -5,7 +5,7 @@ import { inject, injectable } from 'inversify';
 import { Uri } from 'vscode';
 import { traceError } from '../../../../common/logger';
 import { IFileSystem } from '../../../../common/platform/types';
-import { ICondaService, IInterpreterHelper } from '../../../../interpreter/contracts';
+import { ICondaServiceDeprecated, IInterpreterHelper } from '../../../../interpreter/contracts';
 import { IServiceContainer } from '../../../../ioc/types';
 import { PythonEnvironment } from '../../../info';
 import { CacheableLocatorService } from './cacheableLocatorService';
@@ -17,7 +17,7 @@ import { parseCondaInfo } from './conda';
 @injectable()
 export class CondaEnvService extends CacheableLocatorService {
     constructor(
-        @inject(ICondaService) private condaService: ICondaService,
+        @inject(ICondaServiceDeprecated) private condaService: ICondaServiceDeprecated,
         @inject(IInterpreterHelper) private helper: IInterpreterHelper,
         @inject(IServiceContainer) serviceContainer: IServiceContainer,
         @inject(IFileSystem) private fileSystem: IFileSystem,

--- a/src/client/pythonEnvironments/discovery/locators/services/condaEnvService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaEnvService.ts
@@ -5,7 +5,7 @@ import { inject, injectable } from 'inversify';
 import { Uri } from 'vscode';
 import { traceError } from '../../../../common/logger';
 import { IFileSystem } from '../../../../common/platform/types';
-import { ICondaServiceDeprecated, IInterpreterHelper } from '../../../../interpreter/contracts';
+import { ICondaLocatorService, IInterpreterHelper } from '../../../../interpreter/contracts';
 import { IServiceContainer } from '../../../../ioc/types';
 import { PythonEnvironment } from '../../../info';
 import { CacheableLocatorService } from './cacheableLocatorService';
@@ -17,7 +17,7 @@ import { parseCondaInfo } from './conda';
 @injectable()
 export class CondaEnvService extends CacheableLocatorService {
     constructor(
-        @inject(ICondaServiceDeprecated) private condaService: ICondaServiceDeprecated,
+        @inject(ICondaLocatorService) private condaService: ICondaLocatorService,
         @inject(IInterpreterHelper) private helper: IInterpreterHelper,
         @inject(IServiceContainer) serviceContainer: IServiceContainer,
         @inject(IFileSystem) private fileSystem: IFileSystem,

--- a/src/client/pythonEnvironments/discovery/locators/services/condaLocatorService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaLocatorService.ts
@@ -331,7 +331,7 @@ export class CondaLocatorService implements ICondaLocatorService {
      */
     @traceDecorators.verbose('Get Conda File from interpreter')
     @cache(120_000)
-    public async getCondaFileFromInterpreter(interpreterPath?: string, envName?: string): Promise<string | undefined> {
+    public async _getCondaFileFromInterpreter(interpreterPath?: string, envName?: string): Promise<string | undefined> {
         const condaExe = this.platform.isWindows ? 'conda.exe' : 'conda';
         const scriptsDir = this.platform.isWindows ? 'Scripts' : 'bin';
         const interpreterDir = interpreterPath ? path.dirname(interpreterPath) : '';
@@ -404,7 +404,7 @@ export class CondaLocatorService implements ICondaLocatorService {
             const condaInterpreters = interpreters.filter(CondaLocatorService.detectCondaEnvironment);
             const condaInterpreter = CondaLocatorService.getLatestVersion(condaInterpreters);
             if (condaInterpreter) {
-                const interpreterPath = await this.getCondaFileFromInterpreter(
+                const interpreterPath = await this._getCondaFileFromInterpreter(
                     condaInterpreter.path,
                     condaInterpreter.envName,
                 );

--- a/src/client/pythonEnvironments/discovery/locators/services/condaLocatorService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaLocatorService.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { compare } from 'semver';

--- a/src/client/pythonEnvironments/discovery/locators/services/condaLocatorService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaLocatorService.ts
@@ -17,7 +17,7 @@ import {
 import { cache } from '../../../../common/utils/decorators';
 import {
     IComponentAdapter,
-    ICondaServiceDeprecated,
+    ICondaLocatorService,
     IInterpreterLocatorService,
     WINDOWS_REGISTRY_SERVICE,
 } from '../../../../interpreter/contracts';
@@ -61,7 +61,7 @@ export const CondaGetEnvironmentPrefix = 'Outputting Environment Now...';
  * A wrapper around a conda installation.
  */
 @injectable()
-export class CondaServiceDeprecated implements ICondaServiceDeprecated {
+export class CondaLocatorService implements ICondaLocatorService {
     public get condaEnvironmentsFile(): string | undefined {
         const homeDir = this.platform.isWindows ? process.env.USERPROFILE : process.env.HOME || process.env.HOMEPATH;
         return homeDir ? path.join(homeDir, '.conda', 'environments.txt') : undefined;
@@ -213,7 +213,7 @@ export class CondaServiceDeprecated implements ICondaServiceDeprecated {
      * The check is done by simply looking for the 'conda-meta' directory.
      * @param {string} interpreterPath
      * @returns {Promise<boolean>}
-     * @memberof CondaServiceDeprecated
+     * @memberof CondaLocatorService
      */
     public async isCondaEnvironment(interpreterPath: string): Promise<boolean> {
         if (await inDiscoveryExperiment(this.experimentService)) {
@@ -401,8 +401,8 @@ export class CondaServiceDeprecated implements ICondaServiceDeprecated {
         }
         if (this.platform.isWindows) {
             const interpreters: PythonEnvironment[] = await this.getWinRegEnvs();
-            const condaInterpreters = interpreters.filter(CondaServiceDeprecated.detectCondaEnvironment);
-            const condaInterpreter = CondaServiceDeprecated.getLatestVersion(condaInterpreters);
+            const condaInterpreters = interpreters.filter(CondaLocatorService.detectCondaEnvironment);
+            const condaInterpreter = CondaLocatorService.getLatestVersion(condaInterpreters);
             if (condaInterpreter) {
                 const interpreterPath = await this.getCondaFileFromInterpreter(
                     condaInterpreter.path,

--- a/src/client/pythonEnvironments/discovery/locators/services/condaLocatorService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaLocatorService.ts
@@ -69,8 +69,6 @@ export class CondaLocatorService implements ICondaLocatorService {
 
     private condaFile?: Promise<string | undefined>;
 
-    private isAvailable: boolean | undefined;
-
     constructor(
         @inject(IProcessServiceFactory) private processServiceFactory: IProcessServiceFactory,
         @inject(IPlatformService) private platform: IPlatformService,
@@ -128,19 +126,6 @@ export class CondaLocatorService implements ICondaLocatorService {
             this.condaFile = this.getCondaFileImpl();
         }
         return (await this.condaFile)!;
-    }
-
-    /**
-     * Is there a conda install to use?
-     */
-    public async isCondaAvailable(): Promise<boolean> {
-        if (typeof this.isAvailable === 'boolean') {
-            return this.isAvailable;
-        }
-        return this.getCondaVersion()
-
-            .then((version) => (this.isAvailable = version !== undefined)) // eslint-disable-line no-return-assign
-            .catch(() => (this.isAvailable = false)); // eslint-disable-line no-return-assign
     }
 
     /**

--- a/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
@@ -8,12 +8,7 @@ import { inDiscoveryExperiment } from '../../../../common/experiments/helpers';
 import { traceDecorators, traceWarning } from '../../../../common/logger';
 import { IFileSystem, IPlatformService } from '../../../../common/platform/types';
 import { IProcessServiceFactory } from '../../../../common/process/types';
-import {
-    IConfigurationService,
-    IDisposableRegistry,
-    IExperimentService,
-    IPersistentStateFactory,
-} from '../../../../common/types';
+import { IConfigurationService, IDisposableRegistry, IExperimentService } from '../../../../common/types';
 import { cache } from '../../../../common/utils/decorators';
 import { IComponentAdapter, ICondaService, ICondaServiceDeprecated } from '../../../../interpreter/contracts';
 import { IServiceContainer } from '../../../../ioc/types';
@@ -88,6 +83,7 @@ export class CondaService implements ICondaService {
             this.condaFile = setting;
             return setting;
         }
+        return '';
     }
 
     /**
@@ -140,21 +136,6 @@ export class CondaService implements ICondaService {
     public async getCondaInfo(): Promise<CondaInfo | undefined> {
         const condaServiceDeprecated = this.serviceContainer.get<ICondaServiceDeprecated>(ICondaServiceDeprecated);
         return condaServiceDeprecated.getCondaInfo();
-    }
-
-    /**
-     * Determines whether a python interpreter is a conda environment or not.
-     * The check is done by simply looking for the 'conda-meta' directory.
-     * @param {string} interpreterPath
-     * @returns {Promise<boolean>}
-     * @memberof CondaService
-     */
-    public async isCondaEnvironment(interpreterPath: string): Promise<boolean> {
-        if (await inDiscoveryExperiment(this.experimentService)) {
-            return this.pyenvs.isCondaEnvironment(interpreterPath);
-        }
-        const condaServiceDeprecated = this.serviceContainer.get<ICondaServiceDeprecated>(ICondaServiceDeprecated);
-        return condaServiceDeprecated.isCondaEnvironment(interpreterPath);
     }
 
     /**

--- a/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
@@ -1,11 +1,11 @@
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import { compare, parse, SemVer } from 'semver';
+import { parse, SemVer } from 'semver';
 import { ConfigurationChangeEvent, Uri } from 'vscode';
 
 import { IWorkspaceService } from '../../../../common/application/types';
 import { inDiscoveryExperiment } from '../../../../common/experiments/helpers';
-import { traceDecorators, traceError, traceVerbose, traceWarning } from '../../../../common/logger';
+import { traceDecorators, traceWarning } from '../../../../common/logger';
 import { IFileSystem, IPlatformService } from '../../../../common/platform/types';
 import { IProcessServiceFactory } from '../../../../common/process/types';
 import {
@@ -15,16 +15,9 @@ import {
     IPersistentStateFactory,
 } from '../../../../common/types';
 import { cache } from '../../../../common/utils/decorators';
-import {
-    IComponentAdapter,
-    ICondaService,
-    IInterpreterLocatorService,
-    WINDOWS_REGISTRY_SERVICE,
-} from '../../../../interpreter/contracts';
+import { IComponentAdapter, ICondaService, ICondaServiceDeprecated } from '../../../../interpreter/contracts';
 import { IServiceContainer } from '../../../../ioc/types';
-import { EnvironmentType, PythonEnvironment } from '../../../info';
-import { CondaEnvironmentInfo, CondaInfo } from './conda';
-import { parseCondaEnvFileContents } from './condaHelper';
+import { CondaInfo } from './conda';
 
 const untildify: (value: string) => string = require('untildify');
 
@@ -62,20 +55,12 @@ export const CondaGetEnvironmentPrefix = 'Outputting Environment Now...';
  */
 @injectable()
 export class CondaService implements ICondaService {
-    public get condaEnvironmentsFile(): string | undefined {
-        const homeDir = this.platform.isWindows ? process.env.USERPROFILE : process.env.HOME || process.env.HOMEPATH;
-        return homeDir ? path.join(homeDir, '.conda', 'environments.txt') : undefined;
-    }
-
-    private condaFile?: Promise<string | undefined>;
-
-    private isAvailable: boolean | undefined;
+    private condaFile: string | undefined;
 
     constructor(
         @inject(IProcessServiceFactory) private processServiceFactory: IProcessServiceFactory,
         @inject(IPlatformService) private platform: IPlatformService,
         @inject(IFileSystem) private fileSystem: IFileSystem,
-        @inject(IPersistentStateFactory) private persistentStateFactory: IPersistentStateFactory,
         @inject(IConfigurationService) private configService: IConfigurationService,
         @inject(IDisposableRegistry) private disposableRegistry: IDisposableRegistry,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
@@ -87,60 +72,30 @@ export class CondaService implements ICondaService {
     }
 
     /**
-     * Return the highest Python version from the given list.
-     */
-    private static getLatestVersion(interpreters: PythonEnvironment[]): PythonEnvironment | undefined {
-        const sortedInterpreters = interpreters.slice();
-
-        sortedInterpreters.sort((a, b) => (a.version && b.version ? compare(a.version.raw, b.version.raw) : 0));
-        if (sortedInterpreters.length > 0) {
-            return sortedInterpreters[sortedInterpreters.length - 1];
-        }
-
-        return undefined;
-    }
-
-    /**
-     * Is the given interpreter from conda?
-     */
-    private static detectCondaEnvironment(env: PythonEnvironment): boolean {
-        return (
-            env.envType === EnvironmentType.Conda ||
-            (env.displayName ? env.displayName : '').toUpperCase().includes('ANACONDA') ||
-            (env.companyDisplayName ? env.companyDisplayName : '').toUpperCase().includes('ANACONDA') ||
-            (env.companyDisplayName ? env.companyDisplayName : '').toUpperCase().includes('CONTINUUM')
-        );
-    }
-
-    /**
-     * Release any held resources.
-     *
-     * Called by VS Code to indicate it is done with the resource.
-     */
-
-    public dispose(): void {} // eslint-disable-line
-
-    /**
      * Return the path to the "conda file".
      */
     public async getCondaFile(): Promise<string> {
-        if (!this.condaFile) {
-            this.condaFile = this.getCondaFileImpl();
+        if (!(await inDiscoveryExperiment(this.experimentService))) {
+            const condaServiceDeprecated = this.serviceContainer.get<ICondaServiceDeprecated>(ICondaServiceDeprecated);
+            return condaServiceDeprecated.getCondaFile();
         }
-        return (await this.condaFile)!;
+        if (this.condaFile) {
+            return this.condaFile;
+        }
+        const settings = this.configService.getSettings();
+        const setting = settings.condaPath;
+        if (setting && setting !== '') {
+            this.condaFile = setting;
+            return setting;
+        }
     }
 
     /**
      * Is there a conda install to use?
      */
     public async isCondaAvailable(): Promise<boolean> {
-        if (typeof this.isAvailable === 'boolean') {
-            return this.isAvailable;
-        }
-        return this.getCondaVersion()
-
-            .then((version) => (this.isAvailable = version !== undefined)) // eslint-disable-line no-return-assign
-            .catch(() => (this.isAvailable = false)); // eslint-disable-line no-return-assign
+        const condaServiceDeprecated = this.serviceContainer.get<ICondaServiceDeprecated>(ICondaServiceDeprecated);
+        return condaServiceDeprecated.isCondaAvailable();
     }
 
     /**
@@ -178,34 +133,13 @@ export class CondaService implements ICondaService {
     }
 
     /**
-     * Can the shell find conda (to run it)?
-     */
-    public async isCondaInCurrentPath(): Promise<boolean> {
-        const processService = await this.processServiceFactory.create();
-        return processService
-            .exec('conda', ['--version'])
-            .then((output) => output.stdout.length > 0)
-            .catch(() => false);
-    }
-
-    /**
      * Return the info reported by the conda install.
      * The result is cached for 30s.
      */
     @cache(60_000)
     public async getCondaInfo(): Promise<CondaInfo | undefined> {
-        try {
-            const condaFile = await this.getCondaFile();
-            const processService = await this.processServiceFactory.create();
-            const condaInfo = await processService.exec(condaFile, ['info', '--json']).then((output) => output.stdout);
-
-            return JSON.parse(condaInfo) as CondaInfo;
-        } catch (ex) {
-            // Failed because either:
-            //   1. conda is not installed.
-            //   2. `conda info --json` has changed signature.
-            return undefined;
-        }
+        const condaServiceDeprecated = this.serviceContainer.get<ICondaServiceDeprecated>(ICondaServiceDeprecated);
+        return condaServiceDeprecated.getCondaInfo();
     }
 
     /**
@@ -219,11 +153,8 @@ export class CondaService implements ICondaService {
         if (await inDiscoveryExperiment(this.experimentService)) {
             return this.pyenvs.isCondaEnvironment(interpreterPath);
         }
-
-        const dir = path.dirname(interpreterPath);
-        const { isWindows } = this.platform;
-        const condaMetaDirectory = isWindows ? path.join(dir, 'conda-meta') : path.join(dir, '..', 'conda-meta');
-        return this.fileSystem.directoryExists(condaMetaDirectory);
+        const condaServiceDeprecated = this.serviceContainer.get<ICondaServiceDeprecated>(ICondaServiceDeprecated);
+        return condaServiceDeprecated.isCondaEnvironment(interpreterPath);
     }
 
     /**
@@ -233,92 +164,8 @@ export class CondaService implements ICondaService {
         if (await inDiscoveryExperiment(this.experimentService)) {
             return this.pyenvs.getCondaEnvironment(interpreterPath);
         }
-
-        const isCondaEnv = await this.isCondaEnvironment(interpreterPath);
-        if (!isCondaEnv) {
-            return undefined;
-        }
-        let environments = await this.getCondaEnvironments(false);
-        const dir = path.dirname(interpreterPath);
-
-        // If interpreter is in bin or Scripts, then go up one level
-        const subDirName = path.basename(dir);
-        const goUpOnLevel = ['BIN', 'SCRIPTS'].indexOf(subDirName.toUpperCase()) !== -1;
-        const interpreterPathToMatch = goUpOnLevel ? path.join(dir, '..') : dir;
-
-        // From the list of conda environments find this dir.
-        let matchingEnvs = Array.isArray(environments)
-            ? environments.filter((item) => this.fileSystem.arePathsSame(item.path, interpreterPathToMatch))
-            : [];
-        if (matchingEnvs.length === 0) {
-            environments = await this.getCondaEnvironments(true);
-            matchingEnvs = Array.isArray(environments)
-                ? environments.filter((item) => this.fileSystem.arePathsSame(item.path, interpreterPathToMatch))
-                : [];
-        }
-
-        if (matchingEnvs.length > 0) {
-            return { name: matchingEnvs[0].name, path: interpreterPathToMatch };
-        }
-
-        // If still not available, then the user created the env after starting vs code.
-        // The only solution is to get the user to re-start vscode.
-        return undefined;
-    }
-
-    /**
-     * Return the list of conda envs (by name, interpreter filename).
-     */
-    @traceDecorators.verbose('Get Conda environments')
-    public async getCondaEnvironments(ignoreCache: boolean): Promise<CondaEnvironmentInfo[] | undefined> {
-        // Global cache.
-        const globalPersistence = this.persistentStateFactory.createGlobalPersistentState<{
-            data: CondaEnvironmentInfo[] | undefined;
-        }>('CONDA_ENVIRONMENTS', undefined);
-        if (!ignoreCache && globalPersistence.value) {
-            return globalPersistence.value.data;
-        }
-
-        try {
-            const condaFile = await this.getCondaFile();
-            const processService = await this.processServiceFactory.create();
-            let envInfo = await processService.exec(condaFile, ['env', 'list']).then((output) => output.stdout);
-            traceVerbose(`Conda Env List ${envInfo}}`);
-            if (!envInfo) {
-                traceVerbose('Conda env list failure, attempting path additions.');
-                // Try adding different folders to the path. Miniconda fails to run
-                // without them.
-                const baseFolder = path.dirname(path.dirname(condaFile));
-                const binFolder = path.join(baseFolder, 'bin');
-                const condaBinFolder = path.join(baseFolder, 'condabin');
-                const libaryBinFolder = path.join(baseFolder, 'library', 'bin');
-                const newEnv = process.env;
-                newEnv.PATH = `${binFolder};${condaBinFolder};${libaryBinFolder};${newEnv.PATH}`;
-                traceVerbose(`Attempting new path for conda env list: ${newEnv.PATH}`);
-                envInfo = await processService
-                    .exec(condaFile, ['env', 'list'], { env: newEnv })
-                    .then((output) => output.stdout);
-            }
-            const environments = parseCondaEnvFileContents(envInfo);
-            await globalPersistence.updateValue({ data: environments });
-            return environments;
-        } catch (ex) {
-            await globalPersistence.updateValue({ data: undefined });
-            // Failed because either:
-            //   1. conda is not installed.
-            //   2. `conda env list has changed signature.
-            traceError('Failed to get conda environment list from conda', ex);
-            return undefined;
-        }
-    }
-
-    /**
-     * Return the interpreter's filename for the given environment.
-     */
-    public getInterpreterPath(condaEnvironmentPath: string): string {
-        // where to find the Python binary within a conda env.
-        const relativePath = this.platform.isWindows ? 'python.exe' : path.join('bin', 'python');
-        return path.join(condaEnvironmentPath, relativePath);
+        const condaServiceDeprecated = this.serviceContainer.get<ICondaServiceDeprecated>(ICondaServiceDeprecated);
+        return condaServiceDeprecated.getCondaEnvironment(interpreterPath);
     }
 
     /**
@@ -382,65 +229,5 @@ export class CondaService implements ICondaService {
             return;
         }
         this.condaFile = undefined;
-    }
-
-    /**
-     * Return the path to the "conda file", if there is one (in known locations).
-     */
-    private async getCondaFileImpl() {
-        const settings = this.configService.getSettings();
-
-        const setting = settings.condaPath;
-        if (setting && setting !== '') {
-            return setting;
-        }
-
-        const isAvailable = await this.isCondaInCurrentPath();
-        if (isAvailable) {
-            return 'conda';
-        }
-        if (this.platform.isWindows) {
-            const interpreters: PythonEnvironment[] = await this.getWinRegEnvs();
-            const condaInterpreters = interpreters.filter(CondaService.detectCondaEnvironment);
-            const condaInterpreter = CondaService.getLatestVersion(condaInterpreters);
-            if (condaInterpreter) {
-                const interpreterPath = await this.getCondaFileFromInterpreter(
-                    condaInterpreter.path,
-                    condaInterpreter.envName,
-                );
-                if (interpreterPath) {
-                    return interpreterPath;
-                }
-            }
-        }
-        return this.getCondaFileFromKnownLocations();
-    }
-
-    private async getWinRegEnvs(): Promise<PythonEnvironment[]> {
-        if (await inDiscoveryExperiment(this.experimentService)) {
-            return this.pyenvs.getWinRegInterpreters(undefined);
-        }
-
-        const registryLookupForConda: IInterpreterLocatorService = this.serviceContainer.get<
-            IInterpreterLocatorService
-        >(IInterpreterLocatorService, WINDOWS_REGISTRY_SERVICE);
-        return registryLookupForConda.getInterpreters();
-    }
-
-    /**
-     * Return the path to the "conda file", if there is one (in known locations).
-     * Note: For now we simply return the first one found.
-     */
-    private async getCondaFileFromKnownLocations(): Promise<string> {
-        const globPattern = this.platform.isWindows ? CondaLocationsGlobWin : CondaLocationsGlob;
-        const condaFiles = await this.fileSystem.search(globPattern).catch<string[]>((failReason) => {
-            traceWarning(
-                'Default conda location search failed.',
-                `Searching for default install locations for conda results in error: ${failReason}`,
-            );
-            return [];
-        });
-        const validCondaFiles = condaFiles.filter((condaPath) => condaPath.length > 0);
-        return validCondaFiles.length === 0 ? 'conda' : validCondaFiles[0];
     }
 }

--- a/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
@@ -14,6 +14,7 @@ import { CondaInfo } from './conda';
  */
 @injectable()
 export class CondaService implements ICondaService {
+    private isAvailable: boolean | undefined;
     constructor(
         @inject(IProcessServiceFactory) private processServiceFactory: IProcessServiceFactory,
         @inject(IPlatformService) private platform: IPlatformService,
@@ -32,7 +33,13 @@ export class CondaService implements ICondaService {
      * Is there a conda install to use?
      */
     public async isCondaAvailable(): Promise<boolean> {
-        return this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService).isCondaAvailable();
+        if (typeof this.isAvailable === 'boolean') {
+            return this.isAvailable;
+        }
+        return this.getCondaVersion()
+
+            .then((version) => (this.isAvailable = version !== undefined)) // eslint-disable-line no-return-assign
+            .catch(() => (this.isAvailable = false)); // eslint-disable-line no-return-assign
     }
 
     /**

--- a/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
@@ -15,6 +15,7 @@ import { CondaInfo } from './conda';
 @injectable()
 export class CondaService implements ICondaService {
     private isAvailable: boolean | undefined;
+
     constructor(
         @inject(IProcessServiceFactory) private processServiceFactory: IProcessServiceFactory,
         @inject(IPlatformService) private platform: IPlatformService,

--- a/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
@@ -10,7 +10,7 @@ import { IFileSystem, IPlatformService } from '../../../../common/platform/types
 import { IProcessServiceFactory } from '../../../../common/process/types';
 import { IConfigurationService, IDisposableRegistry, IExperimentService } from '../../../../common/types';
 import { cache } from '../../../../common/utils/decorators';
-import { IComponentAdapter, ICondaService, ICondaServiceDeprecated } from '../../../../interpreter/contracts';
+import { IComponentAdapter, ICondaService, ICondaLocatorService } from '../../../../interpreter/contracts';
 import { IServiceContainer } from '../../../../ioc/types';
 import { CondaInfo } from './conda';
 
@@ -71,8 +71,8 @@ export class CondaService implements ICondaService {
      */
     public async getCondaFile(): Promise<string> {
         if (!(await inDiscoveryExperiment(this.experimentService))) {
-            const condaServiceDeprecated = this.serviceContainer.get<ICondaServiceDeprecated>(ICondaServiceDeprecated);
-            return condaServiceDeprecated.getCondaFile();
+            const condaLocatorService = this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService);
+            return condaLocatorService.getCondaFile();
         }
         if (this.condaFile) {
             return this.condaFile;
@@ -90,8 +90,8 @@ export class CondaService implements ICondaService {
      * Is there a conda install to use?
      */
     public async isCondaAvailable(): Promise<boolean> {
-        const condaServiceDeprecated = this.serviceContainer.get<ICondaServiceDeprecated>(ICondaServiceDeprecated);
-        return condaServiceDeprecated.isCondaAvailable();
+        const condaLocatorService = this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService);
+        return condaLocatorService.isCondaAvailable();
     }
 
     /**
@@ -134,8 +134,8 @@ export class CondaService implements ICondaService {
      */
     @cache(60_000)
     public async getCondaInfo(): Promise<CondaInfo | undefined> {
-        const condaServiceDeprecated = this.serviceContainer.get<ICondaServiceDeprecated>(ICondaServiceDeprecated);
-        return condaServiceDeprecated.getCondaInfo();
+        const condaLocatorService = this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService);
+        return condaLocatorService.getCondaInfo();
     }
 
     /**
@@ -145,8 +145,8 @@ export class CondaService implements ICondaService {
         if (await inDiscoveryExperiment(this.experimentService)) {
             return this.pyenvs.getCondaEnvironment(interpreterPath);
         }
-        const condaServiceDeprecated = this.serviceContainer.get<ICondaServiceDeprecated>(ICondaServiceDeprecated);
-        return condaServiceDeprecated.getCondaEnvironment(interpreterPath);
+        const condaLocatorService = this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService);
+        return condaLocatorService.getCondaEnvironment(interpreterPath);
     }
 
     /**

--- a/src/client/pythonEnvironments/discovery/locators/services/condaServiceDeprecated.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaServiceDeprecated.ts
@@ -1,0 +1,446 @@
+import { inject, injectable } from 'inversify';
+import * as path from 'path';
+import { compare, parse, SemVer } from 'semver';
+import { ConfigurationChangeEvent, Uri } from 'vscode';
+
+import { IWorkspaceService } from '../../../../common/application/types';
+import { inDiscoveryExperiment } from '../../../../common/experiments/helpers';
+import { traceDecorators, traceError, traceVerbose, traceWarning } from '../../../../common/logger';
+import { IFileSystem, IPlatformService } from '../../../../common/platform/types';
+import { IProcessServiceFactory } from '../../../../common/process/types';
+import {
+    IConfigurationService,
+    IDisposableRegistry,
+    IExperimentService,
+    IPersistentStateFactory,
+} from '../../../../common/types';
+import { cache } from '../../../../common/utils/decorators';
+import {
+    IComponentAdapter,
+    ICondaServiceDeprecated,
+    IInterpreterLocatorService,
+    WINDOWS_REGISTRY_SERVICE,
+} from '../../../../interpreter/contracts';
+import { IServiceContainer } from '../../../../ioc/types';
+import { EnvironmentType, PythonEnvironment } from '../../../info';
+import { CondaEnvironmentInfo, CondaInfo } from './conda';
+import { parseCondaEnvFileContents } from './condaHelper';
+
+const untildify: (value: string) => string = require('untildify');
+
+// This glob pattern will match all of the following:
+// ~/anaconda/bin/conda, ~/anaconda3/bin/conda, ~/miniconda/bin/conda, ~/miniconda3/bin/conda
+// /usr/share/anaconda/bin/conda, /usr/share/anaconda3/bin/conda, /usr/share/miniconda/bin/conda,
+// /usr/share/miniconda3/bin/conda
+
+const condaGlobPathsForLinuxMac = [
+    untildify('~/opt/*conda*/bin/conda'),
+    '/opt/*conda*/bin/conda',
+    '/usr/share/*conda*/bin/conda',
+    untildify('~/*conda*/bin/conda'),
+];
+
+export const CondaLocationsGlob = `{${condaGlobPathsForLinuxMac.join(',')}}`;
+
+// ...and for windows, the known default install locations:
+const condaGlobPathsForWindows = [
+    '/ProgramData/[Mm]iniconda*/Scripts/conda.exe',
+    '/ProgramData/[Aa]naconda*/Scripts/conda.exe',
+    untildify('~/[Mm]iniconda*/Scripts/conda.exe'),
+    untildify('~/[Aa]naconda*/Scripts/conda.exe'),
+    untildify('~/AppData/Local/Continuum/[Mm]iniconda*/Scripts/conda.exe'),
+    untildify('~/AppData/Local/Continuum/[Aa]naconda*/Scripts/conda.exe'),
+];
+
+// format for glob processing:
+export const CondaLocationsGlobWin = `{${condaGlobPathsForWindows.join(',')}}`;
+
+export const CondaGetEnvironmentPrefix = 'Outputting Environment Now...';
+
+/**
+ * A wrapper around a conda installation.
+ */
+@injectable()
+export class CondaServiceDeprecated implements ICondaServiceDeprecated {
+    public get condaEnvironmentsFile(): string | undefined {
+        const homeDir = this.platform.isWindows ? process.env.USERPROFILE : process.env.HOME || process.env.HOMEPATH;
+        return homeDir ? path.join(homeDir, '.conda', 'environments.txt') : undefined;
+    }
+
+    private condaFile?: Promise<string | undefined>;
+
+    private isAvailable: boolean | undefined;
+
+    constructor(
+        @inject(IProcessServiceFactory) private processServiceFactory: IProcessServiceFactory,
+        @inject(IPlatformService) private platform: IPlatformService,
+        @inject(IFileSystem) private fileSystem: IFileSystem,
+        @inject(IPersistentStateFactory) private persistentStateFactory: IPersistentStateFactory,
+        @inject(IConfigurationService) private configService: IConfigurationService,
+        @inject(IDisposableRegistry) private disposableRegistry: IDisposableRegistry,
+        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
+        @inject(IComponentAdapter) private readonly pyenvs: IComponentAdapter,
+        @inject(IExperimentService) private readonly experimentService: IExperimentService,
+        @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer,
+    ) {
+        this.addCondaPathChangedHandler();
+    }
+
+    /**
+     * Return the highest Python version from the given list.
+     */
+    private static getLatestVersion(interpreters: PythonEnvironment[]): PythonEnvironment | undefined {
+        const sortedInterpreters = interpreters.slice();
+
+        sortedInterpreters.sort((a, b) => (a.version && b.version ? compare(a.version.raw, b.version.raw) : 0));
+        if (sortedInterpreters.length > 0) {
+            return sortedInterpreters[sortedInterpreters.length - 1];
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Is the given interpreter from conda?
+     */
+    private static detectCondaEnvironment(env: PythonEnvironment): boolean {
+        return (
+            env.envType === EnvironmentType.Conda ||
+            (env.displayName ? env.displayName : '').toUpperCase().includes('ANACONDA') ||
+            (env.companyDisplayName ? env.companyDisplayName : '').toUpperCase().includes('ANACONDA') ||
+            (env.companyDisplayName ? env.companyDisplayName : '').toUpperCase().includes('CONTINUUM')
+        );
+    }
+
+    /**
+     * Release any held resources.
+     *
+     * Called by VS Code to indicate it is done with the resource.
+     */
+
+    public dispose(): void {} // eslint-disable-line
+
+    /**
+     * Return the path to the "conda file".
+     */
+    public async getCondaFile(): Promise<string> {
+        if (!this.condaFile) {
+            this.condaFile = this.getCondaFileImpl();
+        }
+        return (await this.condaFile)!;
+    }
+
+    /**
+     * Is there a conda install to use?
+     */
+    public async isCondaAvailable(): Promise<boolean> {
+        if (typeof this.isAvailable === 'boolean') {
+            return this.isAvailable;
+        }
+        return this.getCondaVersion()
+
+            .then((version) => (this.isAvailable = version !== undefined)) // eslint-disable-line no-return-assign
+            .catch(() => (this.isAvailable = false)); // eslint-disable-line no-return-assign
+    }
+
+    /**
+     * Return the conda version.
+     * The version info is cached for some time.
+     * Remember, its possible the user can update the path to `conda` executable in settings.json,
+     * or environment variables.
+     * Doing that could change this value.
+     */
+    @cache(120_000)
+    public async getCondaVersion(): Promise<SemVer | undefined> {
+        const processService = await this.processServiceFactory.create();
+        const info = await this.getCondaInfo().catch<CondaInfo | undefined>(() => undefined);
+        let versionString: string | undefined;
+        if (info && info.conda_version) {
+            versionString = info.conda_version;
+        } else {
+            const stdOut = await this.getCondaFile()
+                .then((condaFile) => processService.exec(condaFile, ['--version'], {}))
+                .then((result) => result.stdout.trim())
+                .catch<string | undefined>(() => undefined);
+
+            versionString = stdOut && stdOut.startsWith('conda ') ? stdOut.substring('conda '.length).trim() : stdOut;
+        }
+        if (!versionString) {
+            return undefined;
+        }
+        const version = parse(versionString, true);
+        if (version) {
+            return version;
+        }
+        // Use a bogus version, at least to indicate the fact that a version was returned.
+        traceWarning(`Unable to parse Version of Conda, ${versionString}`);
+        return new SemVer('0.0.1');
+    }
+
+    /**
+     * Can the shell find conda (to run it)?
+     */
+    public async isCondaInCurrentPath(): Promise<boolean> {
+        const processService = await this.processServiceFactory.create();
+        return processService
+            .exec('conda', ['--version'])
+            .then((output) => output.stdout.length > 0)
+            .catch(() => false);
+    }
+
+    /**
+     * Return the info reported by the conda install.
+     * The result is cached for 30s.
+     */
+    @cache(60_000)
+    public async getCondaInfo(): Promise<CondaInfo | undefined> {
+        try {
+            const condaFile = await this.getCondaFile();
+            const processService = await this.processServiceFactory.create();
+            const condaInfo = await processService.exec(condaFile, ['info', '--json']).then((output) => output.stdout);
+
+            return JSON.parse(condaInfo) as CondaInfo;
+        } catch (ex) {
+            // Failed because either:
+            //   1. conda is not installed.
+            //   2. `conda info --json` has changed signature.
+            return undefined;
+        }
+    }
+
+    /**
+     * Determines whether a python interpreter is a conda environment or not.
+     * The check is done by simply looking for the 'conda-meta' directory.
+     * @param {string} interpreterPath
+     * @returns {Promise<boolean>}
+     * @memberof CondaServiceDeprecated
+     */
+    public async isCondaEnvironment(interpreterPath: string): Promise<boolean> {
+        if (await inDiscoveryExperiment(this.experimentService)) {
+            return this.pyenvs.isCondaEnvironment(interpreterPath);
+        }
+
+        const dir = path.dirname(interpreterPath);
+        const { isWindows } = this.platform;
+        const condaMetaDirectory = isWindows ? path.join(dir, 'conda-meta') : path.join(dir, '..', 'conda-meta');
+        return this.fileSystem.directoryExists(condaMetaDirectory);
+    }
+
+    /**
+     * Return (env name, interpreter filename) for the interpreter.
+     */
+    public async getCondaEnvironment(interpreterPath: string): Promise<{ name: string; path: string } | undefined> {
+        if (await inDiscoveryExperiment(this.experimentService)) {
+            return this.pyenvs.getCondaEnvironment(interpreterPath);
+        }
+
+        const isCondaEnv = await this.isCondaEnvironment(interpreterPath);
+        if (!isCondaEnv) {
+            return undefined;
+        }
+        let environments = await this.getCondaEnvironments(false);
+        const dir = path.dirname(interpreterPath);
+
+        // If interpreter is in bin or Scripts, then go up one level
+        const subDirName = path.basename(dir);
+        const goUpOnLevel = ['BIN', 'SCRIPTS'].indexOf(subDirName.toUpperCase()) !== -1;
+        const interpreterPathToMatch = goUpOnLevel ? path.join(dir, '..') : dir;
+
+        // From the list of conda environments find this dir.
+        let matchingEnvs = Array.isArray(environments)
+            ? environments.filter((item) => this.fileSystem.arePathsSame(item.path, interpreterPathToMatch))
+            : [];
+        if (matchingEnvs.length === 0) {
+            environments = await this.getCondaEnvironments(true);
+            matchingEnvs = Array.isArray(environments)
+                ? environments.filter((item) => this.fileSystem.arePathsSame(item.path, interpreterPathToMatch))
+                : [];
+        }
+
+        if (matchingEnvs.length > 0) {
+            return { name: matchingEnvs[0].name, path: interpreterPathToMatch };
+        }
+
+        // If still not available, then the user created the env after starting vs code.
+        // The only solution is to get the user to re-start vscode.
+        return undefined;
+    }
+
+    /**
+     * Return the list of conda envs (by name, interpreter filename).
+     */
+    @traceDecorators.verbose('Get Conda environments')
+    public async getCondaEnvironments(ignoreCache: boolean): Promise<CondaEnvironmentInfo[] | undefined> {
+        // Global cache.
+        const globalPersistence = this.persistentStateFactory.createGlobalPersistentState<{
+            data: CondaEnvironmentInfo[] | undefined;
+        }>('CONDA_ENVIRONMENTS', undefined);
+        if (!ignoreCache && globalPersistence.value) {
+            return globalPersistence.value.data;
+        }
+
+        try {
+            const condaFile = await this.getCondaFile();
+            const processService = await this.processServiceFactory.create();
+            let envInfo = await processService.exec(condaFile, ['env', 'list']).then((output) => output.stdout);
+            traceVerbose(`Conda Env List ${envInfo}}`);
+            if (!envInfo) {
+                traceVerbose('Conda env list failure, attempting path additions.');
+                // Try adding different folders to the path. Miniconda fails to run
+                // without them.
+                const baseFolder = path.dirname(path.dirname(condaFile));
+                const binFolder = path.join(baseFolder, 'bin');
+                const condaBinFolder = path.join(baseFolder, 'condabin');
+                const libaryBinFolder = path.join(baseFolder, 'library', 'bin');
+                const newEnv = process.env;
+                newEnv.PATH = `${binFolder};${condaBinFolder};${libaryBinFolder};${newEnv.PATH}`;
+                traceVerbose(`Attempting new path for conda env list: ${newEnv.PATH}`);
+                envInfo = await processService
+                    .exec(condaFile, ['env', 'list'], { env: newEnv })
+                    .then((output) => output.stdout);
+            }
+            const environments = parseCondaEnvFileContents(envInfo);
+            await globalPersistence.updateValue({ data: environments });
+            return environments;
+        } catch (ex) {
+            await globalPersistence.updateValue({ data: undefined });
+            // Failed because either:
+            //   1. conda is not installed.
+            //   2. `conda env list has changed signature.
+            traceError('Failed to get conda environment list from conda', ex);
+            return undefined;
+        }
+    }
+
+    /**
+     * Return the interpreter's filename for the given environment.
+     */
+    public getInterpreterPath(condaEnvironmentPath: string): string {
+        // where to find the Python binary within a conda env.
+        const relativePath = this.platform.isWindows ? 'python.exe' : path.join('bin', 'python');
+        return path.join(condaEnvironmentPath, relativePath);
+    }
+
+    /**
+     * Get the conda exe from the path to an interpreter's python. This might be different than the
+     * globally registered conda.exe.
+     *
+     * The value is cached for a while.
+     * The only way this can change is if user installs conda into this same environment.
+     * Generally we expect that to happen the other way, the user creates a conda environment with conda in it.
+     */
+    @traceDecorators.verbose('Get Conda File from interpreter')
+    @cache(120_000)
+    public async getCondaFileFromInterpreter(interpreterPath?: string, envName?: string): Promise<string | undefined> {
+        const condaExe = this.platform.isWindows ? 'conda.exe' : 'conda';
+        const scriptsDir = this.platform.isWindows ? 'Scripts' : 'bin';
+        const interpreterDir = interpreterPath ? path.dirname(interpreterPath) : '';
+
+        // Might be in a situation where this is not the default python env, but rather one running
+        // from a virtualenv
+        const envsPos = envName ? interpreterDir.indexOf(path.join('envs', envName)) : -1;
+        if (envsPos > 0) {
+            // This should be where the original python was run from when the environment was created.
+            const originalPath = interpreterDir.slice(0, envsPos);
+            let condaPath1 = path.join(originalPath, condaExe);
+
+            if (await this.fileSystem.fileExists(condaPath1)) {
+                return condaPath1;
+            }
+
+            // Also look in the scripts directory here too.
+            condaPath1 = path.join(originalPath, scriptsDir, condaExe);
+            if (await this.fileSystem.fileExists(condaPath1)) {
+                return condaPath1;
+            }
+        }
+
+        let condaPath2 = path.join(interpreterDir, condaExe);
+        if (await this.fileSystem.fileExists(condaPath2)) {
+            return condaPath2;
+        }
+        // Conda path has changed locations, check the new location in the scripts directory after checking
+        // the old location
+        condaPath2 = path.join(interpreterDir, scriptsDir, condaExe);
+        if (await this.fileSystem.fileExists(condaPath2)) {
+            return condaPath2;
+        }
+
+        return undefined;
+    }
+
+    private addCondaPathChangedHandler() {
+        const disposable = this.workspaceService.onDidChangeConfiguration(this.onDidChangeConfiguration.bind(this));
+        this.disposableRegistry.push(disposable);
+    }
+
+    private async onDidChangeConfiguration(event: ConfigurationChangeEvent) {
+        const workspacesUris: (Uri | undefined)[] = this.workspaceService.hasWorkspaceFolders
+            ? this.workspaceService.workspaceFolders!.map((workspace) => workspace.uri)
+            : [undefined];
+        if (workspacesUris.findIndex((uri) => event.affectsConfiguration('python.condaPath', uri)) === -1) {
+            return;
+        }
+        this.condaFile = undefined;
+    }
+
+    /**
+     * Return the path to the "conda file", if there is one (in known locations).
+     */
+    private async getCondaFileImpl() {
+        const settings = this.configService.getSettings();
+
+        const setting = settings.condaPath;
+        if (setting && setting !== '') {
+            return setting;
+        }
+
+        const isAvailable = await this.isCondaInCurrentPath();
+        if (isAvailable) {
+            return 'conda';
+        }
+        if (this.platform.isWindows) {
+            const interpreters: PythonEnvironment[] = await this.getWinRegEnvs();
+            const condaInterpreters = interpreters.filter(CondaServiceDeprecated.detectCondaEnvironment);
+            const condaInterpreter = CondaServiceDeprecated.getLatestVersion(condaInterpreters);
+            if (condaInterpreter) {
+                const interpreterPath = await this.getCondaFileFromInterpreter(
+                    condaInterpreter.path,
+                    condaInterpreter.envName,
+                );
+                if (interpreterPath) {
+                    return interpreterPath;
+                }
+            }
+        }
+        return this.getCondaFileFromKnownLocations();
+    }
+
+    private async getWinRegEnvs(): Promise<PythonEnvironment[]> {
+        if (await inDiscoveryExperiment(this.experimentService)) {
+            return this.pyenvs.getWinRegInterpreters(undefined);
+        }
+
+        const registryLookupForConda: IInterpreterLocatorService = this.serviceContainer.get<
+            IInterpreterLocatorService
+        >(IInterpreterLocatorService, WINDOWS_REGISTRY_SERVICE);
+        return registryLookupForConda.getInterpreters();
+    }
+
+    /**
+     * Return the path to the "conda file", if there is one (in known locations).
+     * Note: For now we simply return the first one found.
+     */
+    private async getCondaFileFromKnownLocations(): Promise<string> {
+        const globPattern = this.platform.isWindows ? CondaLocationsGlobWin : CondaLocationsGlob;
+        const condaFiles = await this.fileSystem.search(globPattern).catch<string[]>((failReason) => {
+            traceWarning(
+                'Default conda location search failed.',
+                `Searching for default install locations for conda results in error: ${failReason}`,
+            );
+            return [];
+        });
+        const validCondaFiles = condaFiles.filter((condaPath) => condaPath.length > 0);
+        return validCondaFiles.length === 0 ? 'conda' : validCondaFiles[0];
+    }
+}

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -442,10 +442,10 @@ export async function registerLegacyDiscoveryForIOC(serviceManager: IServiceMana
             WindowsRegistryService,
             WINDOWS_REGISTRY_SERVICE,
         );
-        serviceManager.addSingleton<ICondaLocatorService>(ICondaLocatorService, CondaLocatorService);
     }
     serviceManager.addSingleton<IInterpreterLocatorService>(IInterpreterLocatorService, PipEnvService, PIPENV_SERVICE);
 
+    serviceManager.addSingleton<ICondaLocatorService>(ICondaLocatorService, CondaLocatorService);
     serviceManager.addSingleton<ICondaService>(ICondaService, CondaService);
     serviceManager.addSingleton<IPipEnvServiceHelper>(IPipEnvServiceHelper, PipEnvServiceHelper);
 }

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -18,6 +18,7 @@ import {
     GLOBAL_VIRTUAL_ENV_SERVICE,
     IComponentAdapter,
     ICondaService,
+    ICondaServiceDeprecated,
     IInterpreterLocatorHelper,
     IInterpreterLocatorProgressService,
     IInterpreterLocatorService,
@@ -46,6 +47,7 @@ import { CondaEnvironmentInfo, isCondaEnvironment } from './discovery/locators/s
 import { CondaEnvFileService } from './discovery/locators/services/condaEnvFileService';
 import { CondaEnvService } from './discovery/locators/services/condaEnvService';
 import { CondaService } from './discovery/locators/services/condaService';
+import { CondaServiceDeprecated } from './discovery/locators/services/condaServiceDeprecated';
 import { CurrentPathService, PythonInPathCommandProvider } from './discovery/locators/services/currentPathService';
 import {
     GlobalVirtualEnvironmentsSearchPathProvider,
@@ -440,6 +442,7 @@ export async function registerLegacyDiscoveryForIOC(serviceManager: IServiceMana
             WindowsRegistryService,
             WINDOWS_REGISTRY_SERVICE,
         );
+        serviceManager.addSingleton<ICondaServiceDeprecated>(ICondaServiceDeprecated, CondaServiceDeprecated);
     }
     serviceManager.addSingleton<IInterpreterLocatorService>(IInterpreterLocatorService, PipEnvService, PIPENV_SERVICE);
 

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -18,7 +18,7 @@ import {
     GLOBAL_VIRTUAL_ENV_SERVICE,
     IComponentAdapter,
     ICondaService,
-    ICondaServiceDeprecated,
+    ICondaLocatorService,
     IInterpreterLocatorHelper,
     IInterpreterLocatorProgressService,
     IInterpreterLocatorService,
@@ -47,7 +47,7 @@ import { CondaEnvironmentInfo, isCondaEnvironment } from './discovery/locators/s
 import { CondaEnvFileService } from './discovery/locators/services/condaEnvFileService';
 import { CondaEnvService } from './discovery/locators/services/condaEnvService';
 import { CondaService } from './discovery/locators/services/condaService';
-import { CondaServiceDeprecated } from './discovery/locators/services/condaServiceDeprecated';
+import { CondaLocatorService } from './discovery/locators/services/condaLocatorService';
 import { CurrentPathService, PythonInPathCommandProvider } from './discovery/locators/services/currentPathService';
 import {
     GlobalVirtualEnvironmentsSearchPathProvider,
@@ -442,7 +442,7 @@ export async function registerLegacyDiscoveryForIOC(serviceManager: IServiceMana
             WindowsRegistryService,
             WINDOWS_REGISTRY_SERVICE,
         );
-        serviceManager.addSingleton<ICondaServiceDeprecated>(ICondaServiceDeprecated, CondaServiceDeprecated);
+        serviceManager.addSingleton<ICondaLocatorService>(ICondaLocatorService, CondaLocatorService);
     }
     serviceManager.addSingleton<IInterpreterLocatorService>(IInterpreterLocatorService, PipEnvService, PIPENV_SERVICE);
 

--- a/src/test/common/installer/condaInstaller.unit.test.ts
+++ b/src/test/common/installer/condaInstaller.unit.test.ts
@@ -102,7 +102,7 @@ suite('Common - Conda Installer', () => {
         when(configService.getSettings(uri)).thenReturn(instance(settings));
         when(settings.pythonPath).thenReturn(pythonPath);
         when(condaService.getCondaFile()).thenResolve(condaPath);
-        when(condaService.getCondaEnvironment(pythonPath)).thenResolve(condaEnv);
+        when(condaLocatorService.getCondaEnvironment(pythonPath)).thenResolve(condaEnv);
 
         const execInfo = await installer.getExecutionInfo('abc', uri);
 
@@ -121,7 +121,7 @@ suite('Common - Conda Installer', () => {
         when(configService.getSettings(uri)).thenReturn(instance(settings));
         when(settings.pythonPath).thenReturn(pythonPath);
         when(condaService.getCondaFile()).thenResolve(condaPath);
-        when(condaService.getCondaEnvironment(pythonPath)).thenResolve(condaEnv);
+        when(condaLocatorService.getCondaEnvironment(pythonPath)).thenResolve(condaEnv);
 
         const execInfo = await installer.getExecutionInfo('abc', uri);
 

--- a/src/test/common/installer/condaInstaller.unit.test.ts
+++ b/src/test/common/installer/condaInstaller.unit.test.ts
@@ -11,7 +11,7 @@ import { ConfigurationService } from '../../../client/common/configuration/servi
 import { CondaInstaller } from '../../../client/common/installer/condaInstaller';
 import { InterpreterUri } from '../../../client/common/installer/types';
 import { ExecutionInfo, IConfigurationService, IPythonSettings } from '../../../client/common/types';
-import { ICondaService, ICondaServiceDeprecated } from '../../../client/interpreter/contracts';
+import { ICondaService, ICondaLocatorService } from '../../../client/interpreter/contracts';
 import { ServiceContainer } from '../../../client/ioc/container';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { CondaEnvironmentInfo } from '../../../client/pythonEnvironments/discovery/locators/services/conda';
@@ -21,7 +21,7 @@ suite('Common - Conda Installer', () => {
     let installer: CondaInstallerTest;
     let serviceContainer: IServiceContainer;
     let condaService: ICondaService;
-    let condaServiceDeprecated: ICondaServiceDeprecated;
+    let condaLocatorService: ICondaLocatorService;
     let configService: IConfigurationService;
     class CondaInstallerTest extends CondaInstaller {
         public async getExecutionInfo(moduleName: string, resource?: InterpreterUri): Promise<ExecutionInfo> {
@@ -31,11 +31,11 @@ suite('Common - Conda Installer', () => {
     setup(() => {
         serviceContainer = mock(ServiceContainer);
         condaService = mock(CondaService);
-        condaServiceDeprecated = mock<ICondaServiceDeprecated>();
+        condaLocatorService = mock<ICondaLocatorService>();
         configService = mock(ConfigurationService);
         when(serviceContainer.get<ICondaService>(ICondaService)).thenReturn(instance(condaService));
-        when(serviceContainer.get<ICondaServiceDeprecated>(ICondaServiceDeprecated)).thenReturn(
-            instance(condaServiceDeprecated),
+        when(serviceContainer.get<ICondaLocatorService>(ICondaLocatorService)).thenReturn(
+            instance(condaLocatorService),
         );
         when(serviceContainer.get<IConfigurationService>(IConfigurationService)).thenReturn(instance(configService));
         installer = new CondaInstallerTest(instance(serviceContainer));
@@ -69,7 +69,7 @@ suite('Common - Conda Installer', () => {
         when(settings.pythonPath).thenReturn(pythonPath);
         when(condaService.isCondaAvailable()).thenResolve(true);
         when(configService.getSettings(uri)).thenReturn(instance(settings));
-        when(condaServiceDeprecated.isCondaEnvironment(pythonPath)).thenResolve(false);
+        when(condaLocatorService.isCondaEnvironment(pythonPath)).thenResolve(false);
 
         const supported = await installer.isSupported(uri);
 
@@ -83,7 +83,7 @@ suite('Common - Conda Installer', () => {
         when(settings.pythonPath).thenReturn(pythonPath);
         when(condaService.isCondaAvailable()).thenResolve(true);
         when(configService.getSettings(uri)).thenReturn(instance(settings));
-        when(condaServiceDeprecated.isCondaEnvironment(pythonPath)).thenResolve(true);
+        when(condaLocatorService.isCondaEnvironment(pythonPath)).thenResolve(true);
 
         const supported = await installer.isSupported(uri);
 

--- a/src/test/common/installer/condaInstaller.unit.test.ts
+++ b/src/test/common/installer/condaInstaller.unit.test.ts
@@ -11,7 +11,7 @@ import { ConfigurationService } from '../../../client/common/configuration/servi
 import { CondaInstaller } from '../../../client/common/installer/condaInstaller';
 import { InterpreterUri } from '../../../client/common/installer/types';
 import { ExecutionInfo, IConfigurationService, IPythonSettings } from '../../../client/common/types';
-import { ICondaService } from '../../../client/interpreter/contracts';
+import { ICondaService, ICondaServiceDeprecated } from '../../../client/interpreter/contracts';
 import { ServiceContainer } from '../../../client/ioc/container';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { CondaEnvironmentInfo } from '../../../client/pythonEnvironments/discovery/locators/services/conda';
@@ -21,6 +21,7 @@ suite('Common - Conda Installer', () => {
     let installer: CondaInstallerTest;
     let serviceContainer: IServiceContainer;
     let condaService: ICondaService;
+    let condaServiceDeprecated: ICondaServiceDeprecated;
     let configService: IConfigurationService;
     class CondaInstallerTest extends CondaInstaller {
         public async getExecutionInfo(moduleName: string, resource?: InterpreterUri): Promise<ExecutionInfo> {
@@ -30,8 +31,12 @@ suite('Common - Conda Installer', () => {
     setup(() => {
         serviceContainer = mock(ServiceContainer);
         condaService = mock(CondaService);
+        condaServiceDeprecated = mock<ICondaServiceDeprecated>();
         configService = mock(ConfigurationService);
         when(serviceContainer.get<ICondaService>(ICondaService)).thenReturn(instance(condaService));
+        when(serviceContainer.get<ICondaServiceDeprecated>(ICondaServiceDeprecated)).thenReturn(
+            instance(condaServiceDeprecated),
+        );
         when(serviceContainer.get<IConfigurationService>(IConfigurationService)).thenReturn(instance(configService));
         installer = new CondaInstallerTest(instance(serviceContainer));
     });
@@ -64,7 +69,7 @@ suite('Common - Conda Installer', () => {
         when(settings.pythonPath).thenReturn(pythonPath);
         when(condaService.isCondaAvailable()).thenResolve(true);
         when(configService.getSettings(uri)).thenReturn(instance(settings));
-        when(condaService.isCondaEnvironment(pythonPath)).thenResolve(false);
+        when(condaServiceDeprecated.isCondaEnvironment(pythonPath)).thenResolve(false);
 
         const supported = await installer.isSupported(uri);
 
@@ -78,7 +83,7 @@ suite('Common - Conda Installer', () => {
         when(settings.pythonPath).thenReturn(pythonPath);
         when(condaService.isCondaAvailable()).thenResolve(true);
         when(configService.getSettings(uri)).thenReturn(instance(settings));
-        when(condaService.isCondaEnvironment(pythonPath)).thenResolve(true);
+        when(condaServiceDeprecated.isCondaEnvironment(pythonPath)).thenResolve(true);
 
         const supported = await installer.isSupported(uri);
 

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -40,7 +40,7 @@ import {
 import { getNamesAndValues } from '../../../client/common/utils/enum';
 import { Products } from '../../../client/common/utils/localize';
 import { noop } from '../../../client/common/utils/misc';
-import { ICondaService, IInterpreterService } from '../../../client/interpreter/contracts';
+import { ICondaLocatorService, ICondaService, IInterpreterService } from '../../../client/interpreter/contracts';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../constants';
@@ -237,7 +237,12 @@ suite('Module Installer', () => {
 
                             const condaService = TypeMoq.Mock.ofType<ICondaService>();
                             condaService.setup((c) => c.getCondaFile()).returns(() => Promise.resolve(condaExecutable));
-                            condaService
+
+                            const condaLocatorService = TypeMoq.Mock.ofType<ICondaLocatorService>();
+                            serviceContainer
+                                .setup((c) => c.get(TypeMoq.It.isValue(ICondaLocatorService)))
+                                .returns(() => condaLocatorService.object);
+                            condaLocatorService
                                 .setup((c) => c.getCondaEnvironment(TypeMoq.It.isAny()))
                                 .returns(() => Promise.resolve(condaEnvInfo));
 

--- a/src/test/common/moduleInstaller.test.ts
+++ b/src/test/common/moduleInstaller.test.ts
@@ -118,6 +118,7 @@ import { Architecture } from '../../client/common/utils/platform';
 import { Random } from '../../client/common/utils/random';
 import {
     ICondaService,
+    ICondaServiceDeprecated,
     IInterpreterLocatorService,
     IInterpreterService,
     INTERPRETER_LOCATOR_SERVICE,
@@ -156,6 +157,7 @@ suite('Module Installer', () => {
         let ioc: UnitTestIocContainer;
         let mockTerminalService: TypeMoq.IMock<ITerminalService>;
         let condaService: TypeMoq.IMock<ICondaService>;
+        let condaServiceDeprecated: TypeMoq.IMock<ICondaServiceDeprecated>;
         let interpreterService: TypeMoq.IMock<IInterpreterService>;
         let mockTerminalFactory: TypeMoq.IMock<ITerminalServiceFactory>;
 
@@ -220,6 +222,11 @@ suite('Module Installer', () => {
 
             await ioc.registerMockInterpreterTypes();
             condaService = TypeMoq.Mock.ofType<ICondaService>();
+            condaServiceDeprecated = TypeMoq.Mock.ofType<ICondaServiceDeprecated>();
+            ioc.serviceManager.addSingletonInstance<ICondaServiceDeprecated>(
+                ICondaServiceDeprecated,
+                condaServiceDeprecated.object,
+            );
             ioc.serviceManager.rebindInstance<ICondaService>(ICondaService, condaService.object);
             interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
             ioc.serviceManager.rebindInstance<IInterpreterService>(IInterpreterService, interpreterService.object);
@@ -460,8 +467,11 @@ suite('Module Installer', () => {
             settings.setup((s) => s.pythonPath).returns(() => pythonPath);
             configService.setup((c) => c.getSettings(TypeMoq.It.isAny())).returns(() => settings.object);
             serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(ICondaService))).returns(() => condaService.object);
+            serviceContainer
+                .setup((c) => c.get(TypeMoq.It.isValue(ICondaServiceDeprecated)))
+                .returns(() => condaServiceDeprecated.object);
             condaService.setup((c) => c.isCondaAvailable()).returns(() => Promise.resolve(true));
-            condaService
+            condaServiceDeprecated
                 .setup((c) => c.isCondaEnvironment(TypeMoq.It.isValue(pythonPath)))
                 .returns(() => Promise.resolve(true));
 
@@ -480,8 +490,11 @@ suite('Module Installer', () => {
             settings.setup((s) => s.pythonPath).returns(() => pythonPath);
             configService.setup((c) => c.getSettings(TypeMoq.It.isAny())).returns(() => settings.object);
             serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(ICondaService))).returns(() => condaService.object);
+            serviceContainer
+                .setup((c) => c.get(TypeMoq.It.isValue(ICondaServiceDeprecated)))
+                .returns(() => condaServiceDeprecated.object);
             condaService.setup((c) => c.isCondaAvailable()).returns(() => Promise.resolve(true));
-            condaService
+            condaServiceDeprecated
                 .setup((c) => c.isCondaEnvironment(TypeMoq.It.isValue(pythonPath)))
                 .returns(() => Promise.resolve(false));
 

--- a/src/test/common/moduleInstaller.test.ts
+++ b/src/test/common/moduleInstaller.test.ts
@@ -118,7 +118,7 @@ import { Architecture } from '../../client/common/utils/platform';
 import { Random } from '../../client/common/utils/random';
 import {
     ICondaService,
-    ICondaServiceDeprecated,
+    ICondaLocatorService,
     IInterpreterLocatorService,
     IInterpreterService,
     INTERPRETER_LOCATOR_SERVICE,
@@ -157,7 +157,7 @@ suite('Module Installer', () => {
         let ioc: UnitTestIocContainer;
         let mockTerminalService: TypeMoq.IMock<ITerminalService>;
         let condaService: TypeMoq.IMock<ICondaService>;
-        let condaServiceDeprecated: TypeMoq.IMock<ICondaServiceDeprecated>;
+        let condaLocatorService: TypeMoq.IMock<ICondaLocatorService>;
         let interpreterService: TypeMoq.IMock<IInterpreterService>;
         let mockTerminalFactory: TypeMoq.IMock<ITerminalServiceFactory>;
 
@@ -222,10 +222,10 @@ suite('Module Installer', () => {
 
             await ioc.registerMockInterpreterTypes();
             condaService = TypeMoq.Mock.ofType<ICondaService>();
-            condaServiceDeprecated = TypeMoq.Mock.ofType<ICondaServiceDeprecated>();
-            ioc.serviceManager.addSingletonInstance<ICondaServiceDeprecated>(
-                ICondaServiceDeprecated,
-                condaServiceDeprecated.object,
+            condaLocatorService = TypeMoq.Mock.ofType<ICondaLocatorService>();
+            ioc.serviceManager.addSingletonInstance<ICondaLocatorService>(
+                ICondaLocatorService,
+                condaLocatorService.object,
             );
             ioc.serviceManager.rebindInstance<ICondaService>(ICondaService, condaService.object);
             interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
@@ -468,10 +468,10 @@ suite('Module Installer', () => {
             configService.setup((c) => c.getSettings(TypeMoq.It.isAny())).returns(() => settings.object);
             serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(ICondaService))).returns(() => condaService.object);
             serviceContainer
-                .setup((c) => c.get(TypeMoq.It.isValue(ICondaServiceDeprecated)))
-                .returns(() => condaServiceDeprecated.object);
+                .setup((c) => c.get(TypeMoq.It.isValue(ICondaLocatorService)))
+                .returns(() => condaLocatorService.object);
             condaService.setup((c) => c.isCondaAvailable()).returns(() => Promise.resolve(true));
-            condaServiceDeprecated
+            condaLocatorService
                 .setup((c) => c.isCondaEnvironment(TypeMoq.It.isValue(pythonPath)))
                 .returns(() => Promise.resolve(true));
 
@@ -491,10 +491,10 @@ suite('Module Installer', () => {
             configService.setup((c) => c.getSettings(TypeMoq.It.isAny())).returns(() => settings.object);
             serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(ICondaService))).returns(() => condaService.object);
             serviceContainer
-                .setup((c) => c.get(TypeMoq.It.isValue(ICondaServiceDeprecated)))
-                .returns(() => condaServiceDeprecated.object);
+                .setup((c) => c.get(TypeMoq.It.isValue(ICondaLocatorService)))
+                .returns(() => condaLocatorService.object);
             condaService.setup((c) => c.isCondaAvailable()).returns(() => Promise.resolve(true));
-            condaServiceDeprecated
+            condaLocatorService
                 .setup((c) => c.isCondaEnvironment(TypeMoq.It.isValue(pythonPath)))
                 .returns(() => Promise.resolve(false));
 

--- a/src/test/common/terminals/activation.conda.unit.test.ts
+++ b/src/test/common/terminals/activation.conda.unit.test.ts
@@ -25,7 +25,7 @@ import {
     ITerminalSettings,
 } from '../../../client/common/types';
 import { getNamesAndValues } from '../../../client/common/utils/enum';
-import { ICondaService } from '../../../client/interpreter/contracts';
+import { ICondaServiceDeprecated } from '../../../client/interpreter/contracts';
 import { InterpreterService } from '../../../client/interpreter/interpreterService';
 import { IServiceContainer } from '../../../client/ioc/types';
 
@@ -39,7 +39,7 @@ suite('Terminal Environment Activation conda', () => {
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
     let processService: TypeMoq.IMock<IProcessService>;
     let procServiceFactory: TypeMoq.IMock<IProcessServiceFactory>;
-    let condaService: TypeMoq.IMock<ICondaService>;
+    let condaService: TypeMoq.IMock<ICondaServiceDeprecated>;
     let configService: TypeMoq.IMock<IConfigurationService>;
     let conda: string;
     let bash: ITerminalActivationCommandProvider;
@@ -55,7 +55,7 @@ suite('Terminal Environment Activation conda', () => {
         fileSystem = TypeMoq.Mock.ofType<IFileSystem>();
         platformService = TypeMoq.Mock.ofType<IPlatformService>();
         processService = TypeMoq.Mock.ofType<IProcessService>();
-        condaService = TypeMoq.Mock.ofType<ICondaService>();
+        condaService = TypeMoq.Mock.ofType<ICondaServiceDeprecated>();
         condaService.setup((c) => c.getCondaFile()).returns(() => Promise.resolve(conda));
         bash = mock(Bash);
 
@@ -75,7 +75,7 @@ suite('Terminal Environment Activation conda', () => {
             .setup((c) => c.get(TypeMoq.It.isValue(IProcessServiceFactory), TypeMoq.It.isAny()))
             .returns(() => procServiceFactory.object);
         serviceContainer
-            .setup((c) => c.get(TypeMoq.It.isValue(ICondaService), TypeMoq.It.isAny()))
+            .setup((c) => c.get(TypeMoq.It.isValue(ICondaServiceDeprecated), TypeMoq.It.isAny()))
             .returns(() => condaService.object);
 
         configService = TypeMoq.Mock.ofType<IConfigurationService>();
@@ -608,14 +608,14 @@ suite('Terminal Environment Activation conda', () => {
             // each test simply tests the base windows activate command,
             // and then the specific result from the terminal selected.
             const servCnt = TypeMoq.Mock.ofType<IServiceContainer>();
-            const condaSrv = TypeMoq.Mock.ofType<ICondaService>();
+            const condaSrv = TypeMoq.Mock.ofType<ICondaServiceDeprecated>();
             condaSrv
                 .setup((c) => c.getCondaFile())
                 .returns(async () => {
                     return path.join(testParams.basePath, 'conda.exe');
                 });
             servCnt
-                .setup((s) => s.get(TypeMoq.It.isValue(ICondaService), TypeMoq.It.isAny()))
+                .setup((s) => s.get(TypeMoq.It.isValue(ICondaServiceDeprecated), TypeMoq.It.isAny()))
                 .returns(() => condaSrv.object);
 
             const tstCmdProvider = new CondaActivationCommandProvider(

--- a/src/test/common/terminals/activation.conda.unit.test.ts
+++ b/src/test/common/terminals/activation.conda.unit.test.ts
@@ -25,7 +25,7 @@ import {
     ITerminalSettings,
 } from '../../../client/common/types';
 import { getNamesAndValues } from '../../../client/common/utils/enum';
-import { ICondaLocatorService } from '../../../client/interpreter/contracts';
+import { ICondaLocatorService, ICondaService } from '../../../client/interpreter/contracts';
 import { InterpreterService } from '../../../client/interpreter/interpreterService';
 import { IServiceContainer } from '../../../client/ioc/types';
 
@@ -39,7 +39,8 @@ suite('Terminal Environment Activation conda', () => {
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
     let processService: TypeMoq.IMock<IProcessService>;
     let procServiceFactory: TypeMoq.IMock<IProcessServiceFactory>;
-    let condaService: TypeMoq.IMock<ICondaLocatorService>;
+    let condaService: TypeMoq.IMock<ICondaService>;
+    let condaLocatorService: TypeMoq.IMock<ICondaLocatorService>;
     let configService: TypeMoq.IMock<IConfigurationService>;
     let conda: string;
     let bash: ITerminalActivationCommandProvider;
@@ -55,7 +56,8 @@ suite('Terminal Environment Activation conda', () => {
         fileSystem = TypeMoq.Mock.ofType<IFileSystem>();
         platformService = TypeMoq.Mock.ofType<IPlatformService>();
         processService = TypeMoq.Mock.ofType<IProcessService>();
-        condaService = TypeMoq.Mock.ofType<ICondaLocatorService>();
+        condaLocatorService = TypeMoq.Mock.ofType<ICondaLocatorService>();
+        condaService = TypeMoq.Mock.ofType<ICondaService>();
         condaService.setup((c) => c.getCondaFile()).returns(() => Promise.resolve(conda));
         bash = mock(Bash);
 
@@ -75,8 +77,11 @@ suite('Terminal Environment Activation conda', () => {
             .setup((c) => c.get(TypeMoq.It.isValue(IProcessServiceFactory), TypeMoq.It.isAny()))
             .returns(() => procServiceFactory.object);
         serviceContainer
-            .setup((c) => c.get(TypeMoq.It.isValue(ICondaLocatorService), TypeMoq.It.isAny()))
+            .setup((c) => c.get(TypeMoq.It.isValue(ICondaService), TypeMoq.It.isAny()))
             .returns(() => condaService.object);
+        serviceContainer
+            .setup((c) => c.get(TypeMoq.It.isValue(ICondaLocatorService), TypeMoq.It.isAny()))
+            .returns(() => condaLocatorService.object);
 
         configService = TypeMoq.Mock.ofType<IConfigurationService>();
         serviceContainer
@@ -91,10 +96,15 @@ suite('Terminal Environment Activation conda', () => {
         terminalHelper = new TerminalHelper(
             platformService.object,
             instance(mock(TerminalManager)),
-            condaService.object,
+            condaLocatorService.object,
             instance(mock(InterpreterService)),
             configService.object,
-            new CondaActivationCommandProvider(condaService.object, platformService.object, configService.object),
+            new CondaActivationCommandProvider(
+                condaService.object,
+                platformService.object,
+                configService.object,
+                serviceContainer.object,
+            ),
             instance(bash),
             mock(CommandPromptAndPowerShell),
             mock(PyEnvActivationCommandProvider),
@@ -115,7 +125,7 @@ suite('Terminal Environment Activation conda', () => {
         const envName = 'EnvA';
         const pythonPath = 'python3';
         platformService.setup((p) => p.isWindows).returns(() => false);
-        condaService
+        condaLocatorService
             .setup((c) => c.getCondaEnvironment(TypeMoq.It.isAny()))
             .returns(() => Promise.resolve({ name: envName, path: path.dirname(pythonPath) }));
         const expected = ['"path to conda" activate EnvA'];
@@ -124,6 +134,7 @@ suite('Terminal Environment Activation conda', () => {
             condaService.object,
             platformService.object,
             configService.object,
+            serviceContainer.object,
         );
         const activationCommands = await provider.getActivationCommands(undefined, TerminalShellType.fish);
 
@@ -136,7 +147,7 @@ suite('Terminal Environment Activation conda', () => {
         const condaPath = path.join('a', 'b', 'c', 'conda');
         platformService.setup((p) => p.isWindows).returns(() => false);
         condaService.reset();
-        condaService
+        condaLocatorService
             .setup((c) => c.getCondaEnvironment(TypeMoq.It.isAny()))
             .returns(() =>
                 Promise.resolve({
@@ -152,6 +163,7 @@ suite('Terminal Environment Activation conda', () => {
             condaService.object,
             platformService.object,
             configService.object,
+            serviceContainer.object,
         );
         const activationCommands = await provider.getActivationCommands(undefined, TerminalShellType.bash);
 
@@ -164,7 +176,7 @@ suite('Terminal Environment Activation conda', () => {
         const condaPath = path.join('a', 'b', 'c', 'conda');
         platformService.setup((p) => p.isWindows).returns(() => false);
         condaService.reset();
-        condaService
+        condaLocatorService
             .setup((c) => c.getCondaEnvironment(TypeMoq.It.isAny()))
             .returns(() =>
                 Promise.resolve({
@@ -180,6 +192,7 @@ suite('Terminal Environment Activation conda', () => {
             condaService.object,
             platformService.object,
             configService.object,
+            serviceContainer.object,
         );
         const activationCommands = await provider.getActivationCommands(undefined, TerminalShellType.bash);
 
@@ -239,7 +252,7 @@ suite('Terminal Environment Activation conda', () => {
             const pythonPath = 'python3';
             platformService.setup((p) => p.isWindows).returns(() => testParams.isWindows);
             condaService.reset();
-            condaService
+            condaLocatorService
                 .setup((c) => c.getCondaEnvironment(TypeMoq.It.isAny()))
                 .returns(() =>
                     Promise.resolve({
@@ -256,6 +269,7 @@ suite('Terminal Environment Activation conda', () => {
                 condaService.object,
                 platformService.object,
                 configService.object,
+                serviceContainer.object,
             );
             const activationCommands = await provider.getActivationCommands(undefined, TerminalShellType.bash);
 
@@ -274,9 +288,9 @@ suite('Terminal Environment Activation conda', () => {
         platformService.setup((p) => p.isLinux).returns(() => isLinux);
         platformService.setup((p) => p.isWindows).returns(() => isWindows);
         platformService.setup((p) => p.isMac).returns(() => isOsx);
-        condaService.setup((c) => c.isCondaEnvironment(TypeMoq.It.isAny())).returns(() => Promise.resolve(true));
+        condaLocatorService.setup((c) => c.isCondaEnvironment(TypeMoq.It.isAny())).returns(() => Promise.resolve(true));
         pythonSettings.setup((s) => s.pythonPath).returns(() => pythonPath);
-        condaService
+        condaLocatorService
             .setup((c) => c.getCondaEnvironment(TypeMoq.It.isAny()))
             .returns(() => Promise.resolve({ name: envName, path: path.dirname(pythonPath) }));
 
@@ -284,6 +298,7 @@ suite('Terminal Environment Activation conda', () => {
             condaService.object,
             platformService.object,
             configService.object,
+            serviceContainer.object,
         ).getActivationCommands(undefined, shellType);
         let expectedActivationCommand: string[] | undefined;
         const expectEnvActivatePath = path.dirname(pythonPath);
@@ -374,9 +389,9 @@ suite('Terminal Environment Activation conda', () => {
         platformService.setup((p) => p.isLinux).returns(() => isLinux);
         platformService.setup((p) => p.isWindows).returns(() => isWindows);
         platformService.setup((p) => p.isMac).returns(() => isOsx);
-        condaService.setup((c) => c.isCondaEnvironment(TypeMoq.It.isAny())).returns(() => Promise.resolve(true));
+        condaLocatorService.setup((c) => c.isCondaEnvironment(TypeMoq.It.isAny())).returns(() => Promise.resolve(true));
         pythonSettings.setup((s) => s.pythonPath).returns(() => pythonPath);
-        condaService
+        condaLocatorService
             .setup((c) => c.getCondaEnvironment(TypeMoq.It.isAny()))
             .returns(() => Promise.resolve({ name: 'EnvA', path: path.dirname(pythonPath) }));
 
@@ -418,7 +433,9 @@ suite('Terminal Environment Activation conda', () => {
 
     test('Get activation script command if environment is not a conda environment', async () => {
         const pythonPath = path.join('users', 'xyz', '.conda', 'envs', 'enva', 'bin', 'python');
-        condaService.setup((c) => c.isCondaEnvironment(TypeMoq.It.isAny())).returns(() => Promise.resolve(false));
+        condaLocatorService
+            .setup((c) => c.isCondaEnvironment(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(false));
         pythonSettings.setup((s) => s.pythonPath).returns(() => pythonPath);
 
         const mockProvider = TypeMoq.Mock.ofType<ITerminalActivationCommandProvider>();
@@ -450,8 +467,10 @@ suite('Terminal Environment Activation conda', () => {
         platformService.setup((p) => p.isLinux).returns(() => isLinux);
         platformService.setup((p) => p.isWindows).returns(() => isWindows);
         platformService.setup((p) => p.isMac).returns(() => isOsx);
-        condaService.setup((c) => c.isCondaEnvironment(TypeMoq.It.isAny())).returns(() => Promise.resolve(true));
-        condaService.setup((c) => c.isCondaEnvironment(TypeMoq.It.isAny())).returns(() => Promise.resolve(false));
+        condaLocatorService.setup((c) => c.isCondaEnvironment(TypeMoq.It.isAny())).returns(() => Promise.resolve(true));
+        condaLocatorService
+            .setup((c) => c.isCondaEnvironment(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(false));
         pythonSettings.setup((s) => s.pythonPath).returns(() => pythonPath);
 
         when(bash.isShellSupported(anything())).thenReturn(true);
@@ -496,7 +515,9 @@ suite('Terminal Environment Activation conda', () => {
     test('Return undefined if unable to get activation command', async () => {
         const pythonPath = path.join('c', 'users', 'xyz', '.conda', 'envs', 'enva', 'python.exe');
 
-        condaService.setup((c) => c.isCondaEnvironment(TypeMoq.It.isAny())).returns(() => Promise.resolve(false));
+        condaLocatorService
+            .setup((c) => c.isCondaEnvironment(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(false));
 
         pythonSettings.setup((s) => s.pythonPath).returns(() => pythonPath);
 
@@ -622,6 +643,7 @@ suite('Terminal Environment Activation conda', () => {
                 condaSrv.object,
                 platformService.object,
                 configService.object,
+                serviceContainer.object,
             );
 
             let result: string[] | undefined;

--- a/src/test/common/terminals/activation.conda.unit.test.ts
+++ b/src/test/common/terminals/activation.conda.unit.test.ts
@@ -628,16 +628,12 @@ suite('Terminal Environment Activation conda', () => {
         test(testParams.testName, async () => {
             // each test simply tests the base windows activate command,
             // and then the specific result from the terminal selected.
-            const servCnt = TypeMoq.Mock.ofType<IServiceContainer>();
-            const condaSrv = TypeMoq.Mock.ofType<ICondaLocatorService>();
+            const condaSrv = TypeMoq.Mock.ofType<ICondaService>();
             condaSrv
                 .setup((c) => c.getCondaFile())
                 .returns(async () => {
                     return path.join(testParams.basePath, 'conda.exe');
                 });
-            servCnt
-                .setup((s) => s.get(TypeMoq.It.isValue(ICondaLocatorService), TypeMoq.It.isAny()))
-                .returns(() => condaSrv.object);
 
             const tstCmdProvider = new CondaActivationCommandProvider(
                 condaSrv.object,

--- a/src/test/common/terminals/activation.conda.unit.test.ts
+++ b/src/test/common/terminals/activation.conda.unit.test.ts
@@ -25,7 +25,7 @@ import {
     ITerminalSettings,
 } from '../../../client/common/types';
 import { getNamesAndValues } from '../../../client/common/utils/enum';
-import { ICondaServiceDeprecated } from '../../../client/interpreter/contracts';
+import { ICondaLocatorService } from '../../../client/interpreter/contracts';
 import { InterpreterService } from '../../../client/interpreter/interpreterService';
 import { IServiceContainer } from '../../../client/ioc/types';
 
@@ -39,7 +39,7 @@ suite('Terminal Environment Activation conda', () => {
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
     let processService: TypeMoq.IMock<IProcessService>;
     let procServiceFactory: TypeMoq.IMock<IProcessServiceFactory>;
-    let condaService: TypeMoq.IMock<ICondaServiceDeprecated>;
+    let condaService: TypeMoq.IMock<ICondaLocatorService>;
     let configService: TypeMoq.IMock<IConfigurationService>;
     let conda: string;
     let bash: ITerminalActivationCommandProvider;
@@ -55,7 +55,7 @@ suite('Terminal Environment Activation conda', () => {
         fileSystem = TypeMoq.Mock.ofType<IFileSystem>();
         platformService = TypeMoq.Mock.ofType<IPlatformService>();
         processService = TypeMoq.Mock.ofType<IProcessService>();
-        condaService = TypeMoq.Mock.ofType<ICondaServiceDeprecated>();
+        condaService = TypeMoq.Mock.ofType<ICondaLocatorService>();
         condaService.setup((c) => c.getCondaFile()).returns(() => Promise.resolve(conda));
         bash = mock(Bash);
 
@@ -75,7 +75,7 @@ suite('Terminal Environment Activation conda', () => {
             .setup((c) => c.get(TypeMoq.It.isValue(IProcessServiceFactory), TypeMoq.It.isAny()))
             .returns(() => procServiceFactory.object);
         serviceContainer
-            .setup((c) => c.get(TypeMoq.It.isValue(ICondaServiceDeprecated), TypeMoq.It.isAny()))
+            .setup((c) => c.get(TypeMoq.It.isValue(ICondaLocatorService), TypeMoq.It.isAny()))
             .returns(() => condaService.object);
 
         configService = TypeMoq.Mock.ofType<IConfigurationService>();
@@ -608,14 +608,14 @@ suite('Terminal Environment Activation conda', () => {
             // each test simply tests the base windows activate command,
             // and then the specific result from the terminal selected.
             const servCnt = TypeMoq.Mock.ofType<IServiceContainer>();
-            const condaSrv = TypeMoq.Mock.ofType<ICondaServiceDeprecated>();
+            const condaSrv = TypeMoq.Mock.ofType<ICondaLocatorService>();
             condaSrv
                 .setup((c) => c.getCondaFile())
                 .returns(async () => {
                     return path.join(testParams.basePath, 'conda.exe');
                 });
             servCnt
-                .setup((s) => s.get(TypeMoq.It.isValue(ICondaServiceDeprecated), TypeMoq.It.isAny()))
+                .setup((s) => s.get(TypeMoq.It.isValue(ICondaLocatorService), TypeMoq.It.isAny()))
                 .returns(() => condaSrv.object);
 
             const tstCmdProvider = new CondaActivationCommandProvider(

--- a/src/test/common/terminals/helper.unit.test.ts
+++ b/src/test/common/terminals/helper.unit.test.ts
@@ -27,7 +27,7 @@ import {
 import { IConfigurationService } from '../../../client/common/types';
 import { getNamesAndValues } from '../../../client/common/utils/enum';
 import { Architecture, OSType } from '../../../client/common/utils/platform';
-import { ICondaServiceDeprecated } from '../../../client/interpreter/contracts';
+import { ICondaLocatorService } from '../../../client/interpreter/contracts';
 import { InterpreterService } from '../../../client/interpreter/interpreterService';
 import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
 
@@ -35,7 +35,7 @@ suite('Terminal Service helpers', () => {
     let helper: TerminalHelper;
     let terminalManager: ITerminalManager;
     let platformService: IPlatformService;
-    let condaService: ICondaServiceDeprecated;
+    let condaService: ICondaLocatorService;
     let configurationService: IConfigurationService;
     let condaActivationProvider: ITerminalActivationCommandProvider;
     let bashActivationProvider: ITerminalActivationCommandProvider;
@@ -58,7 +58,7 @@ suite('Terminal Service helpers', () => {
         mockDetector = mock(TerminalNameShellDetector);
         terminalManager = mock(TerminalManager);
         platformService = mock(PlatformService);
-        condaService = mock<ICondaServiceDeprecated>();
+        condaService = mock<ICondaLocatorService>();
         configurationService = mock(ConfigurationService);
         condaActivationProvider = mock(CondaActivationCommandProvider);
         bashActivationProvider = mock(Bash);

--- a/src/test/common/terminals/helper.unit.test.ts
+++ b/src/test/common/terminals/helper.unit.test.ts
@@ -27,16 +27,15 @@ import {
 import { IConfigurationService } from '../../../client/common/types';
 import { getNamesAndValues } from '../../../client/common/utils/enum';
 import { Architecture, OSType } from '../../../client/common/utils/platform';
-import { ICondaService } from '../../../client/interpreter/contracts';
+import { ICondaServiceDeprecated } from '../../../client/interpreter/contracts';
 import { InterpreterService } from '../../../client/interpreter/interpreterService';
-import { CondaService } from '../../../client/pythonEnvironments/discovery/locators/services/condaService';
 import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
 
 suite('Terminal Service helpers', () => {
     let helper: TerminalHelper;
     let terminalManager: ITerminalManager;
     let platformService: IPlatformService;
-    let condaService: ICondaService;
+    let condaService: ICondaServiceDeprecated;
     let configurationService: IConfigurationService;
     let condaActivationProvider: ITerminalActivationCommandProvider;
     let bashActivationProvider: ITerminalActivationCommandProvider;
@@ -59,7 +58,7 @@ suite('Terminal Service helpers', () => {
         mockDetector = mock(TerminalNameShellDetector);
         terminalManager = mock(TerminalManager);
         platformService = mock(PlatformService);
-        condaService = mock(CondaService);
+        condaService = mock<ICondaServiceDeprecated>();
         configurationService = mock(ConfigurationService);
         condaActivationProvider = mock(CondaActivationCommandProvider);
         bashActivationProvider = mock(Bash);

--- a/src/test/linters/lint.functional.test.ts
+++ b/src/test/linters/lint.functional.test.ts
@@ -29,7 +29,12 @@ import {
 import { IConfigurationService, IDisposableRegistry, IExperimentService } from '../../client/common/types';
 import { IEnvironmentVariablesProvider } from '../../client/common/variables/types';
 import { IEnvironmentActivationService } from '../../client/interpreter/activation/types';
-import { IComponentAdapter, ICondaService, IInterpreterService } from '../../client/interpreter/contracts';
+import {
+    IComponentAdapter,
+    ICondaLocatorService,
+    ICondaService,
+    IInterpreterService,
+} from '../../client/interpreter/contracts';
 import { IServiceContainer } from '../../client/ioc/types';
 import { LINTERID_BY_PRODUCT } from '../../client/linters/constants';
 import { ILintMessage, LinterId, LintMessageSeverity } from '../../client/linters/types';
@@ -696,10 +701,14 @@ class TestFixture extends BaseTestFixture {
             .setup((c) => c.get(TypeMoq.It.isValue(IInterpreterService), TypeMoq.It.isAny()))
             .returns(() => interpreterService.object);
 
-        const condaService = TypeMoq.Mock.ofType<ICondaService>(undefined, TypeMoq.MockBehavior.Strict);
-        condaService
+        const condaLocatorService = TypeMoq.Mock.ofType<ICondaLocatorService>();
+        serviceContainer
+            .setup((c) => c.get(TypeMoq.It.isValue(ICondaLocatorService)))
+            .returns(() => condaLocatorService.object);
+        condaLocatorService
             .setup((c) => c.getCondaEnvironment(TypeMoq.It.isAnyString()))
             .returns(() => Promise.resolve(undefined));
+        const condaService = TypeMoq.Mock.ofType<ICondaService>(undefined, TypeMoq.MockBehavior.Strict);
         condaService.setup((c) => c.getCondaVersion()).returns(() => Promise.resolve(undefined));
         condaService.setup((c) => c.getCondaFile()).returns(() => Promise.resolve('conda'));
 

--- a/src/test/pythonEnvironments/discovery/locators/condaEnvFileService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaEnvFileService.unit.test.ts
@@ -5,7 +5,7 @@ import * as TypeMoq from 'typemoq';
 import { IFileSystem } from '../../../../client/common/platform/types';
 import { IPersistentStateFactory } from '../../../../client/common/types';
 import {
-    ICondaServiceDeprecated,
+    ICondaLocatorService,
     IInterpreterHelper,
     IInterpreterLocatorService,
 } from '../../../../client/interpreter/contracts';
@@ -19,7 +19,7 @@ const environmentsPath = path.join(__dirname, '..', '..', '..', 'src', 'test', '
 const environmentsFilePath = path.join(environmentsPath, 'environments.txt');
 
 suite('Interpreters from Conda Environments Text File', () => {
-    let condaService: TypeMoq.IMock<ICondaServiceDeprecated>;
+    let condaService: TypeMoq.IMock<ICondaLocatorService>;
     let interpreterHelper: TypeMoq.IMock<IInterpreterHelper>;
     let condaFileProvider: IInterpreterLocatorService;
     let fileSystem: TypeMoq.IMock<IFileSystem>;
@@ -34,7 +34,7 @@ suite('Interpreters from Conda Environments Text File', () => {
             .setup((s) => s.createGlobalPersistentState(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => state);
 
-        condaService = TypeMoq.Mock.ofType<ICondaServiceDeprecated>();
+        condaService = TypeMoq.Mock.ofType<ICondaLocatorService>();
         interpreterHelper = TypeMoq.Mock.ofType<IInterpreterHelper>();
         fileSystem = TypeMoq.Mock.ofType<IFileSystem>();
         condaFileProvider = new CondaEnvFileService(

--- a/src/test/pythonEnvironments/discovery/locators/condaEnvFileService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaEnvFileService.unit.test.ts
@@ -5,7 +5,7 @@ import * as TypeMoq from 'typemoq';
 import { IFileSystem } from '../../../../client/common/platform/types';
 import { IPersistentStateFactory } from '../../../../client/common/types';
 import {
-    ICondaService,
+    ICondaServiceDeprecated,
     IInterpreterHelper,
     IInterpreterLocatorService,
 } from '../../../../client/interpreter/contracts';
@@ -19,7 +19,7 @@ const environmentsPath = path.join(__dirname, '..', '..', '..', 'src', 'test', '
 const environmentsFilePath = path.join(environmentsPath, 'environments.txt');
 
 suite('Interpreters from Conda Environments Text File', () => {
-    let condaService: TypeMoq.IMock<ICondaService>;
+    let condaService: TypeMoq.IMock<ICondaServiceDeprecated>;
     let interpreterHelper: TypeMoq.IMock<IInterpreterHelper>;
     let condaFileProvider: IInterpreterLocatorService;
     let fileSystem: TypeMoq.IMock<IFileSystem>;
@@ -34,7 +34,7 @@ suite('Interpreters from Conda Environments Text File', () => {
             .setup((s) => s.createGlobalPersistentState(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => state);
 
-        condaService = TypeMoq.Mock.ofType<ICondaService>();
+        condaService = TypeMoq.Mock.ofType<ICondaServiceDeprecated>();
         interpreterHelper = TypeMoq.Mock.ofType<IInterpreterHelper>();
         fileSystem = TypeMoq.Mock.ofType<IFileSystem>();
         condaFileProvider = new CondaEnvFileService(

--- a/src/test/pythonEnvironments/discovery/locators/condaEnvService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaEnvService.unit.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as TypeMoq from 'typemoq';
 import { IFileSystem } from '../../../../client/common/platform/types';
 import { IPersistentStateFactory } from '../../../../client/common/types';
-import { ICondaService, IInterpreterHelper } from '../../../../client/interpreter/contracts';
+import { ICondaServiceDeprecated, IInterpreterHelper } from '../../../../client/interpreter/contracts';
 import { InterpreterHelper } from '../../../../client/interpreter/helpers';
 import { IServiceContainer } from '../../../../client/ioc/types';
 import {
@@ -21,7 +21,7 @@ const environmentsPath = path.join(__dirname, '..', '..', '..', 'src', 'test', '
 suite('Interpreters from Conda Environments', () => {
     let ioc: UnitTestIocContainer;
     let condaProvider: CondaEnvService;
-    let condaService: TypeMoq.IMock<ICondaService>;
+    let condaService: TypeMoq.IMock<ICondaServiceDeprecated>;
     let interpreterHelper: TypeMoq.IMock<InterpreterHelper>;
     let fileSystem: TypeMoq.IMock<IFileSystem>;
     setup(async () => {
@@ -36,7 +36,7 @@ suite('Interpreters from Conda Environments', () => {
             .setup((s) => s.createGlobalPersistentState(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => state);
 
-        condaService = TypeMoq.Mock.ofType<ICondaService>();
+        condaService = TypeMoq.Mock.ofType<ICondaServiceDeprecated>();
         interpreterHelper = TypeMoq.Mock.ofType<InterpreterHelper>();
         fileSystem = TypeMoq.Mock.ofType<IFileSystem>();
         condaProvider = new CondaEnvService(
@@ -53,7 +53,7 @@ suite('Interpreters from Conda Environments', () => {
         ioc.registerVariableTypes();
         ioc.registerProcessTypes();
     }
-    function _parseCondaInfo(info: CondaInfo, conda: ICondaService, fs: IFileSystem, h: IInterpreterHelper) {
+    function _parseCondaInfo(info: CondaInfo, conda: ICondaServiceDeprecated, fs: IFileSystem, h: IInterpreterHelper) {
         return parseCondaInfo(info, conda.getInterpreterPath, fs.fileExists, h.getInterpreterInformation);
     }
 

--- a/src/test/pythonEnvironments/discovery/locators/condaEnvService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaEnvService.unit.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as TypeMoq from 'typemoq';
 import { IFileSystem } from '../../../../client/common/platform/types';
 import { IPersistentStateFactory } from '../../../../client/common/types';
-import { ICondaServiceDeprecated, IInterpreterHelper } from '../../../../client/interpreter/contracts';
+import { ICondaLocatorService, IInterpreterHelper } from '../../../../client/interpreter/contracts';
 import { InterpreterHelper } from '../../../../client/interpreter/helpers';
 import { IServiceContainer } from '../../../../client/ioc/types';
 import {
@@ -21,7 +21,7 @@ const environmentsPath = path.join(__dirname, '..', '..', '..', 'src', 'test', '
 suite('Interpreters from Conda Environments', () => {
     let ioc: UnitTestIocContainer;
     let condaProvider: CondaEnvService;
-    let condaService: TypeMoq.IMock<ICondaServiceDeprecated>;
+    let condaService: TypeMoq.IMock<ICondaLocatorService>;
     let interpreterHelper: TypeMoq.IMock<InterpreterHelper>;
     let fileSystem: TypeMoq.IMock<IFileSystem>;
     setup(async () => {
@@ -36,7 +36,7 @@ suite('Interpreters from Conda Environments', () => {
             .setup((s) => s.createGlobalPersistentState(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => state);
 
-        condaService = TypeMoq.Mock.ofType<ICondaServiceDeprecated>();
+        condaService = TypeMoq.Mock.ofType<ICondaLocatorService>();
         interpreterHelper = TypeMoq.Mock.ofType<InterpreterHelper>();
         fileSystem = TypeMoq.Mock.ofType<IFileSystem>();
         condaProvider = new CondaEnvService(
@@ -53,7 +53,7 @@ suite('Interpreters from Conda Environments', () => {
         ioc.registerVariableTypes();
         ioc.registerProcessTypes();
     }
-    function _parseCondaInfo(info: CondaInfo, conda: ICondaServiceDeprecated, fs: IFileSystem, h: IInterpreterHelper) {
+    function _parseCondaInfo(info: CondaInfo, conda: ICondaLocatorService, fs: IFileSystem, h: IInterpreterHelper) {
         return parseCondaInfo(info, conda.getInterpreterPath, fs.fileExists, h.getInterpreterInformation);
     }
 

--- a/src/test/pythonEnvironments/discovery/locators/condaLocatorService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaLocatorService.unit.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { expect } from 'chai';
 import { EOL } from 'os';
 import * as path from 'path';
-import { parse, SemVer } from 'semver';
+import { SemVer } from 'semver';
 import * as TypeMoq from 'typemoq';
 import { Disposable, EventEmitter } from 'vscode';
 
@@ -939,18 +939,6 @@ suite('Interpreters Conda Service', () => {
 
         const condaExe = await condaService.getCondaFile();
         assert.equal(condaExe, expectedCodaExe, 'Failed to identify conda.exe');
-    });
-
-    test('Version info from conda process will be returned in getCondaVersion', async () => {
-        condaService.getCondaInfo = () => Promise.reject(new Error('Not Found'));
-        condaService.getCondaFile = () => Promise.resolve('conda');
-        const expectedVersion = parse('4.4.4')!.raw;
-        processService
-            .setup((p) => p.exec(TypeMoq.It.isValue('conda'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny()))
-            .returns(() => Promise.resolve({ stdout: '4.4.4' }));
-
-        const version = await condaService.getCondaVersion();
-        assert.equal(version!.raw, expectedVersion);
     });
 
     test('isCondaInCurrentPath will return true if conda is available', async () => {

--- a/src/test/pythonEnvironments/discovery/locators/condaLocatorService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaLocatorService.unit.test.ts
@@ -26,7 +26,7 @@ import {
     WINDOWS_REGISTRY_SERVICE,
 } from '../../../../client/interpreter/contracts';
 import { IServiceContainer } from '../../../../client/ioc/types';
-import { CondaServiceDeprecated } from '../../../../client/pythonEnvironments/discovery/locators/services/condaServiceDeprecated';
+import { CondaLocatorService } from '../../../../client/pythonEnvironments/discovery/locators/services/condaLocatorService';
 import { EnvironmentType, PythonEnvironment } from '../../../../client/pythonEnvironments/info';
 import { MockState } from '../../../interpreters/mocks';
 
@@ -48,7 +48,7 @@ const info: PythonEnvironment = {
 suite('Interpreters Conda Service', () => {
     let processService: TypeMoq.IMock<IProcessService>;
     let platformService: TypeMoq.IMock<IPlatformService>;
-    let condaService: CondaServiceDeprecated;
+    let condaService: CondaLocatorService;
     let pyenvs: TypeMoq.IMock<IComponentAdapter>;
     let fileSystem: TypeMoq.IMock<IFileSystem>;
     let config: TypeMoq.IMock<IConfigurationService>;
@@ -142,7 +142,7 @@ suite('Interpreters Conda Service', () => {
                 return utils.arePathsSame(p1, p2);
             });
 
-        condaService = new CondaServiceDeprecated(
+        condaService = new CondaLocatorService(
             procServiceFactory.object,
             platformService.object,
             fileSystem.object,
@@ -640,13 +640,13 @@ suite('Interpreters Conda Service', () => {
         platformService.setup((p) => p.isWindows).returns(() => true);
 
         fileSystem.setup((f) => f.search(TypeMoq.It.isAnyString())).returns(() => Promise.resolve([expected]));
-        const CondaServiceDeprecatedForTesting = class extends CondaServiceDeprecated {
+        const CondaLocatorServiceForTesting = class extends CondaLocatorService {
             // eslint-disable-next-line class-methods-use-this
             public async isCondaInCurrentPath() {
                 return false;
             }
         };
-        const condaSrv = new CondaServiceDeprecatedForTesting(
+        const condaSrv = new CondaLocatorServiceForTesting(
             procServiceFactory.object,
             platformService.object,
             fileSystem.object,

--- a/src/test/pythonEnvironments/discovery/locators/condaLocatorService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaLocatorService.unit.test.ts
@@ -1087,7 +1087,7 @@ suite('Interpreters Conda Service', () => {
                 )
                 .returns(() => Promise.resolve(true));
 
-            const condaFile = await condaService.getCondaFileFromInterpreter(t.pythonPath, t.environmentName);
+            const condaFile = await condaService._getCondaFileFromInterpreter(t.pythonPath, t.environmentName);
             assert.equal(condaFile, t.expectedCondaPath);
         });
         test(`Finds conda.exe for different ${t.environmentName}`, async () => {
@@ -1107,7 +1107,7 @@ suite('Interpreters Conda Service', () => {
                 )
                 .returns(() => Promise.resolve(true));
 
-            const condaFile = await condaService.getCondaFileFromInterpreter(t.pythonPath, undefined);
+            const condaFile = await condaService._getCondaFileFromInterpreter(t.pythonPath, undefined);
 
             // This should only work if the expectedConda path has the original environment name in it
             if (t.expectedCondaPath.includes(t.environmentName)) {

--- a/src/test/pythonEnvironments/discovery/locators/condaLocatorService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaLocatorService.unit.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 import * as assert from 'assert';
 import { expect } from 'chai';
 import { EOL } from 'os';

--- a/src/test/pythonEnvironments/discovery/locators/condaLocatorService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaLocatorService.unit.test.ts
@@ -941,27 +941,6 @@ suite('Interpreters Conda Service', () => {
         assert.equal(condaExe, expectedCodaExe, 'Failed to identify conda.exe');
     });
 
-    test('isAvailable will return true if conda is available', async () => {
-        processService
-            .setup((p) => p.exec(TypeMoq.It.isValue('conda'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny()))
-            .returns(() => Promise.resolve({ stdout: '4.4.4' }));
-        const isAvailable = await condaService.isCondaAvailable();
-        assert.equal(isAvailable, true);
-    });
-
-    test('isAvailable will return false if conda is not available', async () => {
-        condaService.getCondaFile = () => Promise.resolve('conda');
-        processService
-            .setup((p) => p.exec(TypeMoq.It.isValue('conda'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny()))
-            .returns(() => Promise.reject(new Error('not found')));
-        fileSystem.setup((fs) => fs.fileExists(TypeMoq.It.isAny())).returns(() => Promise.resolve(false));
-        fileSystem.setup((fs) => fs.search(TypeMoq.It.isAny())).returns(() => Promise.resolve([]));
-        platformService.setup((p) => p.isWindows).returns(() => false);
-        condaService.getCondaInfo = () => Promise.reject(new Error('Not Found'));
-        const isAvailable = await condaService.isCondaAvailable();
-        assert.equal(isAvailable, false);
-    });
-
     test('Version info from conda process will be returned in getCondaVersion', async () => {
         condaService.getCondaInfo = () => Promise.reject(new Error('Not Found'));
         condaService.getCondaFile = () => Promise.resolve('conda');

--- a/src/test/pythonEnvironments/discovery/locators/condaService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaService.unit.test.ts
@@ -525,13 +525,13 @@ suite('Interpreters Conda Service', () => {
         fileSystem.setup((fs) => fs.fileExists(TypeMoq.It.isAny())).returns(() => Promise.resolve(false));
         fileSystem.setup((fs) => fs.search(TypeMoq.It.isAny())).returns(() => Promise.resolve([]));
         platformService.setup((p) => p.isWindows).returns(() => false);
-        condaService.getCondaInfo = () => Promise.reject(new Error('Not Found'));
+        condaService._getCondaInfo = () => Promise.reject(new Error('Not Found'));
         const isAvailable = await condaService.isCondaAvailable();
         assert.equal(isAvailable, false);
     });
 
     test('Version info from conda process will be returned in getCondaVersion', async () => {
-        condaService.getCondaInfo = () => Promise.reject(new Error('Not Found'));
+        condaService._getCondaInfo = () => Promise.reject(new Error('Not Found'));
         condaService.getCondaFile = () => Promise.resolve('conda');
         const expectedVersion = parse('4.4.4')!.raw;
         processService


### PR DESCRIPTION
Almost no new code is added, just moved a bunch of code to other class.

Some methods of conda service are not specific to discovery and used all over the extension. We cannot disable those even when in discovery experiment. Hence put the locator part into `CondaLocatorService`, which we can directly delete later once we remove the experiment.

I plan to put `CondaLocatorService` behind the experiment flag in a later PR, where I'll also implement methods of `CondaService` using `conda.ts`, our new conda code that was added.