### PR TITLE
Get "npm audit" passing.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8640,9 +8640,9 @@
                     "dev": true
                 },
                 "gulp-cli": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
-                    "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",
+                    "integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
                     "dev": true,
                     "requires": {
                         "ansi-colors": "^1.0.1",
@@ -8653,7 +8653,7 @@
                         "copy-props": "^2.0.1",
                         "fancy-log": "^1.3.2",
                         "gulplog": "^1.0.0",
-                        "interpret": "^1.1.0",
+                        "interpret": "^1.4.0",
                         "isobject": "^3.0.1",
                         "liftoff": "^3.1.0",
                         "matchdep": "^2.0.0",
@@ -8661,20 +8661,35 @@
                         "pretty-hrtime": "^1.0.0",
                         "replace-homedir": "^1.0.0",
                         "semver-greatest-satisfied-range": "^1.1.0",
-                        "v8flags": "^3.0.1",
+                        "v8flags": "^3.2.0",
                         "yargs": "^7.1.0"
                     }
                 },
+                "interpret": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+                    "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+                    "dev": true
+                },
+                "v8flags": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
+                    "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
+                    "dev": true,
+                    "requires": {
+                        "homedir-polyfill": "^1.0.1"
+                    }
+                },
                 "y18n": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-                    "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+                    "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
                     "dev": true
                 },
                 "yargs": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-                    "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+                    "version": "7.1.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.1.tgz",
+                    "integrity": "sha512-huO4Fr1f9PmiJJdll5kwoS2e4GqzGSsMT3PPMpOwoVkOK8ckqAewMTZyA6LXVQWflleb/Z8oPBEvNsMft0XE+g==",
                     "dev": true,
                     "requires": {
                         "camelcase": "^3.0.0",
@@ -8689,7 +8704,17 @@
                         "string-width": "^1.0.2",
                         "which-module": "^1.0.0",
                         "y18n": "^3.2.1",
-                        "yargs-parser": "^5.0.0"
+                        "yargs-parser": "5.0.0-security.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "5.0.0-security.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0-security.0.tgz",
+                    "integrity": "sha512-T69y4Ps64LNesYxeYGYPvfoMTt/7y1XtfpIslUeK4um+9Hu7hlGoRtaDLvdXb7+/tfq4opVa2HRY5xGip022rQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0",
+                        "object.assign": "^4.1.0"
                     }
                 }
             }
@@ -19364,15 +19389,6 @@
             "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
             "dev": true
         },
-        "v8flags": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
-            "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
-            "dev": true,
-            "requires": {
-                "homedir-polyfill": "^1.0.1"
-            }
-        },
         "validate-npm-package-license": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -20691,23 +20707,6 @@
                         "camelcase": "^5.0.0",
                         "decamelize": "^1.2.0"
                     }
-                }
-            }
-        },
-        "yargs-parser": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-            "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-            "dev": true,
-            "requires": {
-                "camelcase": "^3.0.0"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-                    "dev": true
                 }
             }
         },


### PR DESCRIPTION
We had one dependency failing "npm audit": yargs-parser.  It turns out our npm lockfile was out-of-date.  To fix it we regenerate the lockfile entry for "gulp".  (gulp -> gulp-cli -> yargs -> yargs-parser)