### PR TITLE
Add cached-property package need by JediLS for python 3.6 and 3.7

### DIFF
--- a/news/2 Fixes/15566.md
+++ b/news/2 Fixes/15566.md
@@ -1,0 +1,1 @@
+Add `cached-property` package to bundled python packages. This is needed by `jedi-language-server` running on `python 3.6` and `python 3.7`.

--- a/requirements.in
+++ b/requirements.in
@@ -9,3 +9,4 @@ pygls; python_version >= '3.6'  # To make requirements.txt keep the marker to av
 jedi-language-server<0.22; python_version >= '3.6'  # To work with Jedi 0.17.
 # Sort Imports
 isort==5.7.0; python_version >= '3.6'
+cached-property>=1.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile --generate-hashes requirements.in
 #
+cached-property==1.5.2 \
+    --hash=sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130 \
+    --hash=sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0
+    # via -r requirements.in
 click==7.1.2 \
     --hash=sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a \
     --hash=sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc


### PR DESCRIPTION
Closes #15566