### PR TITLE
Ensure environment variables provider can be created using standard classes

### DIFF
--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -30,7 +30,6 @@ import {
     IOutputChannel,
 } from './common/types';
 import { noop } from './common/utils/misc';
-import { registerTypes as variableRegisterTypes } from './common/variables/serviceRegistry';
 import { DebuggerTypeName } from './debugger/constants';
 import { DebugSessionEventDispatcher } from './debugger/extension/hooks/eventHandlerDispatcher';
 import { IDebugSessionEventHandlers } from './debugger/extension/hooks/types';
@@ -112,7 +111,6 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
     const { enableProposedApi } = applicationEnv.packageJson;
     serviceManager.addSingletonInstance<boolean>(UseProposedApi, enableProposedApi);
     // Feature specific registrations.
-    variableRegisterTypes(serviceManager);
     unitTestsRegisterTypes(serviceManager);
     lintersRegisterTypes(serviceManager);
     interpretersRegisterTypes(serviceManager);

--- a/src/client/extensionInit.ts
+++ b/src/client/extensionInit.ts
@@ -17,6 +17,7 @@ import {
     IOutputChannel,
     WORKSPACE_MEMENTO,
 } from './common/types';
+import { registerTypes as variableRegisterTypes } from './common/variables/serviceRegistry';
 import { OutputChannelNames } from './common/utils/localize';
 import { ExtensionState } from './components';
 import { ServiceContainer } from './ioc/container';
@@ -69,6 +70,7 @@ export function initializeStandard(ext: ExtensionState): void {
     const { serviceManager } = ext.legacyIOC;
     // Core registrations (non-feature specific).
     commonRegisterTypes(serviceManager);
+    variableRegisterTypes(serviceManager);
     platformRegisterTypes(serviceManager);
     processRegisterTypes(serviceManager);
 

--- a/src/test/common/variables/envVarsProvider.multiroot.test.ts
+++ b/src/test/common/variables/envVarsProvider.multiroot.test.ts
@@ -7,7 +7,6 @@ import * as path from 'path';
 import { anything, instance, mock, when } from 'ts-mockito';
 import { ConfigurationTarget, Disposable, Uri, workspace } from 'vscode';
 import { WorkspaceService } from '../../../client/common/application/workspace';
-import { ConfigurationService } from '../../../client/common/configuration/service';
 import { PlatformService } from '../../../client/common/platform/platformService';
 import { IFileSystem } from '../../../client/common/platform/types';
 import { IDisposableRegistry, IPathUtils } from '../../../client/common/types';
@@ -76,14 +75,12 @@ suite('Multiroot Environment Variables Provider', () => {
         const variablesService = new EnvironmentVariablesService(pathUtils, fs);
         const disposables = ioc.serviceContainer.get<Disposable[]>(IDisposableRegistry);
         ioc.serviceManager.addSingletonInstance(IInterpreterAutoSelectionService, new MockAutoSelectionService());
-        const cfgService = new ConfigurationService(ioc.serviceContainer);
         const workspaceService = new WorkspaceService();
         return new EnvironmentVariablesProvider(
             variablesService,
             disposables,
             new PlatformService(),
             workspaceService,
-            cfgService,
             mockProcess,
         );
     }

--- a/src/test/common/variables/environmentVariablesProvider.unit.test.ts
+++ b/src/test/common/variables/environmentVariablesProvider.unit.test.ts
@@ -12,7 +12,6 @@ import { ConfigurationChangeEvent, FileSystemWatcher, Uri } from 'vscode';
 import { IWorkspaceService } from '../../../client/common/application/types';
 import { WorkspaceService } from '../../../client/common/application/workspace';
 import { PythonSettings } from '../../../client/common/configSettings';
-import { ConfigurationService } from '../../../client/common/configuration/service';
 import { PlatformService } from '../../../client/common/platform/platformService';
 import { IPlatformService } from '../../../client/common/platform/types';
 import { CurrentProcess } from '../../../client/common/process/currentProcess';
@@ -37,7 +36,6 @@ suite('Multiroot Environment Variables Provider', () => {
         envVarsService = mock(EnvironmentVariablesService);
         platform = mock(PlatformService);
         workspace = mock(WorkspaceService);
-        configuration = mock(ConfigurationService);
         currentProcess = mock(CurrentProcess);
         settings = mock(PythonSettings);
 
@@ -48,7 +46,6 @@ suite('Multiroot Environment Variables Provider', () => {
             [],
             instance(platform),
             instance(workspace),
-            instance(configuration),
             instance(currentProcess),
         );
 
@@ -300,7 +297,6 @@ suite('Multiroot Environment Variables Provider', () => {
                 [],
                 instance(platform),
                 instance(workspace),
-                instance(configuration),
                 instance(currentProcess),
                 100,
             );


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/15310 https://github.com/microsoft/vscode-python/issues/15361

ConfigurationService is dependent on autoselection service, which is dependent on all of intepreter code, which are not registered before we attempt to activate.
https://github.com/microsoft/vscode-python/pull/15132#issuecomment-776909958

Changed the code to use WorkspaceService for getting the settings instead.