### PR TITLE
Register or access old Conda locator only when not in experiment

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -179,10 +179,8 @@ src/test/common/crypto.unit.test.ts
 src/test/common/configuration/service.unit.test.ts
 src/test/common/net/fileDownloader.unit.test.ts
 src/test/common/net/httpClient.unit.test.ts
-src/test/common/moduleInstaller.test.ts
 src/test/common/terminals/activator/index.unit.test.ts
 src/test/common/terminals/activator/base.unit.test.ts
-src/test/common/terminals/activation.conda.unit.test.ts
 src/test/common/terminals/shellDetector.unit.test.ts
 src/test/common/terminals/service.unit.test.ts
 src/test/common/terminals/helper.unit.test.ts
@@ -222,7 +220,6 @@ src/test/common/installer/channelManager.unit.test.ts
 src/test/common/installer/installer.unit.test.ts
 src/test/common/installer/pipInstaller.unit.test.ts
 src/test/common/installer/installer.invalidPath.unit.test.ts
-src/test/common/installer/moduleInstaller.unit.test.ts
 src/test/common/installer/pipEnvInstaller.unit.test.ts
 src/test/common/installer/productPath.unit.test.ts
 src/test/common/installer/extensionBuildInstaller.unit.test.ts
@@ -559,7 +556,6 @@ src/client/common/terminal/shellDetectors/settingsShellDetector.ts
 src/client/common/terminal/shellDetectors/baseShellDetector.ts
 src/client/common/terminal/environmentActivationProviders/pipEnvActivationProvider.ts
 src/client/common/terminal/environmentActivationProviders/baseActivationProvider.ts
-src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
 src/client/common/terminal/environmentActivationProviders/commandPrompt.ts
 src/client/common/terminal/environmentActivationProviders/bash.ts
 src/client/common/terminal/environmentActivationProviders/pyenvActivationProvider.ts
@@ -622,7 +618,6 @@ src/client/common/application/terminalManager.ts
 src/client/common/application/applicationEnvironment.ts
 src/client/common/errors/errorUtils.ts
 src/client/common/installer/serviceRegistry.ts
-src/client/common/installer/condaInstaller.ts
 src/client/common/installer/extensionBuildInstaller.ts
 src/client/common/installer/productInstaller.ts
 src/client/common/installer/channelManager.ts

--- a/src/client/common/installer/condaInstaller.ts
+++ b/src/client/common/installer/condaInstaller.ts
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
@@ -17,6 +18,9 @@ import { InterpreterUri } from './types';
 export class CondaInstaller extends ModuleInstaller {
     public _isCondaAvailable: boolean | undefined;
 
+    // Unfortunately inversify requires the number of args in constructor to be explictly
+    // specified as more than its base class. So we need the constructor.
+    // eslint-disable-next-line @typescript-eslint/no-useless-constructor
     constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
         super(serviceContainer);
     }
@@ -25,7 +29,7 @@ export class CondaInstaller extends ModuleInstaller {
         return 'Conda';
     }
 
-    public get displayName() {
+    public get displayName(): string {
         return 'Conda';
     }
 

--- a/src/client/common/installer/condaInstaller.ts
+++ b/src/client/common/installer/condaInstaller.ts
@@ -2,9 +2,10 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import { ICondaService, ICondaLocatorService } from '../../interpreter/contracts';
+import { ICondaService, ICondaLocatorService, IComponentAdapter } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
-import { ExecutionInfo, IConfigurationService } from '../types';
+import { inDiscoveryExperiment } from '../experiments/helpers';
+import { ExecutionInfo, IConfigurationService, IExperimentService } from '../types';
 import { isResource } from '../utils/misc';
 import { ModuleInstaller } from './moduleInstaller';
 import { InterpreterUri } from './types';
@@ -67,7 +68,10 @@ export class CondaInstaller extends ModuleInstaller {
         const pythonPath = isResource(resource)
             ? this.serviceContainer.get<IConfigurationService>(IConfigurationService).getSettings(resource).pythonPath
             : resource.path;
-        const condaLocatorService = this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService);
+        const experimentService = this.serviceContainer.get<IExperimentService>(IExperimentService);
+        const condaLocatorService = (await inDiscoveryExperiment(experimentService))
+            ? this.serviceContainer.get<IComponentAdapter>(IComponentAdapter)
+            : this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService);
         const info = await condaLocatorService.getCondaEnvironment(pythonPath);
         const args = [isUpgrade ? 'update' : 'install'];
 
@@ -97,7 +101,10 @@ export class CondaInstaller extends ModuleInstaller {
      * Is the provided interprter a conda environment
      */
     private async isCurrentEnvironmentACondaEnvironment(resource?: InterpreterUri): Promise<boolean> {
-        const condaService = this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService);
+        const experimentService = this.serviceContainer.get<IExperimentService>(IExperimentService);
+        const condaService = (await inDiscoveryExperiment(experimentService))
+            ? this.serviceContainer.get<IComponentAdapter>(IComponentAdapter)
+            : this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService);
         const pythonPath = isResource(resource)
             ? this.serviceContainer.get<IConfigurationService>(IConfigurationService).getSettings(resource).pythonPath
             : resource.path;

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -112,9 +112,12 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
         const processServicePromise = processService
             ? Promise.resolve(processService)
             : this.processServiceFactory.create(resource);
+        const condaLocatorService = (await inDiscoveryExperiment(this.experimentService))
+            ? this.serviceContainer.get<IComponentAdapter>(IComponentAdapter)
+            : this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService);
         const [condaVersion, condaEnvironment, condaFile, procService] = await Promise.all([
             this.condaService.getCondaVersion(),
-            this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService).getCondaEnvironment(pythonPath),
+            condaLocatorService.getCondaEnvironment(pythonPath),
             this.condaService.getCondaFile(),
             processServicePromise,
         ]);

--- a/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 'use strict';
+
 import '../../extensions';
 
 import { inject, injectable } from 'inversify';
@@ -36,7 +38,8 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
     /**
      * Is the given shell supported for activating a conda env?
      */
-    public isShellSupported(_targetShell: TerminalShellType): boolean {
+    // eslint-disable-next-line class-methods-use-this
+    public isShellSupported(): boolean {
         return true;
     }
 
@@ -47,7 +50,7 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
         resource: Uri | undefined,
         targetShell: TerminalShellType,
     ): Promise<string[] | undefined> {
-        const pythonPath = this.configService.getSettings(resource).pythonPath;
+        const { pythonPath } = this.configService.getSettings(resource);
         return this.getActivationCommandsForInterpreter(pythonPath, targetShell);
     }
 
@@ -64,7 +67,7 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
             : this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService);
         const envInfo = await condaLocatorService.getCondaEnvironment(pythonPath);
         if (!envInfo) {
-            return;
+            return undefined;
         }
 
         const condaEnv = envInfo.name.length > 0 ? envInfo.name : envInfo.path;
@@ -80,7 +83,7 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
                 versionInfo.minor >= CondaRequiredMinorForPowerShell &&
                 (targetShell === TerminalShellType.powershell || targetShell === TerminalShellType.powershellCore)
             ) {
-                return this.getPowershellCommands(condaEnv);
+                return _getPowershellCommands(condaEnv);
             }
             if (versionInfo.minor >= CondaRequiredMinor) {
                 // New version.
@@ -96,23 +99,22 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
         switch (targetShell) {
             case TerminalShellType.powershell:
             case TerminalShellType.powershellCore:
-                return this.getPowershellCommands(condaEnv);
+                return _getPowershellCommands(condaEnv);
 
             // TODO: Do we really special-case fish on Windows?
             case TerminalShellType.fish:
-                return this.getFishCommands(condaEnv, await this.condaService.getCondaFile());
+                return getFishCommands(condaEnv, await this.condaService.getCondaFile());
 
             default:
                 if (this.platform.isWindows) {
                     return this.getWindowsCommands(condaEnv);
-                } else {
-                    return this.getUnixCommands(condaEnv, await this.condaService.getCondaFile());
                 }
+                return getUnixCommands(condaEnv, await this.condaService.getCondaFile());
         }
     }
 
     public async getWindowsActivateCommand(): Promise<string> {
-        let activateCmd: string = 'activate';
+        let activateCmd = 'activate';
 
         const condaExePath = await this.condaService.getCondaFile();
 
@@ -130,28 +132,25 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
         const activate = await this.getWindowsActivateCommand();
         return [`${activate} ${condaEnv.toCommandArgument()}`];
     }
-    /**
-     * The expectation is for the user to configure Powershell for Conda.
-     * Hence we just send the command `conda activate ...`.
-     * This configuration is documented on Conda.
-     * Extension will not attempt to work around issues by trying to setup shell for user.
-     *
-     * @param {string} condaEnv
-     * @returns {(Promise<string[] | undefined>)}
-     * @memberof CondaActivationCommandProvider
-     */
-    public async getPowershellCommands(condaEnv: string): Promise<string[] | undefined> {
-        return [`conda activate ${condaEnv.toCommandArgument()}`];
-    }
+}
 
-    public async getFishCommands(condaEnv: string, condaFile: string): Promise<string[] | undefined> {
-        // https://github.com/conda/conda/blob/be8c08c083f4d5e05b06bd2689d2cd0d410c2ffe/shell/etc/fish/conf.d/conda.fish#L18-L28
-        return [`${condaFile.fileToCommandArgument()} activate ${condaEnv.toCommandArgument()}`];
-    }
+/**
+ * The expectation is for the user to configure Powershell for Conda.
+ * Hence we just send the command `conda activate ...`.
+ * This configuration is documented on Conda.
+ * Extension will not attempt to work around issues by trying to setup shell for user.
+ */
+export async function _getPowershellCommands(condaEnv: string): Promise<string[] | undefined> {
+    return [`conda activate ${condaEnv.toCommandArgument()}`];
+}
 
-    public async getUnixCommands(condaEnv: string, condaFile: string): Promise<string[] | undefined> {
-        const condaDir = path.dirname(condaFile);
-        const activateFile = path.join(condaDir, 'activate');
-        return [`source ${activateFile.fileToCommandArgument()} ${condaEnv.toCommandArgument()}`];
-    }
+async function getFishCommands(condaEnv: string, condaFile: string): Promise<string[] | undefined> {
+    // https://github.com/conda/conda/blob/be8c08c083f4d5e05b06bd2689d2cd0d410c2ffe/shell/etc/fish/conf.d/conda.fish#L18-L28
+    return [`${condaFile.fileToCommandArgument()} activate ${condaEnv.toCommandArgument()}`];
+}
+
+async function getUnixCommands(condaEnv: string, condaFile: string): Promise<string[] | undefined> {
+    const condaDir = path.dirname(condaFile);
+    const activateFile = path.join(condaDir, 'activate');
+    return [`source ${activateFile.fileToCommandArgument()} ${condaEnv.toCommandArgument()}`];
 }

--- a/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
@@ -59,11 +59,10 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
         pythonPath: string,
         targetShell: TerminalShellType,
     ): Promise<string[] | undefined> {
-        const envInfo = (await inDiscoveryExperiment(this.experimentService))
-            ? await this.pyenvs.getCondaEnvironment(pythonPath)
-            : await this.serviceContainer
-                  .get<ICondaLocatorService>(ICondaLocatorService)
-                  .getCondaEnvironment(pythonPath);
+        const condaLocatorService = (await inDiscoveryExperiment(this.experimentService))
+            ? this.pyenvs
+            : this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService);
+        const envInfo = await condaLocatorService.getCondaEnvironment(pythonPath);
         if (!envInfo) {
             return;
         }

--- a/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
@@ -48,8 +48,7 @@ export class CondaService implements ICondaService {
      */
     public async getCondaFile(): Promise<string> {
         if (!(await inDiscoveryExperiment(this.experimentService))) {
-            const condaLocatorService = this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService);
-            return condaLocatorService.getCondaFile();
+            return this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService).getCondaFile();
         }
         if (!this.condaFile) {
             this.condaFile = this.getCondaFileImpl();

--- a/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
@@ -1,13 +1,17 @@
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { parse, SemVer } from 'semver';
-import { traceDecorators, traceWarning } from '../../../../common/logger';
+import { ConfigurationChangeEvent, Uri } from 'vscode';
+import { IWorkspaceService } from '../../../../common/application/types';
+import { inDiscoveryExperiment } from '../../../../common/experiments/helpers';
+import { traceDecorators, traceVerbose, traceWarning } from '../../../../common/logger';
 import { IFileSystem, IPlatformService } from '../../../../common/platform/types';
 import { IProcessServiceFactory } from '../../../../common/process/types';
+import { IExperimentService, IConfigurationService, IDisposableRegistry } from '../../../../common/types';
 import { cache } from '../../../../common/utils/decorators';
 import { ICondaService, ICondaLocatorService } from '../../../../interpreter/contracts';
 import { IServiceContainer } from '../../../../ioc/types';
-import { CondaInfo } from './conda';
+import { Conda, CondaInfo } from './conda';
 
 /**
  * A wrapper around a conda installation.
@@ -16,18 +20,41 @@ import { CondaInfo } from './conda';
 export class CondaService implements ICondaService {
     private isAvailable: boolean | undefined;
 
+    private condaFile: Promise<string> | undefined;
+
+    /**
+     * Locating conda binary is expensive, since it potentially involves spawning or
+     * trying to spawn processes; so it's done lazily and asynchronously. Methods that
+     * need a Conda instance should use getConda() to obtain it, and should never access
+     * this property directly.
+     */
+    private condaPromise: Promise<Conda | undefined> | undefined;
+
     constructor(
         @inject(IProcessServiceFactory) private processServiceFactory: IProcessServiceFactory,
         @inject(IPlatformService) private platform: IPlatformService,
         @inject(IFileSystem) private fileSystem: IFileSystem,
         @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer,
-    ) {}
+        @inject(IExperimentService) private readonly experimentService: IExperimentService,
+        @inject(IConfigurationService) private readonly configService: IConfigurationService,
+        @inject(IDisposableRegistry) private disposableRegistry: IDisposableRegistry,
+        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
+    ) {
+        this.addCondaPathChangedHandler();
+    }
 
     /**
      * Return the path to the "conda file".
      */
     public async getCondaFile(): Promise<string> {
-        return this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService).getCondaFile();
+        if (!(await inDiscoveryExperiment(this.experimentService))) {
+            const condaLocatorService = this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService);
+            return condaLocatorService.getCondaFile();
+        }
+        if (!this.condaFile) {
+            this.condaFile = this.getCondaFileImpl();
+        }
+        return this.condaFile;
     }
 
     /**
@@ -131,6 +158,46 @@ export class CondaService implements ICondaService {
      */
     @cache(60_000)
     public async _getCondaInfo(): Promise<CondaInfo | undefined> {
-        return this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService).getCondaInfo();
+        if (!(await inDiscoveryExperiment(this.experimentService))) {
+            return this.serviceContainer.get<ICondaLocatorService>(ICondaLocatorService).getCondaInfo();
+        }
+        const conda = await this.getConda();
+        return conda?.getInfo();
+    }
+
+    /**
+     * Return the path to the "conda file", if there is one (in known locations).
+     */
+    private async getCondaFileImpl(): Promise<string> {
+        const settings = this.configService.getSettings();
+        const setting = settings.condaPath;
+        if (setting && setting !== '') {
+            return setting;
+        }
+        const conda = await this.getConda();
+        return conda?.command ?? 'conda';
+    }
+
+    private async getConda(): Promise<Conda | undefined> {
+        traceVerbose(`Searching for conda.`);
+        if (this.condaPromise === undefined) {
+            this.condaPromise = Conda.locate();
+        }
+        return this.condaPromise;
+    }
+
+    private addCondaPathChangedHandler() {
+        const disposable = this.workspaceService.onDidChangeConfiguration(this.onDidChangeConfiguration.bind(this));
+        this.disposableRegistry.push(disposable);
+    }
+
+    private async onDidChangeConfiguration(event: ConfigurationChangeEvent) {
+        const workspacesUris: (Uri | undefined)[] = this.workspaceService.hasWorkspaceFolders
+            ? this.workspaceService.workspaceFolders!.map((workspace) => workspace.uri)
+            : [undefined];
+        if (workspacesUris.findIndex((uri) => event.affectsConfiguration('python.condaPath', uri)) === -1) {
+            return;
+        }
+        this.condaFile = undefined;
     }
 }

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -451,9 +451,8 @@ export async function registerLegacyDiscoveryForIOC(serviceManager: IServiceMana
             PIPENV_SERVICE,
         );
         serviceManager.addSingleton<IPipEnvServiceHelper>(IPipEnvServiceHelper, PipEnvServiceHelper);
+        serviceManager.addSingleton<ICondaLocatorService>(ICondaLocatorService, CondaLocatorService);
     }
-
-    serviceManager.addSingleton<ICondaLocatorService>(ICondaLocatorService, CondaLocatorService);
     serviceManager.addSingleton<ICondaService>(ICondaService, CondaService);
 }
 

--- a/src/test/common/installer/condaInstaller.unit.test.ts
+++ b/src/test/common/installer/condaInstaller.unit.test.ts
@@ -8,9 +8,15 @@ import { instance, mock, when } from 'ts-mockito';
 import { Uri } from 'vscode';
 import { PythonSettings } from '../../../client/common/configSettings';
 import { ConfigurationService } from '../../../client/common/configuration/service';
+import { DiscoveryVariants } from '../../../client/common/experiments/groups';
 import { CondaInstaller } from '../../../client/common/installer/condaInstaller';
 import { InterpreterUri } from '../../../client/common/installer/types';
-import { ExecutionInfo, IConfigurationService, IPythonSettings } from '../../../client/common/types';
+import {
+    ExecutionInfo,
+    IConfigurationService,
+    IExperimentService,
+    IPythonSettings,
+} from '../../../client/common/types';
 import { ICondaService, ICondaLocatorService } from '../../../client/interpreter/contracts';
 import { ServiceContainer } from '../../../client/ioc/container';
 import { IServiceContainer } from '../../../client/ioc/types';
@@ -23,6 +29,7 @@ suite('Common - Conda Installer', () => {
     let condaService: ICondaService;
     let condaLocatorService: ICondaLocatorService;
     let configService: IConfigurationService;
+    let experimentService: IExperimentService;
     class CondaInstallerTest extends CondaInstaller {
         public async getExecutionInfo(moduleName: string, resource?: InterpreterUri): Promise<ExecutionInfo> {
             return super.getExecutionInfo(moduleName, resource);
@@ -31,13 +38,16 @@ suite('Common - Conda Installer', () => {
     setup(() => {
         serviceContainer = mock(ServiceContainer);
         condaService = mock(CondaService);
+        experimentService = mock<IExperimentService>();
         condaLocatorService = mock<ICondaLocatorService>();
+        when(experimentService.inExperiment(DiscoveryVariants.discoverWithFileWatching)).thenResolve(false);
         configService = mock(ConfigurationService);
         when(serviceContainer.get<ICondaService>(ICondaService)).thenReturn(instance(condaService));
         when(serviceContainer.get<ICondaLocatorService>(ICondaLocatorService)).thenReturn(
             instance(condaLocatorService),
         );
         when(serviceContainer.get<IConfigurationService>(IConfigurationService)).thenReturn(instance(configService));
+        when(serviceContainer.get<IExperimentService>(IExperimentService)).thenReturn(instance(experimentService));
         installer = new CondaInstallerTest(instance(serviceContainer));
     });
     test('Name and priority', async () => {

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -242,6 +242,9 @@ suite('Module Installer', () => {
                             experimentService
                                 .setup((e) => e.inExperiment(DiscoveryVariants.discoverWithFileWatching))
                                 .returns(() => Promise.resolve(false));
+                            experimentService
+                                .setup((e) => e.inExperiment(DiscoveryVariants.discoveryWithoutFileWatching))
+                                .returns(() => Promise.resolve(false));
                             serviceContainer
                                 .setup((c) => c.get(TypeMoq.It.isValue(IExperimentService)))
                                 .returns(() => experimentService.object);

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -20,6 +20,7 @@ import {
 } from 'vscode';
 import { IApplicationShell, IWorkspaceService } from '../../../client/common/application/types';
 import { STANDARD_OUTPUT_CHANNEL } from '../../../client/common/constants';
+import { DiscoveryVariants } from '../../../client/common/experiments/groups';
 import { CondaInstaller } from '../../../client/common/installer/condaInstaller';
 import { ModuleInstaller } from '../../../client/common/installer/moduleInstaller';
 import { PipEnvInstaller, pipenvName } from '../../../client/common/installer/pipEnvInstaller';
@@ -32,6 +33,7 @@ import {
     ExecutionInfo,
     IConfigurationService,
     IDisposableRegistry,
+    IExperimentService,
     IOutputChannel,
     IPythonSettings,
     ModuleNamePurpose,
@@ -207,6 +209,7 @@ suite('Module Installer', () => {
                         let configService: TypeMoq.IMock<IConfigurationService>;
                         let fs: TypeMoq.IMock<IFileSystem>;
                         let pythonSettings: TypeMoq.IMock<IPythonSettings>;
+                        let experimentService: TypeMoq.IMock<IExperimentService>;
                         let interpreterService: TypeMoq.IMock<IInterpreterService>;
                         let installer: IModuleInstaller;
                         const condaExecutable = 'my.exe';
@@ -222,6 +225,14 @@ suite('Module Installer', () => {
                             serviceContainer
                                 .setup((c) => c.get(TypeMoq.It.isValue(IFileSystem)))
                                 .returns(() => fs.object);
+
+                            experimentService = TypeMoq.Mock.ofType<IExperimentService>();
+                            experimentService
+                                .setup((e) => e.inExperiment(DiscoveryVariants.discoverWithFileWatching))
+                                .returns(() => Promise.resolve(false));
+                            serviceContainer
+                                .setup((c) => c.get(TypeMoq.It.isValue(IExperimentService)))
+                                .returns(() => experimentService.object);
 
                             disposables = [];
                             serviceContainer

--- a/src/test/common/moduleInstaller.test.ts
+++ b/src/test/common/moduleInstaller.test.ts
@@ -1,4 +1,4 @@
-import { expect, should as chai_should, use as chai_use } from 'chai';
+import { expect, should as chaiShould, use as chaiUse } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as path from 'path';
 import { SemVer } from 'semver';
@@ -135,9 +135,9 @@ import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants';
 import { MockModuleInstaller } from '../mocks/moduleInstaller';
 import { MockProcessService } from '../mocks/proc';
 import { UnitTestIocContainer } from '../testing/serviceRegistry';
-import { closeActiveWindows, initializeTest } from './../initialize';
+import { closeActiveWindows, initializeTest } from '../initialize';
 
-chai_use(chaiAsPromised);
+chaiUse(chaiAsPromised);
 
 const isolated = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'pyvsc-run-isolated.py');
 
@@ -166,7 +166,7 @@ suite('Module Installer', () => {
         const workspaceUri = Uri.file(path.join(__dirname, '..', '..', '..', 'src', 'test'));
         suiteSetup(initializeTest);
         setup(async () => {
-            chai_should();
+            chaiShould();
             await initializeDI();
             await initializeTest();
             await resetSettings();
@@ -346,15 +346,14 @@ suite('Module Installer', () => {
             );
         }
         async function getCurrentPythonPath(): Promise<string> {
-            const pythonPath = getExtensionSettings(workspaceUri).pythonPath;
+            const { pythonPath } = getExtensionSettings(workspaceUri);
             if (path.basename(pythonPath) === pythonPath) {
                 const pythonProc = await ioc.serviceContainer
                     .get<IPythonExecutionFactory>(IPythonExecutionFactory)
                     .create({ resource: workspaceUri });
                 return pythonProc.getExecutablePath().catch(() => pythonPath);
-            } else {
-                return pythonPath;
             }
+            return pythonPath;
         }
         test('Ensure pip is supported and conda is not', async () => {
             ioc.serviceManager.addSingletonInstance<IModuleInstaller>(
@@ -549,11 +548,12 @@ suite('Module Installer', () => {
                 .setup((t) => t.sendCommand(TypeMoq.It.isAnyString(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
                 .returns((_cmd: string, args: string[]) => {
                     argsSent = args;
-                    return Promise.resolve(void 0);
+                    return Promise.resolve();
                 });
             interpreterService
                 .setup((i) => i.getActiveInterpreter(TypeMoq.It.isAny()))
 
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 .returns(() => Promise.resolve({ envType: EnvironmentType.Unknown } as any));
 
             await pipInstaller.installModule(moduleName, resource);
@@ -594,7 +594,7 @@ suite('Module Installer', () => {
                 .setup((t) => t.sendCommand(TypeMoq.It.isAnyString(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
                 .returns((_cmd: string, args: string[]) => {
                     argsSent = args;
-                    return Promise.resolve(void 0);
+                    return Promise.resolve();
                 });
 
             await pipInstaller.installModule(moduleName, resource);
@@ -632,7 +632,7 @@ suite('Module Installer', () => {
                 .returns((cmd: string, args: string[]) => {
                     argsSent = args;
                     command = cmd;
-                    return Promise.resolve(void 0);
+                    return Promise.resolve();
                 });
 
             await pipInstaller.installModule(moduleName, resource);

--- a/src/test/common/moduleInstaller.test.ts
+++ b/src/test/common/moduleInstaller.test.ts
@@ -34,6 +34,7 @@ import { AsyncDisposableRegistry } from '../../client/common/asyncDisposableRegi
 import { ConfigurationService } from '../../client/common/configuration/service';
 import { CryptoUtils } from '../../client/common/crypto';
 import { EditorUtils } from '../../client/common/editor';
+import { DiscoveryVariants } from '../../client/common/experiments/groups';
 import { ExperimentsManager } from '../../client/common/experiments/manager';
 import { ExperimentService } from '../../client/common/experiments/service';
 import { FeatureDeprecationManager } from '../../client/common/featureDeprecationManager';
@@ -158,6 +159,7 @@ suite('Module Installer', () => {
         let mockTerminalService: TypeMoq.IMock<ITerminalService>;
         let condaService: TypeMoq.IMock<ICondaService>;
         let condaLocatorService: TypeMoq.IMock<ICondaLocatorService>;
+        let experimentService: TypeMoq.IMock<IExperimentService>;
         let interpreterService: TypeMoq.IMock<IInterpreterService>;
         let mockTerminalFactory: TypeMoq.IMock<ITerminalServiceFactory>;
 
@@ -219,6 +221,10 @@ suite('Module Installer', () => {
             await ioc.registerMockInterpreterTypes();
             condaService = TypeMoq.Mock.ofType<ICondaService>();
             condaLocatorService = TypeMoq.Mock.ofType<ICondaLocatorService>();
+            experimentService = TypeMoq.Mock.ofType<IExperimentService>();
+            experimentService
+                .setup((e) => e.inExperiment(DiscoveryVariants.discoverWithFileWatching))
+                .returns(() => Promise.resolve(false));
             ioc.serviceManager.addSingletonInstance<ICondaLocatorService>(
                 ICondaLocatorService,
                 condaLocatorService.object,
@@ -466,6 +472,9 @@ suite('Module Installer', () => {
             serviceContainer
                 .setup((c) => c.get(TypeMoq.It.isValue(ICondaLocatorService)))
                 .returns(() => condaLocatorService.object);
+            serviceContainer
+                .setup((c) => c.get(TypeMoq.It.isValue(IExperimentService)))
+                .returns(() => experimentService.object);
             condaService.setup((c) => c.isCondaAvailable()).returns(() => Promise.resolve(true));
             condaLocatorService
                 .setup((c) => c.isCondaEnvironment(TypeMoq.It.isValue(pythonPath)))
@@ -489,6 +498,9 @@ suite('Module Installer', () => {
             serviceContainer
                 .setup((c) => c.get(TypeMoq.It.isValue(ICondaLocatorService)))
                 .returns(() => condaLocatorService.object);
+            serviceContainer
+                .setup((c) => c.get(TypeMoq.It.isValue(IExperimentService)))
+                .returns(() => experimentService.object);
             condaService.setup((c) => c.isCondaAvailable()).returns(() => Promise.resolve(true));
             condaLocatorService
                 .setup((c) => c.isCondaEnvironment(TypeMoq.It.isValue(pythonPath)))

--- a/src/test/common/process/pythonExecutionFactory.unit.test.ts
+++ b/src/test/common/process/pythonExecutionFactory.unit.test.ts
@@ -107,6 +107,7 @@ suite('Process - PythonExecutionFactory', () => {
                 processLogger = mock(ProcessLogger);
                 experimentService = mock(ExperimentService);
                 when(experimentService.inExperiment(DiscoveryVariants.discoverWithFileWatching)).thenResolve(false);
+                when(experimentService.inExperiment(DiscoveryVariants.discoveryWithoutFileWatching)).thenResolve(false);
 
                 pyenvs = mock<IComponentAdapter>();
                 when(pyenvs.isWindowsStoreInterpreter(anyString())).thenResolve(true);

--- a/src/test/common/process/pythonExecutionFactory.unit.test.ts
+++ b/src/test/common/process/pythonExecutionFactory.unit.test.ts
@@ -41,6 +41,7 @@ import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnviro
 import * as ExperimentHelpers from '../../../client/common/experiments/helpers';
 import * as WindowsStoreInterpreter from '../../../client/pythonEnvironments/discovery/locators/services/windowsStoreInterpreter';
 import { ExperimentService } from '../../../client/common/experiments/service';
+import { DiscoveryVariants } from '../../../client/common/experiments/groups';
 
 const pythonInterpreter: PythonEnvironment = {
     path: '/foo/bar/python.exe',
@@ -105,6 +106,7 @@ suite('Process - PythonExecutionFactory', () => {
                 condaLocatorService = mock<ICondaLocatorService>();
                 processLogger = mock(ProcessLogger);
                 experimentService = mock(ExperimentService);
+                when(experimentService.inExperiment(DiscoveryVariants.discoverWithFileWatching)).thenResolve(false);
 
                 pyenvs = mock<IComponentAdapter>();
                 when(pyenvs.isWindowsStoreInterpreter(anyString())).thenResolve(true);

--- a/src/test/common/terminals/activation.conda.unit.test.ts
+++ b/src/test/common/terminals/activation.conda.unit.test.ts
@@ -69,6 +69,12 @@ suite('Terminal Environment Activation conda', () => {
         platformService = TypeMoq.Mock.ofType<IPlatformService>();
         processService = TypeMoq.Mock.ofType<IProcessService>();
         condaLocatorService = TypeMoq.Mock.ofType<ICondaLocatorService>();
+        serviceContainer
+            .setup((c) => c.get(TypeMoq.It.isValue(ICondaLocatorService)))
+            .returns(() => condaLocatorService.object);
+        serviceContainer
+            .setup((c) => c.get(TypeMoq.It.isValue(IExperimentService)))
+            .returns(() => experimentService.object);
         condaService = TypeMoq.Mock.ofType<ICondaService>();
         condaService.setup((c) => c.getCondaFile()).returns(() => Promise.resolve(conda));
         bash = mock(Bash);
@@ -109,7 +115,7 @@ suite('Terminal Environment Activation conda', () => {
         terminalHelper = new TerminalHelper(
             platformService.object,
             instance(mock(TerminalManager)),
-            condaLocatorService.object,
+            serviceContainer.object,
             instance(mock(InterpreterService)),
             configService.object,
             new CondaActivationCommandProvider(

--- a/src/test/common/terminals/activation.conda.unit.test.ts
+++ b/src/test/common/terminals/activation.conda.unit.test.ts
@@ -14,7 +14,10 @@ import { IFileSystem, IPlatformService } from '../../../client/common/platform/t
 import { IProcessService, IProcessServiceFactory } from '../../../client/common/process/types';
 import { Bash } from '../../../client/common/terminal/environmentActivationProviders/bash';
 import { CommandPromptAndPowerShell } from '../../../client/common/terminal/environmentActivationProviders/commandPrompt';
-import { CondaActivationCommandProvider } from '../../../client/common/terminal/environmentActivationProviders/condaActivationProvider';
+import {
+    CondaActivationCommandProvider,
+    _getPowershellCommands,
+} from '../../../client/common/terminal/environmentActivationProviders/condaActivationProvider';
 import { PipEnvActivationCommandProvider } from '../../../client/common/terminal/environmentActivationProviders/pipEnvActivationProvider';
 import { PyEnvActivationCommandProvider } from '../../../client/common/terminal/environmentActivationProviders/pyenvActivationProvider';
 import { TerminalHelper } from '../../../client/common/terminal/helper';
@@ -70,6 +73,7 @@ suite('Terminal Environment Activation conda', () => {
         condaService.setup((c) => c.getCondaFile()).returns(() => Promise.resolve(conda));
         bash = mock(Bash);
 
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         processService.setup((x: any) => x.then).returns(() => undefined);
         procServiceFactory = TypeMoq.Mock.ofType<IProcessServiceFactory>();
         procServiceFactory
@@ -670,7 +674,7 @@ suite('Terminal Environment Activation conda', () => {
             if (testParams.terminalKind === TerminalShellType.commandPrompt) {
                 result = await tstCmdProvider.getWindowsCommands(testParams.envName);
             } else {
-                result = await tstCmdProvider.getPowershellCommands(testParams.envName);
+                result = await _getPowershellCommands(testParams.envName);
             }
             expect(result).to.deep.equal(testParams.expectedResult, 'Specific terminal command is incorrect.');
         });

--- a/src/test/common/terminals/helper.unit.test.ts
+++ b/src/test/common/terminals/helper.unit.test.ts
@@ -9,6 +9,7 @@ import { TerminalManager } from '../../../client/common/application/terminalMana
 import { ITerminalManager } from '../../../client/common/application/types';
 import { PythonSettings } from '../../../client/common/configSettings';
 import { ConfigurationService } from '../../../client/common/configuration/service';
+import { DiscoveryVariants } from '../../../client/common/experiments/groups';
 import { PlatformService } from '../../../client/common/platform/platformService';
 import { IPlatformService } from '../../../client/common/platform/types';
 import { Bash } from '../../../client/common/terminal/environmentActivationProviders/bash';
@@ -24,11 +25,12 @@ import {
     ITerminalActivationCommandProvider,
     TerminalShellType,
 } from '../../../client/common/terminal/types';
-import { IConfigurationService } from '../../../client/common/types';
+import { IConfigurationService, IExperimentService } from '../../../client/common/types';
 import { getNamesAndValues } from '../../../client/common/utils/enum';
 import { Architecture, OSType } from '../../../client/common/utils/platform';
 import { ICondaLocatorService } from '../../../client/interpreter/contracts';
 import { InterpreterService } from '../../../client/interpreter/interpreterService';
+import { IServiceContainer } from '../../../client/ioc/types';
 import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
 
 suite('Terminal Service helpers', () => {
@@ -36,6 +38,8 @@ suite('Terminal Service helpers', () => {
     let terminalManager: ITerminalManager;
     let platformService: IPlatformService;
     let condaService: ICondaLocatorService;
+    let experimentService: IExperimentService;
+    let serviceContainer: IServiceContainer;
     let configurationService: IConfigurationService;
     let condaActivationProvider: ITerminalActivationCommandProvider;
     let bashActivationProvider: ITerminalActivationCommandProvider;
@@ -58,7 +62,12 @@ suite('Terminal Service helpers', () => {
         mockDetector = mock(TerminalNameShellDetector);
         terminalManager = mock(TerminalManager);
         platformService = mock(PlatformService);
+        experimentService = mock<IExperimentService>();
+        when(experimentService.inExperiment(DiscoveryVariants.discoverWithFileWatching)).thenResolve(false);
+        serviceContainer = mock<IServiceContainer>();
         condaService = mock<ICondaLocatorService>();
+        when(serviceContainer.get<IExperimentService>(IExperimentService)).thenReturn(instance(experimentService));
+        when(serviceContainer.get<ICondaLocatorService>(ICondaLocatorService)).thenReturn(instance(condaService));
         configurationService = mock(ConfigurationService);
         condaActivationProvider = mock(CondaActivationCommandProvider);
         bashActivationProvider = mock(Bash);
@@ -70,7 +79,7 @@ suite('Terminal Service helpers', () => {
         helper = new TerminalHelper(
             instance(platformService),
             instance(terminalManager),
-            instance(condaService),
+            instance(serviceContainer),
             instance(mock(InterpreterService)),
             instance(configurationService),
             instance(condaActivationProvider),

--- a/src/test/linters/lint.functional.test.ts
+++ b/src/test/linters/lint.functional.test.ts
@@ -41,6 +41,7 @@ import { ILintMessage, LinterId, LintMessageSeverity } from '../../client/linter
 import { deleteFile, PYTHON_PATH } from '../common';
 import { BaseTestFixture, getLinterID, getProductName, newMockDocument, throwUnknownProduct } from './common';
 import * as ExperimentHelpers from '../../client/common/experiments/helpers';
+import { DiscoveryVariants } from '../../client/common/experiments/groups';
 
 const workspaceDir = path.join(__dirname, '..', '..', '..', 'src', 'test');
 const workspaceUri = Uri.file(workspaceDir);
@@ -727,6 +728,9 @@ class TestFixture extends BaseTestFixture {
         const pyenvs: IComponentAdapter = mock<IComponentAdapter>();
 
         const experimentService = TypeMoq.Mock.ofType<IExperimentService>(undefined, TypeMoq.MockBehavior.Strict);
+        experimentService
+            .setup((e) => e.inExperiment(DiscoveryVariants.discoverWithFileWatching))
+            .returns(() => Promise.resolve(false));
 
         const inDiscoveryExperimentStub = sinon.stub(ExperimentHelpers, 'inDiscoveryExperiment');
         inDiscoveryExperimentStub.resolves(false);

--- a/src/test/pythonEnvironments/discovery/locators/condaService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaService.unit.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import * as path from 'path';
 import { parse } from 'semver';
 import * as TypeMoq from 'typemoq';
+import { IWorkspaceService } from '../../../../client/common/application/types';
 
 import { DiscoveryVariants } from '../../../../client/common/experiments/groups';
 import { FileSystemPaths, FileSystemPathUtils } from '../../../../client/common/platform/fs-paths';
@@ -22,9 +23,11 @@ suite('Interpreters Conda Service', () => {
     let procServiceFactory: TypeMoq.IMock<IProcessServiceFactory>;
     let condaPathSetting: string;
     let experimentService: TypeMoq.IMock<IExperimentService>;
+    let workspaceService: TypeMoq.IMock<IWorkspaceService>;
     setup(async () => {
         condaPathSetting = '';
         processService = TypeMoq.Mock.ofType<IProcessService>();
+        workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
         platformService = TypeMoq.Mock.ofType<IPlatformService>();
         fileSystem = TypeMoq.Mock.ofType<IFileSystem>();
         config = TypeMoq.Mock.ofType<IConfigurationService>();
@@ -73,6 +76,10 @@ suite('Interpreters Conda Service', () => {
             platformService.object,
             fileSystem.object,
             serviceContainer.object,
+            experimentService.object,
+            config.object,
+            [],
+            workspaceService.object,
         );
     });
 

--- a/src/test/refactor/rename.test.ts
+++ b/src/test/refactor/rename.test.ts
@@ -18,6 +18,7 @@ import {
     workspace,
 } from 'vscode';
 import { EXTENSION_ROOT_DIR } from '../../client/common/constants';
+import { DiscoveryVariants } from '../../client/common/experiments/groups';
 import '../../client/common/extensions';
 import { BufferDecoder } from '../../client/common/process/decoder';
 import { ProcessService } from '../../client/common/process/proc';
@@ -90,6 +91,10 @@ suite('Refactor Rename', () => {
             .returns(() => envActivationService.object);
 
         const pyenvs: IComponentAdapter = mock<IComponentAdapter>();
+
+        experimentService
+            .setup((e) => e.inExperiment(DiscoveryVariants.discoverWithFileWatching))
+            .returns(() => Promise.resolve(false));
 
         serviceContainer
             .setup((s) => s.get(typeMoq.It.isValue(IPythonExecutionFactory), typeMoq.It.isAny()))


### PR DESCRIPTION
Follow up work from https://github.com/microsoft/vscode-python/pull/15276

- Implemented CondaService using `conda.ts`. New code added in `CondaService` is mainly taken from old code in `CondaLocatorService`, and `CondaEnvironmentLocator`.
- Register or access CondaLocatorService only when not in experiment