### PR TITLE
Allow on suggestion refresh by default

### DIFF
--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -142,7 +142,7 @@ class ComponentAdapter implements IComponentAdapter, IExtensionSingleActivationS
 
     private readonly refreshed = new vscode.EventEmitter<void>();
 
-    private allowOnSuggestionRefresh = false;
+    private allowOnSuggestionRefresh = true;
 
     constructor(
         // The adapter only wraps one thing: the component API.


### PR DESCRIPTION
This is necessary to ensure that bitness for workspace envs is eventually shown. This regression slipped through while addressing code reviews.