### PR TITLE
Ensure Posix Path locator doesn't return relative binary paths

### DIFF
--- a/news/2 Fixes/15302.md
+++ b/news/2 Fixes/15302.md
@@ -1,0 +1,1 @@
+Show each python.org install only once on Mac when in discovery experiment.

--- a/news/2 Fixes/15312.md
+++ b/news/2 Fixes/15312.md
@@ -1,0 +1,1 @@
+All relative interpreter path reported start with `~` when in discovery experiment.

--- a/src/client/pythonEnvironments/common/externalDependencies.ts
+++ b/src/client/pythonEnvironments/common/externalDependencies.ts
@@ -105,7 +105,12 @@ export async function resolveSymbolicLink(absPath: string): Promise<string> {
     const stats = await fsapi.lstat(absPath);
     if (stats.isSymbolicLink()) {
         const link = await fsapi.readlink(absPath);
-        return resolveSymbolicLink(link);
+        // Result from readlink is not guaranteed to be an absolute path. For eg. on Mac it resolves
+        // /usr/local/bin/python3.9 -> ../../../Library/Frameworks/Python.framework/Versions/3.9/bin/python3.9
+        //
+        // The resultant path is reported relative to the symlink directory we resolve. Convert that to absolute path.
+        const absLinkPath = path.isAbsolute(link) ? link : path.resolve(path.dirname(absPath), link);
+        return resolveSymbolicLink(absLinkPath);
     }
     return absPath;
 }


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/15312 https://github.com/microsoft/vscode-python/issues/15302

@kimadeline Can you please verify on Mac if it solves https://github.com/microsoft/vscode-python/issues/15302 and https://github.com/microsoft/vscode-python/issues/15312?