### PR TITLE
Don't show bugfix version if it is not accurately known

### DIFF
--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -344,7 +344,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
         const envSuffixParts: string[] = [];
 
         if (info.version) {
-            // Exclude invalid -1 filler values
+            // Exclude invalid -1 filler values.
             const versionParts = [info.version.major, info.version.minor, info.version.patch].filter(
                 (value) => value > -1,
             );

--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -344,7 +344,12 @@ export class InterpreterService implements Disposable, IInterpreterService {
         const envSuffixParts: string[] = [];
 
         if (info.version) {
-            displayNameParts.push(`${info.version.major}.${info.version.minor}.${info.version.patch}`);
+            // Exclude invalid -1 filler values
+            const versionParts = [info.version.major, info.version.minor, info.version.patch].filter(
+                (value) => value > -1,
+            );
+
+            displayNameParts.push(versionParts.join('.'));
         }
         if (info.architecture) {
             displayNameParts.push(getArchitectureDisplayName(info.architecture));

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -106,21 +106,22 @@ function convertEnvInfo(info: PythonEnvInfo): PythonEnvironment {
 
     if (version !== undefined) {
         const { release, sysVersion } = version;
+        const versionPrefix = getVersionString(version);
         let versionStr;
 
         if (release === undefined) {
-            versionStr = `${getVersionString(version)}-final`;
+            versionStr = `${versionPrefix}-final`;
             env.sysVersion = '';
         } else {
             const { level, serial } = release;
             const releaseStr = level === PythonReleaseLevel.Final ? 'final' : `${level}${serial}`;
-            versionStr = `${getVersionString(version)}-${releaseStr}`;
+            versionStr = `${versionPrefix}-${releaseStr}`;
             env.sysVersion = sysVersion;
         }
 
         const result = parseBasicVersion(versionStr)[0];
         const semverLikeVersion: PythonVersion = {
-            raw: versionStr,
+            raw: versionPrefix,
             major: result.major,
             minor: result.minor,
             patch: result.micro,

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -9,7 +9,7 @@ import { DiscoveryVariants } from '../common/experiments/groups';
 import { traceError } from '../common/logger';
 import { FileChangeType } from '../common/platform/fileSystemWatcher';
 import { IDisposableRegistry, Resource } from '../common/types';
-import { getVersionString, parseVersion } from '../common/utils/version';
+import { getVersionString } from '../common/utils/version';
 import {
     CONDA_ENV_FILE_SERVICE,
     CONDA_ENV_SERVICE,
@@ -68,6 +68,8 @@ import {
 import { WorkspaceVirtualEnvWatcherService } from './discovery/locators/services/workspaceVirtualEnvWatcherService';
 import { EnvironmentType, PythonEnvironment } from './info';
 import { EnvironmentsSecurity, IEnvironmentsSecurity } from './security';
+import { parseBasicVersion } from './base/info/pythonVersion';
+import { PythonVersion } from './info/pythonVersion';
 
 const convertedKinds = new Map(
     Object.entries({
@@ -104,17 +106,28 @@ function convertEnvInfo(info: PythonEnvInfo): PythonEnvironment {
 
     if (version !== undefined) {
         const { release, sysVersion } = version;
+        let versionStr;
+
         if (release === undefined) {
-            const versionStr = `${getVersionString(version)}-final`;
-            env.version = parseVersion(versionStr);
+            versionStr = `${getVersionString(version)}-final`;
             env.sysVersion = '';
         } else {
             const { level, serial } = release;
             const releaseStr = level === PythonReleaseLevel.Final ? 'final' : `${level}${serial}`;
-            const versionStr = `${getVersionString(version)}-${releaseStr}`;
-            env.version = parseVersion(versionStr);
+            versionStr = `${getVersionString(version)}-${releaseStr}`;
             env.sysVersion = sysVersion;
         }
+
+        const result = parseBasicVersion(versionStr)[0];
+        const semverLikeVersion: PythonVersion = {
+            raw: versionStr,
+            major: result.major,
+            minor: result.minor,
+            patch: result.micro,
+            build: [],
+            prerelease: [],
+        };
+        env.version = semverLikeVersion;
     }
 
     if (distro !== undefined && distro.org !== '') {

--- a/src/test/interpreters/interpreterService.unit.test.ts
+++ b/src/test/interpreters/interpreterService.unit.test.ts
@@ -486,7 +486,7 @@ suite('Interpreters service', () => {
             const displayName = await service.getDisplayName(interpreterInfo, undefined).catch(() => '');
 
             expect(displayName).to.equal(expectedDisplayName);
-            expect(getInterpreterHashStub.calledOnce).to.equal(true);
+            expect(getInterpreterHashStub.notCalled).to.equal(true);
             persistentStateFactory.verifyAll();
         });
 
@@ -518,7 +518,7 @@ suite('Interpreters service', () => {
             const displayName = await service.getDisplayName(interpreterInfo, undefined).catch(() => '');
 
             expect(displayName).to.equal(expectedDisplayName);
-            expect(getInterpreterHashStub.calledOnce).to.equal(true);
+            expect(getInterpreterHashStub.notCalled).to.equal(true);
             persistentStateFactory.verifyAll();
         });
     });

--- a/src/test/interpreters/interpreterService.unit.test.ts
+++ b/src/test/interpreters/interpreterService.unit.test.ts
@@ -480,7 +480,7 @@ suite('Interpreters service', () => {
                     build: [],
                 },
             };
-            const expectedDisplayName = '2.7';
+            const expectedDisplayName = 'Python 2.7';
 
             const service = new InterpreterService(serviceContainer, pyenvs.object, experimentService.object);
             const displayName = await service.getDisplayName(interpreterInfo, undefined).catch(() => '');
@@ -512,7 +512,7 @@ suite('Interpreters service', () => {
                     build: [],
                 },
             };
-            const expectedDisplayName = '3';
+            const expectedDisplayName = 'Python 3';
 
             const service = new InterpreterService(serviceContainer, pyenvs.object, experimentService.object);
             const displayName = await service.getDisplayName(interpreterInfo, undefined).catch(() => '');

--- a/src/test/interpreters/interpreterService.unit.test.ts
+++ b/src/test/interpreters/interpreterService.unit.test.ts
@@ -441,6 +441,88 @@ suite('Interpreters service', () => {
         });
     });
 
+    suite('Display name with incomplete interpreter versions', () => {
+        let getInterpreterHashStub: sinon.SinonStub;
+
+        setup(() => {
+            setupSuite();
+            fileSystem.reset();
+            persistentStateFactory.reset();
+            getInterpreterHashStub = sinon.stub(hashApi, 'getInterpreterHash');
+
+            const fileHash = 'file_hash';
+            getInterpreterHashStub.resolves(fileHash);
+        });
+
+        teardown(() => {
+            getInterpreterHashStub.restore();
+        });
+
+        test('Python version without micro version should be displayed as X.Y and not default to X.Y.0', async () => {
+            persistentStateFactory
+                .setup((p) => p.createGlobalPersistentState(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                .returns(() => {
+                    const state = {
+                        updateValue: () => Promise.resolve(),
+                        value: undefined,
+                    };
+                    return state as any;
+                })
+                .verifiable(TypeMoq.Times.once());
+
+            const interpreterInfo: Partial<PythonEnvironment> = {
+                version: {
+                    major: 2,
+                    minor: 7,
+                    patch: -1,
+                    raw: 'something',
+                    prerelease: [],
+                    build: [],
+                },
+            };
+            const expectedDisplayName = '2.7';
+
+            const service = new InterpreterService(serviceContainer, pyenvs.object, experimentService.object);
+            const displayName = await service.getDisplayName(interpreterInfo, undefined).catch(() => '');
+
+            expect(displayName).to.equal(expectedDisplayName);
+            expect(getInterpreterHashStub.calledOnce).to.equal(true);
+            persistentStateFactory.verifyAll();
+        });
+
+        test('Python version without minor or micro version should be displayed as X and not default to X.0.0', async () => {
+            persistentStateFactory
+                .setup((p) => p.createGlobalPersistentState(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                .returns(() => {
+                    const state = {
+                        updateValue: () => Promise.resolve(),
+                        value: undefined,
+                    };
+                    return state as any;
+                })
+                .verifiable(TypeMoq.Times.once());
+
+            const interpreterInfo: Partial<PythonEnvironment> = {
+                version: {
+                    major: 3,
+                    minor: -1,
+                    patch: -1,
+                    raw: 'something',
+                    prerelease: [],
+                    build: [],
+                },
+            };
+            const expectedDisplayName = '3';
+
+            const service = new InterpreterService(serviceContainer, pyenvs.object, experimentService.object);
+            const displayName = await service.getDisplayName(interpreterInfo, undefined).catch(() => '');
+
+            expect(displayName).to.equal(expectedDisplayName);
+            expect(getInterpreterHashStub.calledOnce).to.equal(true);
+            persistentStateFactory.verifyAll();
+        });
+    });
+
     // This is kind of a verbose test, but we need to ensure we have covered all permutations.
     // Also we have special handling for certain types of interpreters.
     suite('Display Format (with all permutations)', () => {


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/15362

The problem lies with

https://github.com/microsoft/vscode-python/blob/4501ff53b262c2bf9003361a3225013951caed3f/src/client/common/utils/version.ts#L402-L410

We use `semver.coerce` to parse the version, which, when given strings like `2.7-final`, will parse them as `2.7.0`. We don't want that.


Linting pass pending reviews