### PR TITLE
Declare "Trusted Workspaces" support.

### DIFF
--- a/news/3 Code Health/15525.md
+++ b/news/3 Code Health/15525.md
@@ -1,0 +1,14 @@
+Add support for "Trusted Workspaces".
+
+"Trusted Workspaces" is an upcoming feature in VS Code.  (See:
+https://github.com/microsoft/vscode/issues/106488.)  For now you need
+the following for the experience:
+
+* the latest VS Code Insiders
+* add `"workspace.trustEnabled": true` to your user settings.json
+
+At that point, when the Python extension would normally activate, VS Code
+will prompt you about whether or not the current workspace is trusted.
+If not then the extension will be disabled (but only for that workspace).
+As soon as the workspace is marked as trusted, the extension will
+activate.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "Machine Learning",
         "Notebooks"
     ],
+    "requiresWorkspaceTrust": "onStart",
     "activationEvents": [
         "onLanguage:python",
         "onDebugResolve:python",


### PR DESCRIPTION
(closes #15525)

This change enables the new ["Trusted Workspaces" feature](microsoft/vscode#106488) of VS Code for the extension.  For now a user must put `"workspace.trustEnabled": true` in their settings.json to trigger the functionality (and it only works on VS Code insiders).