### PR TITLE
Re-enable localization on the start page.

### DIFF
--- a/news/2 Fixes/15232.md
+++ b/news/2 Fixes/15232.md
@@ -1,0 +1,2 @@
+Re-enable localization on the start page.  It was accidentally
+disabled in October when the Jupyter extension was split out.

--- a/src/startPage-ui/startPage/startPage.tsx
+++ b/src/startPage-ui/startPage/startPage.tsx
@@ -4,9 +4,10 @@
 
 import * as React from 'react';
 import '../../client/common/extensions';
+import { SharedMessages } from '../../client/common/startPage/messages';
 import { ISettingPackage, IStartPageMapping, StartPageMessages } from '../../client/common/startPage/types';
 import { Image, ImageName } from '../react-common/image';
-import { getLocString } from '../react-common/locReactSide';
+import { getLocString, storeLocStrings } from '../react-common/locReactSide';
 import { IMessageHandler, PostOffice } from '../react-common/postOffice';
 import './startPage.css';
 
@@ -14,6 +15,11 @@ export interface IStartPageProps {
     skipDefault?: boolean;
     baseTheme: string;
     testMode?: boolean;
+}
+
+function initializeLoc(content: string): void {
+    const locJSON = JSON.parse(content);
+    storeLocStrings(locJSON);
 }
 
 // Front end of the Python extension start page.
@@ -146,9 +152,18 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
     }
 
     public handleMessage = (msg: string, payload?: any) => {
-        if (msg === StartPageMessages.SendSetting) {
-            this.releaseNotes.showAgainSetting = payload.showAgainSetting;
-            this.setState({});
+        switch (msg) {
+            case StartPageMessages.SendSetting:
+                this.releaseNotes.showAgainSetting = payload.showAgainSetting;
+                this.setState({});
+                break;
+
+            case SharedMessages.LocInit:
+                initializeLoc(payload);
+                break;
+
+            default:
+                break;
         }
 
         return false;

--- a/src/startPage-ui/startPage/startPage.tsx
+++ b/src/startPage-ui/startPage/startPage.tsx
@@ -17,11 +17,6 @@ export interface IStartPageProps {
     testMode?: boolean;
 }
 
-function initializeLoc(content: string): void {
-    const locJSON = JSON.parse(content);
-    storeLocStrings(locJSON);
-}
-
 // Front end of the Python extension start page.
 // In general it consists of its render method and methods that send and receive messages.
 export class StartPage extends React.Component<IStartPageProps> implements IMessageHandler {
@@ -159,7 +154,9 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
                 break;
 
             case SharedMessages.LocInit:
-                initializeLoc(payload);
+                // Initialize localization.
+                const locJSON = JSON.parse(payload);
+                storeLocStrings(locJSON);
                 break;
 
             default:


### PR DESCRIPTION
(for #15232)

Localization was accidentally disabled in #14447 (October) when we split out the Jupyter extension.