### PR TITLE
Register Jedi regardless of what language server is configured

### DIFF
--- a/news/2 Fixes/15452.md
+++ b/news/2 Fixes/15452.md
@@ -1,0 +1,1 @@
+Register Jedi regardless of what language server is configured.

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -243,6 +243,7 @@ export class LanguageServerExtensionActivationService
             if (serverType === LanguageServerType.Jedi) {
                 throw ex;
             }
+            traceError(ex);
             this.output.appendLine(LanguageService.lsFailedToStart());
             serverType = LanguageServerType.Jedi;
             server = this.serviceContainer.get<ILanguageServerActivator>(ILanguageServerActivator, serverType);

--- a/src/client/activation/serviceRegistry.ts
+++ b/src/client/activation/serviceRegistry.ts
@@ -136,12 +136,6 @@ export function registerTypes(serviceManager: IServiceManager, languageServerTyp
             ILanguageServerFolderService,
             NodeLanguageServerFolderService,
         );
-    } else if (languageServerType === LanguageServerType.Jedi) {
-        serviceManager.add<ILanguageServerActivator>(
-            ILanguageServerActivator,
-            JediExtensionActivator,
-            LanguageServerType.Jedi,
-        );
     } else if (languageServerType === LanguageServerType.JediLSP) {
         serviceManager.add<ILanguageServerActivator>(
             ILanguageServerActivator,
@@ -165,6 +159,11 @@ export function registerTypes(serviceManager: IServiceManager, languageServerTyp
             LanguageServerType.None,
         );
     }
+    serviceManager.add<ILanguageServerActivator>(
+        ILanguageServerActivator,
+        JediExtensionActivator,
+        LanguageServerType.Jedi,
+    ); // We fallback to Jedi if for some reason we're unable to use other language servers, hence register this always.
 
     serviceManager.addSingleton<IDownloadChannelRule>(
         IDownloadChannelRule,

--- a/src/test/activation/serviceRegistry.unit.test.ts
+++ b/src/test/activation/serviceRegistry.unit.test.ts
@@ -9,6 +9,7 @@ import { DownloadBetaChannelRule, DownloadDailyChannelRule } from '../../client/
 import { LanguageServerDownloader } from '../../client/activation/common/downloader';
 import { LanguageServerDownloadChannel } from '../../client/activation/common/packageRepository';
 import { ExtensionSurveyPrompt } from '../../client/activation/extensionSurvey';
+import { JediExtensionActivator } from '../../client/activation/jedi';
 import { DotNetLanguageServerActivator } from '../../client/activation/languageServer/activator';
 import { DotNetLanguageServerAnalysisOptions } from '../../client/activation/languageServer/analysisOptions';
 import { DotNetLanguageClientFactory } from '../../client/activation/languageServer/languageClientFactory';
@@ -159,6 +160,13 @@ suite('Unit Tests - Language Server Activation Service Registry', () => {
                 ILanguageServerAnalysisOptions,
                 DotNetLanguageServerAnalysisOptions,
                 LanguageServerType.Microsoft,
+            ),
+        ).once();
+        verify(
+            serviceManager.add<ILanguageServerActivator>(
+                ILanguageServerActivator,
+                JediExtensionActivator,
+                LanguageServerType.Jedi,
             ),
         ).once();
         verify(serviceManager.add<ILanguageServerProxy>(ILanguageServerProxy, DotNetLanguageServerProxy)).once();


### PR DESCRIPTION
We fallback on Jedi if we're unable to start the configured LS, hence register it always. Fixes flaky tests https://github.com/microsoft/vscode-python/runs/1921832928 where we attempt to access Jedi, but it is not available as it wasn't registered.