### PR TITLE
Add column offset to fix mypy linter pointing to wrong column number (off by one)

### DIFF
--- a/news/2 Fixes/14978.md
+++ b/news/2 Fixes/14978.md
@@ -1,0 +1,1 @@
+Fix Mypy linter pointing to wrong column number (off by one). (thanks [anttipessa](https://github.com/anttipessa/), [haalto](https://github.com/haalto/), [JeonCD](https://github.com/JeonCD/) and [junskU](https://github.com/junskU))

--- a/src/client/linters/mypy.ts
+++ b/src/client/linters/mypy.ts
@@ -6,10 +6,11 @@ import { BaseLinter } from './baseLinter';
 import { ILintMessage } from './types';
 
 export const REGEX = '(?<file>[^:]+):(?<line>\\d+)(:(?<column>\\d+))?: (?<type>\\w+): (?<message>.*)\\r?(\\n|$)';
+const COLUMN_OFF_SET = 1;
 
 export class MyPy extends BaseLinter {
     constructor(outputChannel: OutputChannel, serviceContainer: IServiceContainer) {
-        super(Product.mypy, outputChannel, serviceContainer);
+        super(Product.mypy, outputChannel, serviceContainer, COLUMN_OFF_SET);
     }
 
     protected async runLinter(document: TextDocument, cancellation: CancellationToken): Promise<ILintMessage[]> {

--- a/src/test/linters/mypy.unit.test.ts
+++ b/src/test/linters/mypy.unit.test.ts
@@ -55,7 +55,7 @@ suite('Linting - MyPy', () => {
             ],
         ];
         for (const [line, expected] of tests) {
-            const msg = parseLine(line, REGEX, LinterId.MyPy);
+            const msg = parseLine(line, REGEX, LinterId.MyPy, 1);
 
             expect(msg).to.deep.equal(expected);
         }

--- a/src/test/linters/mypy.unit.test.ts
+++ b/src/test/linters/mypy.unit.test.ts
@@ -47,7 +47,7 @@ suite('Linting - MyPy', () => {
                 {
                     code: undefined,
                     message: 'Expression has type "Any"',
-                    column: 21,
+                    column: 20,
                     line: 12,
                     type: 'error',
                     provider: 'mypy',


### PR DESCRIPTION
Closes #14978 
Before:
![image](https://user-images.githubusercontent.com/33652286/109131237-464b4780-775b-11eb-89b0-b08f828621f0.png)

After: 
![image](https://user-images.githubusercontent.com/33652286/109131277-4ea38280-775b-11eb-872f-ee51ba4d111b.png)
