### PR TITLE
Switch to extension.open for opening the marketplace

### DIFF
--- a/news/2 Fixes/14264.md
+++ b/news/2 Fixes/14264.md
@@ -1,0 +1,1 @@
+Fix marketplace links in popups opening a non-browser VS Code instance in Codespaces.

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -7,12 +7,7 @@ import { ConfigurationChangeEvent, Disposable, OutputChannel, Uri } from 'vscode
 
 import { LSNotSupportedDiagnosticServiceId } from '../application/diagnostics/checks/lsNotSupported';
 import { IDiagnosticsService } from '../application/diagnostics/types';
-import {
-    IApplicationEnvironment,
-    IApplicationShell,
-    ICommandManager,
-    IWorkspaceService,
-} from '../common/application/types';
+import { IApplicationShell, ICommandManager, IWorkspaceService } from '../common/application/types';
 import { STANDARD_OUTPUT_CHANNEL } from '../common/constants';
 import { traceError } from '../common/logger';
 import {
@@ -84,7 +79,6 @@ export class LanguageServerExtensionActivationService
             this.getCurrentLanguageServerType(),
             this.serviceContainer.get<IExtensions>(IExtensions),
             this.serviceContainer.get<IApplicationShell>(IApplicationShell),
-            this.serviceContainer.get<IApplicationEnvironment>(IApplicationEnvironment),
             this.serviceContainer.get<ICommandManager>(ICommandManager),
         );
         disposables.push(this.languageServerChangeHandler);

--- a/src/client/activation/common/languageServerChangeHandler.ts
+++ b/src/client/activation/common/languageServerChangeHandler.ts
@@ -2,17 +2,16 @@
 // Licensed under the MIT License.
 
 import { Disposable } from 'vscode';
-import { IApplicationEnvironment, IApplicationShell, ICommandManager } from '../../common/application/types';
+import { IApplicationShell, ICommandManager } from '../../common/application/types';
 import { PYLANCE_EXTENSION_ID } from '../../common/constants';
 import { IExtensions } from '../../common/types';
 import { createDeferred } from '../../common/utils/async';
 import { Common, LanguageService, Pylance } from '../../common/utils/localize';
-import { getPylanceExtensionUri } from '../../languageServices/proposeLanguageServerBanner';
 import { LanguageServerType } from '../types';
 
 export async function promptForPylanceInstall(
     appShell: IApplicationShell,
-    appEnv: IApplicationEnvironment,
+    commandManager: ICommandManager,
 ): Promise<void> {
     // If not installed, point user to Pylance at the store.
     const response = await appShell.showWarningMessage(
@@ -22,7 +21,7 @@ export async function promptForPylanceInstall(
     );
 
     if (response === Common.bannerLabelYes()) {
-        appShell.openUrl(getPylanceExtensionUri(appEnv));
+        commandManager.executeCommand('extension.open', PYLANCE_EXTENSION_ID);
     }
 }
 
@@ -37,7 +36,6 @@ export class LanguageServerChangeHandler implements Disposable {
         private currentLsType: LanguageServerType | undefined,
         private readonly extensions: IExtensions,
         private readonly appShell: IApplicationShell,
-        private readonly appEnv: IApplicationEnvironment,
         private readonly commands: ICommandManager,
     ) {
         this.pylanceInstalled = this.isPylanceInstalled();
@@ -72,7 +70,7 @@ export class LanguageServerChangeHandler implements Disposable {
         let response: string | undefined;
         if (lsType === LanguageServerType.Node && !this.isPylanceInstalled()) {
             // If not installed, point user to Pylance at the store.
-            await promptForPylanceInstall(this.appShell, this.appEnv);
+            await promptForPylanceInstall(this.appShell, this.commands);
             // At this point Pylance is not yet installed. Skip reload prompt
             // since we are going to show it when Pylance becomes available.
         } else {

--- a/src/client/activation/node/activator.ts
+++ b/src/client/activation/node/activator.ts
@@ -6,7 +6,7 @@ import { CancellationToken, CompletionItem, ProviderResult } from 'vscode';
 
 import ProtocolCompletionItem from 'vscode-languageclient/lib/common/protocolCompletionItem';
 import { CompletionResolveRequest } from 'vscode-languageclient/node';
-import { IApplicationEnvironment, IApplicationShell, IWorkspaceService } from '../../common/application/types';
+import { IApplicationShell, ICommandManager, IWorkspaceService } from '../../common/application/types';
 import { PYLANCE_EXTENSION_ID } from '../../common/constants';
 import { IFileSystem } from '../../common/platform/types';
 import { IConfigurationService, IExtensions, Resource } from '../../common/types';
@@ -32,7 +32,7 @@ export class NodeLanguageServerActivator extends LanguageServerActivatorBase {
         @inject(IConfigurationService) configurationService: IConfigurationService,
         @inject(IExtensions) private readonly extensions: IExtensions,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
-        @inject(IApplicationEnvironment) private readonly appEnv: IApplicationEnvironment,
+        @inject(ICommandManager) readonly commandManager: ICommandManager,
     ) {
         super(manager, workspace, fs, configurationService);
     }
@@ -47,7 +47,7 @@ export class NodeLanguageServerActivator extends LanguageServerActivatorBase {
             // Pylance is not yet installed. Throw will cause activator to use Jedi
             // temporarily. Language server installation tracker will prompt for window
             // reload when Pylance becomes available.
-            await promptForPylanceInstall(this.appShell, this.appEnv);
+            await promptForPylanceInstall(this.appShell, this.commandManager);
             throw new Error(Pylance.pylanceNotInstalledMessage());
         }
     }

--- a/src/client/common/application/commandManager.ts
+++ b/src/client/common/application/commandManager.ts
@@ -74,7 +74,7 @@ export class CommandManager implements ICommandManager {
         U extends ICommandNameArgumentTypeMapping[E]
     >(command: E, ...rest: U): Thenable<T | undefined> {
         if (command.includes('jupyter') && !this.jupyterExtensionDependencyManager.isJupyterExtensionInstalled) {
-            return this.jupyterExtensionDependencyManager.installJupyterExtension();
+            return this.jupyterExtensionDependencyManager.installJupyterExtension(this);
         } else {
             return commands.executeCommand<T>(command, ...rest);
         }

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -84,6 +84,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     ['workbench.action.files.save']: [Uri];
     ['jupyter.opennotebook']: [undefined | Uri, undefined | CommandSource];
     ['jupyter.runallcells']: [Uri];
+    ['extension.open']: [string];
     [Commands.GetSelectedInterpreterPath]: [{ workspaceFolder: string } | string[]];
     [Commands.Build_Workspace_Symbols]: [boolean, CancellationToken];
     [Commands.Sort_Imports]: [undefined, Uri];

--- a/src/client/common/application/types.ts
+++ b/src/client/common/application/types.ts
@@ -503,7 +503,7 @@ export interface ICommandManager {
 export const IJupyterExtensionDependencyManager = Symbol('IJupyterExtensionDependencyManager');
 export interface IJupyterExtensionDependencyManager {
     readonly isJupyterExtensionInstalled: boolean;
-    installJupyterExtension(): Promise<undefined>;
+    installJupyterExtension(commandManager: ICommandManager): Promise<undefined>;
 }
 
 export const IDocumentManager = Symbol('IDocumentManager');

--- a/src/client/jupyter/jupyterExtensionDependencyManager.ts
+++ b/src/client/jupyter/jupyterExtensionDependencyManager.ts
@@ -1,9 +1,5 @@
 import { inject, injectable } from 'inversify';
-import {
-    IApplicationEnvironment,
-    IApplicationShell,
-    IJupyterExtensionDependencyManager,
-} from '../common/application/types';
+import { IApplicationShell, ICommandManager, IJupyterExtensionDependencyManager } from '../common/application/types';
 import { JUPYTER_EXTENSION_ID } from '../common/constants';
 import { IExtensions } from '../common/types';
 import { Common, Jupyter } from '../common/utils/localize';
@@ -13,7 +9,7 @@ export class JupyterExtensionDependencyManager implements IJupyterExtensionDepen
     constructor(
         @inject(IExtensions) private extensions: IExtensions,
         @inject(IApplicationShell) private appShell: IApplicationShell,
-        @inject(IApplicationEnvironment) private appEnv: IApplicationEnvironment,
+        @inject(ICommandManager) private commandManager: ICommandManager,
     ) {}
 
     public get isJupyterExtensionInstalled(): boolean {
@@ -25,7 +21,7 @@ export class JupyterExtensionDependencyManager implements IJupyterExtensionDepen
         const no = Common.bannerLabelNo();
         const answer = await this.appShell.showErrorMessage(Jupyter.jupyterExtensionRequired(), yes, no);
         if (answer === yes) {
-            this.appShell.openUrl(`${this.appEnv.uriScheme}:extension/${JUPYTER_EXTENSION_ID}`);
+            this.commandManager.executeCommand('extension.open', JUPYTER_EXTENSION_ID);
         }
         return undefined;
     }

--- a/src/client/jupyter/jupyterExtensionDependencyManager.ts
+++ b/src/client/jupyter/jupyterExtensionDependencyManager.ts
@@ -9,19 +9,18 @@ export class JupyterExtensionDependencyManager implements IJupyterExtensionDepen
     constructor(
         @inject(IExtensions) private extensions: IExtensions,
         @inject(IApplicationShell) private appShell: IApplicationShell,
-        @inject(ICommandManager) private commandManager: ICommandManager,
     ) {}
 
     public get isJupyterExtensionInstalled(): boolean {
         return this.extensions.getExtension(JUPYTER_EXTENSION_ID) !== undefined;
     }
 
-    public async installJupyterExtension(): Promise<undefined> {
+    public async installJupyterExtension(commandManager: ICommandManager): Promise<undefined> {
         const yes = Common.bannerLabelYes();
         const no = Common.bannerLabelNo();
         const answer = await this.appShell.showErrorMessage(Jupyter.jupyterExtensionRequired(), yes, no);
         if (answer === yes) {
-            this.commandManager.executeCommand('extension.open', JUPYTER_EXTENSION_ID);
+            commandManager.executeCommand('extension.open', JUPYTER_EXTENSION_ID);
         }
         return undefined;
     }

--- a/src/client/languageServices/proposeLanguageServerBanner.ts
+++ b/src/client/languageServices/proposeLanguageServerBanner.ts
@@ -5,7 +5,7 @@
 
 import { inject, injectable } from 'inversify';
 import { LanguageServerType } from '../activation/types';
-import { IApplicationEnvironment, IApplicationShell } from '../common/application/types';
+import { IApplicationShell, ICommandManager } from '../common/application/types';
 import { PYLANCE_EXTENSION_ID } from '../common/constants';
 import { TryPylance } from '../common/experiments/groups';
 import '../common/extensions';
@@ -19,10 +19,6 @@ import {
 import { Common, Pylance } from '../common/utils/localize';
 import { sendTelemetryEvent } from '../telemetry';
 import { EventName } from '../telemetry/constants';
-
-export function getPylanceExtensionUri(appEnv: IApplicationEnvironment): string {
-    return `${appEnv.uriScheme}:extension/${PYLANCE_EXTENSION_ID}`;
-}
 
 // persistent state names, exported to make use of in testing
 export enum ProposeLSStateKeys {
@@ -42,7 +38,7 @@ export class ProposePylanceBanner implements IPythonExtensionBanner {
 
     constructor(
         @inject(IApplicationShell) private appShell: IApplicationShell,
-        @inject(IApplicationEnvironment) private appEnv: IApplicationEnvironment,
+        @inject(ICommandManager) readonly commandManager: ICommandManager,
         @inject(IPersistentStateFactory) private persistentState: IPersistentStateFactory,
         @inject(IConfigurationService) private configuration: IConfigurationService,
         @inject(IExperimentService) private experiments: IExperimentService,
@@ -73,7 +69,7 @@ export class ProposePylanceBanner implements IPythonExtensionBanner {
 
         let userAction: string;
         if (response === Pylance.tryItNow()) {
-            this.appShell.openUrl(getPylanceExtensionUri(this.appEnv));
+            this.commandManager.executeCommand('extension.open', PYLANCE_EXTENSION_ID);
             userAction = 'yes';
             await this.disable();
         } else if (response === Common.bannerLabelNo()) {

--- a/src/test/activation/node/activator.unit.test.ts
+++ b/src/test/activation/node/activator.unit.test.ts
@@ -9,11 +9,7 @@ import { EventEmitter, Extension, Uri } from 'vscode';
 import { NodeLanguageServerActivator } from '../../../client/activation/node/activator';
 import { NodeLanguageServerManager } from '../../../client/activation/node/manager';
 import { ILanguageServerManager } from '../../../client/activation/types';
-import {
-    IApplicationEnvironment,
-    IApplicationShell,
-    IWorkspaceService,
-} from '../../../client/common/application/types';
+import { IApplicationShell, ICommandManager, IWorkspaceService } from '../../../client/common/application/types';
 import { WorkspaceService } from '../../../client/common/application/workspace';
 import { PythonSettings } from '../../../client/common/configSettings';
 import { ConfigurationService } from '../../../client/common/configuration/service';
@@ -32,7 +28,7 @@ suite('Pylance Language Server - Activator', () => {
     let settings: IPythonSettings;
     let extensions: IExtensions;
     let appShell: IApplicationShell;
-    let appEnv: IApplicationEnvironment;
+    let commandManager: ICommandManager;
     let extensionsChangedEvent: EventEmitter<void>;
 
     let pylanceExtension: Extension<any>;
@@ -44,12 +40,10 @@ suite('Pylance Language Server - Activator', () => {
         settings = mock(PythonSettings);
         extensions = mock<IExtensions>();
         appShell = mock<IApplicationShell>();
-        appEnv = mock<IApplicationEnvironment>();
-        when(appEnv.uriScheme).thenReturn('scheme');
+        commandManager = mock<ICommandManager>();
 
         pylanceExtension = mock<Extension<any>>();
         when(configuration.getSettings(anything())).thenReturn(instance(settings));
-        when(appEnv.uriScheme).thenReturn('scheme');
 
         extensionsChangedEvent = new EventEmitter<void>();
         when(extensions.onDidChange).thenReturn(extensionsChangedEvent.event);
@@ -61,7 +55,7 @@ suite('Pylance Language Server - Activator', () => {
             instance(configuration),
             instance(extensions),
             instance(appShell),
-            instance(appEnv),
+            instance(commandManager),
         );
     });
     teardown(() => {
@@ -114,7 +108,7 @@ suite('Pylance Language Server - Activator', () => {
                 Common.bannerLabelNo(),
             ),
         ).once();
-        verify(appShell.openUrl(`scheme:extension/${PYLANCE_EXTENSION_ID}`)).never();
+        verify(commandManager.executeCommand('extension.open', PYLANCE_EXTENSION_ID)).never();
     });
 
     test('When Pylance is not installed activator should open Pylance install page if users clicks Yes', async () => {
@@ -129,7 +123,7 @@ suite('Pylance Language Server - Activator', () => {
         try {
             await activator.start(undefined);
         } catch {}
-        verify(appShell.openUrl(`scheme:extension/${PYLANCE_EXTENSION_ID}`)).once();
+        verify(commandManager.executeCommand('extension.open', PYLANCE_EXTENSION_ID)).once();
     });
 
     test('Activator should throw if Pylance is not installed', async () => {

--- a/src/test/activation/node/languageServerChangeHandler.unit.test.ts
+++ b/src/test/activation/node/languageServerChangeHandler.unit.test.ts
@@ -7,7 +7,7 @@ import { anyString, instance, mock, verify, when } from 'ts-mockito';
 import { EventEmitter, Extension } from 'vscode';
 import { LanguageServerChangeHandler } from '../../../client/activation/common/languageServerChangeHandler';
 import { LanguageServerType } from '../../../client/activation/types';
-import { IApplicationEnvironment, IApplicationShell, ICommandManager } from '../../../client/common/application/types';
+import { IApplicationShell, ICommandManager } from '../../../client/common/application/types';
 import { PYLANCE_EXTENSION_ID } from '../../../client/common/constants';
 import { IExtensions } from '../../../client/common/types';
 import { Common, LanguageService, Pylance } from '../../../client/common/utils/localize';
@@ -15,7 +15,6 @@ import { Common, LanguageService, Pylance } from '../../../client/common/utils/l
 suite('Language Server - Change Handler', () => {
     let extensions: IExtensions;
     let appShell: IApplicationShell;
-    let appEnv: IApplicationEnvironment;
     let commands: ICommandManager;
     let extensionsChangedEvent: EventEmitter<void>;
     let handler: LanguageServerChangeHandler;
@@ -24,11 +23,9 @@ suite('Language Server - Change Handler', () => {
     setup(() => {
         extensions = mock<IExtensions>();
         appShell = mock<IApplicationShell>();
-        appEnv = mock<IApplicationEnvironment>();
         commands = mock<ICommandManager>();
 
         pylanceExtension = mock<Extension<any>>();
-        when(appEnv.uriScheme).thenReturn('scheme');
 
         extensionsChangedEvent = new EventEmitter<void>();
         when(extensions.onDidChange).thenReturn(extensionsChangedEvent.event);
@@ -44,7 +41,6 @@ suite('Language Server - Change Handler', () => {
             await handler.handleLanguageServerChange(t);
 
             verify(extensions.getExtension(anyString())).once();
-            verify(appShell.openUrl(anyString())).never();
             verify(appShell.showInformationMessage(anyString(), anyString())).never();
             verify(appShell.showWarningMessage(anyString(), anyString())).never();
             verify(commands.executeCommand(anyString())).never();
@@ -121,7 +117,7 @@ suite('Language Server - Change Handler', () => {
         handler = makeHandler(undefined);
         await handler.handleLanguageServerChange(LanguageServerType.Node);
 
-        verify(appShell.openUrl(`scheme:extension/${PYLANCE_EXTENSION_ID}`)).once();
+        verify(commands.executeCommand('extension.open', PYLANCE_EXTENSION_ID)).once();
         verify(commands.executeCommand('workbench.action.reloadWindow')).never();
     });
 
@@ -137,7 +133,7 @@ suite('Language Server - Change Handler', () => {
         handler = makeHandler(undefined);
         await handler.handleLanguageServerChange(LanguageServerType.Node);
 
-        verify(appShell.openUrl(`scheme:extension/${PYLANCE_EXTENSION_ID}`)).never();
+        verify(commands.executeCommand('extension.open', PYLANCE_EXTENSION_ID)).never();
         verify(commands.executeCommand('workbench.action.reloadWindow')).never();
     });
 
@@ -180,7 +176,6 @@ suite('Language Server - Change Handler', () => {
             initialLSType,
             instance(extensions),
             instance(appShell),
-            instance(appEnv),
             instance(commands),
         );
     }


### PR DESCRIPTION
For #14264

Thanks to https://github.com/microsoft/vscode/issues/115344#issuecomment-772370394, we don't need to use `open` with the schema hack. This command does the same thing.