### PR TITLE
Trigger watcher on windows store directory instead of file

### DIFF
--- a/news/2 Fixes/15541.md
+++ b/news/2 Fixes/15541.md
@@ -1,0 +1,1 @@
+Fixes issue with detecting new installations of Windows Store python.

--- a/src/client/pythonEnvironments/base/locators/lowLevel/fsWatchingLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/lowLevel/fsWatchingLocator.ts
@@ -65,9 +65,9 @@ export abstract class FSWatchingLocator extends LazyResourceBasedLocator {
         private readonly getKind: (executable: string) => Promise<PythonEnvKind>,
         private readonly opts: {
             /**
-             * Glob which represents basename of the executable to watch.
+             * Glob which represents basename of the executable or directory to watch.
              */
-            executableBaseGlob?: string;
+            baseGlob?: string;
             /**
              * Time to wait before handling an environment-created event.
              */
@@ -143,7 +143,7 @@ export abstract class FSWatchingLocator extends LazyResourceBasedLocator {
         };
 
         const globs = resolvePythonExeGlobs(
-            this.opts.executableBaseGlob,
+            this.opts.baseGlob,
             // The structure determines which globs are returned.
             this.opts.envStructure,
         );

--- a/src/client/pythonEnvironments/discovery/locators/services/windowsStoreLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/windowsStoreLocator.ts
@@ -199,8 +199,14 @@ export class WindowsStoreLocator extends FSWatchingLocator {
     private readonly kind: PythonEnvKind = PythonEnvKind.WindowsStore;
 
     constructor() {
+        // We have to watch the directory instead of the executable here because
+        // FS events are not triggered for `*.exe` in the WindowsApps folder. The
+        // .exe files here are reparse points and not real files. Watching the
+        // PythonSoftwareFoundation directory will trigger both for new install
+        // and update case. Update is handled by deleting and recreating the
+        // PythonSoftwareFoundation directory.
         super(getWindowsStoreAppsRoot, async () => this.kind, {
-            executableBaseGlob: storePythonDirGlob,
+            baseGlob: storePythonDirGlob,
             searchLocation: getWindowsStoreAppsRoot(),
             envStructure: PythonEnvStructure.Flat,
         });

--- a/src/client/pythonEnvironments/discovery/locators/services/windowsStoreLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/windowsStoreLocator.ts
@@ -147,6 +147,16 @@ export async function isWindowsStoreEnvironment(interpreterPath: string): Promis
 const pythonExeGlob = 'python3.{[0-9],[0-9][0-9]}.exe';
 
 /**
+ * This is a glob pattern which matches following dir names:
+ * PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0
+ * PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0
+ *
+ * Note chokidar fails to match multiple digits using +([0-9]), even though the underlying glob pattern matcher
+ * they use (picomatch), or any other glob matcher does. Hence why we had to use {[0-9],[0-9][0-9]} instead.
+ */
+const storePythonDirGlob = 'PythonSoftwareFoundation.Python.3.{[0-9],[0-9][0-9]}_*';
+
+/**
  * Checks if a given path ends with python3.*.exe. Not all python executables are matched as
  * we do not want to return duplicate executables.
  * @param {string} interpreterPath : Path to python interpreter.
@@ -190,7 +200,7 @@ export class WindowsStoreLocator extends FSWatchingLocator {
 
     constructor() {
         super(getWindowsStoreAppsRoot, async () => this.kind, {
-            executableBaseGlob: pythonExeGlob,
+            executableBaseGlob: storePythonDirGlob,
             searchLocation: getWindowsStoreAppsRoot(),
             envStructure: PythonEnvStructure.Flat,
         });

--- a/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.test.ts
@@ -43,12 +43,12 @@ class WindowsStoreEnvs {
         return filename;
     }
 
-    public async update(basename: string): Promise<void> {
-        const filename = path.join(this.storeAppRoot, basename);
+    public async update(version: string): Promise<void> {
+        const dirName = path.join(this.storeAppRoot, `PythonSoftwareFoundation.Python.${version}_qbz5n2kfra8p0`);
         try {
-            await fs.writeFile(filename, 'Environment has been updated');
+            await fs.utimes(dirName, Date.now(), Date.now());
         } catch (err) {
-            throw new Error(`Failed to update Windows Apps executable ${filename}, Error: ${err}`);
+            throw new Error(`Failed to update Windows Apps executable ${dirName}, Error: ${err}`);
         }
     }
 
@@ -184,7 +184,7 @@ suite('Windows Store Locator', async () => {
             deferred.resolve();
         });
 
-        await windowsStoreEnvs.update('python3.4.exe');
+        await windowsStoreEnvs.update('3.4');
         await waitForChangeToBeDetected(deferred);
         const isFound = await isLocated(executable);
 

--- a/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.test.ts
@@ -27,12 +27,13 @@ class WindowsStoreEnvs {
 
     public async create(version: string): Promise<string> {
         const dirName = path.join(this.storeAppRoot, `PythonSoftwareFoundation.Python.${version}_qbz5n2kfra8p0`);
-        const filename = path.join(this.storeAppRoot, `python${version}.exe`);
+        const mainExe = path.join(this.storeAppRoot, `python${version}.exe`);
+        const subExe = path.join(dirName, `python${version}.exe`);
         try {
-            await fs.createFile(filename);
-            this.executables.push(filename);
+            await fs.createFile(mainExe);
+            this.executables.push(mainExe);
         } catch (err) {
-            throw new Error(`Failed to create Windows Apps executable ${filename}, Error: ${err}`);
+            throw new Error(`Failed to create Windows Apps executable ${mainExe}, Error: ${err}`);
         }
         try {
             await fs.mkdir(dirName);
@@ -40,13 +41,21 @@ class WindowsStoreEnvs {
         } catch (err) {
             throw new Error(`Failed to create Windows Apps directory ${dirName}, Error: ${err}`);
         }
-        return filename;
+        try {
+            await fs.createFile(subExe);
+            this.executables.push(subExe);
+        } catch (err) {
+            throw new Error(`Failed to create Windows Apps executable ${subExe}, Error: ${err}`);
+        }
+        return mainExe;
     }
 
     public async update(version: string): Promise<void> {
         const dirName = path.join(this.storeAppRoot, `PythonSoftwareFoundation.Python.${version}_qbz5n2kfra8p0`);
+        const fileName = path.join(dirName, `python${version}.exe`);
         try {
-            await fs.utimes(dirName, Date.now(), Date.now());
+            await fs.remove(fileName);
+            await fs.createFile(fileName);
         } catch (err) {
             throw new Error(`Failed to update Windows Apps executable ${dirName}, Error: ${err}`);
         }

--- a/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.test.ts
@@ -43,12 +43,12 @@ class WindowsStoreEnvs {
         return filename;
     }
 
-    public async update(version: string): Promise<void> {
-        const dirName = path.join(this.storeAppRoot, `PythonSoftwareFoundation.Python.${version}_qbz5n2kfra8p0`);
+    public async update(basename: string): Promise<void> {
+        const filename = path.join(this.storeAppRoot, basename);
         try {
-            await fs.utimes(dirName, Date.now(), Date.now());
+            await fs.writeFile(filename, 'Environment has been updated');
         } catch (err) {
-            throw new Error(`Failed to update Windows Apps executable ${dirName}, Error: ${err}`);
+            throw new Error(`Failed to update Windows Apps executable ${filename}, Error: ${err}`);
         }
     }
 
@@ -184,7 +184,7 @@ suite('Windows Store Locator', async () => {
             deferred.resolve();
         });
 
-        await windowsStoreEnvs.update('3.4');
+        await windowsStoreEnvs.update('python3.4.exe');
         await waitForChangeToBeDetected(deferred);
         const isFound = await isLocated(executable);
 

--- a/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.test.ts
@@ -43,12 +43,14 @@ class WindowsStoreEnvs {
         return filename;
     }
 
-    public async update(basename: string): Promise<void> {
-        const filename = path.join(this.storeAppRoot, basename);
+    public async update(version: string): Promise<void> {
+        // On update windows store removes the directory and re-adds it.
+        const dirName = path.join(this.storeAppRoot, `PythonSoftwareFoundation.Python.${version}_qbz5n2kfra8p0`);
         try {
-            await fs.writeFile(filename, 'Environment has been updated');
+            await fs.rmdir(dirName);
+            await fs.mkdir(dirName);
         } catch (err) {
-            throw new Error(`Failed to update Windows Apps executable ${filename}, Error: ${err}`);
+            throw new Error(`Failed to update Windows Apps directory ${dirName}, Error: ${err}`);
         }
     }
 
@@ -184,7 +186,7 @@ suite('Windows Store Locator', async () => {
             deferred.resolve();
         });
 
-        await windowsStoreEnvs.update('python3.4.exe');
+        await windowsStoreEnvs.update('3.4');
         await waitForChangeToBeDetected(deferred);
         const isFound = await isLocated(executable);
 

--- a/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.test.ts
@@ -30,16 +30,16 @@ class WindowsStoreEnvs {
         const filename = path.join(this.storeAppRoot, `python${version}.exe`);
         try {
             await fs.createFile(filename);
-            this.executables.push(filename);
         } catch (err) {
             throw new Error(`Failed to create Windows Apps executable ${filename}, Error: ${err}`);
         }
         try {
             await fs.mkdir(dirName);
-            this.dirs.push(dirName);
         } catch (err) {
             throw new Error(`Failed to create Windows Apps directory ${dirName}, Error: ${err}`);
         }
+        this.executables.push(filename);
+        this.dirs.push(dirName);
         return filename;
     }
 

--- a/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.test.ts
@@ -27,13 +27,12 @@ class WindowsStoreEnvs {
 
     public async create(version: string): Promise<string> {
         const dirName = path.join(this.storeAppRoot, `PythonSoftwareFoundation.Python.${version}_qbz5n2kfra8p0`);
-        const mainExe = path.join(this.storeAppRoot, `python${version}.exe`);
-        const subExe = path.join(dirName, `python${version}.exe`);
+        const filename = path.join(this.storeAppRoot, `python${version}.exe`);
         try {
-            await fs.createFile(mainExe);
-            this.executables.push(mainExe);
+            await fs.createFile(filename);
+            this.executables.push(filename);
         } catch (err) {
-            throw new Error(`Failed to create Windows Apps executable ${mainExe}, Error: ${err}`);
+            throw new Error(`Failed to create Windows Apps executable ${filename}, Error: ${err}`);
         }
         try {
             await fs.mkdir(dirName);
@@ -41,21 +40,13 @@ class WindowsStoreEnvs {
         } catch (err) {
             throw new Error(`Failed to create Windows Apps directory ${dirName}, Error: ${err}`);
         }
-        try {
-            await fs.createFile(subExe);
-            this.executables.push(subExe);
-        } catch (err) {
-            throw new Error(`Failed to create Windows Apps executable ${subExe}, Error: ${err}`);
-        }
-        return mainExe;
+        return filename;
     }
 
     public async update(version: string): Promise<void> {
         const dirName = path.join(this.storeAppRoot, `PythonSoftwareFoundation.Python.${version}_qbz5n2kfra8p0`);
-        const fileName = path.join(dirName, `python${version}.exe`);
         try {
-            await fs.remove(fileName);
-            await fs.createFile(fileName);
+            await fs.utimes(dirName, Date.now(), Date.now());
         } catch (err) {
             throw new Error(`Failed to update Windows Apps executable ${dirName}, Error: ${err}`);
         }


### PR DESCRIPTION
Closes: #15541

Turns out FS events are not triggered for Store apps because they are not real files. So triggering using the directory pattern for the python store app.