### PR TITLE
Move Pylance banner ExP check earlier to try and mitigate issues

### DIFF
--- a/src/client/languageServices/proposeLanguageServerBanner.ts
+++ b/src/client/languageServices/proposeLanguageServerBanner.ts
@@ -54,12 +54,12 @@ export class ProposePylanceBanner implements IPythonExtensionBanner {
     }
 
     public async showBanner(): Promise<void> {
-        if (!this.enabled) {
+        const message = await this.getPromptMessage();
+        if (!message) {
             return;
         }
 
-        const message = await this.getPromptMessage();
-        if (!message) {
+        if (!this.enabled) {
             return;
         }
 
@@ -96,25 +96,27 @@ export class ProposePylanceBanner implements IPythonExtensionBanner {
             return undefined;
         }
 
+        const lsType = this.configuration.getSettings().languageServer ?? LanguageServerType.Jedi;
+
+        let message: string | undefined;
+
+        if (lsType === LanguageServerType.Jedi) {
+            if (await this.experiments.inExperiment(TryPylance.jediPrompt1)) {
+                message = await this.experiments.getExperimentValue<string>(TryPylance.jediPrompt1);
+            } else if (await this.experiments.inExperiment(TryPylance.jediPrompt2)) {
+                message = await this.experiments.getExperimentValue<string>(TryPylance.jediPrompt2);
+            }
+        } else if (lsType === LanguageServerType.Microsoft || lsType === LanguageServerType.None) {
+            if (await this.experiments.inExperiment(TryPylance.experiment)) {
+                message = Pylance.proposePylanceMessage();
+            }
+        }
+
         // Do not prompt if Pylance is already installed.
         if (this.extensions.getExtension(PYLANCE_EXTENSION_ID)) {
             return undefined;
         }
 
-        const lsType = this.configuration.getSettings().languageServer ?? LanguageServerType.Jedi;
-
-        if (lsType === LanguageServerType.Jedi) {
-            if (await this.experiments.inExperiment(TryPylance.jediPrompt1)) {
-                return this.experiments.getExperimentValue<string>(TryPylance.jediPrompt1);
-            } else if (await this.experiments.inExperiment(TryPylance.jediPrompt2)) {
-                return this.experiments.getExperimentValue<string>(TryPylance.jediPrompt2);
-            }
-        } else if (lsType === LanguageServerType.Microsoft || lsType === LanguageServerType.None) {
-            if (await this.experiments.inExperiment(TryPylance.experiment)) {
-                return Pylance.proposePylanceMessage();
-            }
-        }
-
-        return undefined;
+        return message;
     }
 }

--- a/src/client/languageServices/proposeLanguageServerBanner.ts
+++ b/src/client/languageServices/proposeLanguageServerBanner.ts
@@ -54,6 +54,7 @@ export class ProposePylanceBanner implements IPythonExtensionBanner {
     }
 
     public async showBanner(): Promise<void> {
+        // Call this first to ensure that the experiment service is called.
         const message = await this.getPromptMessage();
         if (!message) {
             return;


### PR DESCRIPTION
We're trying to diagnose issues with the ExP scorecard, and one thing that may be causing an issue is that this code bails out early before checking in with the experiment system, which means shifts in groups where people say "don't show this message again" may never update their groups (or so the theory goes). This moves the check earlier so that it always runs to see if this helps.