### PR TITLE
Fix problem with notebook apis not being used.

### DIFF
--- a/news/2 Fixes/15364.md
+++ b/news/2 Fixes/15364.md
@@ -1,0 +1,1 @@
+Allow support for using notebook APIs in the VS code stable build.

--- a/src/client/common/application/notebook.ts
+++ b/src/client/common/application/notebook.ts
@@ -85,7 +85,7 @@ export class VSCodeNotebook implements IVSCodeNotebook {
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
         @inject(IApplicationEnvironment) readonly env: IApplicationEnvironment,
     ) {
-        if (this.useProposedApi && this.env.channel === 'insiders') {
+        if (this.useProposedApi) {
             this.addEventHandlers();
             this.canUseNotebookApi = true;
         }


### PR DESCRIPTION
This fix is required before we ship as we're attempting to turn on native notebook support in stable.