### PR TITLE
Don't outdent on enter after raise with arguments

### DIFF
--- a/news/2 Fixes/10583.md
+++ b/news/2 Fixes/10583.md
@@ -1,0 +1,4 @@
+Make on-enter behaviour after `raise` much more like that of `return`, fixing
+handling in the case of pressing enter to wrap the parentheses of an exception
+call.
+(thanks [PeterJCLaw](https://github.com/PeterJCLaw))

--- a/src/client/language/languageConfiguration.ts
+++ b/src/client/language/languageConfiguration.ts
@@ -76,14 +76,20 @@ export function getLanguageConfiguration(): LanguageConfiguration {
             },
             // outdent on enter (block-ending statements)
             {
+                /**
+                 * This does not handle all cases. Notable omissions here are
+                 * "return" and "raise" which are complicated by the need to
+                 * only outdent when the cursor is at the end of an expression
+                 * rather than, say, between the parentheses of a tail-call or
+                 * exception construction. (see issue #10583)
+                 */
                 beforeText: verboseRegExp(`
                     ^
                     (?:
                         (?:
                             \\s*
                             (?:
-                                pass |
-                                raise \\s+ [^#\\s] [^#]*
+                                pass
                             )
                         ) |
                         (?:

--- a/src/test/language/languageConfiguration.unit.test.ts
+++ b/src/test/language/languageConfiguration.unit.test.ts
@@ -10,7 +10,8 @@ import { getLanguageConfiguration } from '../../client/language/languageConfigur
 const NEEDS_INDENT = [
     /^break$/,
     /^continue$/,
-    /^raise$/, // only re-raise
+    // raise is indented unless it's the only thing on the line
+    /^raise\b/,
     /^return\b/,
 ];
 const INDENT_ON_ENTER = [
@@ -37,7 +38,9 @@ const DEDENT_ON_ENTER = [
     ///^return\b/,
     /^break$/,
     /^continue$/,
-    /^raise\b/,
+    // For now we are mostly ignoring "return".
+    // See https://github.com/microsoft/vscode-python/issues/10583.
+    /^raise$/,
     /^pass\b/,
 ];
 


### PR DESCRIPTION
This changes the behaviour of pressing enter after a raise statement which involves an explicit value so that the cursor position is no longer outdented. Previously this worked well for things like:

``` python
    raise
    raise e
```

but less well for things like:

``` python
    raise Exception(|)
```

which wouuld end up like:

``` python
    raise Exception(
|)
```

With this change applied the latter case will end up like:

``` python
    raise Exception(
        |
    )
```

which matches the behaviour of 'return'. The first case (without
a value) is unaffected, though the case of:

``` python
    raise e
```

will, just like 'return' now require the user to explicitly outdent after pressing enter. It is expected that this is an acceptable trade-off, especially as it is already the case for return statements.

Fixes https://github.com/microsoft/vscode-python/issues/10583.