### PR TITLE
Ignore directories with the same name as python binaries

### DIFF
--- a/src/client/pythonEnvironments/common/commonUtils.ts
+++ b/src/client/pythonEnvironments/common/commonUtils.ts
@@ -12,10 +12,10 @@ import { comparePythonVersionSpecificity } from '../base/info/env';
 import { parseVersion } from '../base/info/pythonVersion';
 import { getPythonVersionFromConda } from '../discovery/locators/services/conda';
 import { getPythonVersionFromPyvenvCfg } from '../discovery/locators/services/virtualEnvironmentIdentifier';
-import { isPosixPythonBin } from './posixUtils';
+import { isPosixPythonBinPattern } from './posixUtils';
 import { isWindowsPythonExe } from './windowsUtils';
 
-const matchPythonExecutable = getOSType() === OSType.Windows ? isWindowsPythonExe : isPosixPythonBin;
+const matchPythonExecutable = getOSType() === OSType.Windows ? isWindowsPythonExe : isPosixPythonBinPattern;
 
 type FileFilterFunc = (filename: string) => boolean;
 
@@ -33,7 +33,7 @@ export async function* findInterpretersInDir(
 ): AsyncIterableIterator<string> {
     // "checkBin" is a local variable rather than global
     // so we can stub it out during unit testing.
-    const checkBin = getOSType() === OSType.Windows ? isWindowsPythonExe : isPosixPythonBin;
+    const checkBin = getOSType() === OSType.Windows ? isWindowsPythonExe : isPosixPythonBinPattern;
     const cfg = {
         ignoreErrors,
         filterSubDir,

--- a/src/client/pythonEnvironments/common/posixUtils.ts
+++ b/src/client/pythonEnvironments/common/posixUtils.ts
@@ -10,7 +10,7 @@ import { getSearchPathEntries } from '../../common/utils/exec';
  * @param {string} interpreterPath : Path to python interpreter.
  * @returns {boolean} : Returns true if the path matches pattern for windows python executable.
  */
-export function isPosixPythonBin(interpreterPath: string): boolean {
+export function isPosixPythonBinPattern(interpreterPath: string): boolean {
     /**
      * This Reg-ex matches following file names:
      * python

--- a/src/test/pythonEnvironments/common/envlayouts/posixroot/location3/python3.9/empty
+++ b/src/test/pythonEnvironments/common/envlayouts/posixroot/location3/python3.9/empty
@@ -1,0 +1,1 @@
+this is intentionally empty


### PR DESCRIPTION
For #15357 

The test already looked verified the files. It just needed a "dir" with the same name as a python binary. Added a empty file in such a dir.

Adding "skip tests" label because the test was just missing a entry in the FS layout.