### PR TITLE
Ensure pyenv virtual envs are not skipped when in discovery experiment

### DIFF
--- a/news/2 Fixes/15439.md
+++ b/news/2 Fixes/15439.md
@@ -1,1 +1,1 @@
-Fix for missing pyenv virutal environments from selectable environments.
+Fix for missing pyenv virtual environments from selectable environments.

--- a/news/2 Fixes/15439.md
+++ b/news/2 Fixes/15439.md
@@ -1,0 +1,1 @@
+Fix for missing pyenv virutal environments from selectable environments.

--- a/src/client/pythonEnvironments/discovery/locators/services/pyenvLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/pyenvLocator.ts
@@ -259,15 +259,15 @@ export function parsePyenvVersion(str: string): Promise<IPyenvVersionStrings | u
 async function* getPyenvEnvironments(): AsyncIterableIterator<PythonEnvInfo> {
     const pyenvVersionDir = getPyenvVersionsDir();
 
-    const subDirs = getSubDirs(pyenvVersionDir);
+    const subDirs = getSubDirs(pyenvVersionDir, true);
     for await (const subDir of subDirs) {
-        const envDir = path.join(pyenvVersionDir, subDir);
-        const interpreterPath = await getInterpreterPathFromDir(envDir);
+        const envDirName = path.basename(subDir);
+        const interpreterPath = await getInterpreterPathFromDir(subDir);
 
         if (interpreterPath) {
             // The sub-directory name sometimes can contain distro and python versions.
             // here we attempt to extract the texts out of the name.
-            const versionStrings = await parsePyenvVersion(subDir);
+            const versionStrings = await parsePyenvVersion(envDirName);
 
             // Here we look for near by files, or config files to see if we can get python version info
             // without running python itself.
@@ -290,7 +290,7 @@ async function* getPyenvEnvironments(): AsyncIterableIterator<PythonEnvInfo> {
             // `pyenv local|global <env-name>` or `pyenv shell <env-name>`
             //
             // For the display name we are going to treat these as `pyenv` environments.
-            const display = `${subDir}:pyenv`;
+            const display = `${envDirName}:pyenv`;
 
             const org = versionStrings && versionStrings.distro ? versionStrings.distro : '';
 
@@ -299,14 +299,14 @@ async function* getPyenvEnvironments(): AsyncIterableIterator<PythonEnvInfo> {
             const envInfo = buildEnvInfo({
                 kind: PythonEnvKind.Pyenv,
                 executable: interpreterPath,
-                location: envDir,
+                location: subDir,
                 version: pythonVersion,
                 source: [PythonEnvSource.Pyenv],
                 display,
                 org,
                 fileInfo,
             });
-            envInfo.name = subDir;
+            envInfo.name = envDirName;
 
             yield envInfo;
         }

--- a/src/client/pythonEnvironments/discovery/locators/services/pyenvLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/pyenvLocator.ts
@@ -260,9 +260,9 @@ async function* getPyenvEnvironments(): AsyncIterableIterator<PythonEnvInfo> {
     const pyenvVersionDir = getPyenvVersionsDir();
 
     const subDirs = getSubDirs(pyenvVersionDir, true);
-    for await (const subDir of subDirs) {
-        const envDirName = path.basename(subDir);
-        const interpreterPath = await getInterpreterPathFromDir(subDir);
+    for await (const subDirPath of subDirs) {
+        const envDirName = path.basename(subDirPath);
+        const interpreterPath = await getInterpreterPathFromDir(subDirPath);
 
         if (interpreterPath) {
             // The sub-directory name sometimes can contain distro and python versions.
@@ -299,7 +299,7 @@ async function* getPyenvEnvironments(): AsyncIterableIterator<PythonEnvInfo> {
             const envInfo = buildEnvInfo({
                 kind: PythonEnvKind.Pyenv,
                 executable: interpreterPath,
-                location: subDir,
+                location: subDirPath,
                 version: pythonVersion,
                 source: [PythonEnvSource.Pyenv],
                 display,


### PR DESCRIPTION
For #15439

This is a special case for `pyenv` where the env dirs are listed a symbolic links. To add tests for this scenario we need to bring up the virutal FS test framework so we can use declarative test file layout for things like symbolic links and other OS and FS specific things.