### PR TITLE
Do not display environments in the list for which running python binary fails

### DIFF
--- a/pythonFiles/interpreterInfo.py
+++ b/pythonFiles/interpreterInfo.py
@@ -12,5 +12,7 @@ try:
     obj["is64Bit"] = sys.maxsize > 2 ** 32
 
     print(json.dumps(obj))
+except Exception as e:
+    print("Interpreter info script failed", str(e))
 finally:
     sys.exit(42)

--- a/pythonFiles/interpreterInfo.py
+++ b/pythonFiles/interpreterInfo.py
@@ -1,13 +1,15 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-
-import json
 import sys
+try:
+    import json
 
-obj = {}
-obj["versionInfo"] = tuple(sys.version_info)
-obj["sysPrefix"] = sys.prefix
-obj["sysVersion"] = sys.version
-obj["is64Bit"] = sys.maxsize > 2 ** 32
+    obj = {}
+    obj["versionInfo"] = tuple(sys.version_info)
+    obj["sysPrefix"] = sys.prefix
+    obj["sysVersion"] = sys.version
+    obj["is64Bit"] = sys.maxsize > 2 ** 32
 
-print(json.dumps(obj))
+    print(json.dumps(obj))
+finally:
+    sys.exit(42)

--- a/pythonFiles/interpreterInfo.py
+++ b/pythonFiles/interpreterInfo.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 import sys
+
 try:
     import json
 

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -243,6 +243,7 @@ export class LanguageServerExtensionActivationService
             if (serverType === LanguageServerType.Jedi) {
                 throw ex;
             }
+            traceError(ex);
             this.output.appendLine(LanguageService.lsFailedToStart());
             serverType = LanguageServerType.Jedi;
             server = this.serviceContainer.get<ILanguageServerActivator>(ILanguageServerActivator, serverType);

--- a/src/client/activation/serviceRegistry.ts
+++ b/src/client/activation/serviceRegistry.ts
@@ -136,12 +136,6 @@ export function registerTypes(serviceManager: IServiceManager, languageServerTyp
             ILanguageServerFolderService,
             NodeLanguageServerFolderService,
         );
-    } else if (languageServerType === LanguageServerType.Jedi) {
-        serviceManager.add<ILanguageServerActivator>(
-            ILanguageServerActivator,
-            JediExtensionActivator,
-            LanguageServerType.Jedi,
-        );
     } else if (languageServerType === LanguageServerType.JediLSP) {
         serviceManager.add<ILanguageServerActivator>(
             ILanguageServerActivator,

--- a/src/client/activation/serviceRegistry.ts
+++ b/src/client/activation/serviceRegistry.ts
@@ -165,6 +165,11 @@ export function registerTypes(serviceManager: IServiceManager, languageServerTyp
             LanguageServerType.None,
         );
     }
+    serviceManager.add<ILanguageServerActivator>(
+        ILanguageServerActivator,
+        JediExtensionActivator,
+        LanguageServerType.Jedi,
+    ); // We fallback to Jedi if for some reason we're unable to use other language servers, hence register this always.
 
     serviceManager.addSingleton<IDownloadChannelRule>(
         IDownloadChannelRule,

--- a/src/client/common/process/rawProcessApis.ts
+++ b/src/client/common/process/rawProcessApis.ts
@@ -63,14 +63,15 @@ export function shellExec(
     return new Promise((resolve, reject) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const callback = (e: any, stdout: any, stderr: any) => {
-            if (e && e !== null) {
+            if (e && e !== null && !shellOptions.doNotThrowExecException) {
                 reject(e);
-            } else if (shellOptions.throwOnStdErr && stderr && stderr.length) {
+            }
+            if (shellOptions.throwOnStdErr && stderr && stderr.length) {
                 reject(new Error(stderr));
             } else {
                 // Make sure stderr is undefined if we actually had none. This is checked
                 // elsewhere because that's how exec behaves.
-                resolve({ stderr: stderr && stderr.length > 0 ? stderr : undefined, stdout });
+                resolve({ stderr: stderr && stderr.length > 0 ? stderr : undefined, stdout, error: e });
             }
         };
         const proc = exec(command, shellOptions, callback); // NOSONAR

--- a/src/client/common/process/types.ts
+++ b/src/client/common/process/types.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ChildProcess, ExecOptions, SpawnOptions as ChildProcessSpawnOptions } from 'child_process';
+import { ChildProcess, ExecException, ExecOptions, SpawnOptions as ChildProcessSpawnOptions } from 'child_process';
 import { Observable } from 'rxjs/Observable';
 import { CancellationToken, Uri } from 'vscode';
 import { PythonExecInfo } from '../../pythonEnvironments/exec';
@@ -32,11 +32,12 @@ export type SpawnOptions = ChildProcessSpawnOptions & {
     extraVariables?: NodeJS.ProcessEnv;
 };
 
-export type ShellOptions = ExecOptions & { throwOnStdErr?: boolean };
+export type ShellOptions = ExecOptions & { throwOnStdErr?: boolean; doNotThrowExecException?: boolean };
 
 export type ExecutionResult<T extends string | Buffer> = {
     stdout: T;
     stderr?: T;
+    error?: ExecException | null;
 };
 
 export const IProcessLogger = Symbol('IProcessLogger');

--- a/src/client/common/process/types.ts
+++ b/src/client/common/process/types.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ChildProcess, ExecException, ExecOptions, SpawnOptions as ChildProcessSpawnOptions } from 'child_process';
+import { ChildProcess, ExecOptions, SpawnOptions as ChildProcessSpawnOptions } from 'child_process';
 import { Observable } from 'rxjs/Observable';
 import { CancellationToken, Uri } from 'vscode';
 import { PythonExecInfo } from '../../pythonEnvironments/exec';
@@ -32,12 +32,12 @@ export type SpawnOptions = ChildProcessSpawnOptions & {
     extraVariables?: NodeJS.ProcessEnv;
 };
 
-export type ShellOptions = ExecOptions & { throwOnStdErr?: boolean; doNotThrowExecException?: boolean };
+export type ShellOptions = ExecOptions & { throwOnStdErr?: boolean; ignoreExitCode?: boolean };
 
 export type ExecutionResult<T extends string | Buffer> = {
     stdout: T;
     stderr?: T;
-    error?: ExecException | null;
+    exitCode?: number;
 };
 
 export const IProcessLogger = Symbol('IProcessLogger');

--- a/src/client/pythonEnvironments/base/info/interpreter.ts
+++ b/src/client/pythonEnvironments/base/info/interpreter.ts
@@ -92,11 +92,11 @@ export async function getInterpreterInfo(
             /**
              * We're exiting using `sys.exit(42)` in the interpreter info script, hence we're expecting an exec exception.
              */
-            doNotThrowExecException: true,
+            ignoreExitCode: true,
         },
         disposables,
     );
-    const isValidExecutable = result.error?.code === 42; // Error code 42 is thrown from interpreter info script.
+    const isValidExecutable = result.exitCode === 42; // Error code 42 is thrown from interpreter info script.
     if (result.stderr) {
         traceError(`Failed to parse interpreter information for ${argv} stderr: ${result.stderr}`);
         return { interpreterExecInfo: undefined, isValidExecutable };

--- a/src/client/pythonEnvironments/base/locator.ts
+++ b/src/client/pythonEnvironments/base/locator.ts
@@ -22,8 +22,9 @@ export type PythonEnvUpdatedEvent = {
     old?: PythonEnvInfo;
     /**
      * The env info that replaces the old info.
+     * Update is sent as `undefined` if we find out that the environment is no longer valid.
      */
-    update: PythonEnvInfo;
+    update: PythonEnvInfo | undefined;
 };
 
 /**

--- a/src/client/pythonEnvironments/base/locatorUtils.ts
+++ b/src/client/pythonEnvironments/base/locatorUtils.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { Uri } from 'vscode';
+import { traceVerbose } from '../../common/logger';
 import { createDeferred } from '../../common/utils/async';
 import { getURIFilter } from '../../common/utils/misc';
 import { IDisposable } from '../../common/utils/resourceLifecycle';
@@ -87,11 +88,15 @@ export async function getEnvs(iterator: IPythonEnvsIterator): Promise<PythonEnvI
                 listener.dispose();
             } else {
                 const { index, update } = event;
-                // If envs[index] is undefined, environment is not valid. So do not accept updates for the env.
-                if (envs[index] !== undefined) {
-                    // We don't worry about if envs[index] is set already.
-                    envs[index] = update;
+                if (envs[index] === undefined) {
+                    traceVerbose(
+                        `Updates sent for an env which was classified as invalid earlier, currently not expected, ${JSON.stringify(
+                            update,
+                        )}`,
+                    );
                 }
+                // We don't worry about if envs[index] is set already.
+                envs[index] = update;
             }
         });
     }

--- a/src/client/pythonEnvironments/base/locators/composite/environmentsReducer.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/environmentsReducer.ts
@@ -3,7 +3,7 @@
 
 import { isEqual } from 'lodash';
 import { Event, EventEmitter } from 'vscode';
-import { traceVerbose } from '../../../../common/logger';
+import { traceError, traceVerbose } from '../../../../common/logger';
 import { PythonEnvInfo, PythonEnvKind } from '../../info';
 import { areSameEnv, mergeEnvironments } from '../../info/env';
 import { ILocator, IPythonEnvsIterator, PythonEnvUpdatedEvent, PythonLocatorQuery } from '../../locator';
@@ -59,6 +59,10 @@ async function* iterEnvsIterator(
             } else if (event.update && seen[event.index] !== undefined) {
                 state.pending += 1;
                 resolveDifferencesInBackground(event.index, event.update, state, didUpdate, seen).ignoreErrors();
+            } else if (event.update === undefined) {
+                traceError(
+                    'Unsupported behavior: `undefined` environment updates are not supported from downstream locators in reducer',
+                );
             } else {
                 // This implies a problem in a downstream locator
                 traceVerbose(`Expected already iterated env, got ${event.old} (#${event.index})`);

--- a/src/client/pythonEnvironments/base/locators/composite/environmentsReducer.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/environmentsReducer.ts
@@ -3,7 +3,7 @@
 
 import { isEqual } from 'lodash';
 import { Event, EventEmitter } from 'vscode';
-import { traceError, traceVerbose } from '../../../../common/logger';
+import { traceVerbose } from '../../../../common/logger';
 import { PythonEnvInfo, PythonEnvKind } from '../../info';
 import { areSameEnv, mergeEnvironments } from '../../info/env';
 import { ILocator, IPythonEnvsIterator, PythonEnvUpdatedEvent, PythonLocatorQuery } from '../../locator';
@@ -60,7 +60,7 @@ async function* iterEnvsIterator(
                 state.pending += 1;
                 resolveDifferencesInBackground(event.index, event.update, state, didUpdate, seen).ignoreErrors();
             } else if (event.update === undefined) {
-                traceError(
+                throw new Error(
                     'Unsupported behavior: `undefined` environment updates are not supported from downstream locators in reducer',
                 );
             } else {

--- a/src/client/pythonEnvironments/base/locators/composite/environmentsReducer.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/environmentsReducer.ts
@@ -56,7 +56,7 @@ async function* iterEnvsIterator(
                 state.done = true;
                 checkIfFinishedAndNotify(state, didUpdate);
                 listener.dispose();
-            } else if (seen[event.index] !== undefined) {
+            } else if (event.update && seen[event.index] !== undefined) {
                 state.pending += 1;
                 resolveDifferencesInBackground(event.index, event.update, state, didUpdate, seen).ignoreErrors();
             } else {

--- a/src/client/pythonEnvironments/base/locators/composite/environmentsReducer.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/environmentsReducer.ts
@@ -56,13 +56,13 @@ async function* iterEnvsIterator(
                 state.done = true;
                 checkIfFinishedAndNotify(state, didUpdate);
                 listener.dispose();
-            } else if (event.update && seen[event.index] !== undefined) {
-                state.pending += 1;
-                resolveDifferencesInBackground(event.index, event.update, state, didUpdate, seen).ignoreErrors();
             } else if (event.update === undefined) {
                 throw new Error(
                     'Unsupported behavior: `undefined` environment updates are not supported from downstream locators in reducer',
                 );
+            } else if (seen[event.index] !== undefined) {
+                state.pending += 1;
+                resolveDifferencesInBackground(event.index, event.update, state, didUpdate, seen).ignoreErrors();
             } else {
                 // This implies a problem in a downstream locator
                 traceVerbose(`Expected already iterated env, got ${event.old} (#${event.index})`);

--- a/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
@@ -61,13 +61,13 @@ export class PythonEnvsResolver implements ILocator {
                     state.done = true;
                     checkIfFinishedAndNotify(state, didUpdate);
                     listener.dispose();
-                } else if (event.update && seen[event.index] !== undefined) {
-                    seen[event.index] = event.update;
-                    this.resolveInBackground(event.index, state, didUpdate, seen).ignoreErrors();
                 } else if (event.update === undefined) {
                     throw new Error(
                         'Unsupported behavior: `undefined` environment updates are not supported from downstream locators in resolver',
                     );
+                } else if (seen[event.index] !== undefined) {
+                    seen[event.index] = event.update;
+                    this.resolveInBackground(event.index, state, didUpdate, seen).ignoreErrors();
                 } else {
                     // This implies a problem in a downstream locator
                     traceVerbose(`Expected already iterated env, got ${event.old} (#${event.index})`);

--- a/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
@@ -3,7 +3,7 @@
 
 import { cloneDeep } from 'lodash';
 import { Event, EventEmitter } from 'vscode';
-import { traceError, traceVerbose } from '../../../../common/logger';
+import { traceVerbose } from '../../../../common/logger';
 import { IEnvironmentInfoService } from '../../../info/environmentInfoService';
 import { PythonEnvInfo } from '../../info';
 import { InterpreterExecInformation } from '../../info/interpreter';
@@ -65,7 +65,7 @@ export class PythonEnvsResolver implements ILocator {
                     seen[event.index] = event.update;
                     this.resolveInBackground(event.index, state, didUpdate, seen).ignoreErrors();
                 } else if (event.update === undefined) {
-                    traceError(
+                    throw new Error(
                         'Unsupported behavior: `undefined` environment updates are not supported from downstream locators in resolver',
                     );
                 } else {

--- a/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
@@ -3,7 +3,7 @@
 
 import { cloneDeep } from 'lodash';
 import { Event, EventEmitter } from 'vscode';
-import { traceVerbose } from '../../../../common/logger';
+import { traceError, traceVerbose } from '../../../../common/logger';
 import { IEnvironmentInfoService } from '../../../info/environmentInfoService';
 import { PythonEnvInfo } from '../../info';
 import { InterpreterExecInformation } from '../../info/interpreter';
@@ -64,6 +64,10 @@ export class PythonEnvsResolver implements ILocator {
                 } else if (event.update && seen[event.index] !== undefined) {
                     seen[event.index] = event.update;
                     this.resolveInBackground(event.index, state, didUpdate, seen).ignoreErrors();
+                } else if (event.update === undefined) {
+                    traceError(
+                        'Unsupported behavior: `undefined` environment updates are not supported from downstream locators in resolver',
+                    );
                 } else {
                     // This implies a problem in a downstream locator
                     traceVerbose(`Expected already iterated env, got ${event.old} (#${event.index})`);

--- a/src/client/pythonEnvironments/common/externalDependencies.ts
+++ b/src/client/pythonEnvironments/common/externalDependencies.ts
@@ -4,7 +4,7 @@
 import * as fsapi from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { ExecutionResult, SpawnOptions } from '../../common/process/types';
+import { ExecutionResult, ShellOptions, SpawnOptions } from '../../common/process/types';
 import { IExperimentService, IDisposable } from '../../common/types';
 import { chain, iterable } from '../../common/utils/async';
 import { normalizeFilename } from '../../common/utils/filesystem';
@@ -27,10 +27,10 @@ export function initializeExternalDependencies(serviceContainer: IServiceContain
  */
 export async function shellExecute(
     command: string,
-    timeout: number,
+    options?: ShellOptions,
     disposables?: Set<IDisposable>,
 ): Promise<ExecutionResult<string>> {
-    return shellExec(command, { timeout }, undefined, disposables);
+    return shellExec(command, options, undefined, disposables);
 }
 
 /**

--- a/src/client/pythonEnvironments/info/environmentInfoService.ts
+++ b/src/client/pythonEnvironments/info/environmentInfoService.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { traceVerbose } from '../../common/logger';
 import { IDisposable } from '../../common/types';
 import { createDeferred, Deferred } from '../../common/utils/async';
 import { createRunningWorkerPool, IWorkerPool, QueuePosition } from '../../common/utils/workerPool';
@@ -22,7 +23,13 @@ export interface IEnvironmentInfoService {
 
 async function buildEnvironmentInfo(interpreterPath: string): Promise<InterpreterInformation> {
     const disposables = new Set<IDisposable>();
-    const info = await getInterpreterInfo(buildPythonExecInfo(interpreterPath), disposables);
+    const info: InterpreterInformation = await getInterpreterInfo(
+        buildPythonExecInfo(interpreterPath),
+        disposables,
+    ).catch((reason) => {
+        traceVerbose(reason);
+        return { interpreterExecInfo: undefined, isValidExecutable: false };
+    });
 
     // Ensure the process we started is cleaned up.
     disposables.forEach((p) => {

--- a/src/test/activation/serviceRegistry.unit.test.ts
+++ b/src/test/activation/serviceRegistry.unit.test.ts
@@ -9,6 +9,7 @@ import { DownloadBetaChannelRule, DownloadDailyChannelRule } from '../../client/
 import { LanguageServerDownloader } from '../../client/activation/common/downloader';
 import { LanguageServerDownloadChannel } from '../../client/activation/common/packageRepository';
 import { ExtensionSurveyPrompt } from '../../client/activation/extensionSurvey';
+import { JediExtensionActivator } from '../../client/activation/jedi';
 import { DotNetLanguageServerActivator } from '../../client/activation/languageServer/activator';
 import { DotNetLanguageServerAnalysisOptions } from '../../client/activation/languageServer/analysisOptions';
 import { DotNetLanguageClientFactory } from '../../client/activation/languageServer/languageClientFactory';
@@ -159,6 +160,13 @@ suite('Unit Tests - Language Server Activation Service Registry', () => {
                 ILanguageServerAnalysisOptions,
                 DotNetLanguageServerAnalysisOptions,
                 LanguageServerType.Microsoft,
+            ),
+        ).once();
+        verify(
+            serviceManager.add<ILanguageServerActivator>(
+                ILanguageServerActivator,
+                JediExtensionActivator,
+                LanguageServerType.Jedi,
             ),
         ).once();
         verify(serviceManager.add<ILanguageServerProxy>(ILanguageServerProxy, DotNetLanguageServerProxy)).once();

--- a/src/test/pythonEnvironments/base/locators/composite/environmentsResolver.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/composite/environmentsResolver.unit.test.ts
@@ -56,11 +56,7 @@ suite('Python envs locator - Environments Resolver', () => {
                     resolve({
                         stdout:
                             '{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}',
-                        error: {
-                            code: 42,
-                            name: '',
-                            message: '',
-                        },
+                        exitCode: 42, // Any code other than 42 means it's not a valid executable
                     });
                 }),
             );
@@ -126,11 +122,7 @@ suite('Python envs locator - Environments Resolver', () => {
                     resolve({
                         stderr: 'Kaboom',
                         stdout: '',
-                        error: {
-                            code: 1, // Any code other than 42 means it's not a valid executable
-                            name: '',
-                            message: '',
-                        },
+                        exitCode: 1, // Any code other than 42 means it's not a valid executable
                     });
                 }),
             );
@@ -155,11 +147,7 @@ suite('Python envs locator - Environments Resolver', () => {
                     resolve({
                         stderr: 'Kaboom',
                         stdout: '',
-                        error: {
-                            code: 42, // Any code other than 42 means it's not a valid executable
-                            name: '',
-                            message: '',
-                        },
+                        exitCode: 42, // Any code other than 42 means it's not a valid executable
                     });
                 }),
             );
@@ -286,11 +274,7 @@ suite('Python envs locator - Environments Resolver', () => {
                     resolve({
                         stdout:
                             '{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}',
-                        error: {
-                            code: 42,
-                            name: '',
-                            message: '',
-                        },
+                        exitCode: 42,
                     });
                 }),
             );
@@ -357,11 +341,7 @@ suite('Python envs locator - Environments Resolver', () => {
                     resolve({
                         stderr: 'Kaboom',
                         stdout: '',
-                        error: {
-                            code: 1,
-                            name: '',
-                            message: '',
-                        },
+                        exitCode: 1,
                     });
                 }),
             );
@@ -393,11 +373,7 @@ suite('Python envs locator - Environments Resolver', () => {
                     resolve({
                         stderr: 'Kaboom',
                         stdout: '',
-                        error: {
-                            code: 42,
-                            name: '',
-                            message: '',
-                        },
+                        exitCode: 42,
                     });
                 }),
             );

--- a/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.unit.test.ts
@@ -15,7 +15,7 @@ import {
     PythonVersion,
     UNKNOWN_PYTHON_VERSION,
 } from '../../../../client/pythonEnvironments/base/info';
-import { InterpreterInformation } from '../../../../client/pythonEnvironments/base/info/interpreter';
+import { InterpreterExecInformation } from '../../../../client/pythonEnvironments/base/info/interpreter';
 import { parseVersion } from '../../../../client/pythonEnvironments/base/info/pythonVersion';
 import * as externalDep from '../../../../client/pythonEnvironments/common/externalDependencies';
 import {
@@ -102,7 +102,7 @@ suite('Windows Store', () => {
             sysVersion?: string,
             sysPrefix?: string,
             versionStr?: string,
-        ): InterpreterInformation {
+        ): InterpreterExecInformation {
             let version: PythonVersion;
             try {
                 version = parseVersion(versionStr ?? path.basename(executable));

--- a/src/test/pythonEnvironments/info/environmentInfoService.functional.test.ts
+++ b/src/test/pythonEnvironments/info/environmentInfoService.functional.test.ts
@@ -46,11 +46,7 @@ suite('Environment Info Service', () => {
                 resolve({
                     stdout:
                         '{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}',
-                    error: {
-                        code: 42,
-                        name: '',
-                        message: '',
-                    },
+                    exitCode: 42,
                 });
             }),
         );

--- a/src/test/pythonEnvironments/info/environmentInfoService.functional.test.ts
+++ b/src/test/pythonEnvironments/info/environmentInfoService.functional.test.ts
@@ -21,17 +21,20 @@ suite('Environment Info Service', () => {
 
     function createExpectedEnvInfo(executable: string): InterpreterInformation {
         return {
-            version: {
-                ...parseVersion('3.8.3-final'),
-                sysVersion: '3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]',
+            interpreterExecInfo: {
+                version: {
+                    ...parseVersion('3.8.3-final'),
+                    sysVersion: '3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]',
+                },
+                arch: Architecture.x64,
+                executable: {
+                    filename: executable,
+                    sysPrefix: 'path',
+                    mtime: -1,
+                    ctime: -1,
+                },
             },
-            arch: Architecture.x64,
-            executable: {
-                filename: executable,
-                sysPrefix: 'path',
-                mtime: -1,
-                ctime: -1,
-            },
+            isValidExecutable: true,
         };
     }
 
@@ -43,6 +46,11 @@ suite('Environment Info Service', () => {
                 resolve({
                     stdout:
                         '{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}',
+                    error: {
+                        code: 42,
+                        name: '',
+                        message: '',
+                    },
                 });
             }),
         );


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/15371

- Modify interpreter info helper to return whether the executable is valid
- Resolver can now send update as undefined to signify env is no longer valid. Such envs won't be reported.