### PR TITLE
Fix flaky CI failure: Command 'workbench.action.closeAllEditors' timed out

### DIFF
--- a/src/test/initialize.ts
+++ b/src/test/initialize.ts
@@ -86,7 +86,7 @@ async function closeWindowsInteral() {
         // Lets not waste too much time.
         const timer = setTimeout(() => {
             reject(new Error("Command 'workbench.action.closeAllEditors' timed out"));
-        }, 2000);
+        }, 15000);
         vscode.commands.executeCommand('workbench.action.closeAllEditors').then(
             () => {
                 clearTimeout(timer);


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/15313

https://github.com/microsoft/vscode-python/pull/15208#discussion_r570640144