### PR TITLE
Enable middleware telemetry for JediLSP, count resultLength

### DIFF
--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -1299,6 +1299,8 @@ export interface IEventNamePropertyMapping {
     [EventName.PYTHON_LANGUAGE_SERVER_TELEMETRY]: unknown;
     /**
      * Telemetry sent when the client makes a request to the language server
+     *
+     * This event also has a measure, "resultLength", which records the number of completions provided.
      */
     [EventName.PYTHON_LANGUAGE_SERVER_REQUEST]: unknown;
     /**
@@ -1367,6 +1369,8 @@ export interface IEventNamePropertyMapping {
     [EventName.LANGUAGE_SERVER_TELEMETRY]: unknown;
     /**
      * Telemetry sent when the client makes a request to the Node.js server
+     *
+     * This event also has a measure, "resultLength", which records the number of completions provided.
      */
     [EventName.LANGUAGE_SERVER_REQUEST]: unknown;
     /**
@@ -1403,6 +1407,8 @@ export interface IEventNamePropertyMapping {
     [EventName.JEDI_LANGUAGE_SERVER_TELEMETRY]: unknown;
     /**
      * Telemetry sent when the client makes a request to the Node.js server
+     *
+     * This event also has a measure, "resultLength", which records the number of completions provided.
      */
     [EventName.JEDI_LANGUAGE_SERVER_REQUEST]: unknown;
     /**


### PR DESCRIPTION
Add `resultLength` to completion telemetry via `lazyMeasures` just as I did in #15242. This means we'll still send data for the JediLSP experiment and can continue to compare completion coverage results.

I tweaked the group logic to always send; we'll remove this group logic anyway in the future.

I've documented the measures next to the properties (which is as good as it gets for now, until the measures are also statically typed).