### PR TITLE
Fix the "Problem" messages for pytest failures when debugging.

### DIFF
--- a/src/client/testing/common/managers/baseTestManager.ts
+++ b/src/client/testing/common/managers/baseTestManager.ts
@@ -538,7 +538,7 @@ export abstract class BaseTestManager implements ITestManager {
     private createDiagnostics(message: ITestNonPassingMessage): Diagnostic {
         const stackStart = message.locationStack[0];
         const diagMsg = this.getDiagnosticMessage(message);
-        const severity = this.unitTestDiagnosticService.getSeverity(message.severity)!;
+        const severity = this.unitTestDiagnosticService.getSeverity(message.severity);
         const diagnostic = new Diagnostic(stackStart.location.range, diagMsg, severity);
         diagnostic.code = message.code;
         diagnostic.source = message.provider;
@@ -554,23 +554,6 @@ export abstract class BaseTestManager implements ITestManager {
     private getDiagnosticMessage(message: ITestNonPassingMessage): string {
         const diagMsg = message.message ? message.message.split('\n')[0] : '';
         const diagPrefix = this.unitTestDiagnosticService.getMessagePrefix(message.status);
-        if (diagPrefix === undefined) {
-            // This isn't something we should expect to happen, but
-            // `getMessagePrefix()` can return undefined.  (See the note
-            // there for when it can heppen.)  In the meantime, we play
-            // it safe here to be a bit resilient to accidents.
-            if (diagMsg === '') {
-                // This is the value we decied to use in #14311.  It
-                // isn't the most helpful message, but it's better than
-                // the failure we fixed with that PR.  Regardless, we
-                // don't expect to reach this case.
-                return 'Ok';
-            }
-            // With #14311 this case led to a confusing diagnostic
-            // message, partly we did not anticipate having a message
-            // without a prefix.
-            return diagMsg;
-        }
         if (diagMsg === '') {
             return diagPrefix;
         }

--- a/src/client/testing/common/managers/baseTestManager.ts
+++ b/src/client/testing/common/managers/baseTestManager.ts
@@ -552,8 +552,28 @@ export abstract class BaseTestManager implements ITestManager {
     }
 
     private getDiagnosticMessage(message: ITestNonPassingMessage): string {
-        const diagPrefix = this.unitTestDiagnosticService.getMessagePrefix(message.status)!;
         const diagMsg = message.message ? message.message.split('\n')[0] : '';
+        const diagPrefix = this.unitTestDiagnosticService.getMessagePrefix(message.status);
+        if (diagPrefix === undefined) {
+            // This isn't something we should expect to happen, but
+            // `getMessagePrefix()` can return undefined.  (See the note
+            // there for when it can heppen.)  In the meantime, we play
+            // it safe here to be a bit resilient to accidents.
+            if (diagMsg === '') {
+                // This is the value we decied to use in #14311.  It
+                // isn't the most helpful message, but it's better than
+                // the failure we fixed with that PR.  Regardless, we
+                // don't expect to reach this case.
+                return 'Ok';
+            }
+            // With #14311 this case led to a confusing diagnostic
+            // message, partly we did not anticipate having a message
+            // without a prefix.
+            return diagMsg;
+        }
+        if (diagMsg === '') {
+            return diagPrefix;
+        }
         return `${diagPrefix}: ${diagMsg}`;
     }
 }

--- a/src/client/testing/common/managers/baseTestManager.ts
+++ b/src/client/testing/common/managers/baseTestManager.ts
@@ -552,8 +552,8 @@ export abstract class BaseTestManager implements ITestManager {
     }
 
     private getDiagnosticMessage(message: ITestNonPassingMessage): string {
-        const diagPrefix = this.unitTestDiagnosticService.getMessagePrefix(message.status);
+        const diagPrefix = this.unitTestDiagnosticService.getMessagePrefix(message.status)!;
         const diagMsg = message.message ? message.message.split('\n')[0] : '';
-        return `${diagPrefix ? `${diagPrefix}: ` : 'Ok'}${diagMsg}`;
+        return `${diagPrefix}: ${diagMsg}`;
     }
 }

--- a/src/client/testing/common/services/unitTestDiagnosticService.ts
+++ b/src/client/testing/common/services/unitTestDiagnosticService.ts
@@ -37,13 +37,17 @@ export class UnitTestDiagnosticService implements ITestDiagnosticService {
     }
 
     public getMessagePrefix(status: NonPassingTestStatus): string {
+        // If `msgType` ends up `undefined` then it means we've added
+        // a new failing test status but forgot to support it here
+        // (or it means elsewhere we asserted a bogus value, like
+        // `undefined`).  The same goes for `msgPrefix`.
         const msgType = this.MessageTypes.get(status);
-        const msgPrefix = msgType ? this.MessagePrefixes.get(msgType) : undefined;
-        if (msgType === undefined || msgPrefix === undefined) {
-            // If `msgType` is `undefined` then it means we've added a new
-            // failing test status but forgot to support it here (or it means
-            // elsewhere we asserted a bogus value, like `undefined`).
+        if (msgType === undefined) {
             throw Error(`unsupported status (${status})`);
+        }
+        const msgPrefix = this.MessagePrefixes.get(msgType);
+        if (msgType === undefined || msgPrefix === undefined) {
+            throw Error(`unsupported message type (${msgType})`);
         }
         return msgPrefix;
     }

--- a/src/client/testing/common/services/unitTestDiagnosticService.ts
+++ b/src/client/testing/common/services/unitTestDiagnosticService.ts
@@ -36,15 +36,23 @@ export class UnitTestDiagnosticService implements ITestDiagnosticService {
         this.MessagePrefixes.set(DiagnosticMessageType.Skipped, localize.Testing.testSkippedDiagnosticMessage());
     }
 
-    public getMessagePrefix(status: NonPassingTestStatus): string | undefined {
+    public getMessagePrefix(status: NonPassingTestStatus): string {
         const msgType = this.MessageTypes.get(status);
-        // If `msgType` is `undefined` then it means we've added a new
-        // failing test status but forgot to support it here (or it means
-        // elsewhere we asserted a bogus value, like `undefined`).
-        return msgType !== undefined ? this.MessagePrefixes.get(msgType) : undefined;
+        const msgPrefix = msgType ? this.MessagePrefixes.get(msgType) : undefined;
+        if (msgType === undefined || msgPrefix === undefined) {
+            // If `msgType` is `undefined` then it means we've added a new
+            // failing test status but forgot to support it here (or it means
+            // elsewhere we asserted a bogus value, like `undefined`).
+            throw Error(`unsupported status (${status})`);
+        }
+        return msgPrefix;
     }
 
-    public getSeverity(unitTestSeverity: NonPassingTestSeverity): DiagnosticSeverity | undefined {
-        return this.MessageSeverities.get(unitTestSeverity);
+    public getSeverity(unitTestSeverity: NonPassingTestSeverity): DiagnosticSeverity {
+        const severity = this.MessageSeverities.get(unitTestSeverity);
+        if (severity === undefined) {
+            throw Error(`unsupported severity (${unitTestSeverity})`);
+        }
+        return severity;
     }
 }

--- a/src/client/testing/common/types.ts
+++ b/src/client/testing/common/types.ts
@@ -522,8 +522,8 @@ export interface ITestsStatusUpdaterService {
 
 export const ITestDiagnosticService = Symbol('ITestDiagnosticService');
 export interface ITestDiagnosticService {
-    getMessagePrefix(status: TestStatus): string | undefined;
-    getSeverity(unitTestSeverity: PythonTestMessageSeverity): DiagnosticSeverity | undefined;
+    getMessagePrefix(status: TestStatus): string;
+    getSeverity(unitTestSeverity: PythonTestMessageSeverity): DiagnosticSeverity;
 }
 
 export const IArgumentsService = Symbol('IArgumentsService');

--- a/src/test/testing/unittest/unittest.diagnosticService.unit.test.ts
+++ b/src/test/testing/unittest/unittest.diagnosticService.unit.test.ts
@@ -21,8 +21,8 @@ suite('UnitTestDiagnosticService: unittest', () => {
         let expectedPrefix: string;
         let expectedSeverity: DiagnosticSeverity;
         suiteSetup(() => {
-            actualPrefix = diagnosticService.getMessagePrefix(TestStatus.Error)!;
-            actualSeverity = diagnosticService.getSeverity(PythonTestMessageSeverity.Error)!;
+            actualPrefix = diagnosticService.getMessagePrefix(TestStatus.Error);
+            actualSeverity = diagnosticService.getSeverity(PythonTestMessageSeverity.Error);
             expectedPrefix = localize.Testing.testErrorDiagnosticMessage();
             expectedSeverity = DiagnosticSeverity.Error;
         });
@@ -39,8 +39,8 @@ suite('UnitTestDiagnosticService: unittest', () => {
         let expectedPrefix: string;
         let expectedSeverity: DiagnosticSeverity;
         suiteSetup(() => {
-            actualPrefix = diagnosticService.getMessagePrefix(TestStatus.Fail)!;
-            actualSeverity = diagnosticService.getSeverity(PythonTestMessageSeverity.Failure)!;
+            actualPrefix = diagnosticService.getMessagePrefix(TestStatus.Fail);
+            actualSeverity = diagnosticService.getSeverity(PythonTestMessageSeverity.Failure);
             expectedPrefix = localize.Testing.testFailDiagnosticMessage();
             expectedSeverity = DiagnosticSeverity.Error;
         });
@@ -57,8 +57,8 @@ suite('UnitTestDiagnosticService: unittest', () => {
         let expectedPrefix: string;
         let expectedSeverity: DiagnosticSeverity;
         suiteSetup(() => {
-            actualPrefix = diagnosticService.getMessagePrefix(TestStatus.Skipped)!;
-            actualSeverity = diagnosticService.getSeverity(PythonTestMessageSeverity.Skip)!;
+            actualPrefix = diagnosticService.getMessagePrefix(TestStatus.Skipped);
+            actualSeverity = diagnosticService.getSeverity(PythonTestMessageSeverity.Skip);
             expectedPrefix = localize.Testing.testSkippedDiagnosticMessage();
             expectedSeverity = DiagnosticSeverity.Information;
         });


### PR DESCRIPTION
fixes #14866

In #14311 we worked around a bug in a way that caused the strange message reported in #14866 (pytest with debugger).  This change fixes that one without regressing the previous fix.