### PR TITLE
Move the "Play" button down a level to the "Run" submenu.

### DIFF
--- a/package.json
+++ b/package.json
@@ -400,7 +400,7 @@
                     "group": "Python"
                 }
             ],
-            "editor/title": [
+            "editor/title/run": [
                 {
                     "command": "python.execInTerminal-icon",
                     "title": "%python.command.python.execInTerminal.title%",

--- a/package.json
+++ b/package.json
@@ -177,11 +177,7 @@
             {
                 "command": "python.execInTerminal-icon",
                 "title": "%python.command.python.execInTerminal.title%",
-                "category": "Python",
-                "icon": {
-                    "light": "resources/light/run-file.svg",
-                    "dark": "resources/dark/run-file.svg"
-                }
+                "category": "Python"
             },
             {
                 "command": "python.setInterpreter",

--- a/resources/dark/run-file.svg
+++ b/resources/dark/run-file.svg
@@ -1,3 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M4 2.00005V13.82L13 7.88006L4 2.00005ZM5.5 4.82L10.3101 7.88006L5.5 11.0001V4.82Z" fill="#89D185"/>
-</svg>

--- a/resources/light/run-file.svg
+++ b/resources/light/run-file.svg
@@ -1,4 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" 
-    xmlns="http://www.w3.org/2000/svg">
-    <path d="M4 2.00005V13.82L13 7.88006L4 2.00005ZM5.5 4.82L10.3101 7.88006L5.5 11.0001V4.82Z" fill="#388A34"/>
-</svg>


### PR DESCRIPTION
According to the VS Code [Feb 2021 release notes](https://code.visualstudio.com/updates/v1_54#_limits-for-editor-title-menu-and-run-submenu), we should avoid putting anything directly in the "editor/title" menu.  This change addresses that by moving our "Play" button down into the new "run" submenu.