### PR TITLE
Add getCachedEnvInfo helper

### DIFF
--- a/src/client/pythonEnvironments/base/envsCache.ts
+++ b/src/client/pythonEnvironments/base/envsCache.ts
@@ -103,6 +103,14 @@ export interface IEnvsCache {
     filterEnvs(query: Partial<PythonEnvInfo>): PythonEnvInfo[] | undefined;
 
     /**
+     * Return cached environment information for a given interpreter path if it exists,
+     * otherwise return `undefined`.
+     *
+     * @param path Path to a Python interpreter.
+     */
+    getCachedEnvInfo(path: string): PythonEnvInfo | undefined;
+
+    /**
      * Writes the content of the in-memory cache to persistent storage.
      */
     flush(): Promise<void>;
@@ -136,6 +144,23 @@ export class PythonEnvInfoCache implements IEnvsCache {
 
     public filterEnvs(query: Partial<PythonEnvInfo>): PythonEnvInfo[] | undefined {
         return this.inMemory?.filter((info) => areSameEnv(info, query));
+    }
+
+    public getCachedEnvInfo(path: string): PythonEnvInfo | undefined {
+        const envs = this.filterEnvs({
+            executable: {
+                filename: path,
+                sysPrefix: '',
+                ctime: -1,
+                mtime: -1,
+            },
+        });
+
+        if (envs && envs.length) {
+            return envs[0];
+        }
+
+        return undefined;
     }
 
     public async clearAndReloadFromStorage(): Promise<void> {

--- a/src/client/pythonEnvironments/base/envsCache.ts
+++ b/src/client/pythonEnvironments/base/envsCache.ts
@@ -147,20 +147,7 @@ export class PythonEnvInfoCache implements IEnvsCache {
     }
 
     public getCachedEnvInfo(path: string): PythonEnvInfo | undefined {
-        const envs = this.filterEnvs({
-            executable: {
-                filename: path,
-                sysPrefix: '',
-                ctime: -1,
-                mtime: -1,
-            },
-        });
-
-        if (envs && envs.length) {
-            return envs[0];
-        }
-
-        return undefined;
+        return this.inMemory?.lookUp(path);
     }
 
     public async clearAndReloadFromStorage(): Promise<void> {

--- a/src/test/pythonEnvironments/base/envsCache.unit.test.ts
+++ b/src/test/pythonEnvironments/base/envsCache.unit.test.ts
@@ -152,7 +152,7 @@ suite('Environment Info cache', () => {
         assert.deepStrictEqual(result, envToFind);
     });
 
-    test('`getCachedEnvInfo` should undefined if no environment matches the input path', () => {
+    test('`getCachedEnvInfo` should return undefined if no environment matches the input path', () => {
         const envsCache = new PythonEnvInfoCache(getGlobalPersistentStore(), allEnvsComplete);
         envsCache.setAllEnvs(envInfoArray);
 
@@ -161,7 +161,7 @@ suite('Environment Info cache', () => {
         assert.strictEqual(result, undefined);
     });
 
-    test("`getCachedEnvInfo` should undefined if the cache hasn't been activated", () => {
+    test("`getCachedEnvInfo` should return undefined if the cache hasn't been activated", () => {
         const envsCache = new PythonEnvInfoCache(getGlobalPersistentStore(), allEnvsComplete);
 
         const result = envsCache.getCachedEnvInfo('my-nonexistent-env');

--- a/src/test/pythonEnvironments/base/envsCache.unit.test.ts
+++ b/src/test/pythonEnvironments/base/envsCache.unit.test.ts
@@ -90,7 +90,7 @@ suite('Environment Info cache', () => {
         assert.strictEqual(envs === envInfoArray, false);
     });
 
-    test('`filterEnvs` should return environments that match its argument using areSameEnvironmnet', async () => {
+    test('`filterEnvs` should return environments that match its argument using areSameEnvironment', async () => {
         const env: PythonEnvInfo = ({ executable: { filename: 'my-venv-env' } } as unknown) as PythonEnvInfo;
         const envsCache = await getPersistentCache(getGlobalPersistentStore(), allEnvsComplete);
 
@@ -134,6 +134,37 @@ suite('Environment Info cache', () => {
         const envsCache = new PythonEnvInfoCache(getGlobalPersistentStore(), allEnvsComplete);
 
         const result = envsCache.filterEnvs(env);
+
+        assert.strictEqual(result, undefined);
+    });
+
+    test('`getCachedEnvInfo` should return an environment that matches the input path', () => {
+        const envToFind = ({
+            kind: PythonEnvKind.System,
+            executable: { filename: 'my-system-env' },
+        } as unknown) as PythonEnvInfo;
+        const envsCache = new PythonEnvInfoCache(getGlobalPersistentStore(), allEnvsComplete);
+
+        envsCache.setAllEnvs([...envInfoArray, envToFind]);
+
+        const result = envsCache.getCachedEnvInfo('my-system-env');
+
+        assert.deepStrictEqual(result, envToFind);
+    });
+
+    test('`getCachedEnvInfo` should undefined if no environment matches the input path', () => {
+        const envsCache = new PythonEnvInfoCache(getGlobalPersistentStore(), allEnvsComplete);
+        envsCache.setAllEnvs(envInfoArray);
+
+        const result = envsCache.getCachedEnvInfo('my-nonexistent-env');
+
+        assert.strictEqual(result, undefined);
+    });
+
+    test("`getCachedEnvInfo` should undefined if the cache hasn't been activated", () => {
+        const envsCache = new PythonEnvInfoCache(getGlobalPersistentStore(), allEnvsComplete);
+
+        const result = envsCache.getCachedEnvInfo('my-nonexistent-env');
 
         assert.strictEqual(result, undefined);
     });


### PR DESCRIPTION
https://github.com/microsoft/vscode-python/issues/15499

Add a helper in preparation for a telemetry event to be sent at the end of the "Enter interpreter path" flow. This event will include a boolean representing whether an entered path had already been discovered.