### PR TITLE
Consolidate some filesystem utils.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -513,7 +513,6 @@ src/client/common/platform/errors.ts
 src/client/common/platform/fs-temp.ts
 src/client/common/platform/fs-paths.ts
 src/client/common/platform/platformService.ts
-src/client/common/platform/types.ts
 src/client/common/platform/registry.ts
 src/client/common/platform/pathUtils.ts
 src/client/common/persistentState.ts

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -12,6 +12,7 @@ import { promisify } from 'util';
 import * as vscode from 'vscode';
 import '../extensions';
 import { traceError } from '../logger';
+import { convertFileType } from '../utils/filesystem';
 import { createDirNotEmptyError, isFileExistsError, isFileNotFoundError, isNoPermissionsError } from './errors';
 import { FileSystemPaths, FileSystemPathUtils } from './fs-paths';
 import { TemporaryFileSystem } from './fs-temp';
@@ -30,30 +31,6 @@ import {
 } from './types';
 
 const ENCODING = 'utf8';
-
-interface IKnowsFileType {
-    isFile(): boolean;
-    isDirectory(): boolean;
-    isSymbolicLink(): boolean;
-}
-
-// This helper function determines the file type of the given stats
-// object.  The type follows the convention of node's fs module, where
-// a file has exactly one type.  Symlinks are not resolved.
-export function convertFileType(info: IKnowsFileType): FileType {
-    if (info.isFile()) {
-        return FileType.File;
-    }
-    if (info.isDirectory()) {
-        return FileType.Directory;
-    }
-    if (info.isSymbolicLink()) {
-        // The caller is responsible for combining this ("logical or")
-        // with File or Directory as necessary.
-        return FileType.SymbolicLink;
-    }
-    return FileType.Unknown;
-}
 
 export function convertStat(old: fs.Stats, filetype: FileType): FileStat {
     return {

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -527,7 +527,7 @@ export class FileSystem implements IFileSystem {
     }
 
     // eslint-disable-next-line @typescript-eslint/ban-types
-    public async writeFile(filename: string, data: {}): Promise<void> {
+    public async writeFile(filename: string, data: string | Buffer): Promise<void> {
         return this.utils.raw.writeText(filename, data);
     }
 

--- a/src/client/common/platform/types.ts
+++ b/src/client/common/platform/types.ts
@@ -7,7 +7,7 @@ import { SemVer } from 'semver';
 import * as vscode from 'vscode';
 import { Architecture, OSType } from '../utils/platform';
 
-//===========================
+//= ==========================
 // registry
 
 export enum RegistryHive {
@@ -21,7 +21,7 @@ export interface IRegistry {
     getValue(key: string, hive: RegistryHive, arch?: Architecture, name?: string): Promise<string | undefined | null>;
 }
 
-//===========================
+//= ==========================
 // platform
 
 export const IsWindows = Symbol('IS_WINDOWS');
@@ -41,7 +41,7 @@ export interface IPlatformService {
     getVersion(): Promise<SemVer>;
 }
 
-//===========================
+//= ==========================
 // temp FS
 
 export type TemporaryFile = { filePath: string } & vscode.Disposable;
@@ -51,7 +51,7 @@ export interface ITempFileSystem {
     createFile(suffix: string, mode?: number): Promise<TemporaryFile>;
 }
 
-//===========================
+//= ==========================
 // FS paths
 
 // The low-level file path operations used by the extension.
@@ -87,7 +87,7 @@ export interface IFileSystemPathUtils {
     getDisplayName(pathValue: string, cwd?: string): string;
 }
 
-//===========================
+//= ==========================
 // filesystem operations
 
 // We could use FileType from utils/filesystem.ts, but it's simpler this way.
@@ -107,7 +107,7 @@ export interface IRawFileSystem {
     // Move the file to a different location (and/or rename it).
     move(src: string, tgt: string): Promise<void>;
 
-    //***********************
+    //* **********************
     // files
 
     // Return the raw bytes of the given file.
@@ -115,7 +115,7 @@ export interface IRawFileSystem {
     // Return the text of the given file (decoded from UTF-8).
     readText(filename: string): Promise<string>;
     // Write the given text to the file (UTF-8 encoded).
-    writeText(filename: string, data: {}): Promise<void>;
+    writeText(filename: string, data: string | Buffer): Promise<void>;
     // Write the given text to the end of the file (UTF-8 encoded).
     appendText(filename: string, text: string): Promise<void>;
     // Copy a file.
@@ -123,7 +123,7 @@ export interface IRawFileSystem {
     // Delete a file.
     rmfile(filename: string): Promise<void>;
 
-    //***********************
+    //* **********************
     // directories
 
     // Create the directory and any missing parent directories.
@@ -135,7 +135,7 @@ export interface IRawFileSystem {
     // Return the contents of the directory.
     listdir(dirname: string): Promise<[string, FileType][]>;
 
-    //***********************
+    //* **********************
     // not async
 
     // Get information about a file (resolve symlinks).
@@ -155,14 +155,14 @@ export interface IFileSystemUtils {
     readonly pathUtils: IFileSystemPathUtils;
     readonly tmp: ITempFileSystem;
 
-    //***********************
+    //* **********************
     // aliases
 
     createDirectory(dirname: string): Promise<void>;
     deleteDirectory(dirname: string): Promise<void>;
     deleteFile(filename: string): Promise<void>;
 
-    //***********************
+    //* **********************
     // helpers
 
     // Determine if the file exists, optionally requiring the type.
@@ -184,7 +184,7 @@ export interface IFileSystemUtils {
     // Get the paths of all files matching the pattern.
     search(globPattern: string): Promise<string[]>;
 
-    //***********************
+    //* **********************
     // helpers (non-async)
 
     fileExistsSync(path: string): boolean;

--- a/src/client/common/platform/types.ts
+++ b/src/client/common/platform/types.ts
@@ -90,15 +90,11 @@ export interface IFileSystemPathUtils {
 //===========================
 // filesystem operations
 
+// We could use FileType from utils/filesystem.ts, but it's simpler this way.
 export import FileType = vscode.FileType;
 export import FileStat = vscode.FileStat;
 export type ReadStream = fs.ReadStream;
 export type WriteStream = fs.WriteStream;
-
-export type DirEntry = {
-    filename: string;
-    filetype: FileType;
-};
 
 // The low-level filesystem operations on which the extension depends.
 export interface IRawFileSystem {

--- a/src/client/common/utils/filesystem.ts
+++ b/src/client/common/utils/filesystem.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import * as fs from 'fs';
 import * as path from 'path';
+import * as vscode from 'vscode';
+import { logError } from '../../logging';
 import { getOSType, OSType } from './platform';
 
 /**
@@ -27,4 +30,60 @@ export function areSameFilename(filename1: string, filename2: string): boolean {
     const norm1 = normalizeFilename(filename1);
     const norm2 = normalizeFilename(filename2);
     return norm1 === norm2;
+}
+
+export import FileType = vscode.FileType;
+
+export type DirEntry = {
+    filename: string;
+    filetype: FileType;
+};
+
+interface IKnowsFileType {
+    isFile(): boolean;
+    isDirectory(): boolean;
+    isSymbolicLink(): boolean;
+}
+
+// This helper function determines the file type of the given stats
+// object.  The type follows the convention of node's fs module, where
+// a file has exactly one type.  Symlinks are not resolved.
+export function convertFileType(info: IKnowsFileType): FileType {
+    if (info.isFile()) {
+        return FileType.File;
+    }
+    if (info.isDirectory()) {
+        return FileType.Directory;
+    }
+    if (info.isSymbolicLink()) {
+        // The caller is responsible for combining this ("logical or")
+        // with File or Directory as necessary.
+        return FileType.SymbolicLink;
+    }
+    return FileType.Unknown;
+}
+
+/**
+ * Identify the file type for the given file.
+ */
+export async function getFileType(
+    filename: string,
+    opts: {
+        ignoreErrors: boolean;
+    } = { ignoreErrors: true },
+): Promise<FileType | undefined> {
+    let stat: fs.Stats;
+    try {
+        stat = await fs.promises.lstat(filename);
+    } catch (err) {
+        if (err.code === 'ENOENT') {
+            return undefined;
+        }
+        if (opts.ignoreErrors) {
+            logError(`lstat() failed for "${filename}" (${err})`);
+            return FileType.Unknown;
+        }
+        throw err; // re-throw
+    }
+    return convertFileType(stat);
 }

--- a/src/client/pythonEnvironments/common/commonUtils.ts
+++ b/src/client/pythonEnvironments/common/commonUtils.ts
@@ -3,8 +3,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { convertFileType } from '../../common/platform/fileSystem';
-import { DirEntry, FileType } from '../../common/platform/types';
+import { convertFileType, DirEntry, FileType, getFileType } from '../../common/utils/filesystem';
 import { getOSType, OSType } from '../../common/utils/platform';
 import { logError } from '../../logging';
 import { PythonVersion, UNKNOWN_PYTHON_VERSION } from '../base/info';
@@ -170,28 +169,6 @@ async function readDirEntries(
         return entries.filter((e) => matchFile(e.filename, opts.filterFilename, ignoreErrors));
     }
     return entries;
-}
-
-async function getFileType(
-    filename: string,
-    opts: {
-        ignoreErrors: boolean;
-    } = { ignoreErrors: true },
-): Promise<FileType | undefined> {
-    let stat: fs.Stats;
-    try {
-        stat = await fs.promises.lstat(filename);
-    } catch (err) {
-        if (err.code === 'ENOENT') {
-            return undefined;
-        }
-        if (opts.ignoreErrors) {
-            logError(`lstat() failed for "${filename}" (${err})`);
-            return FileType.Unknown;
-        }
-        throw err; // re-throw
-    }
-    return convertFileType(stat);
 }
 
 function matchFile(


### PR DESCRIPTION
As part of the work on improving `isStandardPythonBinary()`, we make use of several filesystem-related utilities.  They are encapsulated here and will be used in a succeeding PR.

Note: I will be updating for eslint once reviews are done.