### PR TITLE
Fix CI failing with the number of constructor arguments error

### DIFF
--- a/src/test/serviceRegistry.ts
+++ b/src/test/serviceRegistry.ts
@@ -175,7 +175,7 @@ export class IocContainer {
     private disposables: Disposable[] = [];
 
     constructor() {
-        const cont = new Container();
+        const cont = new Container({ skipBaseClassChecks: true });
         this.serviceManager = new ServiceManager(cont);
         this.serviceContainer = new ServiceContainer(cont);
 


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/15328

See [this](https://github.com/inversify/InversifyJS/pull/841/files#diff-9819b4bb6445131f0d24f148b8a3dbd440da1864e1472ce5e7a7afc87cc9eef1). This error is thrown by inversify in cases where base class does not have `@injectable()` decorator. In our case `UnitTestSocketServer` extends from a third party class `EventEmitter`, where we cannot have the `@injectable()` decorator.

The [original motivation](https://github.com/inversify/InversifyJS/pull/841#issue-179215594) why inversify added this base class check doesn't apply to us, as we already have other checks in place to ensure that. Hence we can safely disable this error message for all base classes. This was already done for actual code in https://github.com/microsoft/vscode-python/pull/15049, but not for test code.