### PR TITLE
Restore the play button icon.

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,11 @@
             {
                 "command": "python.execInTerminal-icon",
                 "title": "%python.command.python.execInTerminal.title%",
-                "category": "Python"
+                "category": "Python",
+                "icon": {
+                    "light": "resources/light/run-file.svg",
+                    "dark": "resources/dark/run-file.svg"
+                }
             },
             {
                 "command": "python.setInterpreter",
@@ -396,7 +400,7 @@
                     "group": "Python"
                 }
             ],
-            "editor/title/run": [
+            "editor/title": [
                 {
                     "command": "python.execInTerminal-icon",
                     "title": "%python.command.python.execInTerminal.title%",

--- a/package.json
+++ b/package.json
@@ -400,7 +400,7 @@
                     "group": "Python"
                 }
             ],
-            "editor/title": [
+            "editor/title/run": [
                 {
                     "command": "python.execInTerminal-icon",
                     "title": "%python.command.python.execInTerminal.title%",

--- a/resources/dark/run-file.svg
+++ b/resources/dark/run-file.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 2.00005V13.82L13 7.88006L4 2.00005ZM5.5 4.82L10.3101 7.88006L5.5 11.0001V4.82Z" fill="#89D185"/>
+</svg>

--- a/resources/light/run-file.svg
+++ b/resources/light/run-file.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" 
+    xmlns="http://www.w3.org/2000/svg">
+    <path d="M4 2.00005V13.82L13 7.88006L4 2.00005ZM5.5 4.82L10.3101 7.88006L5.5 11.0001V4.82Z" fill="#388A34"/>
+</svg>


### PR DESCRIPTION
(fixes #15613)

In #15555 we moved the play button down into a submenu.  At that time we also removed the command's icon since it looked like VS Code always uses their own.  However, we found that is not the case.  This PR restores our original icon.