### PR TITLE
Fix all system tests and some unit tests when discovery experiment is on

### DIFF
--- a/src/client/common/experiments/helpers.ts
+++ b/src/client/common/experiments/helpers.ts
@@ -14,7 +14,6 @@ export async function inDiscoveryExperiment(experimentService: IExperimentServic
     const results = await Promise.all([
         experimentService.inExperiment(DiscoveryVariants.discoverWithFileWatching),
         experimentService.inExperiment(DiscoveryVariants.discoveryWithoutFileWatching),
-        true,
     ]);
     return results.includes(true);
 }

--- a/src/client/common/experiments/helpers.ts
+++ b/src/client/common/experiments/helpers.ts
@@ -14,6 +14,7 @@ export async function inDiscoveryExperiment(experimentService: IExperimentServic
     const results = await Promise.all([
         experimentService.inExperiment(DiscoveryVariants.discoverWithFileWatching),
         experimentService.inExperiment(DiscoveryVariants.discoveryWithoutFileWatching),
+        true,
     ]);
     return results.includes(true);
 }

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -43,7 +43,7 @@ import {
 import { getNamesAndValues } from '../../../client/common/utils/enum';
 import { Products } from '../../../client/common/utils/localize';
 import { noop } from '../../../client/common/utils/misc';
-import { ICondaLocatorService, ICondaService, IInterpreterService } from '../../../client/interpreter/contracts';
+import { IComponentAdapter, ICondaLocatorService, ICondaService, IInterpreterService } from '../../../client/interpreter/contracts';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../constants';
@@ -267,6 +267,9 @@ suite('Module Installer', () => {
                             const condaLocatorService = TypeMoq.Mock.ofType<ICondaLocatorService>();
                             serviceContainer
                                 .setup((c) => c.get(TypeMoq.It.isValue(ICondaLocatorService)))
+                                .returns(() => condaLocatorService.object);
+                            serviceContainer
+                                .setup((c) => c.get(TypeMoq.It.isValue(IComponentAdapter)))
                                 .returns(() => condaLocatorService.object);
                             condaLocatorService
                                 .setup((c) => c.getCondaEnvironment(TypeMoq.It.isAny()))

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -43,7 +43,12 @@ import {
 import { getNamesAndValues } from '../../../client/common/utils/enum';
 import { Products } from '../../../client/common/utils/localize';
 import { noop } from '../../../client/common/utils/misc';
-import { IComponentAdapter, ICondaLocatorService, ICondaService, IInterpreterService } from '../../../client/interpreter/contracts';
+import {
+    IComponentAdapter,
+    ICondaLocatorService,
+    ICondaService,
+    IInterpreterService,
+} from '../../../client/interpreter/contracts';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../constants';

--- a/src/test/common/moduleInstaller.test.ts
+++ b/src/test/common/moduleInstaller.test.ts
@@ -124,6 +124,7 @@ import {
     IInterpreterService,
     INTERPRETER_LOCATOR_SERVICE,
     PIPENV_SERVICE,
+    IComponentAdapter,
 } from '../../client/interpreter/contracts';
 import { IServiceContainer } from '../../client/ioc/types';
 import { JupyterExtensionDependencyManager } from '../../client/jupyter/jupyterExtensionDependencyManager';
@@ -472,6 +473,9 @@ suite('Module Installer', () => {
                 .setup((c) => c.get(TypeMoq.It.isValue(ICondaLocatorService)))
                 .returns(() => condaLocatorService.object);
             serviceContainer
+                .setup((c) => c.get(TypeMoq.It.isValue(IComponentAdapter)))
+                .returns(() => condaLocatorService.object);
+            serviceContainer
                 .setup((c) => c.get(TypeMoq.It.isValue(IExperimentService)))
                 .returns(() => experimentService.object);
             condaService.setup((c) => c.isCondaAvailable()).returns(() => Promise.resolve(true));
@@ -494,6 +498,9 @@ suite('Module Installer', () => {
             settings.setup((s) => s.pythonPath).returns(() => pythonPath);
             configService.setup((c) => c.getSettings(TypeMoq.It.isAny())).returns(() => settings.object);
             serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(ICondaService))).returns(() => condaService.object);
+            serviceContainer
+                .setup((c) => c.get(TypeMoq.It.isValue(IComponentAdapter)))
+                .returns(() => condaLocatorService.object);
             serviceContainer
                 .setup((c) => c.get(TypeMoq.It.isValue(ICondaLocatorService)))
                 .returns(() => condaLocatorService.object);


### PR DESCRIPTION
Fixing system tests is essential, as it may indicate underlying problems with discovery component. Unit tests can be fixed when we're removing the experiment.