### PR TITLE
Cleanup for "Don't show bugfix version if it is not accurately known"

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -292,7 +292,6 @@ src/test/workspaceSymbols/common.ts
 src/test/workspaceSymbols/main.unit.test.ts
 src/test/workspaceSymbols/generator.unit.test.ts
 
-src/client/interpreter/interpreterService.ts
 src/client/interpreter/configuration/interpreterComparer.ts
 src/client/interpreter/configuration/interpreterSelector/commands/base.ts
 src/client/interpreter/configuration/interpreterSelector/commands/resetInterpreter.ts
@@ -493,7 +492,6 @@ src/client/common/platform/serviceRegistry.ts
 src/client/common/platform/errors.ts
 src/client/common/platform/fs-temp.ts
 src/client/common/platform/fs-paths.ts
-src/client/common/platform/platformService.ts
 src/client/common/platform/registry.ts
 src/client/common/platform/pathUtils.ts
 src/client/common/persistentState.ts
@@ -522,7 +520,6 @@ src/client/common/utils/stopWatch.ts
 src/client/common/utils/random.ts
 src/client/common/utils/serializers.ts
 src/client/common/utils/sysTypes.ts
-src/client/common/utils/version.ts
 src/client/common/utils/misc.ts
 src/client/common/utils/logging.ts
 src/client/common/utils/cacheUtils.ts

--- a/.eslintignore
+++ b/.eslintignore
@@ -177,7 +177,6 @@ src/test/common/experiments/manager.unit.test.ts
 src/test/common/experiments/telemetry.unit.test.ts
 src/test/common/platform/filesystem.unit.test.ts
 src/test/common/platform/errors.unit.test.ts
-src/test/common/platform/platformService.test.ts
 src/test/common/platform/utils.ts
 src/test/common/platform/fs-temp.unit.test.ts
 src/test/common/platform/fs-temp.functional.test.ts

--- a/src/client/common/platform/platformService.ts
+++ b/src/client/common/platform/platformService.ts
@@ -4,12 +4,11 @@
 
 import { injectable } from 'inversify';
 import * as os from 'os';
-import { coerce, SemVer } from 'semver';
+import { coerce, SemVer, valid } from 'semver';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName, PlatformErrors } from '../../telemetry/constants';
 import { getSearchPathEnvVarNames } from '../utils/exec';
 import { Architecture, getArchitecture, getOSType, OSType } from '../utils/platform';
-import { parseVersion } from '../utils/version';
 import { IPlatformService } from './types';
 
 @injectable()
@@ -74,4 +73,14 @@ export class PlatformService implements IPlatformService {
     public get is64bit(): boolean {
         return getArchitecture() === Architecture.x64;
     }
+}
+
+function parseVersion(raw: string): SemVer {
+    raw = raw.replace(/\.00*(?=[1-9]|0\.)/, '.');
+    const ver = coerce(raw);
+    if (ver === null || !valid(ver)) {
+        // TODO: Raise an exception instead?
+        return new SemVer('0.0.0');
+    }
+    return ver;
 }

--- a/src/client/common/platform/platformService.ts
+++ b/src/client/common/platform/platformService.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 'use strict';
 
 import { injectable } from 'inversify';
@@ -14,7 +15,9 @@ import { IPlatformService } from './types';
 @injectable()
 export class PlatformService implements IPlatformService {
     public readonly osType: OSType = getOSType();
+
     public version?: SemVer;
+
     constructor() {
         if (this.osType === OSType.Unknown) {
             sendTelemetryEvent(EventName.PLATFORM_INFO, undefined, {
@@ -22,12 +25,15 @@ export class PlatformService implements IPlatformService {
             });
         }
     }
-    public get pathVariableName() {
+
+    public get pathVariableName(): 'Path' | 'PATH' {
         return getSearchPathEnvVarNames(this.osType)[0];
     }
-    public get virtualEnvBinName() {
+
+    public get virtualEnvBinName(): 'Scripts' | 'bin' {
         return this.isWindows ? 'Scripts' : 'bin';
     }
+
     public async getVersion(): Promise<SemVer> {
         if (this.version) {
             return this.version;
@@ -44,7 +50,8 @@ export class PlatformService implements IPlatformService {
                         sendTelemetryEvent(EventName.PLATFORM_INFO, undefined, {
                             osVersion: `${ver.major}.${ver.minor}.${ver.patch}`,
                         });
-                        return (this.version = ver);
+                        this.version = ver;
+                        return this.version;
                     }
                     throw new Error('Unable to parse version');
                 } catch (ex) {
@@ -61,15 +68,21 @@ export class PlatformService implements IPlatformService {
     public get isWindows(): boolean {
         return this.osType === OSType.Windows;
     }
+
     public get isMac(): boolean {
         return this.osType === OSType.OSX;
     }
+
     public get isLinux(): boolean {
         return this.osType === OSType.Linux;
     }
+
+    // eslint-disable-next-line class-methods-use-this
     public get osRelease(): string {
         return os.release();
     }
+
+    // eslint-disable-next-line class-methods-use-this
     public get is64bit(): boolean {
         return getArchitecture() === Architecture.x64;
     }

--- a/src/client/common/platform/platformService.ts
+++ b/src/client/common/platform/platformService.ts
@@ -5,11 +5,12 @@
 
 import { injectable } from 'inversify';
 import * as os from 'os';
-import { coerce, SemVer, valid } from 'semver';
+import { coerce, SemVer } from 'semver';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName, PlatformErrors } from '../../telemetry/constants';
 import { getSearchPathEnvVarNames } from '../utils/exec';
 import { Architecture, getArchitecture, getOSType, OSType } from '../utils/platform';
+import { parseSemVerSafe } from '../utils/version';
 import { IPlatformService } from './types';
 
 @injectable()
@@ -58,7 +59,7 @@ export class PlatformService implements IPlatformService {
                     sendTelemetryEvent(EventName.PLATFORM_INFO, undefined, {
                         failureType: PlatformErrors.FailedToParseVersion,
                     });
-                    return parseVersion(os.release());
+                    return parseSemVerSafe(os.release());
                 }
             default:
                 throw new Error('Not Supported');
@@ -86,14 +87,4 @@ export class PlatformService implements IPlatformService {
     public get is64bit(): boolean {
         return getArchitecture() === Architecture.x64;
     }
-}
-
-function parseVersion(raw: string): SemVer {
-    raw = raw.replace(/\.00*(?=[1-9]|0\.)/, '.');
-    const ver = coerce(raw);
-    if (ver === null || !valid(ver)) {
-        // TODO: Raise an exception instead?
-        return new SemVer('0.0.0');
-    }
-    return ver;
 }

--- a/src/client/common/utils/version.ts
+++ b/src/client/common/utils/version.ts
@@ -3,10 +3,8 @@
 
 'use strict';
 
-import * as semver from 'semver';
 import { verboseRegExp } from './regexp';
 
-//===========================
 // basic version info
 
 /**
@@ -34,7 +32,7 @@ type ErrorMsg = string;
 function normalizeVersionPart(part: unknown): [number, ErrorMsg] {
     // Any -1 values where the original is not a number are handled in validation.
     if (typeof part === 'number') {
-        if (isNaN(part)) {
+        if (Number.isNaN(part)) {
             return [-1, 'missing'];
         }
         if (part < 0) {
@@ -45,7 +43,7 @@ function normalizeVersionPart(part: unknown): [number, ErrorMsg] {
     }
     if (typeof part === 'string') {
         const parsed = parseInt(part, 10);
-        if (isNaN(parsed)) {
+        if (Number.isNaN(parsed)) {
             return [-1, 'string not numeric'];
         }
         if (parsed < 0) {
@@ -86,7 +84,7 @@ function copyStrict<T extends BasicVersionInfo>(info: T): RawBasicVersionInfo {
         micro: info.micro,
     };
 
-    const unnormalized = ((info as unknown) as RawBasicVersionInfo).unnormalized;
+    const { unnormalized } = (info as unknown) as RawBasicVersionInfo;
     if (unnormalized !== undefined) {
         copied.unnormalized = {
             major: unnormalized.major,
@@ -139,7 +137,7 @@ function validateVersionPart(prop: string, part: number, unnormalized?: ErrorMsg
  * Only the "basic" version info will be validated.  The caller
  * is responsible for any other properties beyond that.
  */
-export function validateBasicVersionInfo<T extends BasicVersionInfo>(info: T) {
+export function validateBasicVersionInfo<T extends BasicVersionInfo>(info: T): void {
     const raw = (info as unknown) as RawBasicVersionInfo;
     validateVersionPart('major', info.major, raw.unnormalized?.major);
     validateVersionPart('minor', info.minor, raw.unnormalized?.minor);
@@ -164,9 +162,11 @@ export function validateBasicVersionInfo<T extends BasicVersionInfo>(info: T) {
 export function getVersionString<T extends BasicVersionInfo>(info: T): string {
     if (info.major < 0) {
         return '';
-    } else if (info.minor < 0) {
+    }
+    if (info.minor < 0) {
         return `${info.major}`;
-    } else if (info.micro < 0) {
+    }
+    if (info.micro < 0) {
         return `${info.major}.${info.minor}`;
     }
     return `${info.major}.${info.minor}.${info.micro}`;
@@ -269,25 +269,30 @@ export function compareVersions<T extends BasicVersionInfo, V extends BasicVersi
 ): [number, string] {
     if (left.major < right.major) {
         return [1, 'major'];
-    } else if (left.major > right.major) {
+    }
+    if (left.major > right.major) {
         return [-1, 'major'];
-    } else if (left.major === -1) {
+    }
+    if (left.major === -1) {
         // Don't bother checking minor or micro.
         return [0, ''];
     }
 
     if (left.minor < right.minor) {
         return [1, 'minor'];
-    } else if (left.minor > right.minor) {
+    }
+    if (left.minor > right.minor) {
         return [-1, 'minor'];
-    } else if (left.minor === -1) {
+    }
+    if (left.minor === -1) {
         // Don't bother checking micro.
         return [0, ''];
     }
 
     if (left.micro < right.micro) {
         return [1, 'micro'];
-    } else if (left.micro > right.micro) {
+    }
+    if (left.micro > right.micro) {
         return [-1, 'micro'];
     }
 
@@ -298,7 +303,7 @@ export function compareVersions<T extends BasicVersionInfo, V extends BasicVersi
     return [0, ''];
 }
 
-//===========================
+//= ==========================
 // base version info
 
 /**
@@ -330,7 +335,7 @@ export function normalizeVersionInfo<T extends VersionInfo>(info: T): T {
  *
  * This assumes that the info has already been normalized.
  */
-export function validateVersionInfo<T extends VersionInfo>(info: T) {
+export function validateVersionInfo<T extends VersionInfo>(info: T): void {
     validateBasicVersionInfo(info);
     // `info.raw` can be anything.
 }
@@ -394,17 +399,4 @@ export function areSimilarVersions<T extends BasicVersionInfo, V extends BasicVe
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return ((left as unknown) as any)[prop] === -1;
     // tslint:enable:no-any
-}
-
-//===========================
-// semver
-
-export function parseVersion(raw: string): semver.SemVer {
-    raw = raw.replace(/\.00*(?=[1-9]|0\.)/, '.');
-    const ver = semver.coerce(raw);
-    if (ver === null || !semver.valid(ver)) {
-        // TODO: Raise an exception instead?
-        return new semver.SemVer('0.0.0');
-    }
-    return ver;
 }

--- a/src/client/common/utils/version.ts
+++ b/src/client/common/utils/version.ts
@@ -303,7 +303,6 @@ export function compareVersions<T extends BasicVersionInfo, V extends BasicVersi
     return [0, ''];
 }
 
-//= ==========================
 // base version info
 
 /**

--- a/src/client/common/utils/version.ts
+++ b/src/client/common/utils/version.ts
@@ -401,6 +401,8 @@ export function areSimilarVersions<T extends BasicVersionInfo, V extends BasicVe
     // tslint:enable:no-any
 }
 
+// semver
+
 export function parseSemVerSafe(raw: string): semver.SemVer {
     raw = raw.replace(/\.00*(?=[1-9]|0\.)/, '.');
     const ver = semver.coerce(raw);

--- a/src/client/common/utils/version.ts
+++ b/src/client/common/utils/version.ts
@@ -3,6 +3,7 @@
 
 'use strict';
 
+import * as semver from 'semver';
 import { verboseRegExp } from './regexp';
 
 // basic version info
@@ -398,4 +399,14 @@ export function areSimilarVersions<T extends BasicVersionInfo, V extends BasicVe
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return ((left as unknown) as any)[prop] === -1;
     // tslint:enable:no-any
+}
+
+export function parseSemVerSafe(raw: string): semver.SemVer {
+    raw = raw.replace(/\.00*(?=[1-9]|0\.)/, '.');
+    const ver = semver.coerce(raw);
+    if (ver === null || !semver.valid(ver)) {
+        // TODO: Raise an exception instead?
+        return new semver.SemVer('0.0.0');
+    }
+    return ver;
 }


### PR DESCRIPTION
Follow-up for https://github.com/microsoft/vscode-python/pull/15436
- Linting
- Move `parseVersion` to the only place where it's used: https://github.com/microsoft/vscode-python/pull/15436#discussion_r578832891