### PR TITLE
Updates to notebook API

### DIFF
--- a/news/2 Fixes/15638.md
+++ b/news/2 Fixes/15638.md
@@ -1,0 +1,1 @@
+Updates to Proposed API, and fix the failure in VS Code Insider tests.

--- a/src/client/common/application/notebook.ts
+++ b/src/client/common/application/notebook.ts
@@ -2,42 +2,13 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import { Disposable, DocumentSelector, Event, EventEmitter } from 'vscode';
-import type {
-    notebook,
-    NotebookCellMetadata,
-    NotebookCellsChangeEvent as VSCNotebookCellsChangeEvent,
-    NotebookConcatTextDocument,
-    NotebookContentProvider,
-    NotebookDocument,
-    NotebookDocumentFilter,
-    NotebookEditor,
-    NotebookKernel,
-    NotebookKernelProvider,
-    window,
-} from 'vscode-proposed';
+import { DocumentSelector, Event, EventEmitter } from 'vscode';
+import type { notebook, NotebookConcatTextDocument, NotebookDocument } from 'vscode-proposed';
 import { UseProposedApi } from '../constants';
-import { IDisposableRegistry } from '../types';
-import { IApplicationEnvironment, IVSCodeNotebook, NotebookCellChangedEvent } from './types';
+import { IApplicationEnvironment, IVSCodeNotebook } from './types';
 
 @injectable()
 export class VSCodeNotebook implements IVSCodeNotebook {
-    public get onDidChangeActiveNotebookKernel(): Event<{
-        document: NotebookDocument;
-        kernel: NotebookKernel | undefined;
-    }> {
-        return this.canUseNotebookApi
-            ? this.notebook.onDidChangeActiveNotebookKernel
-            : new EventEmitter<{
-                  document: NotebookDocument;
-                  kernel: NotebookKernel | undefined;
-              }>().event;
-    }
-    public get onDidChangeActiveNotebookEditor(): Event<NotebookEditor | undefined> {
-        return this.canUseNotebookApi
-            ? this.window.onDidChangeActiveNotebookEditor
-            : new EventEmitter<NotebookEditor | undefined>().event;
-    }
     public get onDidOpenNotebookDocument(): Event<NotebookDocument> {
         return this.canUseNotebookApi
             ? this.notebook.onDidOpenNotebookDocument
@@ -48,27 +19,8 @@ export class VSCodeNotebook implements IVSCodeNotebook {
             ? this.notebook.onDidCloseNotebookDocument
             : new EventEmitter<NotebookDocument>().event;
     }
-    public get onDidSaveNotebookDocument(): Event<NotebookDocument> {
-        return this.canUseNotebookApi
-            ? this.notebook.onDidSaveNotebookDocument
-            : new EventEmitter<NotebookDocument>().event;
-    }
     public get notebookDocuments(): ReadonlyArray<NotebookDocument> {
         return this.canUseNotebookApi ? this.notebook.notebookDocuments : [];
-    }
-    public get notebookEditors() {
-        return this.canUseNotebookApi ? this.window.visibleNotebookEditors : [];
-    }
-    public get onDidChangeNotebookDocument(): Event<NotebookCellChangedEvent> {
-        return this.canUseNotebookApi
-            ? this._onDidChangeNotebookDocument.event
-            : new EventEmitter<NotebookCellChangedEvent>().event;
-    }
-    public get activeNotebookEditor(): NotebookEditor | undefined {
-        if (!this.useProposedApi) {
-            return;
-        }
-        return this.window.activeNotebookEditor;
     }
     private get notebook() {
         if (!this._notebook) {
@@ -76,25 +28,13 @@ export class VSCodeNotebook implements IVSCodeNotebook {
         }
         return this._notebook!;
     }
-    private get window() {
-        if (!this._window) {
-            this._window = require('vscode').window;
-        }
-        return this._window!;
-    }
-    private readonly _onDidChangeNotebookDocument = new EventEmitter<NotebookCellChangedEvent>();
-    private addedEventHandlers?: boolean;
     private _notebook?: typeof notebook;
-    private _window?: typeof window;
     private readonly canUseNotebookApi?: boolean;
-    private readonly handledCellChanges = new WeakSet<VSCNotebookCellsChangeEvent>();
     constructor(
         @inject(UseProposedApi) private readonly useProposedApi: boolean,
-        @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
         @inject(IApplicationEnvironment) readonly env: IApplicationEnvironment,
     ) {
         if (this.useProposedApi) {
-            this.addEventHandlers();
             this.canUseNotebookApi = true;
         }
     }
@@ -103,50 +43,5 @@ export class VSCodeNotebook implements IVSCodeNotebook {
             return this.notebook.createConcatTextDocument(doc, selector) as any; // Types of Position are different for some reason. Fix this later.
         }
         throw new Error('createConcatDocument not supported');
-    }
-    public registerNotebookContentProvider(
-        notebookType: string,
-        provider: NotebookContentProvider,
-        options?: {
-            transientOutputs: boolean;
-            transientMetadata: { [K in keyof NotebookCellMetadata]?: boolean };
-        },
-    ): Disposable {
-        return this.notebook.registerNotebookContentProvider(notebookType, provider, options);
-    }
-    public registerNotebookKernelProvider(
-        selector: NotebookDocumentFilter,
-        provider: NotebookKernelProvider,
-    ): Disposable {
-        return this.notebook.registerNotebookKernelProvider(selector, provider);
-    }
-    private addEventHandlers() {
-        if (this.addedEventHandlers) {
-            return;
-        }
-        this.addedEventHandlers = true;
-        this.disposables.push(
-            ...[
-                this.notebook.onDidChangeCellLanguage((e) =>
-                    this._onDidChangeNotebookDocument.fire({ ...e, type: 'changeCellLanguage' }),
-                ),
-                this.notebook.onDidChangeCellMetadata((e) =>
-                    this._onDidChangeNotebookDocument.fire({ ...e, type: 'changeCellMetadata' }),
-                ),
-                this.notebook.onDidChangeNotebookDocumentMetadata((e) =>
-                    this._onDidChangeNotebookDocument.fire({ ...e, type: 'changeNotebookMetadata' }),
-                ),
-                this.notebook.onDidChangeCellOutputs((e) =>
-                    this._onDidChangeNotebookDocument.fire({ ...e, type: 'changeCellOutputs' }),
-                ),
-                this.notebook.onDidChangeNotebookCells((e) => {
-                    if (this.handledCellChanges.has(e)) {
-                        return;
-                    }
-                    this.handledCellChanges.add(e);
-                    this._onDidChangeNotebookDocument.fire({ ...e, type: 'changeCells' });
-                }),
-            ],
-        );
     }
 }

--- a/src/client/common/application/types.ts
+++ b/src/client/common/application/types.ts
@@ -59,21 +59,7 @@ import {
     WorkspaceFolderPickOptions,
     WorkspaceFoldersChangeEvent,
 } from 'vscode';
-import type {
-    NotebookCellLanguageChangeEvent as VSCNotebookCellLanguageChangeEvent,
-    NotebookCellMetadata,
-    NotebookCellMetadataChangeEvent as VSCNotebookCellMetadataChangeEvent,
-    NotebookCellOutputsChangeEvent as VSCNotebookCellOutputsChangeEvent,
-    NotebookCellsChangeEvent as VSCNotebookCellsChangeEvent,
-    NotebookConcatTextDocument,
-    NotebookContentProvider,
-    NotebookDocument,
-    NotebookDocumentFilter,
-    NotebookDocumentMetadataChangeEvent as VSCNotebookDocumentMetadataChangeEvent,
-    NotebookEditor,
-    NotebookKernel,
-    NotebookKernelProvider,
-} from 'vscode-proposed';
+import type { NotebookConcatTextDocument, NotebookDocument } from 'vscode-proposed';
 
 import { IAsyncDisposable, Resource } from '../types';
 
@@ -1520,52 +1506,10 @@ export interface IClipboard {
      */
     writeText(value: string): Promise<void>;
 }
-
-export type NotebookCellsChangeEvent = { type: 'changeCells' } & VSCNotebookCellsChangeEvent;
-export type NotebookCellOutputsChangeEvent = { type: 'changeCellOutputs' } & VSCNotebookCellOutputsChangeEvent;
-export type NotebookCellMetadataChangeEvent = { type: 'changeCellMetadata' } & VSCNotebookCellMetadataChangeEvent;
-export type NotebookCellLanguageChangeEvent = { type: 'changeCellLanguage' } & VSCNotebookCellLanguageChangeEvent;
-export type NotebookDocumentMetadataChangeEvent = {
-    type: 'changeNotebookMetadata';
-} & VSCNotebookDocumentMetadataChangeEvent;
-export type NotebookCellChangedEvent =
-    | NotebookCellsChangeEvent
-    | NotebookCellOutputsChangeEvent
-    | NotebookCellMetadataChangeEvent
-    | NotebookDocumentMetadataChangeEvent
-    | NotebookCellLanguageChangeEvent;
 export const IVSCodeNotebook = Symbol('IVSCodeNotebook');
 export interface IVSCodeNotebook {
-    readonly onDidChangeActiveNotebookKernel: Event<{
-        document: NotebookDocument;
-        kernel: NotebookKernel | undefined;
-    }>;
     readonly notebookDocuments: ReadonlyArray<NotebookDocument>;
     readonly onDidOpenNotebookDocument: Event<NotebookDocument>;
     readonly onDidCloseNotebookDocument: Event<NotebookDocument>;
-    readonly onDidSaveNotebookDocument: Event<NotebookDocument>;
-    readonly onDidChangeActiveNotebookEditor: Event<NotebookEditor | undefined>;
-    readonly onDidChangeNotebookDocument: Event<NotebookCellChangedEvent>;
-    readonly notebookEditors: Readonly<NotebookEditor[]>;
-    readonly activeNotebookEditor: NotebookEditor | undefined;
-    registerNotebookContentProvider(
-        notebookType: string,
-        provider: NotebookContentProvider,
-        options?: {
-            /**
-             * Controls if outputs change will trigger notebook document content change and if it will be used in the diff editor
-             * Default to false. If the content provider doesn't persisit the outputs in the file document, this should be set to true.
-             */
-            transientOutputs: boolean;
-            /**
-             * Controls if a meetadata property change will trigger notebook document content change and if it will be used in the diff editor
-             * Default to false. If the content provider doesn't persisit a metadata property in the file document, it should be set to true.
-             */
-            transientMetadata: { [K in keyof NotebookCellMetadata]?: boolean };
-        },
-    ): Disposable;
-
-    registerNotebookKernelProvider(selector: NotebookDocumentFilter, provider: NotebookKernelProvider): Disposable;
-
     createConcatTextDocument(notebook: NotebookDocument, selector?: DocumentSelector): NotebookConcatTextDocument;
 }

--- a/src/client/jupyter/languageserver/notebookConcatDocument.ts
+++ b/src/client/jupyter/languageserver/notebookConcatDocument.ts
@@ -48,13 +48,18 @@ export class NotebookConcatDocument implements TextDocument, IDisposable {
         // eslint-disable-next-line global-require
         const { NotebookCellKind } = require('vscode');
         // Return Python if we have python cells.
-        if (this.notebook.cells.some((item) => item.language.toLowerCase() === PYTHON_LANGUAGE.toLowerCase())) {
+        if (
+            this.notebook.cells.some(
+                (item) => (item.language || item.document.languageId).toLowerCase() === PYTHON_LANGUAGE.toLowerCase(),
+            )
+        ) {
             return PYTHON_LANGUAGE;
         }
         // Return the language of the first available cell, else assume its a Python notebook.
         // The latter is not possible, except for the case where we have all markdown cells,
         // in which case the language server will never kick in.
-        return this.notebook.cells.find((item) => item.cellKind === NotebookCellKind.Code)?.language || PYTHON_LANGUAGE;
+        const cell = this.notebook.cells.find((item) => (item.cellKind || item.cellKind) === NotebookCellKind.Code);
+        return cell?.language || cell?.document?.languageId || PYTHON_LANGUAGE;
     }
 
     public get version(): number {

--- a/src/client/jupyter/languageserver/notebookConcatDocument.ts
+++ b/src/client/jupyter/languageserver/notebookConcatDocument.ts
@@ -49,17 +49,20 @@ export class NotebookConcatDocument implements TextDocument, IDisposable {
         const { NotebookCellKind } = require('vscode');
         // Return Python if we have python cells.
         if (
-            this.notebook.cells.some(
-                (item) => (item.language || item.document.languageId).toLowerCase() === PYTHON_LANGUAGE.toLowerCase(),
-            )
+            this.notebook.cells.some((item) => item.document.languageId.toLowerCase() === PYTHON_LANGUAGE.toLowerCase())
         ) {
             return PYTHON_LANGUAGE;
         }
         // Return the language of the first available cell, else assume its a Python notebook.
         // The latter is not possible, except for the case where we have all markdown cells,
         // in which case the language server will never kick in.
-        const cell = this.notebook.cells.find((item) => (item.cellKind || item.cellKind) === NotebookCellKind.Code);
-        return cell?.language || cell?.document?.languageId || PYTHON_LANGUAGE;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (
+            this.notebook.cells.find(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (item) => ((item as any).cellKind || item.kind) === NotebookCellKind.Code,
+            )?.document?.languageId || PYTHON_LANGUAGE
+        );
     }
 
     public get version(): number {
@@ -138,7 +141,7 @@ export class NotebookConcatDocument implements TextDocument, IDisposable {
         const location = this.concatDocument.locationAt(position);
 
         // Get the cell at this location
-        const cell = this.notebook.cells.find((c) => c.uri.toString() === location.uri.toString());
+        const cell = this.notebook.cells.find((c) => c.document.uri.toString() === location.uri.toString());
         return cell!.document.lineAt(location.range.start);
     }
 
@@ -160,7 +163,7 @@ export class NotebookConcatDocument implements TextDocument, IDisposable {
         const location = this.concatDocument.locationAt(position);
 
         // Get the cell at this location
-        const cell = this.notebook.cells.find((c) => c.uri.toString() === location.uri.toString());
+        const cell = this.notebook.cells.find((c) => c.document.uri.toString() === location.uri.toString());
         return cell!.document.getWordRangeAtPosition(location.range.start, regexp);
     }
 
@@ -174,7 +177,7 @@ export class NotebookConcatDocument implements TextDocument, IDisposable {
 
     public getCellAtPosition(position: Position): NotebookCell | undefined {
         const location = this.concatDocument.locationAt(position);
-        return this.notebook.cells.find((c) => c.uri === location.uri);
+        return this.notebook.cells.find((c) => c.document.uri === location.uri);
     }
 
     private updateCellTracking() {
@@ -185,7 +188,7 @@ export class NotebookConcatDocument implements TextDocument, IDisposable {
             const lines = cellText.splitLines({ trim: false });
 
             this.cellTracking.push({
-                uri: c.uri,
+                uri: c.document.uri,
                 length: cellText.length + 1, // \n is included concat length
                 lineCount: lines.length,
             });
@@ -194,7 +197,7 @@ export class NotebookConcatDocument implements TextDocument, IDisposable {
 
     private onDidChange() {
         this._version += 1;
-        const newUris = this.notebook.cells.map((c) => c.uri.toString());
+        const newUris = this.notebook.cells.map((c) => c.document.uri.toString());
         const oldUris = this.cellTracking.map((c) => c.uri.toString());
 
         // See if number of cells or cell positions changed
@@ -215,7 +218,7 @@ export class NotebookConcatDocument implements TextDocument, IDisposable {
     public getEndPosition(): Position {
         if (this.notebook.cells.length > 0) {
             const finalCell = this.notebook.cells[this.notebook.cells.length - 1];
-            const start = this.getPositionOfCell(finalCell.uri);
+            const start = this.getPositionOfCell(finalCell.document.uri);
             const lines = finalCell.document.getText().splitLines({ trim: false });
             return new Position(start.line + lines.length, 0);
         }
@@ -224,13 +227,13 @@ export class NotebookConcatDocument implements TextDocument, IDisposable {
 
     private raiseCellInsertions(oldUris: string[]) {
         // One or more cells were added. Add a change event for each
-        const insertions = this.notebook.cells.filter((c) => !oldUris.includes(c.uri.toString()));
+        const insertions = this.notebook.cells.filter((c) => !oldUris.includes(c.document.uri.toString()));
 
         const changes = insertions.map((insertion) => {
             // Figure out the position of the item. This is where we're inserting the cell
             // Note: The first insertion will line up with the old cell at this position
             // The second or other insertions will line up with their new positions.
-            const position = this.getPositionOfCell(insertion.uri);
+            const position = this.getPositionOfCell(insertion.document.uri);
 
             // Text should be the contents of the new cell plus the '\n'
             const text = `${insertion.document.getText()}\n`;
@@ -261,7 +264,7 @@ export class NotebookConcatDocument implements TextDocument, IDisposable {
         const changes = oldIndexes.map((index) => {
             // Figure out the position of the item in the new list
             const position =
-                index < newUris.length ? this.getPositionOfCell(this.notebook.cells[index].uri) : this.getEndPosition();
+                index < newUris.length ? this.getPositionOfCell(this.notebook.cells[index].document.uri) : this.getEndPosition();
 
             // Length should be old length
             const { length } = this.cellTracking[index];

--- a/src/client/jupyter/languageserver/notebookConcatDocument.ts
+++ b/src/client/jupyter/languageserver/notebookConcatDocument.ts
@@ -264,7 +264,9 @@ export class NotebookConcatDocument implements TextDocument, IDisposable {
         const changes = oldIndexes.map((index) => {
             // Figure out the position of the item in the new list
             const position =
-                index < newUris.length ? this.getPositionOfCell(this.notebook.cells[index].document.uri) : this.getEndPosition();
+                index < newUris.length
+                    ? this.getPositionOfCell(this.notebook.cells[index].document.uri)
+                    : this.getEndPosition();
 
             // Length should be old length
             const { length } = this.cellTracking[index];

--- a/src/client/jupyter/languageserver/notebookConverter.ts
+++ b/src/client/jupyter/languageserver/notebookConverter.ts
@@ -127,7 +127,7 @@ export class NotebookConverter implements Disposable {
             // Diagnostics are supposed to be per file and are updated each time
             // Make sure to clear out old ones first
             wrapper.notebook.cells.forEach((c: NotebookCell) => {
-                result.set(c.uri, []);
+                result.set(c.document.uri, []);
             });
 
             // Then for all the new ones, set their values.

--- a/src/test/insiders/languageServer.insiders.test.ts
+++ b/src/test/insiders/languageServer.insiders.test.ts
@@ -90,7 +90,7 @@ suite('Insiders Test: Language Server', () => {
         for (let i = 0; i < 5; i += 1) {
             const locations = await vscode.commands.executeCommand<vscode.Location[]>(
                 'vscode.executeDefinitionProvider',
-                notebookDocument.cells[2].uri, // Second cell should have a function with the decorator on it
+                notebookDocument.cells[2].document.uri, // Second cell should have a function with the decorator on it
                 startPosition,
             );
             if (locations && locations.length > 0) {

--- a/src/test/smoke/common.ts
+++ b/src/test/smoke/common.ts
@@ -61,7 +61,7 @@ export async function openNotebookAndWaitForLS(file: string): Promise<vscode.Not
     // to fetch data for completion, hover.etc.
     await vscode.commands.executeCommand(
         'vscode.executeCompletionItemProvider',
-        notebook.document.cells[0].uri,
+        notebook.document.cells[0].document.uri,
         new vscode.Position(0, 0),
     );
     // For for LS to get extracted.

--- a/src/test/tensorBoard/nbextensionCodeLensProvider.insiders.test.ts
+++ b/src/test/tensorBoard/nbextensionCodeLensProvider.insiders.test.ts
@@ -77,7 +77,7 @@ suite('TensorBoard code lens provider', () => {
             assert(window.activeTextEditor, 'No active editor');
             const codeLenses = await commands.executeCommand<CodeLens[]>(
                 'vscode.executeCodeLensProvider',
-                notebook.document.cells[0].uri,
+                notebook.document.cells[0].document.uri,
             );
             assert.ok(codeLenses?.length && codeLenses.length > 0, 'Code lens provider did not provide codelenses');
         });
@@ -134,7 +134,7 @@ suite('TensorBoard code lens provider', () => {
             assert(window.activeTextEditor, 'No active editor');
             const codeLenses = await commands.executeCommand<CodeLens[]>(
                 'vscode.executeCodeLensProvider',
-                notebook.document.cells[0].uri,
+                notebook.document.cells[0].document.uri,
             );
             assert.ok(codeLenses?.length && codeLenses.length > 0, 'Code lens provider did not provide codelenses');
         });

--- a/types/vscode-proposed/index.d.ts
+++ b/types/vscode-proposed/index.d.ts
@@ -314,15 +314,6 @@ import {
         readonly cells: NotebookCell[];
     }
 
-    export interface NotebookCellLanguageChangeEvent {
-        /**
-         * The affected document.
-         */
-        readonly document: NotebookDocument;
-        readonly cell: NotebookCell;
-        readonly language: string;
-    }
-
     export interface NotebookCellMetadataChangeEvent {
         readonly document: NotebookDocument;
         readonly cell: NotebookCell;
@@ -422,10 +413,6 @@ import {
         export const onDidChangeNotebookDocumentMetadata: Event<NotebookDocumentMetadataChangeEvent>;
         export const onDidChangeNotebookCells: Event<NotebookCellsChangeEvent>;
         export const onDidChangeCellOutputs: Event<NotebookCellOutputsChangeEvent>;
-
-        // todo@API we send document close and open events when the language of a document changes and
-        // I believe we should stick that for cells as well
-        export const onDidChangeCellLanguage: Event<NotebookCellLanguageChangeEvent>;
         export const onDidChangeCellMetadata: Event<NotebookCellMetadataChangeEvent>;
     }
 
@@ -841,7 +828,6 @@ import {
     }
 
     //#endregion
-
 // #region debug
 
 /**

--- a/types/vscode-proposed/index.d.ts
+++ b/types/vscode-proposed/index.d.ts
@@ -22,813 +22,817 @@ import {
     ThemableDecorationAttachmentRenderOptions,
 } from 'vscode';
 
-    //#region https://github.com/microsoft/vscode/issues/106744, Notebooks (misc)
+//#region https://github.com/microsoft/vscode/issues/106744, Notebooks (misc)
 
-    export enum NotebookCellKind {
-        Markdown = 1,
-        Code = 2
-    }
+export enum NotebookCellKind {
+    Markdown = 1,
+    Code = 2,
+}
 
-    export enum NotebookCellRunState {
-        Running = 1,
-        Idle = 2,
-        Success = 3,
-        Error = 4
-    }
+export enum NotebookCellRunState {
+    Running = 1,
+    Idle = 2,
+    Success = 3,
+    Error = 4,
+}
 
-    export enum NotebookRunState {
-        Running = 1,
-        Idle = 2
-    }
+export enum NotebookRunState {
+    Running = 1,
+    Idle = 2,
+}
 
-    export class NotebookCellMetadata {
-        /**
-         * Controls whether a cell's editor is editable/readonly.
-         */
-        readonly editable?: boolean;
-        /**
-         * Controls if the cell has a margin to support the breakpoint UI.
-         * This metadata is ignored for markdown cell.
-         */
-        readonly breakpointMargin?: boolean;
-        /**
-         * Whether a code cell's editor is collapsed
-         */
-        readonly outputCollapsed?: boolean;
-        /**
-         * Whether a code cell's outputs are collapsed
-         */
-        readonly inputCollapsed?: boolean;
-        /**
-         * Additional attributes of a cell metadata.
-         */
-        readonly custom?: Record<string, any>;
+export class NotebookCellMetadata {
+    /**
+     * Controls whether a cell's editor is editable/readonly.
+     */
+    readonly editable?: boolean;
+    /**
+     * Controls if the cell has a margin to support the breakpoint UI.
+     * This metadata is ignored for markdown cell.
+     */
+    readonly breakpointMargin?: boolean;
+    /**
+     * Whether a code cell's editor is collapsed
+     */
+    readonly outputCollapsed?: boolean;
+    /**
+     * Whether a code cell's outputs are collapsed
+     */
+    readonly inputCollapsed?: boolean;
+    /**
+     * Additional attributes of a cell metadata.
+     */
+    readonly custom?: Record<string, any>;
 
-        // todo@API duplicates status bar API
-        readonly statusMessage?: string;
+    // todo@API duplicates status bar API
+    readonly statusMessage?: string;
 
-        // run related API, will be removed
-        readonly runnable?: boolean;
-        readonly hasExecutionOrder?: boolean;
-        readonly executionOrder?: number;
-        readonly runState?: NotebookCellRunState;
-        readonly runStartTime?: number;
-        readonly lastRunDuration?: number;
+    // run related API, will be removed
+    readonly hasExecutionOrder?: boolean;
+    readonly executionOrder?: number;
+    readonly runState?: NotebookCellRunState;
+    readonly runStartTime?: number;
+    readonly lastRunDuration?: number;
 
-        constructor(
-            editable?: boolean,
-            breakpointMargin?: boolean,
-            runnable?: boolean,
-            hasExecutionOrder?: boolean,
-            executionOrder?: number,
-            runState?: NotebookCellRunState,
-            runStartTime?: number,
-            statusMessage?: string,
-            lastRunDuration?: number,
-            inputCollapsed?: boolean,
-            outputCollapsed?: boolean,
-            custom?: Record<string, any>
-        );
+    constructor(
+        editable?: boolean,
+        breakpointMargin?: boolean,
+        hasExecutionOrder?: boolean,
+        executionOrder?: number,
+        runState?: NotebookCellRunState,
+        runStartTime?: number,
+        statusMessage?: string,
+        lastRunDuration?: number,
+        inputCollapsed?: boolean,
+        outputCollapsed?: boolean,
+        custom?: Record<string, any>,
+    );
 
-        with(change: {
-            editable?: boolean | null;
-            breakpointMargin?: boolean | null;
-            runnable?: boolean | null;
-            hasExecutionOrder?: boolean | null;
-            executionOrder?: number | null;
-            runState?: NotebookCellRunState | null;
-            runStartTime?: number | null;
-            statusMessage?: string | null;
-            lastRunDuration?: number | null;
-            inputCollapsed?: boolean | null;
-            outputCollapsed?: boolean | null;
-            custom?: Record<string, any> | null;
-        }): NotebookCellMetadata;
-    }
+    with(change: {
+        editable?: boolean | null;
+        breakpointMargin?: boolean | null;
+        hasExecutionOrder?: boolean | null;
+        executionOrder?: number | null;
+        runState?: NotebookCellRunState | null;
+        runStartTime?: number | null;
+        statusMessage?: string | null;
+        lastRunDuration?: number | null;
+        inputCollapsed?: boolean | null;
+        outputCollapsed?: boolean | null;
+        custom?: Record<string, any> | null;
+    }): NotebookCellMetadata;
+}
 
-    // todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
-    export interface NotebookCell {
-        readonly index: number;
-        readonly notebook: NotebookDocument;
-        readonly cellKind: NotebookCellKind;
-        // todo@API duplicates #document.uri
-        readonly uri: Uri;
-        // todo@API duplicates #document.languageId
-        readonly language: string;
-        readonly document: TextDocument;
-        readonly outputs: readonly NotebookCellOutput[];
-        readonly metadata: NotebookCellMetadata;
-    }
+// todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
+export interface NotebookCell {
+    readonly index: number;
+    readonly notebook: NotebookDocument;
+    readonly kind: NotebookCellKind;
+    readonly document: TextDocument;
+    readonly metadata: NotebookCellMetadata;
+    readonly outputs: ReadonlyArray<NotebookCellOutput>;
+}
 
-    export class NotebookDocumentMetadata {
-        /**
-         * Controls if users can add or delete cells
-         * Defaults to true
-         */
-        readonly editable: boolean;
-        /**
-         * Default value for [cell editable metadata](#NotebookCellMetadata.editable).
-         * Defaults to true.
-         */
-        readonly cellEditable: boolean;
-        /**
-         * Additional attributes of the document metadata.
-         */
-        readonly custom: { [key: string]: any };
-        /**
-         * Whether the document is trusted, default to true
-         * When false, insecure outputs like HTML, JavaScript, SVG will not be rendered.
-         */
-        readonly trusted: boolean;
+export class NotebookDocumentMetadata {
+    /**
+     * Controls if users can add or delete cells
+     * Defaults to true
+     */
+    readonly editable: boolean;
+    /**
+     * Default value for [cell editable metadata](#NotebookCellMetadata.editable).
+     * Defaults to true.
+     */
+    readonly cellEditable: boolean;
+    /**
+     * Additional attributes of the document metadata.
+     */
+    readonly custom: { [key: string]: any };
+    /**
+     * Whether the document is trusted, default to true
+     * When false, insecure outputs like HTML, JavaScript, SVG will not be rendered.
+     */
+    readonly trusted: boolean;
 
-        // todo@API is this a kernel property?
-        readonly cellHasExecutionOrder: boolean;
+    // todo@API is this a kernel property?
+    readonly cellHasExecutionOrder: boolean;
 
-        // run related, remove infer from kernel, exec
-        // todo@API infer from kernel
-        // todo@API remove
-        readonly runnable: boolean;
-        readonly cellRunnable: boolean;
-        readonly runState: NotebookRunState;
+    // todo@API remove
+    readonly runState: NotebookRunState;
 
-        constructor(
-            editable?: boolean,
-            runnable?: boolean,
-            cellEditable?: boolean,
-            cellRunnable?: boolean,
-            cellHasExecutionOrder?: boolean,
-            custom?: { [key: string]: any },
-            runState?: NotebookRunState,
-            trusted?: boolean
-        );
+    constructor(
+        editable?: boolean,
+        cellEditable?: boolean,
+        cellHasExecutionOrder?: boolean,
+        custom?: { [key: string]: any },
+        runState?: NotebookRunState,
+        trusted?: boolean,
+    );
 
-        with(change: {
-            editable?: boolean | null;
-            runnable?: boolean | null;
-            cellEditable?: boolean | null;
-            cellRunnable?: boolean | null;
-            cellHasExecutionOrder?: boolean | null;
-            custom?: { [key: string]: any } | null;
-            runState?: NotebookRunState | null;
-            trusted?: boolean | null;
-        }): NotebookDocumentMetadata;
-    }
+    with(change: {
+        editable?: boolean | null;
+        cellEditable?: boolean | null;
+        cellHasExecutionOrder?: boolean | null;
+        custom?: { [key: string]: any } | null;
+        runState?: NotebookRunState | null;
+        trusted?: boolean | null;
+    }): NotebookDocumentMetadata;
+}
 
-    export interface NotebookDocumentContentOptions {
-        /**
-         * Controls if outputs change will trigger notebook document content change and if it will be used in the diff editor
-         * Default to false. If the content provider doesn't persisit the outputs in the file document, this should be set to true.
-         */
-        transientOutputs: boolean;
-
-        /**
-         * Controls if a meetadata property change will trigger notebook document content change and if it will be used in the diff editor
-         * Default to false. If the content provider doesn't persisit a metadata property in the file document, it should be set to true.
-         */
-        transientMetadata: { [K in keyof NotebookCellMetadata]?: boolean };
-    }
-
-    export interface NotebookDocument {
-        readonly uri: Uri;
-        readonly version: number;
-        // todo@API don't have this...
-        readonly fileName: string;
-        // todo@API should we really expose this?
-        readonly viewType: string;
-        readonly isDirty: boolean;
-        readonly isUntitled: boolean;
-        readonly cells: ReadonlyArray<NotebookCell>;
-        readonly contentOptions: NotebookDocumentContentOptions;
-        readonly metadata: NotebookDocumentMetadata;
-
-        /**
-         * Save the document. The saving will be handled by the corresponding content provider
-         *
-         * @return A promise that will resolve to true when the document
-         * has been saved. If the file was not dirty or the save failed,
-         * will return false.
-         */
-        save(): Thenable<boolean>;
-    }
-
-    // todo@API maybe have a NotebookCellPosition sibling
-    export class NotebookCellRange {
-        readonly start: number;
-        /**
-         * exclusive
-         */
-        readonly end: number;
-
-        constructor(start: number, end: number);
-    }
-
-    export enum NotebookEditorRevealType {
-        /**
-         * The range will be revealed with as little scrolling as possible.
-         */
-        Default = 0,
-        /**
-         * The range will always be revealed in the center of the viewport.
-         */
-        InCenter = 1,
-
-        /**
-         * If the range is outside the viewport, it will be revealed in the center of the viewport.
-         * Otherwise, it will be revealed with as little scrolling as possible.
-         */
-        InCenterIfOutsideViewport = 2,
-
-        /**
-         * The range will always be revealed at the top of the viewport.
-         */
-        AtTop = 3
-    }
-
-    export interface NotebookEditor {
-        /**
-         * The document associated with this notebook editor.
-         */
-        readonly document: NotebookDocument;
-
-        /**
-         * The primary selected cell on this notebook editor.
-         */
-        // todo@API should not be undefined, rather a default
-        readonly selection?: NotebookCell;
-
-        /**
-         * todo@API should replace selection
-         * The selections on this notebook editor.
-         *
-         * The primary selection (or focused range) is `selections[0]`. When the document has no cells, the primary selection is empty `{ start: 0, end: 0 }`;
-         */
-        readonly selections: NotebookCellRange[];
-
-        /**
-         * The current visible ranges in the editor (vertically).
-         */
-        readonly visibleRanges: NotebookCellRange[];
-
-        revealRange(range: NotebookCellRange, revealType?: NotebookEditorRevealType): void;
-
-        /**
-         * The column in which this editor shows.
-         */
-        // @jrieken
-        // todo@API maybe never undefined because notebooks always show in the editor area (unlike text editors)
-        // maybe for notebook diff editor
-        readonly viewColumn?: ViewColumn;
-
-        /**
-         * Fired when the panel is disposed.
-         */
-        // @rebornix REMOVE/REplace NotebookCommunication
-        // todo@API fishy? notebooks are public objects, there should be a "global" events for this
-        readonly onDidDispose: Event<void>;
-    }
-
-    export interface NotebookDocumentMetadataChangeEvent {
-        readonly document: NotebookDocument;
-    }
-
-    export interface NotebookCellsChangeData {
-        readonly start: number;
-        readonly deletedCount: number;
-        readonly deletedItems: NotebookCell[];
-        readonly items: NotebookCell[];
-    }
-
-    export interface NotebookCellsChangeEvent {
-        /**
-         * The affected document.
-         */
-        readonly document: NotebookDocument;
-        readonly changes: ReadonlyArray<NotebookCellsChangeData>;
-    }
-
-    export interface NotebookCellOutputsChangeEvent {
-        /**
-         * The affected document.
-         */
-        readonly document: NotebookDocument;
-        readonly cells: NotebookCell[];
-    }
-
-    export interface NotebookCellMetadataChangeEvent {
-        readonly document: NotebookDocument;
-        readonly cell: NotebookCell;
-    }
-
-    export interface NotebookEditorSelectionChangeEvent {
-        readonly notebookEditor: NotebookEditor;
-        readonly selections: ReadonlyArray<NotebookCellRange>;
-    }
-
-    export interface NotebookEditorVisibleRangesChangeEvent {
-        readonly notebookEditor: NotebookEditor;
-        readonly visibleRanges: ReadonlyArray<NotebookCellRange>;
-    }
-
-    // todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
-    export class NotebookCellData {
-        kind: NotebookCellKind;
-        // todo@API better names: value? text?
-        source: string;
-        // todo@API how does language and MD relate?
-        language: string;
-        outputs?: NotebookCellOutput[];
-        metadata?: NotebookCellMetadata;
-        constructor(
-            kind: NotebookCellKind,
-            source: string,
-            language: string,
-            outputs?: NotebookCellOutput[],
-            metadata?: NotebookCellMetadata
-        );
-    }
-
-    export class NotebookData {
-        cells: NotebookCellData[];
-        metadata?: NotebookDocumentMetadata;
-        constructor(cells: NotebookCellData[], metadata?: NotebookDocumentMetadata);
-    }
+export interface NotebookDocumentContentOptions {
+    /**
+     * Controls if outputs change will trigger notebook document content change and if it will be used in the diff editor
+     * Default to false. If the content provider doesn't persisit the outputs in the file document, this should be set to true.
+     */
+    transientOutputs: boolean;
 
     /**
-     * Communication object passed to the {@link NotebookContentProvider} and
-     * {@link NotebookOutputRenderer} to communicate with the webview.
+     * Controls if a meetadata property change will trigger notebook document content change and if it will be used in the diff editor
+     * Default to false. If the content provider doesn't persisit a metadata property in the file document, it should be set to true.
      */
-    export interface NotebookCommunication {
-        /**
-         * ID of the editor this object communicates with. A single notebook
-         * document can have multiple attached webviews and editors, when the
-         * notebook is split for instance. The editor ID lets you differentiate
-         * between them.
-         */
-        readonly editorId: string;
+    transientMetadata: { [K in keyof NotebookCellMetadata]?: boolean };
+}
 
-        /**
-         * Fired when the output hosting webview posts a message.
-         */
-        readonly onDidReceiveMessage: Event<any>;
-        /**
-         * Post a message to the output hosting webview.
-         *
-         * Messages are only delivered if the editor is live.
-         *
-         * @param message Body of the message. This must be a string or other json serializable object.
-         */
-        postMessage(message: any): Thenable<boolean>;
+export interface NotebookDocument {
+    readonly uri: Uri;
+    readonly version: number;
 
-        /**
-         * Convert a uri for the local file system to one that can be used inside outputs webview.
-         */
-        asWebviewUri(localResource: Uri): Uri;
+    // todo@API don't have this...
+    readonly fileName: string;
 
-        // @rebornix
-        // readonly onDidDispose: Event<void>;
-    }
+    readonly isDirty: boolean;
+    readonly isUntitled: boolean;
+    readonly cells: ReadonlyArray<NotebookCell>;
 
-    // export function registerNotebookKernel(selector: string, kernel: NotebookKernel): Disposable;
+    readonly metadata: NotebookDocumentMetadata;
 
-    export interface NotebookDocumentShowOptions {
-        viewColumn?: ViewColumn;
-        preserveFocus?: boolean;
-        preview?: boolean;
-        selection?: NotebookCellRange;
-    }
+    // todo@API should we really expose this?
+    readonly viewType: string;
 
-    export namespace notebook {
-        // todo@API should we really support to pass the viewType? We do NOT support
-        // to open the same file with different viewTypes at the same time
-        export function openNotebookDocument(uri: Uri, viewType?: string): Thenable<NotebookDocument>;
-        export const onDidOpenNotebookDocument: Event<NotebookDocument>;
-        export const onDidCloseNotebookDocument: Event<NotebookDocument>;
+    /**
+     * Save the document. The saving will be handled by the corresponding content provider
+     *
+     * @return A promise that will resolve to true when the document
+     * has been saved. If the file was not dirty or the save failed,
+     * will return false.
+     */
+    save(): Thenable<boolean>;
+}
 
-        export const onDidSaveNotebookDocument: Event<NotebookDocument>;
+// todo@API maybe have a NotebookCellPosition sibling
+export class NotebookCellRange {
+    readonly start: number;
+    /**
+     * exclusive
+     */
+    readonly end: number;
 
-        /**
-         * All currently known notebook documents.
-         */
-        export const notebookDocuments: ReadonlyArray<NotebookDocument>;
-        export const onDidChangeNotebookDocumentMetadata: Event<NotebookDocumentMetadataChangeEvent>;
-        export const onDidChangeNotebookCells: Event<NotebookCellsChangeEvent>;
-        export const onDidChangeCellOutputs: Event<NotebookCellOutputsChangeEvent>;
-        export const onDidChangeCellMetadata: Event<NotebookCellMetadataChangeEvent>;
-    }
+    isEmpty: boolean;
 
-    export namespace window {
-        export const visibleNotebookEditors: NotebookEditor[];
-        export const onDidChangeVisibleNotebookEditors: Event<NotebookEditor[]>;
-        export const activeNotebookEditor: NotebookEditor | undefined;
-        export const onDidChangeActiveNotebookEditor: Event<NotebookEditor | undefined>;
-        export const onDidChangeNotebookEditorSelection: Event<NotebookEditorSelectionChangeEvent>;
-        export const onDidChangeNotebookEditorVisibleRanges: Event<NotebookEditorVisibleRangesChangeEvent>;
+    constructor(start: number, end: number);
+}
 
-        export function showNotebookDocument(uri: Uri, options?: NotebookDocumentShowOptions): Thenable<NotebookEditor>;
-        export function showNotebookDocument(
-            document: NotebookDocument,
-            options?: NotebookDocumentShowOptions
-        ): Thenable<NotebookEditor>;
-    }
+export enum NotebookEditorRevealType {
+    /**
+     * The range will be revealed with as little scrolling as possible.
+     */
+    Default = 0,
+    /**
+     * The range will always be revealed in the center of the viewport.
+     */
+    InCenter = 1,
 
-    //#endregion
+    /**
+     * If the range is outside the viewport, it will be revealed in the center of the viewport.
+     * Otherwise, it will be revealed with as little scrolling as possible.
+     */
+    InCenterIfOutsideViewport = 2,
 
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookCellOutput
+    /**
+     * The range will always be revealed at the top of the viewport.
+     */
+    AtTop = 3,
+}
 
-    // code specific mime types
-    // application/x.notebook.error-traceback
-    // application/x.notebook.stream
-    export class NotebookCellOutputItem {
-        // todo@API
-        // add factory functions for common mime types
-        // static textplain(value:string): NotebookCellOutputItem;
-        // static errortrace(value:any): NotebookCellOutputItem;
+export interface NotebookEditor {
+    /**
+     * The document associated with this notebook editor.
+     */
+    readonly document: NotebookDocument;
 
-        readonly mime: string;
-        readonly value: unknown;
-        readonly metadata?: Record<string, any>;
+    /**
+     * The primary selected cell on this notebook editor.
+     */
+    // todo@API should not be undefined, rather a default
+    readonly selection?: NotebookCell;
 
-        constructor(mime: string, value: unknown, metadata?: Record<string, any>);
-    }
+    /**
+     * todo@API should replace selection
+     * The selections on this notebook editor.
+     *
+     * The primary selection (or focused range) is `selections[0]`. When the document has no cells, the primary selection is empty `{ start: 0, end: 0 }`;
+     */
+    readonly selections: NotebookCellRange[];
 
+    /**
+     * The current visible ranges in the editor (vertically).
+     */
+    readonly visibleRanges: NotebookCellRange[];
+
+    revealRange(range: NotebookCellRange, revealType?: NotebookEditorRevealType): void;
+
+    /**
+     * The column in which this editor shows.
+     */
     // @jrieken
-    // todo@API think about readonly...
-    //TODO@API add execution count to cell output?
-    export class NotebookCellOutput {
-        readonly id: string;
-        readonly outputs: NotebookCellOutputItem[];
-        readonly metadata?: Record<string, any>;
-
-        constructor(outputs: NotebookCellOutputItem[], metadata?: Record<string, any>);
-
-        constructor(outputs: NotebookCellOutputItem[], id: string, metadata?: Record<string, any>);
-    }
-
-    //#endregion
-
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorEdit
-
-    export interface WorkspaceEdit {
-        replaceNotebookMetadata(uri: Uri, value: NotebookDocumentMetadata): void;
-
-        // todo@API use NotebookCellRange
-        replaceNotebookCells(
-            uri: Uri,
-            start: number,
-            end: number,
-            cells: NotebookCellData[],
-            metadata?: WorkspaceEditEntryMetadata
-        ): void;
-        replaceNotebookCellMetadata(
-            uri: Uri,
-            index: number,
-            cellMetadata: NotebookCellMetadata,
-            metadata?: WorkspaceEditEntryMetadata
-        ): void;
-
-        replaceNotebookCellOutput(
-            uri: Uri,
-            index: number,
-            outputs: NotebookCellOutput[],
-            metadata?: WorkspaceEditEntryMetadata
-        ): void;
-        appendNotebookCellOutput(
-            uri: Uri,
-            index: number,
-            outputs: NotebookCellOutput[],
-            metadata?: WorkspaceEditEntryMetadata
-        ): void;
-
-        // TODO@api
-        // https://jupyter-protocol.readthedocs.io/en/latest/messaging.html#update-display-data
-        replaceNotebookCellOutputItems(
-            uri: Uri,
-            index: number,
-            outputId: string,
-            items: NotebookCellOutputItem[],
-            metadata?: WorkspaceEditEntryMetadata
-        ): void;
-        appendNotebookCellOutputItems(
-            uri: Uri,
-            index: number,
-            outputId: string,
-            items: NotebookCellOutputItem[],
-            metadata?: WorkspaceEditEntryMetadata
-        ): void;
-    }
-
-    export interface NotebookEditorEdit {
-        replaceMetadata(value: NotebookDocumentMetadata): void;
-        replaceCells(start: number, end: number, cells: NotebookCellData[]): void;
-        replaceCellOutput(index: number, outputs: NotebookCellOutput[]): void;
-        replaceCellMetadata(index: number, metadata: NotebookCellMetadata): void;
-    }
-
-    export interface NotebookEditor {
-        /**
-         * Perform an edit on the notebook associated with this notebook editor.
-         *
-         * The given callback-function is invoked with an [edit-builder](#NotebookEditorEdit) which must
-         * be used to make edits. Note that the edit-builder is only valid while the
-         * callback executes.
-         *
-         * @param callback A function which can create edits using an [edit-builder](#NotebookEditorEdit).
-         * @return A promise that resolves with a value indicating if the edits could be applied.
-         */
-        // @jrieken REMOVE maybe
-        edit(callback: (editBuilder: NotebookEditorEdit) => void): Thenable<boolean>;
-    }
-
-    //#endregion
-
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookContentProvider
-
-    interface NotebookDocumentBackup {
-        /**
-         * Unique identifier for the backup.
-         *
-         * This id is passed back to your extension in `openNotebook` when opening a notebook editor from a backup.
-         */
-        readonly id: string;
-
-        /**
-         * Delete the current backup.
-         *
-         * This is called by VS Code when it is clear the current backup is no longer needed, such as when a new backup
-         * is made or when the file is saved.
-         */
-        delete(): void;
-    }
-
-    interface NotebookDocumentBackupContext {
-        readonly destination: Uri;
-    }
-
-    interface NotebookDocumentOpenContext {
-        readonly backupId?: string;
-    }
-
-    export interface NotebookContentProvider {
-        readonly options?: NotebookDocumentContentOptions;
-        readonly onDidChangeNotebookContentOptions?: Event<NotebookDocumentContentOptions>;
-        /**
-         * Content providers should always use [file system providers](#FileSystemProvider) to
-         * resolve the raw content for `uri` as the resouce is not necessarily a file on disk.
-         */
-        openNotebook(uri: Uri, openContext: NotebookDocumentOpenContext): NotebookData | Thenable<NotebookData>;
-        resolveNotebook(document: NotebookDocument, webview: NotebookCommunication): Thenable<void>;
-        saveNotebook(document: NotebookDocument, cancellation: CancellationToken): Thenable<void>;
-        saveNotebookAs(
-            targetResource: Uri,
-            document: NotebookDocument,
-            cancellation: CancellationToken
-        ): Thenable<void>;
-        backupNotebook(
-            document: NotebookDocument,
-            context: NotebookDocumentBackupContext,
-            cancellation: CancellationToken
-        ): Thenable<NotebookDocumentBackup>;
-
-        // ???
-        // provideKernels(document: NotebookDocument, token: CancellationToken): ProviderResult<T[]>;
-    }
-
-    export namespace notebook {
-        // TODO@api use NotebookDocumentFilter instead of just notebookType:string?
-        // TODO@API options duplicates the more powerful variant on NotebookContentProvider
-        export function registerNotebookContentProvider(
-            notebookType: string,
-            provider: NotebookContentProvider,
-            options?: NotebookDocumentContentOptions & {
-                /**
-                 * Not ready for production or development use yet.
-                 */
-                viewOptions?: {
-                    displayName: string;
-                    filenamePattern: NotebookFilenamePattern[];
-                    exclusive?: boolean;
-                };
-            }
-        ): Disposable;
-    }
-
-    //#endregion
-
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookKernel
-
-    // todo@API use the NotebookCellExecution-object as a container to model and enforce
-    // the flow of a cell execution
-
-    // kernel -> execute_info
-    // ext -> createNotebookCellExecution(cell)
-    // kernel -> done
-    // exec.dispose();
-
-    // export interface NotebookCellExecution {
-    // 	dispose(): void;
-    // 	clearOutput(): void;
-    // 	appendOutput(out: NotebookCellOutput): void;
-    // 	replaceOutput(out: NotebookCellOutput): void;
-    //  appendOutputItems(output:string, items: NotebookCellOutputItem[]):void;
-    //  replaceOutputItems(output:string, items: NotebookCellOutputItem[]):void;
-    // }
-
-    // export function createNotebookCellExecution(cell: NotebookCell, startTime?: number): NotebookCellExecution;
-    // export const onDidStartNotebookCellExecution: Event<any>;
-    // export const onDidStopNotebookCellExecution: Event<any>;
-
-    export interface NotebookKernel {
-        // todo@API make this mandatory?
-        readonly id?: string;
-
-        label: string;
-        description?: string;
-        detail?: string;
-        isPreferred?: boolean;
-
-        // todo@API is this maybe an output property?
-        preloads?: Uri[];
-
-        /**
-         * languages supported by kernel
-         * - first is preferred
-         * - `undefined` means all languages available in the editor
-         */
-        supportedLanguages?: string[];
-
-        // todo@API kernel updating itself
-        // fired when properties like the supported languages etc change
-        // onDidChangeProperties?: Event<void>
-
-        // @roblourens
-        // todo@API change to `executeCells(document: NotebookDocument, cells: NotebookCellRange[], context:{isWholeNotebooke: boolean}, token: CancelationToken): void;`
-        // todo@API interrupt vs cancellation, https://github.com/microsoft/vscode/issues/106741
-        // interrupt?():void;
-        executeCell(document: NotebookDocument, cell: NotebookCell): void;
-        cancelCellExecution(document: NotebookDocument, cell: NotebookCell): void;
-        executeAllCells(document: NotebookDocument): void;
-        cancelAllCellsExecution(document: NotebookDocument): void;
-    }
-
-    export type NotebookFilenamePattern = GlobPattern | { include: GlobPattern; exclude: GlobPattern };
-
-    // todo@API why not for NotebookContentProvider?
-    export interface NotebookDocumentFilter {
-        viewType?: string | string[];
-        filenamePattern?: NotebookFilenamePattern;
-    }
-
-    // todo@API very unclear, provider MUST not return alive object but only data object
-    // todo@API unclear how the flow goes
-    export interface NotebookKernelProvider<T extends NotebookKernel = NotebookKernel> {
-        onDidChangeKernels?: Event<NotebookDocument | undefined>;
-        provideKernels(document: NotebookDocument, token: CancellationToken): ProviderResult<T[]>;
-        resolveKernel?(
-            kernel: T,
-            document: NotebookDocument,
-            webview: NotebookCommunication,
-            token: CancellationToken
-        ): ProviderResult<void>;
-    }
-
-    export interface NotebookEditor {
-        /**
-         * Active kernel used in the editor
-         */
-        // todo@API unsure about that
-        // kernel, kernel selection, kernel provider
-        readonly kernel?: NotebookKernel;
-    }
-
-    export namespace notebook {
-        export const onDidChangeActiveNotebookKernel: Event<{
-            document: NotebookDocument;
-            kernel: NotebookKernel | undefined;
-        }>;
-
-        export function registerNotebookKernelProvider(
-            selector: NotebookDocumentFilter,
-            provider: NotebookKernelProvider
-        ): Disposable;
-    }
-
-    //#endregion
-
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorDecorationType
-
-    export interface NotebookEditor {
-        setDecorations(decorationType: NotebookEditorDecorationType, range: NotebookCellRange): void;
-    }
-
-    export interface NotebookDecorationRenderOptions {
-        backgroundColor?: string | ThemeColor;
-        borderColor?: string | ThemeColor;
-        top: ThemableDecorationAttachmentRenderOptions;
-    }
-
-    export interface NotebookEditorDecorationType {
-        readonly key: string;
-        dispose(): void;
-    }
-
-    export namespace notebook {
-        export function createNotebookEditorDecorationType(
-            options: NotebookDecorationRenderOptions
-        ): NotebookEditorDecorationType;
-    }
-
-    //#endregion
-
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookCellStatusBarItem
+    // this is not implemented...
+    readonly viewColumn?: ViewColumn;
 
     /**
-     * Represents the alignment of status bar items.
+     * Fired when the panel is disposed.
      */
-    export enum NotebookCellStatusBarAlignment {
-        /**
-         * Aligned to the left side.
-         */
-        Left = 1,
+    // @rebornix REMOVE/REplace NotebookCommunication
+    // todo@API fishy? notebooks are public objects, there should be a "global" events for this
+    readonly onDidDispose: Event<void>;
+}
 
-        /**
-         * Aligned to the right side.
-         */
-        Right = 2
-    }
+export interface NotebookDocumentMetadataChangeEvent {
+    readonly document: NotebookDocument;
+}
 
-    export interface NotebookCellStatusBarItem {
-        readonly cell: NotebookCell;
-        readonly alignment: NotebookCellStatusBarAlignment;
-        readonly priority?: number;
-        text: string;
-        tooltip: string | undefined;
-        command: string | Command | undefined;
-        accessibilityInformation?: AccessibilityInformation;
-        show(): void;
-        hide(): void;
-        dispose(): void;
-    }
+export interface NotebookCellsChangeData {
+    readonly start: number;
+    readonly deletedCount: number;
+    readonly deletedItems: NotebookCell[];
+    readonly items: NotebookCell[];
+}
 
-    export namespace notebook {
-        /**
-         * Creates a notebook cell status bar [item](#NotebookCellStatusBarItem).
-         * It will be disposed automatically when the notebook document is closed or the cell is deleted.
-         *
-         * @param cell The cell on which this item should be shown.
-         * @param alignment The alignment of the item.
-         * @param priority The priority of the item. Higher values mean the item should be shown more to the left.
-         * @return A new status bar item.
-         */
-        // @roblourens
-        // todo@API this should be a provider, https://github.com/microsoft/vscode/issues/105809
-        export function createCellStatusBarItem(
-            cell: NotebookCell,
-            alignment?: NotebookCellStatusBarAlignment,
-            priority?: number
-        ): NotebookCellStatusBarItem;
-    }
+export interface NotebookCellsChangeEvent {
+    /**
+     * The affected document.
+     */
+    readonly document: NotebookDocument;
+    readonly changes: ReadonlyArray<NotebookCellsChangeData>;
+}
 
-    //#endregion
+export interface NotebookCellOutputsChangeEvent {
+    /**
+     * The affected document.
+     */
+    readonly document: NotebookDocument;
+    readonly cells: NotebookCell[];
+}
 
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookConcatTextDocument
+export interface NotebookCellLanguageChangeEvent {
+    /**
+     * The affected document.
+     */
+    readonly document: NotebookDocument;
+    readonly cell: NotebookCell;
+    readonly language: string;
+}
 
-    export namespace notebook {
-        /**
-         * Create a document that is the concatenation of all  notebook cells. By default all code-cells are included
-         * but a selector can be provided to narrow to down the set of cells.
-         *
-         * @param notebook
-         * @param selector
-         */
-        // @jrieken REMOVE. p_never
-        // todo@API really needed? we didn't find a user here
-        export function createConcatTextDocument(
-            notebook: NotebookDocument,
-            selector?: DocumentSelector
-        ): NotebookConcatTextDocument;
-    }
+export interface NotebookCellMetadataChangeEvent {
+    readonly document: NotebookDocument;
+    readonly cell: NotebookCell;
+}
 
-    export interface NotebookConcatTextDocument {
-        uri: Uri;
-        isClosed: boolean;
-        dispose(): void;
-        onDidChange: Event<void>;
-        version: number;
-        getText(): string;
-        getText(range: Range): string;
+export interface NotebookEditorSelectionChangeEvent {
+    readonly notebookEditor: NotebookEditor;
+    readonly selections: ReadonlyArray<NotebookCellRange>;
+}
 
-        offsetAt(position: Position): number;
-        positionAt(offset: number): Position;
-        validateRange(range: Range): Range;
-        validatePosition(position: Position): Position;
+export interface NotebookEditorVisibleRangesChangeEvent {
+    readonly notebookEditor: NotebookEditor;
+    readonly visibleRanges: ReadonlyArray<NotebookCellRange>;
+}
 
-        locationAt(positionOrRange: Position | Range): Location;
-        positionAt(location: Location): Position;
-        contains(uri: Uri): boolean;
-    }
+// todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
+export class NotebookCellData {
+    kind: NotebookCellKind;
+    // todo@API better names: value? text?
+    source: string;
+    // todo@API how does language and MD relate?
+    language: string;
+    outputs?: NotebookCellOutput[];
+    metadata?: NotebookCellMetadata;
+    constructor(
+        kind: NotebookCellKind,
+        source: string,
+        language: string,
+        outputs?: NotebookCellOutput[],
+        metadata?: NotebookCellMetadata,
+    );
+}
 
-    //#endregion
-// #region debug
+export class NotebookData {
+    cells: NotebookCellData[];
+    metadata?: NotebookDocumentMetadata;
+    constructor(cells: NotebookCellData[], metadata?: NotebookDocumentMetadata);
+}
+
+/**
+ * Communication object passed to the {@link NotebookContentProvider} and
+ * {@link NotebookOutputRenderer} to communicate with the webview.
+ */
+export interface NotebookCommunication {
+    /**
+     * ID of the editor this object communicates with. A single notebook
+     * document can have multiple attached webviews and editors, when the
+     * notebook is split for instance. The editor ID lets you differentiate
+     * between them.
+     */
+    readonly editorId: string;
+
+    /**
+     * Fired when the output hosting webview posts a message.
+     */
+    readonly onDidReceiveMessage: Event<any>;
+    /**
+     * Post a message to the output hosting webview.
+     *
+     * Messages are only delivered if the editor is live.
+     *
+     * @param message Body of the message. This must be a string or other json serializable object.
+     */
+    postMessage(message: any): Thenable<boolean>;
+
+    /**
+     * Convert a uri for the local file system to one that can be used inside outputs webview.
+     */
+    asWebviewUri(localResource: Uri): Uri;
+
+    // @rebornix
+    // readonly onDidDispose: Event<void>;
+}
+
+// export function registerNotebookKernel(selector: string, kernel: NotebookKernel): Disposable;
+
+export interface NotebookDocumentShowOptions {
+    viewColumn?: ViewColumn;
+    preserveFocus?: boolean;
+    preview?: boolean;
+    selection?: NotebookCellRange;
+}
+
+export namespace notebook {
+    export function openNotebookDocument(uri: Uri): Thenable<NotebookDocument>;
+
+    export const onDidOpenNotebookDocument: Event<NotebookDocument>;
+    export const onDidCloseNotebookDocument: Event<NotebookDocument>;
+
+    export const onDidSaveNotebookDocument: Event<NotebookDocument>;
+
+    /**
+     * All currently known notebook documents.
+     */
+    export const notebookDocuments: ReadonlyArray<NotebookDocument>;
+    export const onDidChangeNotebookDocumentMetadata: Event<NotebookDocumentMetadataChangeEvent>;
+    export const onDidChangeNotebookCells: Event<NotebookCellsChangeEvent>;
+    export const onDidChangeCellOutputs: Event<NotebookCellOutputsChangeEvent>;
+
+    export const onDidChangeCellMetadata: Event<NotebookCellMetadataChangeEvent>;
+}
+
+export namespace window {
+    export const visibleNotebookEditors: NotebookEditor[];
+    export const onDidChangeVisibleNotebookEditors: Event<NotebookEditor[]>;
+    export const activeNotebookEditor: NotebookEditor | undefined;
+    export const onDidChangeActiveNotebookEditor: Event<NotebookEditor | undefined>;
+    export const onDidChangeNotebookEditorSelection: Event<NotebookEditorSelectionChangeEvent>;
+    export const onDidChangeNotebookEditorVisibleRanges: Event<NotebookEditorVisibleRangesChangeEvent>;
+
+    export function showNotebookDocument(uri: Uri, options?: NotebookDocumentShowOptions): Thenable<NotebookEditor>;
+    export function showNotebookDocument(
+        document: NotebookDocument,
+        options?: NotebookDocumentShowOptions,
+    ): Thenable<NotebookEditor>;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookCellOutput
+
+// code specific mime types
+// application/x.notebook.error-traceback
+// application/x.notebook.stream
+export class NotebookCellOutputItem {
+    // todo@API
+    // add factory functions for common mime types
+    // static textplain(value:string): NotebookCellOutputItem;
+    // static errortrace(value:any): NotebookCellOutputItem;
+
+    readonly mime: string;
+    readonly value: unknown;
+    readonly metadata?: Record<string, any>;
+
+    constructor(mime: string, value: unknown, metadata?: Record<string, any>);
+}
+
+// @jrieken
+// todo@API think about readonly...
+//TODO@API add execution count to cell output?
+export class NotebookCellOutput {
+    readonly id: string;
+    readonly outputs: NotebookCellOutputItem[];
+    readonly metadata?: Record<string, any>;
+
+    constructor(outputs: NotebookCellOutputItem[], metadata?: Record<string, any>);
+
+    constructor(outputs: NotebookCellOutputItem[], id: string, metadata?: Record<string, any>);
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorEdit
+
+export interface WorkspaceEdit {
+    replaceNotebookMetadata(uri: Uri, value: NotebookDocumentMetadata): void;
+
+    // todo@API use NotebookCellRange
+    replaceNotebookCells(
+        uri: Uri,
+        start: number,
+        end: number,
+        cells: NotebookCellData[],
+        metadata?: WorkspaceEditEntryMetadata,
+    ): void;
+    replaceNotebookCellMetadata(
+        uri: Uri,
+        index: number,
+        cellMetadata: NotebookCellMetadata,
+        metadata?: WorkspaceEditEntryMetadata,
+    ): void;
+
+    replaceNotebookCellOutput(
+        uri: Uri,
+        index: number,
+        outputs: NotebookCellOutput[],
+        metadata?: WorkspaceEditEntryMetadata,
+    ): void;
+    appendNotebookCellOutput(
+        uri: Uri,
+        index: number,
+        outputs: NotebookCellOutput[],
+        metadata?: WorkspaceEditEntryMetadata,
+    ): void;
+
+    // TODO@api
+    // https://jupyter-protocol.readthedocs.io/en/latest/messaging.html#update-display-data
+    replaceNotebookCellOutputItems(
+        uri: Uri,
+        index: number,
+        outputId: string,
+        items: NotebookCellOutputItem[],
+        metadata?: WorkspaceEditEntryMetadata,
+    ): void;
+    appendNotebookCellOutputItems(
+        uri: Uri,
+        index: number,
+        outputId: string,
+        items: NotebookCellOutputItem[],
+        metadata?: WorkspaceEditEntryMetadata,
+    ): void;
+}
+
+export interface NotebookEditorEdit {
+    replaceMetadata(value: NotebookDocumentMetadata): void;
+    replaceCells(start: number, end: number, cells: NotebookCellData[]): void;
+    replaceCellOutput(index: number, outputs: NotebookCellOutput[]): void;
+    replaceCellMetadata(index: number, metadata: NotebookCellMetadata): void;
+}
+
+export interface NotebookEditor {
+    /**
+     * Perform an edit on the notebook associated with this notebook editor.
+     *
+     * The given callback-function is invoked with an [edit-builder](#NotebookEditorEdit) which must
+     * be used to make edits. Note that the edit-builder is only valid while the
+     * callback executes.
+     *
+     * @param callback A function which can create edits using an [edit-builder](#NotebookEditorEdit).
+     * @return A promise that resolves with a value indicating if the edits could be applied.
+     */
+    // @jrieken REMOVE maybe
+    edit(callback: (editBuilder: NotebookEditorEdit) => void): Thenable<boolean>;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookContentProvider
+
+interface NotebookDocumentBackup {
+    /**
+     * Unique identifier for the backup.
+     *
+     * This id is passed back to your extension in `openNotebook` when opening a notebook editor from a backup.
+     */
+    readonly id: string;
+
+    /**
+     * Delete the current backup.
+     *
+     * This is called by VS Code when it is clear the current backup is no longer needed, such as when a new backup
+     * is made or when the file is saved.
+     */
+    delete(): void;
+}
+
+interface NotebookDocumentBackupContext {
+    readonly destination: Uri;
+}
+
+interface NotebookDocumentOpenContext {
+    readonly backupId?: string;
+    readonly untitledDocumentData?: Uint8Array;
+}
+
+// todo@API use openNotebookDOCUMENT to align with openCustomDocument etc?
+// todo@API rename to NotebookDocumentContentProvider
+export interface NotebookContentProvider {
+    readonly options?: NotebookDocumentContentOptions;
+    readonly onDidChangeNotebookContentOptions?: Event<NotebookDocumentContentOptions>;
+
+    // todo@API remove! against separation of data provider and renderer
+    // eslint-disable-next-line vscode-dts-cancellation
+    resolveNotebook(document: NotebookDocument, webview: NotebookCommunication): Thenable<void>;
+
+    /**
+     * Content providers should always use [file system providers](#FileSystemProvider) to
+     * resolve the raw content for `uri` as the resouce is not necessarily a file on disk.
+     */
+    openNotebook(
+        uri: Uri,
+        openContext: NotebookDocumentOpenContext,
+        token: CancellationToken,
+    ): NotebookData | Thenable<NotebookData>;
+
+    saveNotebook(document: NotebookDocument, token: CancellationToken): Thenable<void>;
+
+    saveNotebookAs(targetResource: Uri, document: NotebookDocument, token: CancellationToken): Thenable<void>;
+
+    backupNotebook(
+        document: NotebookDocument,
+        context: NotebookDocumentBackupContext,
+        token: CancellationToken,
+    ): Thenable<NotebookDocumentBackup>;
+}
+
+export namespace notebook {
+    // TODO@api use NotebookDocumentFilter instead of just notebookType:string?
+    // TODO@API options duplicates the more powerful variant on NotebookContentProvider
+    export function registerNotebookContentProvider(
+        notebookType: string,
+        provider: NotebookContentProvider,
+        options?: NotebookDocumentContentOptions & {
+            /**
+             * Not ready for production or development use yet.
+             */
+            viewOptions?: {
+                displayName: string;
+                filenamePattern: NotebookFilenamePattern[];
+                exclusive?: boolean;
+            };
+        },
+    ): Disposable;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookKernel
+
+// todo@API use the NotebookCellExecution-object as a container to model and enforce
+// the flow of a cell execution
+
+// kernel -> execute_info
+// ext -> createNotebookCellExecution(cell)
+// kernel -> done
+// exec.dispose();
+
+// export interface NotebookCellExecution {
+// 	dispose(): void;
+// 	clearOutput(): void;
+// 	appendOutput(out: NotebookCellOutput): void;
+// 	replaceOutput(out: NotebookCellOutput): void;
+//  appendOutputItems(output:string, items: NotebookCellOutputItem[]):void;
+//  replaceOutputItems(output:string, items: NotebookCellOutputItem[]):void;
+// }
+
+// export function createNotebookCellExecution(cell: NotebookCell, startTime?: number): NotebookCellExecution;
+// export const onDidStartNotebookCellExecution: Event<any>;
+// export const onDidStopNotebookCellExecution: Event<any>;
+
+export interface NotebookKernel {
+    // todo@API make this mandatory?
+    readonly id?: string;
+
+    label: string;
+    description?: string;
+    detail?: string;
+    isPreferred?: boolean;
+
+    // todo@API is this maybe an output property?
+    preloads?: Uri[];
+
+    /**
+     * languages supported by kernel
+     * - first is preferred
+     * - `undefined` means all languages available in the editor
+     */
+    supportedLanguages?: string[];
+
+    // todo@API kernel updating itself
+    // fired when properties like the supported languages etc change
+    // onDidChangeProperties?: Event<void>
+
+    // @roblourens
+    // todo@API change to `executeCells(document: NotebookDocument, cells: NotebookCellRange[], context:{isWholeNotebooke: boolean}, token: CancelationToken): void;`
+    // todo@API interrupt vs cancellation, https://github.com/microsoft/vscode/issues/106741
+    // interrupt?():void;
+    executeCell(document: NotebookDocument, cell: NotebookCell): void;
+    cancelCellExecution(document: NotebookDocument, cell: NotebookCell): void;
+    executeAllCells(document: NotebookDocument): void;
+    cancelAllCellsExecution(document: NotebookDocument): void;
+}
+
+export type NotebookFilenamePattern = GlobPattern | { include: GlobPattern; exclude: GlobPattern };
+
+// todo@API why not for NotebookContentProvider?
+export interface NotebookDocumentFilter {
+    viewType?: string | string[];
+    filenamePattern?: NotebookFilenamePattern;
+}
+
+// todo@API very unclear, provider MUST not return alive object but only data object
+// todo@API unclear how the flow goes
+export interface NotebookKernelProvider<T extends NotebookKernel = NotebookKernel> {
+    onDidChangeKernels?: Event<NotebookDocument | undefined>;
+    provideKernels(document: NotebookDocument, token: CancellationToken): ProviderResult<T[]>;
+    resolveKernel?(
+        kernel: T,
+        document: NotebookDocument,
+        webview: NotebookCommunication,
+        token: CancellationToken,
+    ): ProviderResult<void>;
+}
+
+export interface NotebookEditor {
+    /**
+     * Active kernel used in the editor
+     */
+    // todo@API unsure about that
+    // kernel, kernel selection, kernel provider
+    readonly kernel?: NotebookKernel;
+}
+
+export namespace notebook {
+    export const onDidChangeActiveNotebookKernel: Event<{
+        document: NotebookDocument;
+        kernel: NotebookKernel | undefined;
+    }>;
+
+    export function registerNotebookKernelProvider(
+        selector: NotebookDocumentFilter,
+        provider: NotebookKernelProvider,
+    ): Disposable;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorDecorationType
+
+export interface NotebookEditor {
+    setDecorations(decorationType: NotebookEditorDecorationType, range: NotebookCellRange): void;
+}
+
+export interface NotebookDecorationRenderOptions {
+    backgroundColor?: string | ThemeColor;
+    borderColor?: string | ThemeColor;
+    top: ThemableDecorationAttachmentRenderOptions;
+}
+
+export interface NotebookEditorDecorationType {
+    readonly key: string;
+    dispose(): void;
+}
+
+export namespace notebook {
+    export function createNotebookEditorDecorationType(
+        options: NotebookDecorationRenderOptions,
+    ): NotebookEditorDecorationType;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookCellStatusBarItem
+
+/**
+ * Represents the alignment of status bar items.
+ */
+export enum NotebookCellStatusBarAlignment {
+    /**
+     * Aligned to the left side.
+     */
+    Left = 1,
+
+    /**
+     * Aligned to the right side.
+     */
+    Right = 2,
+}
+
+export interface NotebookCellStatusBarItem {
+    readonly cell: NotebookCell;
+    readonly alignment: NotebookCellStatusBarAlignment;
+    readonly priority?: number;
+    text: string;
+    tooltip: string | undefined;
+    command: string | Command | undefined;
+    accessibilityInformation?: AccessibilityInformation;
+    show(): void;
+    hide(): void;
+    dispose(): void;
+}
+
+export namespace notebook {
+    /**
+     * Creates a notebook cell status bar [item](#NotebookCellStatusBarItem).
+     * It will be disposed automatically when the notebook document is closed or the cell is deleted.
+     *
+     * @param cell The cell on which this item should be shown.
+     * @param alignment The alignment of the item.
+     * @param priority The priority of the item. Higher values mean the item should be shown more to the left.
+     * @return A new status bar item.
+     */
+    // @roblourens
+    // todo@API this should be a provider, https://github.com/microsoft/vscode/issues/105809
+    export function createCellStatusBarItem(
+        cell: NotebookCell,
+        alignment?: NotebookCellStatusBarAlignment,
+        priority?: number,
+    ): NotebookCellStatusBarItem;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookConcatTextDocument
+
+export namespace notebook {
+    /**
+     * Create a document that is the concatenation of all  notebook cells. By default all code-cells are included
+     * but a selector can be provided to narrow to down the set of cells.
+     *
+     * @param notebook
+     * @param selector
+     */
+    // @jrieken REMOVE. p_never
+    // todo@API really needed? we didn't find a user here
+    export function createConcatTextDocument(
+        notebook: NotebookDocument,
+        selector?: DocumentSelector,
+    ): NotebookConcatTextDocument;
+}
+
+export interface NotebookConcatTextDocument {
+    uri: Uri;
+    isClosed: boolean;
+    dispose(): void;
+    onDidChange: Event<void>;
+    version: number;
+    getText(): string;
+    getText(range: Range): string;
+
+    offsetAt(position: Position): number;
+    positionAt(offset: number): Position;
+    validateRange(range: Range): Range;
+    validatePosition(position: Position): Position;
+
+    locationAt(positionOrRange: Position | Range): Location;
+    positionAt(location: Location): Position;
+    contains(uri: Uri): boolean;
+}
+
+//#endregion
 
 /**
  * A DebugProtocolVariableContainer is an opaque stand-in type for the intersection of the Scope and Variable types defined in the Debug Adapter Protocol.

--- a/types/vscode.proposed.d.ts
+++ b/types/vscode.proposed.d.ts
@@ -4,812 +4,817 @@
 /* eslint-disable */
 // Copy nb section from https://github.com/microsoft/vscode/blob/master/src/vs/vscode.proposed.d.ts.
 declare module 'vscode' {
-    //#region https://github.com/microsoft/vscode/issues/106744, Notebooks (misc)
+//#region https://github.com/microsoft/vscode/issues/106744, Notebooks (misc)
 
-    export enum NotebookCellKind {
-        Markdown = 1,
-        Code = 2,
-    }
+export enum NotebookCellKind {
+    Markdown = 1,
+    Code = 2
+}
 
-    export enum NotebookCellRunState {
-        Running = 1,
-        Idle = 2,
-        Success = 3,
-        Error = 4,
-    }
+export enum NotebookCellRunState {
+    Running = 1,
+    Idle = 2,
+    Success = 3,
+    Error = 4
+}
 
-    export enum NotebookRunState {
-        Running = 1,
-        Idle = 2,
-    }
+export enum NotebookRunState {
+    Running = 1,
+    Idle = 2
+}
 
-    export class NotebookCellMetadata {
-        /**
-         * Controls whether a cell's editor is editable/readonly.
-         */
-        readonly editable?: boolean;
-        /**
-         * Controls if the cell has a margin to support the breakpoint UI.
-         * This metadata is ignored for markdown cell.
-         */
-        readonly breakpointMargin?: boolean;
-        /**
-         * Whether a code cell's editor is collapsed
-         */
-        readonly outputCollapsed?: boolean;
-        /**
-         * Whether a code cell's outputs are collapsed
-         */
-        readonly inputCollapsed?: boolean;
-        /**
-         * Additional attributes of a cell metadata.
-         */
-        readonly custom?: Record<string, any>;
+export class NotebookCellMetadata {
+    /**
+     * Controls whether a cell's editor is editable/readonly.
+     */
+    readonly editable?: boolean;
+    /**
+     * Controls if the cell has a margin to support the breakpoint UI.
+     * This metadata is ignored for markdown cell.
+     */
+    readonly breakpointMargin?: boolean;
+    /**
+     * Whether a code cell's editor is collapsed
+     */
+    readonly outputCollapsed?: boolean;
+    /**
+     * Whether a code cell's outputs are collapsed
+     */
+    readonly inputCollapsed?: boolean;
+    /**
+     * Additional attributes of a cell metadata.
+     */
+    readonly custom?: Record<string, any>;
 
-        // todo@API duplicates status bar API
-        readonly statusMessage?: string;
+    // todo@API duplicates status bar API
+    readonly statusMessage?: string;
 
-        // run related API, will be removed
-        readonly runnable?: boolean;
-        readonly hasExecutionOrder?: boolean;
-        readonly executionOrder?: number;
-        readonly runState?: NotebookCellRunState;
-        readonly runStartTime?: number;
-        readonly lastRunDuration?: number;
+    // run related API, will be removed
+    readonly hasExecutionOrder?: boolean;
+    readonly executionOrder?: number;
+    readonly runState?: NotebookCellRunState;
+    readonly runStartTime?: number;
+    readonly lastRunDuration?: number;
 
-        constructor(
-            editable?: boolean,
-            breakpointMargin?: boolean,
-            runnable?: boolean,
-            hasExecutionOrder?: boolean,
-            executionOrder?: number,
-            runState?: NotebookCellRunState,
-            runStartTime?: number,
-            statusMessage?: string,
-            lastRunDuration?: number,
-            inputCollapsed?: boolean,
-            outputCollapsed?: boolean,
-            custom?: Record<string, any>,
-        );
+    constructor(
+        editable?: boolean,
+        breakpointMargin?: boolean,
+        hasExecutionOrder?: boolean,
+        executionOrder?: number,
+        runState?: NotebookCellRunState,
+        runStartTime?: number,
+        statusMessage?: string,
+        lastRunDuration?: number,
+        inputCollapsed?: boolean,
+        outputCollapsed?: boolean,
+        custom?: Record<string, any>
+    );
 
-        with(change: {
-            editable?: boolean | null;
-            breakpointMargin?: boolean | null;
-            runnable?: boolean | null;
-            hasExecutionOrder?: boolean | null;
-            executionOrder?: number | null;
-            runState?: NotebookCellRunState | null;
-            runStartTime?: number | null;
-            statusMessage?: string | null;
-            lastRunDuration?: number | null;
-            inputCollapsed?: boolean | null;
-            outputCollapsed?: boolean | null;
-            custom?: Record<string, any> | null;
-        }): NotebookCellMetadata;
-    }
+    with(change: {
+        editable?: boolean | null;
+        breakpointMargin?: boolean | null;
+        hasExecutionOrder?: boolean | null;
+        executionOrder?: number | null;
+        runState?: NotebookCellRunState | null;
+        runStartTime?: number | null;
+        statusMessage?: string | null;
+        lastRunDuration?: number | null;
+        inputCollapsed?: boolean | null;
+        outputCollapsed?: boolean | null;
+        custom?: Record<string, any> | null;
+    }): NotebookCellMetadata;
+}
 
-    // todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
-    export interface NotebookCell {
-        readonly index: number;
-        readonly notebook: NotebookDocument;
-        readonly cellKind: NotebookCellKind;
-        // todo@API duplicates #document.uri
-        readonly uri: Uri;
-        // todo@API duplicates #document.languageId
-        readonly language: string;
-        readonly document: TextDocument;
-        readonly outputs: readonly NotebookCellOutput[];
-        readonly metadata: NotebookCellMetadata;
-    }
+// todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
+export interface NotebookCell {
+    readonly index: number;
+    readonly notebook: NotebookDocument;
+    readonly kind: NotebookCellKind;
+    readonly document: TextDocument;
+    readonly metadata: NotebookCellMetadata;
+    readonly outputs: ReadonlyArray<NotebookCellOutput>;
+}
 
-    export class NotebookDocumentMetadata {
-        /**
-         * Controls if users can add or delete cells
-         * Defaults to true
-         */
-        readonly editable: boolean;
-        /**
-         * Default value for [cell editable metadata](#NotebookCellMetadata.editable).
-         * Defaults to true.
-         */
-        readonly cellEditable: boolean;
-        /**
-         * Additional attributes of the document metadata.
-         */
-        readonly custom: { [key: string]: any };
-        /**
-         * Whether the document is trusted, default to true
-         * When false, insecure outputs like HTML, JavaScript, SVG will not be rendered.
-         */
-        readonly trusted: boolean;
+export class NotebookDocumentMetadata {
+    /**
+     * Controls if users can add or delete cells
+     * Defaults to true
+     */
+    readonly editable: boolean;
+    /**
+     * Default value for [cell editable metadata](#NotebookCellMetadata.editable).
+     * Defaults to true.
+     */
+    readonly cellEditable: boolean;
+    /**
+     * Additional attributes of the document metadata.
+     */
+    readonly custom: { [key: string]: any };
+    /**
+     * Whether the document is trusted, default to true
+     * When false, insecure outputs like HTML, JavaScript, SVG will not be rendered.
+     */
+    readonly trusted: boolean;
 
-        // todo@API is this a kernel property?
-        readonly cellHasExecutionOrder: boolean;
+    // todo@API is this a kernel property?
+    readonly cellHasExecutionOrder: boolean;
 
-        // run related, remove infer from kernel, exec
-        // todo@API infer from kernel
-        // todo@API remove
-        readonly runnable: boolean;
-        readonly cellRunnable: boolean;
-        readonly runState: NotebookRunState;
+    // todo@API remove
+    readonly runState: NotebookRunState;
 
-        constructor(
-            editable?: boolean,
-            runnable?: boolean,
-            cellEditable?: boolean,
-            cellRunnable?: boolean,
-            cellHasExecutionOrder?: boolean,
-            custom?: { [key: string]: any },
-            runState?: NotebookRunState,
-            trusted?: boolean,
-        );
+    constructor(
+        editable?: boolean,
+        cellEditable?: boolean,
+        cellHasExecutionOrder?: boolean,
+        custom?: { [key: string]: any },
+        runState?: NotebookRunState,
+        trusted?: boolean
+    );
 
-        with(change: {
-            editable?: boolean | null;
-            runnable?: boolean | null;
-            cellEditable?: boolean | null;
-            cellRunnable?: boolean | null;
-            cellHasExecutionOrder?: boolean | null;
-            custom?: { [key: string]: any } | null;
-            runState?: NotebookRunState | null;
-            trusted?: boolean | null;
-        }): NotebookDocumentMetadata;
-    }
+    with(change: {
+        editable?: boolean | null;
+        cellEditable?: boolean | null;
+        cellHasExecutionOrder?: boolean | null;
+        custom?: { [key: string]: any } | null;
+        runState?: NotebookRunState | null;
+        trusted?: boolean | null;
+    }): NotebookDocumentMetadata;
+}
 
-    export interface NotebookDocumentContentOptions {
-        /**
-         * Controls if outputs change will trigger notebook document content change and if it will be used in the diff editor
-         * Default to false. If the content provider doesn't persisit the outputs in the file document, this should be set to true.
-         */
-        transientOutputs: boolean;
-
-        /**
-         * Controls if a meetadata property change will trigger notebook document content change and if it will be used in the diff editor
-         * Default to false. If the content provider doesn't persisit a metadata property in the file document, it should be set to true.
-         */
-        transientMetadata: { [K in keyof NotebookCellMetadata]?: boolean };
-    }
-
-    export interface NotebookDocument {
-        readonly uri: Uri;
-        readonly version: number;
-        // todo@API don't have this...
-        readonly fileName: string;
-        // todo@API should we really expose this?
-        readonly viewType: string;
-        readonly isDirty: boolean;
-        readonly isUntitled: boolean;
-        readonly cells: ReadonlyArray<NotebookCell>;
-        readonly contentOptions: NotebookDocumentContentOptions;
-        readonly metadata: NotebookDocumentMetadata;
-
-        /**
-         * Save the document. The saving will be handled by the corresponding content provider
-         *
-         * @return A promise that will resolve to true when the document
-         * has been saved. If the file was not dirty or the save failed,
-         * will return false.
-         */
-        save(): Thenable<boolean>;
-    }
-
-    // todo@API maybe have a NotebookCellPosition sibling
-    export class NotebookCellRange {
-        readonly start: number;
-        /**
-         * exclusive
-         */
-        readonly end: number;
-
-        constructor(start: number, end: number);
-    }
-
-    export enum NotebookEditorRevealType {
-        /**
-         * The range will be revealed with as little scrolling as possible.
-         */
-        Default = 0,
-        /**
-         * The range will always be revealed in the center of the viewport.
-         */
-        InCenter = 1,
-
-        /**
-         * If the range is outside the viewport, it will be revealed in the center of the viewport.
-         * Otherwise, it will be revealed with as little scrolling as possible.
-         */
-        InCenterIfOutsideViewport = 2,
-
-        /**
-         * The range will always be revealed at the top of the viewport.
-         */
-        AtTop = 3,
-    }
-
-    export interface NotebookEditor {
-        /**
-         * The document associated with this notebook editor.
-         */
-        readonly document: NotebookDocument;
-
-        /**
-         * The primary selected cell on this notebook editor.
-         */
-        // todo@API should not be undefined, rather a default
-        readonly selection?: NotebookCell;
-
-        /**
-         * todo@API should replace selection
-         * The selections on this notebook editor.
-         *
-         * The primary selection (or focused range) is `selections[0]`. When the document has no cells, the primary selection is empty `{ start: 0, end: 0 }`;
-         */
-        readonly selections: NotebookCellRange[];
-
-        /**
-         * The current visible ranges in the editor (vertically).
-         */
-        readonly visibleRanges: NotebookCellRange[];
-
-        revealRange(range: NotebookCellRange, revealType?: NotebookEditorRevealType): void;
-
-        /**
-         * The column in which this editor shows.
-         */
-        // @jrieken
-        // todo@API maybe never undefined because notebooks always show in the editor area (unlike text editors)
-        // maybe for notebook diff editor
-        readonly viewColumn?: ViewColumn;
-
-        /**
-         * Fired when the panel is disposed.
-         */
-        // @rebornix REMOVE/REplace NotebookCommunication
-        // todo@API fishy? notebooks are public objects, there should be a "global" events for this
-        readonly onDidDispose: Event<void>;
-    }
-
-    export interface NotebookDocumentMetadataChangeEvent {
-        readonly document: NotebookDocument;
-    }
-
-    export interface NotebookCellsChangeData {
-        readonly start: number;
-        readonly deletedCount: number;
-        readonly deletedItems: NotebookCell[];
-        readonly items: NotebookCell[];
-    }
-
-    export interface NotebookCellsChangeEvent {
-        /**
-         * The affected document.
-         */
-        readonly document: NotebookDocument;
-        readonly changes: ReadonlyArray<NotebookCellsChangeData>;
-    }
-
-    export interface NotebookCellOutputsChangeEvent {
-        /**
-         * The affected document.
-         */
-        readonly document: NotebookDocument;
-        readonly cells: NotebookCell[];
-    }
-
-    export interface NotebookCellMetadataChangeEvent {
-        readonly document: NotebookDocument;
-        readonly cell: NotebookCell;
-    }
-
-    export interface NotebookEditorSelectionChangeEvent {
-        readonly notebookEditor: NotebookEditor;
-        readonly selections: ReadonlyArray<NotebookCellRange>;
-    }
-
-    export interface NotebookEditorVisibleRangesChangeEvent {
-        readonly notebookEditor: NotebookEditor;
-        readonly visibleRanges: ReadonlyArray<NotebookCellRange>;
-    }
-
-    // todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
-    export class NotebookCellData {
-        kind: NotebookCellKind;
-        // todo@API better names: value? text?
-        source: string;
-        // todo@API how does language and MD relate?
-        language: string;
-        outputs?: NotebookCellOutput[];
-        metadata?: NotebookCellMetadata;
-        constructor(
-            kind: NotebookCellKind,
-            source: string,
-            language: string,
-            outputs?: NotebookCellOutput[],
-            metadata?: NotebookCellMetadata,
-        );
-    }
-
-    export class NotebookData {
-        cells: NotebookCellData[];
-        metadata?: NotebookDocumentMetadata;
-        constructor(cells: NotebookCellData[], metadata?: NotebookDocumentMetadata);
-    }
+export interface NotebookDocumentContentOptions {
+    /**
+     * Controls if outputs change will trigger notebook document content change and if it will be used in the diff editor
+     * Default to false. If the content provider doesn't persisit the outputs in the file document, this should be set to true.
+     */
+    transientOutputs: boolean;
 
     /**
-     * Communication object passed to the {@link NotebookContentProvider} and
-     * {@link NotebookOutputRenderer} to communicate with the webview.
+     * Controls if a meetadata property change will trigger notebook document content change and if it will be used in the diff editor
+     * Default to false. If the content provider doesn't persisit a metadata property in the file document, it should be set to true.
      */
-    export interface NotebookCommunication {
-        /**
-         * ID of the editor this object communicates with. A single notebook
-         * document can have multiple attached webviews and editors, when the
-         * notebook is split for instance. The editor ID lets you differentiate
-         * between them.
-         */
-        readonly editorId: string;
+    transientMetadata: { [K in keyof NotebookCellMetadata]?: boolean };
+}
 
-        /**
-         * Fired when the output hosting webview posts a message.
-         */
-        readonly onDidReceiveMessage: Event<any>;
-        /**
-         * Post a message to the output hosting webview.
-         *
-         * Messages are only delivered if the editor is live.
-         *
-         * @param message Body of the message. This must be a string or other json serializable object.
-         */
-        postMessage(message: any): Thenable<boolean>;
+export interface NotebookDocument {
+    readonly uri: Uri;
+    readonly version: number;
 
-        /**
-         * Convert a uri for the local file system to one that can be used inside outputs webview.
-         */
-        asWebviewUri(localResource: Uri): Uri;
+    // todo@API don't have this...
+    readonly fileName: string;
 
-        // @rebornix
-        // readonly onDidDispose: Event<void>;
-    }
+    readonly isDirty: boolean;
+    readonly isUntitled: boolean;
+    readonly cells: ReadonlyArray<NotebookCell>;
 
-    // export function registerNotebookKernel(selector: string, kernel: NotebookKernel): Disposable;
+    readonly metadata: NotebookDocumentMetadata;
 
-    export interface NotebookDocumentShowOptions {
-        viewColumn?: ViewColumn;
-        preserveFocus?: boolean;
-        preview?: boolean;
-        selection?: NotebookCellRange;
-    }
+    // todo@API should we really expose this?
+    readonly viewType: string;
 
-    export namespace notebook {
-        // todo@API should we really support to pass the viewType? We do NOT support
-        // to open the same file with different viewTypes at the same time
-        export function openNotebookDocument(uri: Uri, viewType?: string): Thenable<NotebookDocument>;
-        export const onDidOpenNotebookDocument: Event<NotebookDocument>;
-        export const onDidCloseNotebookDocument: Event<NotebookDocument>;
+    /**
+     * Save the document. The saving will be handled by the corresponding content provider
+     *
+     * @return A promise that will resolve to true when the document
+     * has been saved. If the file was not dirty or the save failed,
+     * will return false.
+     */
+    save(): Thenable<boolean>;
+}
 
-        export const onDidSaveNotebookDocument: Event<NotebookDocument>;
+// todo@API maybe have a NotebookCellPosition sibling
+export class NotebookCellRange {
+    readonly start: number;
+    /**
+     * exclusive
+     */
+    readonly end: number;
 
-        /**
-         * All currently known notebook documents.
-         */
-        export const notebookDocuments: ReadonlyArray<NotebookDocument>;
-        export const onDidChangeNotebookDocumentMetadata: Event<NotebookDocumentMetadataChangeEvent>;
-        export const onDidChangeNotebookCells: Event<NotebookCellsChangeEvent>;
-        export const onDidChangeCellOutputs: Event<NotebookCellOutputsChangeEvent>;
-        export const onDidChangeCellMetadata: Event<NotebookCellMetadataChangeEvent>;
-    }
+    isEmpty: boolean;
 
-    export namespace window {
-        export const visibleNotebookEditors: NotebookEditor[];
-        export const onDidChangeVisibleNotebookEditors: Event<NotebookEditor[]>;
-        export const activeNotebookEditor: NotebookEditor | undefined;
-        export const onDidChangeActiveNotebookEditor: Event<NotebookEditor | undefined>;
-        export const onDidChangeNotebookEditorSelection: Event<NotebookEditorSelectionChangeEvent>;
-        export const onDidChangeNotebookEditorVisibleRanges: Event<NotebookEditorVisibleRangesChangeEvent>;
+    constructor(start: number, end: number);
+}
 
-        export function showNotebookDocument(uri: Uri, options?: NotebookDocumentShowOptions): Thenable<NotebookEditor>;
-        export function showNotebookDocument(
-            document: NotebookDocument,
-            options?: NotebookDocumentShowOptions,
-        ): Thenable<NotebookEditor>;
-    }
+export enum NotebookEditorRevealType {
+    /**
+     * The range will be revealed with as little scrolling as possible.
+     */
+    Default = 0,
+    /**
+     * The range will always be revealed in the center of the viewport.
+     */
+    InCenter = 1,
 
-    //#endregion
+    /**
+     * If the range is outside the viewport, it will be revealed in the center of the viewport.
+     * Otherwise, it will be revealed with as little scrolling as possible.
+     */
+    InCenterIfOutsideViewport = 2,
 
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookCellOutput
+    /**
+     * The range will always be revealed at the top of the viewport.
+     */
+    AtTop = 3
+}
 
-    // code specific mime types
-    // application/x.notebook.error-traceback
-    // application/x.notebook.stream
-    export class NotebookCellOutputItem {
-        // todo@API
-        // add factory functions for common mime types
-        // static textplain(value:string): NotebookCellOutputItem;
-        // static errortrace(value:any): NotebookCellOutputItem;
+export interface NotebookEditor {
+    /**
+     * The document associated with this notebook editor.
+     */
+    readonly document: NotebookDocument;
 
-        readonly mime: string;
-        readonly value: unknown;
-        readonly metadata?: Record<string, any>;
+    /**
+     * The primary selected cell on this notebook editor.
+     */
+    // todo@API should not be undefined, rather a default
+    readonly selection?: NotebookCell;
 
-        constructor(mime: string, value: unknown, metadata?: Record<string, any>);
-    }
+    /**
+     * todo@API should replace selection
+     * The selections on this notebook editor.
+     *
+     * The primary selection (or focused range) is `selections[0]`. When the document has no cells, the primary selection is empty `{ start: 0, end: 0 }`;
+     */
+    readonly selections: NotebookCellRange[];
 
+    /**
+     * The current visible ranges in the editor (vertically).
+     */
+    readonly visibleRanges: NotebookCellRange[];
+
+    revealRange(range: NotebookCellRange, revealType?: NotebookEditorRevealType): void;
+
+    /**
+     * The column in which this editor shows.
+     */
     // @jrieken
-    // todo@API think about readonly...
-    //TODO@API add execution count to cell output?
-    export class NotebookCellOutput {
-        readonly id: string;
-        readonly outputs: NotebookCellOutputItem[];
-        readonly metadata?: Record<string, any>;
-
-        constructor(outputs: NotebookCellOutputItem[], metadata?: Record<string, any>);
-
-        constructor(outputs: NotebookCellOutputItem[], id: string, metadata?: Record<string, any>);
-    }
-
-    //#endregion
-
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorEdit
-
-    export interface WorkspaceEdit {
-        replaceNotebookMetadata(uri: Uri, value: NotebookDocumentMetadata): void;
-
-        // todo@API use NotebookCellRange
-        replaceNotebookCells(
-            uri: Uri,
-            start: number,
-            end: number,
-            cells: NotebookCellData[],
-            metadata?: WorkspaceEditEntryMetadata,
-        ): void;
-        replaceNotebookCellMetadata(
-            uri: Uri,
-            index: number,
-            cellMetadata: NotebookCellMetadata,
-            metadata?: WorkspaceEditEntryMetadata,
-        ): void;
-
-        replaceNotebookCellOutput(
-            uri: Uri,
-            index: number,
-            outputs: NotebookCellOutput[],
-            metadata?: WorkspaceEditEntryMetadata,
-        ): void;
-        appendNotebookCellOutput(
-            uri: Uri,
-            index: number,
-            outputs: NotebookCellOutput[],
-            metadata?: WorkspaceEditEntryMetadata,
-        ): void;
-
-        // TODO@api
-        // https://jupyter-protocol.readthedocs.io/en/latest/messaging.html#update-display-data
-        replaceNotebookCellOutputItems(
-            uri: Uri,
-            index: number,
-            outputId: string,
-            items: NotebookCellOutputItem[],
-            metadata?: WorkspaceEditEntryMetadata,
-        ): void;
-        appendNotebookCellOutputItems(
-            uri: Uri,
-            index: number,
-            outputId: string,
-            items: NotebookCellOutputItem[],
-            metadata?: WorkspaceEditEntryMetadata,
-        ): void;
-    }
-
-    export interface NotebookEditorEdit {
-        replaceMetadata(value: NotebookDocumentMetadata): void;
-        replaceCells(start: number, end: number, cells: NotebookCellData[]): void;
-        replaceCellOutput(index: number, outputs: NotebookCellOutput[]): void;
-        replaceCellMetadata(index: number, metadata: NotebookCellMetadata): void;
-    }
-
-    export interface NotebookEditor {
-        /**
-         * Perform an edit on the notebook associated with this notebook editor.
-         *
-         * The given callback-function is invoked with an [edit-builder](#NotebookEditorEdit) which must
-         * be used to make edits. Note that the edit-builder is only valid while the
-         * callback executes.
-         *
-         * @param callback A function which can create edits using an [edit-builder](#NotebookEditorEdit).
-         * @return A promise that resolves with a value indicating if the edits could be applied.
-         */
-        // @jrieken REMOVE maybe
-        edit(callback: (editBuilder: NotebookEditorEdit) => void): Thenable<boolean>;
-    }
-
-    //#endregion
-
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookContentProvider
-
-    interface NotebookDocumentBackup {
-        /**
-         * Unique identifier for the backup.
-         *
-         * This id is passed back to your extension in `openNotebook` when opening a notebook editor from a backup.
-         */
-        readonly id: string;
-
-        /**
-         * Delete the current backup.
-         *
-         * This is called by VS Code when it is clear the current backup is no longer needed, such as when a new backup
-         * is made or when the file is saved.
-         */
-        delete(): void;
-    }
-
-    interface NotebookDocumentBackupContext {
-        readonly destination: Uri;
-    }
-
-    interface NotebookDocumentOpenContext {
-        readonly backupId?: string;
-    }
-
-    export interface NotebookContentProvider {
-        readonly options?: NotebookDocumentContentOptions;
-        readonly onDidChangeNotebookContentOptions?: Event<NotebookDocumentContentOptions>;
-        /**
-         * Content providers should always use [file system providers](#FileSystemProvider) to
-         * resolve the raw content for `uri` as the resouce is not necessarily a file on disk.
-         */
-        openNotebook(uri: Uri, openContext: NotebookDocumentOpenContext): NotebookData | Thenable<NotebookData>;
-        resolveNotebook(document: NotebookDocument, webview: NotebookCommunication): Thenable<void>;
-        saveNotebook(document: NotebookDocument, cancellation: CancellationToken): Thenable<void>;
-        saveNotebookAs(
-            targetResource: Uri,
-            document: NotebookDocument,
-            cancellation: CancellationToken,
-        ): Thenable<void>;
-        backupNotebook(
-            document: NotebookDocument,
-            context: NotebookDocumentBackupContext,
-            cancellation: CancellationToken,
-        ): Thenable<NotebookDocumentBackup>;
-
-        // ???
-        // provideKernels(document: NotebookDocument, token: CancellationToken): ProviderResult<T[]>;
-    }
-
-    export namespace notebook {
-        // TODO@api use NotebookDocumentFilter instead of just notebookType:string?
-        // TODO@API options duplicates the more powerful variant on NotebookContentProvider
-        export function registerNotebookContentProvider(
-            notebookType: string,
-            provider: NotebookContentProvider,
-            options?: NotebookDocumentContentOptions & {
-                /**
-                 * Not ready for production or development use yet.
-                 */
-                viewOptions?: {
-                    displayName: string;
-                    filenamePattern: NotebookFilenamePattern[];
-                    exclusive?: boolean;
-                };
-            },
-        ): Disposable;
-    }
-
-    //#endregion
-
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookKernel
-
-    // todo@API use the NotebookCellExecution-object as a container to model and enforce
-    // the flow of a cell execution
-
-    // kernel -> execute_info
-    // ext -> createNotebookCellExecution(cell)
-    // kernel -> done
-    // exec.dispose();
-
-    // export interface NotebookCellExecution {
-    // 	dispose(): void;
-    // 	clearOutput(): void;
-    // 	appendOutput(out: NotebookCellOutput): void;
-    // 	replaceOutput(out: NotebookCellOutput): void;
-    //  appendOutputItems(output:string, items: NotebookCellOutputItem[]):void;
-    //  replaceOutputItems(output:string, items: NotebookCellOutputItem[]):void;
-    // }
-
-    // export function createNotebookCellExecution(cell: NotebookCell, startTime?: number): NotebookCellExecution;
-    // export const onDidStartNotebookCellExecution: Event<any>;
-    // export const onDidStopNotebookCellExecution: Event<any>;
-
-    export interface NotebookKernel {
-        // todo@API make this mandatory?
-        readonly id?: string;
-
-        label: string;
-        description?: string;
-        detail?: string;
-        isPreferred?: boolean;
-
-        // todo@API is this maybe an output property?
-        preloads?: Uri[];
-
-        /**
-         * languages supported by kernel
-         * - first is preferred
-         * - `undefined` means all languages available in the editor
-         */
-        supportedLanguages?: string[];
-
-        // todo@API kernel updating itself
-        // fired when properties like the supported languages etc change
-        // onDidChangeProperties?: Event<void>
-
-        // @roblourens
-        // todo@API change to `executeCells(document: NotebookDocument, cells: NotebookCellRange[], context:{isWholeNotebooke: boolean}, token: CancelationToken): void;`
-        // todo@API interrupt vs cancellation, https://github.com/microsoft/vscode/issues/106741
-        // interrupt?():void;
-        executeCell(document: NotebookDocument, cell: NotebookCell): void;
-        cancelCellExecution(document: NotebookDocument, cell: NotebookCell): void;
-        executeAllCells(document: NotebookDocument): void;
-        cancelAllCellsExecution(document: NotebookDocument): void;
-    }
-
-    export type NotebookFilenamePattern = GlobPattern | { include: GlobPattern; exclude: GlobPattern };
-
-    // todo@API why not for NotebookContentProvider?
-    export interface NotebookDocumentFilter {
-        viewType?: string | string[];
-        filenamePattern?: NotebookFilenamePattern;
-    }
-
-    // todo@API very unclear, provider MUST not return alive object but only data object
-    // todo@API unclear how the flow goes
-    export interface NotebookKernelProvider<T extends NotebookKernel = NotebookKernel> {
-        onDidChangeKernels?: Event<NotebookDocument | undefined>;
-        provideKernels(document: NotebookDocument, token: CancellationToken): ProviderResult<T[]>;
-        resolveKernel?(
-            kernel: T,
-            document: NotebookDocument,
-            webview: NotebookCommunication,
-            token: CancellationToken,
-        ): ProviderResult<void>;
-    }
-
-    export interface NotebookEditor {
-        /**
-         * Active kernel used in the editor
-         */
-        // todo@API unsure about that
-        // kernel, kernel selection, kernel provider
-        readonly kernel?: NotebookKernel;
-    }
-
-    export namespace notebook {
-        export const onDidChangeActiveNotebookKernel: Event<{
-            document: NotebookDocument;
-            kernel: NotebookKernel | undefined;
-        }>;
-
-        export function registerNotebookKernelProvider(
-            selector: NotebookDocumentFilter,
-            provider: NotebookKernelProvider,
-        ): Disposable;
-    }
-
-    //#endregion
-
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorDecorationType
-
-    export interface NotebookEditor {
-        setDecorations(decorationType: NotebookEditorDecorationType, range: NotebookCellRange): void;
-    }
-
-    export interface NotebookDecorationRenderOptions {
-        backgroundColor?: string | ThemeColor;
-        borderColor?: string | ThemeColor;
-        top: ThemableDecorationAttachmentRenderOptions;
-    }
-
-    export interface NotebookEditorDecorationType {
-        readonly key: string;
-        dispose(): void;
-    }
-
-    export namespace notebook {
-        export function createNotebookEditorDecorationType(
-            options: NotebookDecorationRenderOptions,
-        ): NotebookEditorDecorationType;
-    }
-
-    //#endregion
-
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookCellStatusBarItem
+    // this is not implemented...
+    readonly viewColumn?: ViewColumn;
 
     /**
-     * Represents the alignment of status bar items.
+     * Fired when the panel is disposed.
      */
-    export enum NotebookCellStatusBarAlignment {
-        /**
-         * Aligned to the left side.
-         */
-        Left = 1,
+    // @rebornix REMOVE/REplace NotebookCommunication
+    // todo@API fishy? notebooks are public objects, there should be a "global" events for this
+    readonly onDidDispose: Event<void>;
+}
 
-        /**
-         * Aligned to the right side.
-         */
-        Right = 2,
-    }
+export interface NotebookDocumentMetadataChangeEvent {
+    readonly document: NotebookDocument;
+}
 
-    export interface NotebookCellStatusBarItem {
-        readonly cell: NotebookCell;
-        readonly alignment: NotebookCellStatusBarAlignment;
-        readonly priority?: number;
-        text: string;
-        tooltip: string | undefined;
-        command: string | Command | undefined;
-        accessibilityInformation?: AccessibilityInformation;
-        show(): void;
-        hide(): void;
-        dispose(): void;
-    }
+export interface NotebookCellsChangeData {
+    readonly start: number;
+    readonly deletedCount: number;
+    readonly deletedItems: NotebookCell[];
+    readonly items: NotebookCell[];
+}
 
-    export namespace notebook {
-        /**
-         * Creates a notebook cell status bar [item](#NotebookCellStatusBarItem).
-         * It will be disposed automatically when the notebook document is closed or the cell is deleted.
-         *
-         * @param cell The cell on which this item should be shown.
-         * @param alignment The alignment of the item.
-         * @param priority The priority of the item. Higher values mean the item should be shown more to the left.
-         * @return A new status bar item.
-         */
-        // @roblourens
-        // todo@API this should be a provider, https://github.com/microsoft/vscode/issues/105809
-        export function createCellStatusBarItem(
-            cell: NotebookCell,
-            alignment?: NotebookCellStatusBarAlignment,
-            priority?: number,
-        ): NotebookCellStatusBarItem;
-    }
+export interface NotebookCellsChangeEvent {
+    /**
+     * The affected document.
+     */
+    readonly document: NotebookDocument;
+    readonly changes: ReadonlyArray<NotebookCellsChangeData>;
+}
 
-    //#endregion
+export interface NotebookCellOutputsChangeEvent {
+    /**
+     * The affected document.
+     */
+    readonly document: NotebookDocument;
+    readonly cells: NotebookCell[];
+}
 
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookConcatTextDocument
+export interface NotebookCellLanguageChangeEvent {
+    /**
+     * The affected document.
+     */
+    readonly document: NotebookDocument;
+    readonly cell: NotebookCell;
+    readonly language: string;
+}
 
-    export namespace notebook {
-        /**
-         * Create a document that is the concatenation of all  notebook cells. By default all code-cells are included
-         * but a selector can be provided to narrow to down the set of cells.
-         *
-         * @param notebook
-         * @param selector
-         */
-        // @jrieken REMOVE. p_never
-        // todo@API really needed? we didn't find a user here
-        export function createConcatTextDocument(
-            notebook: NotebookDocument,
-            selector?: DocumentSelector,
-        ): NotebookConcatTextDocument;
-    }
+export interface NotebookCellMetadataChangeEvent {
+    readonly document: NotebookDocument;
+    readonly cell: NotebookCell;
+}
 
-    export interface NotebookConcatTextDocument {
-        uri: Uri;
-        isClosed: boolean;
-        dispose(): void;
-        onDidChange: Event<void>;
-        version: number;
-        getText(): string;
-        getText(range: Range): string;
+export interface NotebookEditorSelectionChangeEvent {
+    readonly notebookEditor: NotebookEditor;
+    readonly selections: ReadonlyArray<NotebookCellRange>;
+}
 
-        offsetAt(position: Position): number;
-        positionAt(offset: number): Position;
-        validateRange(range: Range): Range;
-        validatePosition(position: Position): Position;
+export interface NotebookEditorVisibleRangesChangeEvent {
+    readonly notebookEditor: NotebookEditor;
+    readonly visibleRanges: ReadonlyArray<NotebookCellRange>;
+}
 
-        locationAt(positionOrRange: Position | Range): Location;
-        positionAt(location: Location): Position;
-        contains(uri: Uri): boolean;
-    }
+// todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
+export class NotebookCellData {
+    kind: NotebookCellKind;
+    // todo@API better names: value? text?
+    source: string;
+    // todo@API how does language and MD relate?
+    language: string;
+    outputs?: NotebookCellOutput[];
+    metadata?: NotebookCellMetadata;
+    constructor(
+        kind: NotebookCellKind,
+        source: string,
+        language: string,
+        outputs?: NotebookCellOutput[],
+        metadata?: NotebookCellMetadata
+    );
+}
 
-    //#endregion
+export class NotebookData {
+    cells: NotebookCellData[];
+    metadata?: NotebookDocumentMetadata;
+    constructor(cells: NotebookCellData[], metadata?: NotebookDocumentMetadata);
+}
+
+/**
+ * Communication object passed to the {@link NotebookContentProvider} and
+ * {@link NotebookOutputRenderer} to communicate with the webview.
+ */
+export interface NotebookCommunication {
+    /**
+     * ID of the editor this object communicates with. A single notebook
+     * document can have multiple attached webviews and editors, when the
+     * notebook is split for instance. The editor ID lets you differentiate
+     * between them.
+     */
+    readonly editorId: string;
+
+    /**
+     * Fired when the output hosting webview posts a message.
+     */
+    readonly onDidReceiveMessage: Event<any>;
+    /**
+     * Post a message to the output hosting webview.
+     *
+     * Messages are only delivered if the editor is live.
+     *
+     * @param message Body of the message. This must be a string or other json serializable object.
+     */
+    postMessage(message: any): Thenable<boolean>;
+
+    /**
+     * Convert a uri for the local file system to one that can be used inside outputs webview.
+     */
+    asWebviewUri(localResource: Uri): Uri;
+
+    // @rebornix
+    // readonly onDidDispose: Event<void>;
+}
+
+// export function registerNotebookKernel(selector: string, kernel: NotebookKernel): Disposable;
+
+export interface NotebookDocumentShowOptions {
+    viewColumn?: ViewColumn;
+    preserveFocus?: boolean;
+    preview?: boolean;
+    selection?: NotebookCellRange;
+}
+
+export namespace notebook {
+    export function openNotebookDocument(uri: Uri): Thenable<NotebookDocument>;
+
+    export const onDidOpenNotebookDocument: Event<NotebookDocument>;
+    export const onDidCloseNotebookDocument: Event<NotebookDocument>;
+
+    export const onDidSaveNotebookDocument: Event<NotebookDocument>;
+
+    /**
+     * All currently known notebook documents.
+     */
+    export const notebookDocuments: ReadonlyArray<NotebookDocument>;
+    export const onDidChangeNotebookDocumentMetadata: Event<NotebookDocumentMetadataChangeEvent>;
+    export const onDidChangeNotebookCells: Event<NotebookCellsChangeEvent>;
+    export const onDidChangeCellOutputs: Event<NotebookCellOutputsChangeEvent>;
+
+    export const onDidChangeCellMetadata: Event<NotebookCellMetadataChangeEvent>;
+}
+
+export namespace window {
+    export const visibleNotebookEditors: NotebookEditor[];
+    export const onDidChangeVisibleNotebookEditors: Event<NotebookEditor[]>;
+    export const activeNotebookEditor: NotebookEditor | undefined;
+    export const onDidChangeActiveNotebookEditor: Event<NotebookEditor | undefined>;
+    export const onDidChangeNotebookEditorSelection: Event<NotebookEditorSelectionChangeEvent>;
+    export const onDidChangeNotebookEditorVisibleRanges: Event<NotebookEditorVisibleRangesChangeEvent>;
+
+    export function showNotebookDocument(uri: Uri, options?: NotebookDocumentShowOptions): Thenable<NotebookEditor>;
+    export function showNotebookDocument(
+        document: NotebookDocument,
+        options?: NotebookDocumentShowOptions
+    ): Thenable<NotebookEditor>;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookCellOutput
+
+// code specific mime types
+// application/x.notebook.error-traceback
+// application/x.notebook.stream
+export class NotebookCellOutputItem {
+    // todo@API
+    // add factory functions for common mime types
+    // static textplain(value:string): NotebookCellOutputItem;
+    // static errortrace(value:any): NotebookCellOutputItem;
+
+    readonly mime: string;
+    readonly value: unknown;
+    readonly metadata?: Record<string, any>;
+
+    constructor(mime: string, value: unknown, metadata?: Record<string, any>);
+}
+
+// @jrieken
+// todo@API think about readonly...
+//TODO@API add execution count to cell output?
+export class NotebookCellOutput {
+    readonly id: string;
+    readonly outputs: NotebookCellOutputItem[];
+    readonly metadata?: Record<string, any>;
+
+    constructor(outputs: NotebookCellOutputItem[], metadata?: Record<string, any>);
+
+    constructor(outputs: NotebookCellOutputItem[], id: string, metadata?: Record<string, any>);
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorEdit
+
+export interface WorkspaceEdit {
+    replaceNotebookMetadata(uri: Uri, value: NotebookDocumentMetadata): void;
+
+    // todo@API use NotebookCellRange
+    replaceNotebookCells(
+        uri: Uri,
+        start: number,
+        end: number,
+        cells: NotebookCellData[],
+        metadata?: WorkspaceEditEntryMetadata
+    ): void;
+    replaceNotebookCellMetadata(
+        uri: Uri,
+        index: number,
+        cellMetadata: NotebookCellMetadata,
+        metadata?: WorkspaceEditEntryMetadata
+    ): void;
+
+    replaceNotebookCellOutput(
+        uri: Uri,
+        index: number,
+        outputs: NotebookCellOutput[],
+        metadata?: WorkspaceEditEntryMetadata
+    ): void;
+    appendNotebookCellOutput(
+        uri: Uri,
+        index: number,
+        outputs: NotebookCellOutput[],
+        metadata?: WorkspaceEditEntryMetadata
+    ): void;
+
+    // TODO@api
+    // https://jupyter-protocol.readthedocs.io/en/latest/messaging.html#update-display-data
+    replaceNotebookCellOutputItems(
+        uri: Uri,
+        index: number,
+        outputId: string,
+        items: NotebookCellOutputItem[],
+        metadata?: WorkspaceEditEntryMetadata
+    ): void;
+    appendNotebookCellOutputItems(
+        uri: Uri,
+        index: number,
+        outputId: string,
+        items: NotebookCellOutputItem[],
+        metadata?: WorkspaceEditEntryMetadata
+    ): void;
+}
+
+export interface NotebookEditorEdit {
+    replaceMetadata(value: NotebookDocumentMetadata): void;
+    replaceCells(start: number, end: number, cells: NotebookCellData[]): void;
+    replaceCellOutput(index: number, outputs: NotebookCellOutput[]): void;
+    replaceCellMetadata(index: number, metadata: NotebookCellMetadata): void;
+}
+
+export interface NotebookEditor {
+    /**
+     * Perform an edit on the notebook associated with this notebook editor.
+     *
+     * The given callback-function is invoked with an [edit-builder](#NotebookEditorEdit) which must
+     * be used to make edits. Note that the edit-builder is only valid while the
+     * callback executes.
+     *
+     * @param callback A function which can create edits using an [edit-builder](#NotebookEditorEdit).
+     * @return A promise that resolves with a value indicating if the edits could be applied.
+     */
+    // @jrieken REMOVE maybe
+    edit(callback: (editBuilder: NotebookEditorEdit) => void): Thenable<boolean>;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookContentProvider
+
+interface NotebookDocumentBackup {
+    /**
+     * Unique identifier for the backup.
+     *
+     * This id is passed back to your extension in `openNotebook` when opening a notebook editor from a backup.
+     */
+    readonly id: string;
+
+    /**
+     * Delete the current backup.
+     *
+     * This is called by VS Code when it is clear the current backup is no longer needed, such as when a new backup
+     * is made or when the file is saved.
+     */
+    delete(): void;
+}
+
+interface NotebookDocumentBackupContext {
+    readonly destination: Uri;
+}
+
+interface NotebookDocumentOpenContext {
+    readonly backupId?: string;
+    readonly untitledDocumentData?: Uint8Array;
+}
+
+// todo@API use openNotebookDOCUMENT to align with openCustomDocument etc?
+// todo@API rename to NotebookDocumentContentProvider
+export interface NotebookContentProvider {
+    readonly options?: NotebookDocumentContentOptions;
+    readonly onDidChangeNotebookContentOptions?: Event<NotebookDocumentContentOptions>;
+
+    // todo@API remove! against separation of data provider and renderer
+    // eslint-disable-next-line vscode-dts-cancellation
+    resolveNotebook(document: NotebookDocument, webview: NotebookCommunication): Thenable<void>;
+
+    /**
+     * Content providers should always use [file system providers](#FileSystemProvider) to
+     * resolve the raw content for `uri` as the resouce is not necessarily a file on disk.
+     */
+    openNotebook(
+        uri: Uri,
+        openContext: NotebookDocumentOpenContext,
+        token: CancellationToken
+    ): NotebookData | Thenable<NotebookData>;
+
+    saveNotebook(document: NotebookDocument, token: CancellationToken): Thenable<void>;
+
+    saveNotebookAs(targetResource: Uri, document: NotebookDocument, token: CancellationToken): Thenable<void>;
+
+    backupNotebook(
+        document: NotebookDocument,
+        context: NotebookDocumentBackupContext,
+        token: CancellationToken
+    ): Thenable<NotebookDocumentBackup>;
+}
+
+export namespace notebook {
+    // TODO@api use NotebookDocumentFilter instead of just notebookType:string?
+    // TODO@API options duplicates the more powerful variant on NotebookContentProvider
+    export function registerNotebookContentProvider(
+        notebookType: string,
+        provider: NotebookContentProvider,
+        options?: NotebookDocumentContentOptions & {
+            /**
+             * Not ready for production or development use yet.
+             */
+            viewOptions?: {
+                displayName: string;
+                filenamePattern: NotebookFilenamePattern[];
+                exclusive?: boolean;
+            };
+        }
+    ): Disposable;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookKernel
+
+// todo@API use the NotebookCellExecution-object as a container to model and enforce
+// the flow of a cell execution
+
+// kernel -> execute_info
+// ext -> createNotebookCellExecution(cell)
+// kernel -> done
+// exec.dispose();
+
+// export interface NotebookCellExecution {
+// 	dispose(): void;
+// 	clearOutput(): void;
+// 	appendOutput(out: NotebookCellOutput): void;
+// 	replaceOutput(out: NotebookCellOutput): void;
+//  appendOutputItems(output:string, items: NotebookCellOutputItem[]):void;
+//  replaceOutputItems(output:string, items: NotebookCellOutputItem[]):void;
+// }
+
+// export function createNotebookCellExecution(cell: NotebookCell, startTime?: number): NotebookCellExecution;
+// export const onDidStartNotebookCellExecution: Event<any>;
+// export const onDidStopNotebookCellExecution: Event<any>;
+
+export interface NotebookKernel {
+    // todo@API make this mandatory?
+    readonly id?: string;
+
+    label: string;
+    description?: string;
+    detail?: string;
+    isPreferred?: boolean;
+
+    // todo@API is this maybe an output property?
+    preloads?: Uri[];
+
+    /**
+     * languages supported by kernel
+     * - first is preferred
+     * - `undefined` means all languages available in the editor
+     */
+    supportedLanguages?: string[];
+
+    // todo@API kernel updating itself
+    // fired when properties like the supported languages etc change
+    // onDidChangeProperties?: Event<void>
+
+    // @roblourens
+    // todo@API change to `executeCells(document: NotebookDocument, cells: NotebookCellRange[], context:{isWholeNotebooke: boolean}, token: CancelationToken): void;`
+    // todo@API interrupt vs cancellation, https://github.com/microsoft/vscode/issues/106741
+    // interrupt?():void;
+    executeCell(document: NotebookDocument, cell: NotebookCell): void;
+    cancelCellExecution(document: NotebookDocument, cell: NotebookCell): void;
+    executeAllCells(document: NotebookDocument): void;
+    cancelAllCellsExecution(document: NotebookDocument): void;
+}
+
+export type NotebookFilenamePattern = GlobPattern | { include: GlobPattern; exclude: GlobPattern };
+
+// todo@API why not for NotebookContentProvider?
+export interface NotebookDocumentFilter {
+    viewType?: string | string[];
+    filenamePattern?: NotebookFilenamePattern;
+}
+
+// todo@API very unclear, provider MUST not return alive object but only data object
+// todo@API unclear how the flow goes
+export interface NotebookKernelProvider<T extends NotebookKernel = NotebookKernel> {
+    onDidChangeKernels?: Event<NotebookDocument | undefined>;
+    provideKernels(document: NotebookDocument, token: CancellationToken): ProviderResult<T[]>;
+    resolveKernel?(
+        kernel: T,
+        document: NotebookDocument,
+        webview: NotebookCommunication,
+        token: CancellationToken
+    ): ProviderResult<void>;
+}
+
+export interface NotebookEditor {
+    /**
+     * Active kernel used in the editor
+     */
+    // todo@API unsure about that
+    // kernel, kernel selection, kernel provider
+    readonly kernel?: NotebookKernel;
+}
+
+export namespace notebook {
+    export const onDidChangeActiveNotebookKernel: Event<{
+        document: NotebookDocument;
+        kernel: NotebookKernel | undefined;
+    }>;
+
+    export function registerNotebookKernelProvider(
+        selector: NotebookDocumentFilter,
+        provider: NotebookKernelProvider
+    ): Disposable;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorDecorationType
+
+export interface NotebookEditor {
+    setDecorations(decorationType: NotebookEditorDecorationType, range: NotebookCellRange): void;
+}
+
+export interface NotebookDecorationRenderOptions {
+    backgroundColor?: string | ThemeColor;
+    borderColor?: string | ThemeColor;
+    top: ThemableDecorationAttachmentRenderOptions;
+}
+
+export interface NotebookEditorDecorationType {
+    readonly key: string;
+    dispose(): void;
+}
+
+export namespace notebook {
+    export function createNotebookEditorDecorationType(
+        options: NotebookDecorationRenderOptions
+    ): NotebookEditorDecorationType;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookCellStatusBarItem
+
+/**
+ * Represents the alignment of status bar items.
+ */
+export enum NotebookCellStatusBarAlignment {
+    /**
+     * Aligned to the left side.
+     */
+    Left = 1,
+
+    /**
+     * Aligned to the right side.
+     */
+    Right = 2
+}
+
+export interface NotebookCellStatusBarItem {
+    readonly cell: NotebookCell;
+    readonly alignment: NotebookCellStatusBarAlignment;
+    readonly priority?: number;
+    text: string;
+    tooltip: string | undefined;
+    command: string | Command | undefined;
+    accessibilityInformation?: AccessibilityInformation;
+    show(): void;
+    hide(): void;
+    dispose(): void;
+}
+
+export namespace notebook {
+    /**
+     * Creates a notebook cell status bar [item](#NotebookCellStatusBarItem).
+     * It will be disposed automatically when the notebook document is closed or the cell is deleted.
+     *
+     * @param cell The cell on which this item should be shown.
+     * @param alignment The alignment of the item.
+     * @param priority The priority of the item. Higher values mean the item should be shown more to the left.
+     * @return A new status bar item.
+     */
+    // @roblourens
+    // todo@API this should be a provider, https://github.com/microsoft/vscode/issues/105809
+    export function createCellStatusBarItem(
+        cell: NotebookCell,
+        alignment?: NotebookCellStatusBarAlignment,
+        priority?: number
+    ): NotebookCellStatusBarItem;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookConcatTextDocument
+
+export namespace notebook {
+    /**
+     * Create a document that is the concatenation of all  notebook cells. By default all code-cells are included
+     * but a selector can be provided to narrow to down the set of cells.
+     *
+     * @param notebook
+     * @param selector
+     */
+    // @jrieken REMOVE. p_never
+    // todo@API really needed? we didn't find a user here
+    export function createConcatTextDocument(
+        notebook: NotebookDocument,
+        selector?: DocumentSelector
+    ): NotebookConcatTextDocument;
+}
+
+export interface NotebookConcatTextDocument {
+    uri: Uri;
+    isClosed: boolean;
+    dispose(): void;
+    onDidChange: Event<void>;
+    version: number;
+    getText(): string;
+    getText(range: Range): string;
+
+    offsetAt(position: Position): number;
+    positionAt(offset: number): Position;
+    validateRange(range: Range): Range;
+    validatePosition(position: Position): Position;
+
+    locationAt(positionOrRange: Position | Range): Location;
+    positionAt(location: Location): Position;
+    contains(uri: Uri): boolean;
+}
+
+//#endregion
     // #region debug
 
     /**

--- a/types/vscode.proposed.d.ts
+++ b/types/vscode.proposed.d.ts
@@ -296,15 +296,6 @@ declare module 'vscode' {
         readonly cells: NotebookCell[];
     }
 
-    export interface NotebookCellLanguageChangeEvent {
-        /**
-         * The affected document.
-         */
-        readonly document: NotebookDocument;
-        readonly cell: NotebookCell;
-        readonly language: string;
-    }
-
     export interface NotebookCellMetadataChangeEvent {
         readonly document: NotebookDocument;
         readonly cell: NotebookCell;
@@ -404,10 +395,6 @@ declare module 'vscode' {
         export const onDidChangeNotebookDocumentMetadata: Event<NotebookDocumentMetadataChangeEvent>;
         export const onDidChangeNotebookCells: Event<NotebookCellsChangeEvent>;
         export const onDidChangeCellOutputs: Event<NotebookCellOutputsChangeEvent>;
-
-        // todo@API we send document close and open events when the language of a document changes and
-        // I believe we should stick that for cells as well
-        export const onDidChangeCellLanguage: Event<NotebookCellLanguageChangeEvent>;
         export const onDidChangeCellMetadata: Event<NotebookCellMetadataChangeEvent>;
     }
 
@@ -823,6 +810,8 @@ declare module 'vscode' {
     }
 
     //#endregion
+    // #region debug
+
     /**
      * A DebugProtocolVariableContainer is an opaque stand-in type for the intersection of the Scope and Variable types defined in the Debug Adapter Protocol.
      * See https://microsoft.github.io/debug-adapter-protocol/specification#Types_Scope and https://microsoft.github.io/debug-adapter-protocol/specification#Types_Variable.

--- a/typings/vscode-proposed/index.d.ts
+++ b/typings/vscode-proposed/index.d.ts
@@ -23,818 +23,809 @@ import {
     ThemeColor,
 } from 'vscode';
 
-//#region https://github.com/microsoft/vscode/issues/106744, Notebooks (misc)
+    //#region https://github.com/microsoft/vscode/issues/106744, Notebooks (misc)
 
-export enum NotebookCellKind {
-    Markdown = 1,
-    Code = 2,
-}
+    export enum NotebookCellKind {
+        Markdown = 1,
+        Code = 2
+    }
 
-export enum NotebookCellRunState {
-    Running = 1,
-    Idle = 2,
-    Success = 3,
-    Error = 4,
-}
+    export enum NotebookCellRunState {
+        Running = 1,
+        Idle = 2,
+        Success = 3,
+        Error = 4
+    }
 
-export enum NotebookRunState {
-    Running = 1,
-    Idle = 2,
-}
+    export enum NotebookRunState {
+        Running = 1,
+        Idle = 2
+    }
 
-export class NotebookCellMetadata {
+    export class NotebookCellMetadata {
+        /**
+         * Controls whether a cell's editor is editable/readonly.
+         */
+        readonly editable?: boolean;
+        /**
+         * Controls if the cell has a margin to support the breakpoint UI.
+         * This metadata is ignored for markdown cell.
+         */
+        readonly breakpointMargin?: boolean;
+        /**
+         * Whether a code cell's editor is collapsed
+         */
+        readonly outputCollapsed?: boolean;
+        /**
+         * Whether a code cell's outputs are collapsed
+         */
+        readonly inputCollapsed?: boolean;
+        /**
+         * Additional attributes of a cell metadata.
+         */
+        readonly custom?: Record<string, any>;
+
+        // todo@API duplicates status bar API
+        readonly statusMessage?: string;
+
+        // run related API, will be removed
+        readonly runnable?: boolean;
+        readonly hasExecutionOrder?: boolean;
+        readonly executionOrder?: number;
+        readonly runState?: NotebookCellRunState;
+        readonly runStartTime?: number;
+        readonly lastRunDuration?: number;
+
+        constructor(
+            editable?: boolean,
+            breakpointMargin?: boolean,
+            runnable?: boolean,
+            hasExecutionOrder?: boolean,
+            executionOrder?: number,
+            runState?: NotebookCellRunState,
+            runStartTime?: number,
+            statusMessage?: string,
+            lastRunDuration?: number,
+            inputCollapsed?: boolean,
+            outputCollapsed?: boolean,
+            custom?: Record<string, any>
+        );
+
+        with(change: {
+            editable?: boolean | null;
+            breakpointMargin?: boolean | null;
+            runnable?: boolean | null;
+            hasExecutionOrder?: boolean | null;
+            executionOrder?: number | null;
+            runState?: NotebookCellRunState | null;
+            runStartTime?: number | null;
+            statusMessage?: string | null;
+            lastRunDuration?: number | null;
+            inputCollapsed?: boolean | null;
+            outputCollapsed?: boolean | null;
+            custom?: Record<string, any> | null;
+        }): NotebookCellMetadata;
+    }
+
+    // todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
+    export interface NotebookCell {
+        readonly index: number;
+        readonly notebook: NotebookDocument;
+        readonly cellKind: NotebookCellKind;
+        // todo@API duplicates #document.uri
+        readonly uri: Uri;
+        // todo@API duplicates #document.languageId
+        readonly language: string;
+        readonly document: TextDocument;
+        readonly outputs: readonly NotebookCellOutput[];
+        readonly metadata: NotebookCellMetadata;
+    }
+
+    export class NotebookDocumentMetadata {
+        /**
+         * Controls if users can add or delete cells
+         * Defaults to true
+         */
+        readonly editable: boolean;
+        /**
+         * Default value for [cell editable metadata](#NotebookCellMetadata.editable).
+         * Defaults to true.
+         */
+        readonly cellEditable: boolean;
+        /**
+         * Additional attributes of the document metadata.
+         */
+        readonly custom: { [key: string]: any };
+        /**
+         * Whether the document is trusted, default to true
+         * When false, insecure outputs like HTML, JavaScript, SVG will not be rendered.
+         */
+        readonly trusted: boolean;
+
+        // todo@API is this a kernel property?
+        readonly cellHasExecutionOrder: boolean;
+
+        // run related, remove infer from kernel, exec
+        // todo@API infer from kernel
+        // todo@API remove
+        readonly runnable: boolean;
+        readonly cellRunnable: boolean;
+        readonly runState: NotebookRunState;
+
+        constructor(
+            editable?: boolean,
+            runnable?: boolean,
+            cellEditable?: boolean,
+            cellRunnable?: boolean,
+            cellHasExecutionOrder?: boolean,
+            custom?: { [key: string]: any },
+            runState?: NotebookRunState,
+            trusted?: boolean
+        );
+
+        with(change: {
+            editable?: boolean | null;
+            runnable?: boolean | null;
+            cellEditable?: boolean | null;
+            cellRunnable?: boolean | null;
+            cellHasExecutionOrder?: boolean | null;
+            custom?: { [key: string]: any } | null;
+            runState?: NotebookRunState | null;
+            trusted?: boolean | null;
+        }): NotebookDocumentMetadata;
+    }
+
+    export interface NotebookDocumentContentOptions {
+        /**
+         * Controls if outputs change will trigger notebook document content change and if it will be used in the diff editor
+         * Default to false. If the content provider doesn't persisit the outputs in the file document, this should be set to true.
+         */
+        transientOutputs: boolean;
+
+        /**
+         * Controls if a meetadata property change will trigger notebook document content change and if it will be used in the diff editor
+         * Default to false. If the content provider doesn't persisit a metadata property in the file document, it should be set to true.
+         */
+        transientMetadata: { [K in keyof NotebookCellMetadata]?: boolean };
+    }
+
+    export interface NotebookDocument {
+        readonly uri: Uri;
+        readonly version: number;
+        // todo@API don't have this...
+        readonly fileName: string;
+        // todo@API should we really expose this?
+        readonly viewType: string;
+        readonly isDirty: boolean;
+        readonly isUntitled: boolean;
+        readonly cells: ReadonlyArray<NotebookCell>;
+        readonly contentOptions: NotebookDocumentContentOptions;
+        readonly metadata: NotebookDocumentMetadata;
+
+        /**
+         * Save the document. The saving will be handled by the corresponding content provider
+         *
+         * @return A promise that will resolve to true when the document
+         * has been saved. If the file was not dirty or the save failed,
+         * will return false.
+         */
+        save(): Thenable<boolean>;
+    }
+
+    // todo@API maybe have a NotebookCellPosition sibling
+    export class NotebookCellRange {
+        readonly start: number;
+        /**
+         * exclusive
+         */
+        readonly end: number;
+
+        constructor(start: number, end: number);
+    }
+
+    export enum NotebookEditorRevealType {
+        /**
+         * The range will be revealed with as little scrolling as possible.
+         */
+        Default = 0,
+        /**
+         * The range will always be revealed in the center of the viewport.
+         */
+        InCenter = 1,
+
+        /**
+         * If the range is outside the viewport, it will be revealed in the center of the viewport.
+         * Otherwise, it will be revealed with as little scrolling as possible.
+         */
+        InCenterIfOutsideViewport = 2,
+
+        /**
+         * The range will always be revealed at the top of the viewport.
+         */
+        AtTop = 3
+    }
+
+    export interface NotebookEditor {
+        /**
+         * The document associated with this notebook editor.
+         */
+        readonly document: NotebookDocument;
+
+        /**
+         * The primary selected cell on this notebook editor.
+         */
+        // todo@API should not be undefined, rather a default
+        readonly selection?: NotebookCell;
+
+        /**
+         * todo@API should replace selection
+         * The selections on this notebook editor.
+         *
+         * The primary selection (or focused range) is `selections[0]`. When the document has no cells, the primary selection is empty `{ start: 0, end: 0 }`;
+         */
+        readonly selections: NotebookCellRange[];
+
+        /**
+         * The current visible ranges in the editor (vertically).
+         */
+        readonly visibleRanges: NotebookCellRange[];
+
+        revealRange(range: NotebookCellRange, revealType?: NotebookEditorRevealType): void;
+
+        /**
+         * The column in which this editor shows.
+         */
+        // @jrieken
+        // todo@API maybe never undefined because notebooks always show in the editor area (unlike text editors)
+        // maybe for notebook diff editor
+        readonly viewColumn?: ViewColumn;
+
+        /**
+         * Fired when the panel is disposed.
+         */
+        // @rebornix REMOVE/REplace NotebookCommunication
+        // todo@API fishy? notebooks are public objects, there should be a "global" events for this
+        readonly onDidDispose: Event<void>;
+    }
+
+    export interface NotebookDocumentMetadataChangeEvent {
+        readonly document: NotebookDocument;
+    }
+
+    export interface NotebookCellsChangeData {
+        readonly start: number;
+        readonly deletedCount: number;
+        readonly deletedItems: NotebookCell[];
+        readonly items: NotebookCell[];
+    }
+
+    export interface NotebookCellsChangeEvent {
+        /**
+         * The affected document.
+         */
+        readonly document: NotebookDocument;
+        readonly changes: ReadonlyArray<NotebookCellsChangeData>;
+    }
+
+    export interface NotebookCellOutputsChangeEvent {
+        /**
+         * The affected document.
+         */
+        readonly document: NotebookDocument;
+        readonly cells: NotebookCell[];
+    }
+
+    export interface NotebookCellMetadataChangeEvent {
+        readonly document: NotebookDocument;
+        readonly cell: NotebookCell;
+    }
+
+    export interface NotebookEditorSelectionChangeEvent {
+        readonly notebookEditor: NotebookEditor;
+        readonly selections: ReadonlyArray<NotebookCellRange>;
+    }
+
+    export interface NotebookEditorVisibleRangesChangeEvent {
+        readonly notebookEditor: NotebookEditor;
+        readonly visibleRanges: ReadonlyArray<NotebookCellRange>;
+    }
+
+    // todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
+    export class NotebookCellData {
+        kind: NotebookCellKind;
+        // todo@API better names: value? text?
+        source: string;
+        // todo@API how does language and MD relate?
+        language: string;
+        outputs?: NotebookCellOutput[];
+        metadata?: NotebookCellMetadata;
+        constructor(
+            kind: NotebookCellKind,
+            source: string,
+            language: string,
+            outputs?: NotebookCellOutput[],
+            metadata?: NotebookCellMetadata
+        );
+    }
+
+    export class NotebookData {
+        cells: NotebookCellData[];
+        metadata?: NotebookDocumentMetadata;
+        constructor(cells: NotebookCellData[], metadata?: NotebookDocumentMetadata);
+    }
+
     /**
-     * Controls whether a cell's editor is editable/readonly.
+     * Communication object passed to the {@link NotebookContentProvider} and
+     * {@link NotebookOutputRenderer} to communicate with the webview.
      */
-    readonly editable?: boolean;
-    /**
-     * Controls if the cell has a margin to support the breakpoint UI.
-     * This metadata is ignored for markdown cell.
-     */
-    readonly breakpointMargin?: boolean;
-    /**
-     * Whether a code cell's editor is collapsed
-     */
-    readonly outputCollapsed?: boolean;
-    /**
-     * Whether a code cell's outputs are collapsed
-     */
-    readonly inputCollapsed?: boolean;
-    /**
-     * Additional attributes of a cell metadata.
-     */
-    readonly custom?: Record<string, any>;
+    export interface NotebookCommunication {
+        /**
+         * ID of the editor this object communicates with. A single notebook
+         * document can have multiple attached webviews and editors, when the
+         * notebook is split for instance. The editor ID lets you differentiate
+         * between them.
+         */
+        readonly editorId: string;
 
-    // todo@API duplicates status bar API
-    readonly statusMessage?: string;
+        /**
+         * Fired when the output hosting webview posts a message.
+         */
+        readonly onDidReceiveMessage: Event<any>;
+        /**
+         * Post a message to the output hosting webview.
+         *
+         * Messages are only delivered if the editor is live.
+         *
+         * @param message Body of the message. This must be a string or other json serializable object.
+         */
+        postMessage(message: any): Thenable<boolean>;
 
-    // run related API, will be removed
-    readonly runnable?: boolean;
-    readonly hasExecutionOrder?: boolean;
-    readonly executionOrder?: number;
-    readonly runState?: NotebookCellRunState;
-    readonly runStartTime?: number;
-    readonly lastRunDuration?: number;
+        /**
+         * Convert a uri for the local file system to one that can be used inside outputs webview.
+         */
+        asWebviewUri(localResource: Uri): Uri;
 
-    constructor(
-        editable?: boolean,
-        breakpointMargin?: boolean,
-        runnable?: boolean,
-        hasExecutionOrder?: boolean,
-        executionOrder?: number,
-        runState?: NotebookCellRunState,
-        runStartTime?: number,
-        statusMessage?: string,
-        lastRunDuration?: number,
-        inputCollapsed?: boolean,
-        outputCollapsed?: boolean,
-        custom?: Record<string, any>,
-    );
+        // @rebornix
+        // readonly onDidDispose: Event<void>;
+    }
 
-    with(change: {
-        editable?: boolean | null;
-        breakpointMargin?: boolean | null;
-        runnable?: boolean | null;
-        hasExecutionOrder?: boolean | null;
-        executionOrder?: number | null;
-        runState?: NotebookCellRunState | null;
-        runStartTime?: number | null;
-        statusMessage?: string | null;
-        lastRunDuration?: number | null;
-        inputCollapsed?: boolean | null;
-        outputCollapsed?: boolean | null;
-        custom?: Record<string, any> | null;
-    }): NotebookCellMetadata;
-}
+    // export function registerNotebookKernel(selector: string, kernel: NotebookKernel): Disposable;
 
-// todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
-export interface NotebookCell {
-    readonly index: number;
-    readonly notebook: NotebookDocument;
-    readonly cellKind: NotebookCellKind;
-    // todo@API duplicates #document.uri
-    readonly uri: Uri;
-    // todo@API duplicates #document.languageId
-    readonly language: string;
-    readonly document: TextDocument;
-    readonly outputs: readonly NotebookCellOutput[];
-    readonly metadata: NotebookCellMetadata;
-}
+    export interface NotebookDocumentShowOptions {
+        viewColumn?: ViewColumn;
+        preserveFocus?: boolean;
+        preview?: boolean;
+        selection?: NotebookCellRange;
+    }
 
-export class NotebookDocumentMetadata {
-    /**
-     * Controls if users can add or delete cells
-     * Defaults to true
-     */
-    readonly editable: boolean;
-    /**
-     * Default value for [cell editable metadata](#NotebookCellMetadata.editable).
-     * Defaults to true.
-     */
-    readonly cellEditable: boolean;
-    /**
-     * Additional attributes of the document metadata.
-     */
-    readonly custom: { [key: string]: any };
-    /**
-     * Whether the document is trusted, default to true
-     * When false, insecure outputs like HTML, JavaScript, SVG will not be rendered.
-     */
-    readonly trusted: boolean;
+    export namespace notebook {
+        // todo@API should we really support to pass the viewType? We do NOT support
+        // to open the same file with different viewTypes at the same time
+        export function openNotebookDocument(uri: Uri, viewType?: string): Thenable<NotebookDocument>;
+        export const onDidOpenNotebookDocument: Event<NotebookDocument>;
+        export const onDidCloseNotebookDocument: Event<NotebookDocument>;
 
-    // todo@API is this a kernel property?
-    readonly cellHasExecutionOrder: boolean;
+        export const onDidSaveNotebookDocument: Event<NotebookDocument>;
 
-    // run related, remove infer from kernel, exec
-    // todo@API infer from kernel
-    // todo@API remove
-    readonly runnable: boolean;
-    readonly cellRunnable: boolean;
-    readonly runState: NotebookRunState;
+        /**
+         * All currently known notebook documents.
+         */
+        export const notebookDocuments: ReadonlyArray<NotebookDocument>;
+        export const onDidChangeNotebookDocumentMetadata: Event<NotebookDocumentMetadataChangeEvent>;
+        export const onDidChangeNotebookCells: Event<NotebookCellsChangeEvent>;
+        export const onDidChangeCellOutputs: Event<NotebookCellOutputsChangeEvent>;
+        export const onDidChangeCellMetadata: Event<NotebookCellMetadataChangeEvent>;
+    }
 
-    constructor(
-        editable?: boolean,
-        runnable?: boolean,
-        cellEditable?: boolean,
-        cellRunnable?: boolean,
-        cellHasExecutionOrder?: boolean,
-        custom?: { [key: string]: any },
-        runState?: NotebookRunState,
-        trusted?: boolean,
-    );
+    export namespace window {
+        export const visibleNotebookEditors: NotebookEditor[];
+        export const onDidChangeVisibleNotebookEditors: Event<NotebookEditor[]>;
+        export const activeNotebookEditor: NotebookEditor | undefined;
+        export const onDidChangeActiveNotebookEditor: Event<NotebookEditor | undefined>;
+        export const onDidChangeNotebookEditorSelection: Event<NotebookEditorSelectionChangeEvent>;
+        export const onDidChangeNotebookEditorVisibleRanges: Event<NotebookEditorVisibleRangesChangeEvent>;
 
-    with(change: {
-        editable?: boolean | null;
-        runnable?: boolean | null;
-        cellEditable?: boolean | null;
-        cellRunnable?: boolean | null;
-        cellHasExecutionOrder?: boolean | null;
-        custom?: { [key: string]: any } | null;
-        runState?: NotebookRunState | null;
-        trusted?: boolean | null;
-    }): NotebookDocumentMetadata;
-}
+        export function showNotebookDocument(uri: Uri, options?: NotebookDocumentShowOptions): Thenable<NotebookEditor>;
+        export function showNotebookDocument(
+            document: NotebookDocument,
+            options?: NotebookDocumentShowOptions
+        ): Thenable<NotebookEditor>;
+    }
 
-export interface NotebookDocumentContentOptions {
-    /**
-     * Controls if outputs change will trigger notebook document content change and if it will be used in the diff editor
-     * Default to false. If the content provider doesn't persisit the outputs in the file document, this should be set to true.
-     */
-    transientOutputs: boolean;
+    //#endregion
 
-    /**
-     * Controls if a meetadata property change will trigger notebook document content change and if it will be used in the diff editor
-     * Default to false. If the content provider doesn't persisit a metadata property in the file document, it should be set to true.
-     */
-    transientMetadata: { [K in keyof NotebookCellMetadata]?: boolean };
-}
+    //#region https://github.com/microsoft/vscode/issues/106744, NotebookCellOutput
 
-export interface NotebookDocument {
-    readonly uri: Uri;
-    readonly version: number;
-    // todo@API don't have this...
-    readonly fileName: string;
-    // todo@API should we really expose this?
-    readonly viewType: string;
-    readonly isDirty: boolean;
-    readonly isUntitled: boolean;
-    readonly cells: ReadonlyArray<NotebookCell>;
-    readonly contentOptions: NotebookDocumentContentOptions;
-    readonly metadata: NotebookDocumentMetadata;
+    // code specific mime types
+    // application/x.notebook.error-traceback
+    // application/x.notebook.stream
+    export class NotebookCellOutputItem {
+        // todo@API
+        // add factory functions for common mime types
+        // static textplain(value:string): NotebookCellOutputItem;
+        // static errortrace(value:any): NotebookCellOutputItem;
 
-    /**
-     * Save the document. The saving will be handled by the corresponding content provider
-     *
-     * @return A promise that will resolve to true when the document
-     * has been saved. If the file was not dirty or the save failed,
-     * will return false.
-     */
-    save(): Thenable<boolean>;
-}
+        readonly mime: string;
+        readonly value: unknown;
+        readonly metadata?: Record<string, any>;
 
-// todo@API maybe have a NotebookCellPosition sibling
-export class NotebookCellRange {
-    readonly start: number;
-    /**
-     * exclusive
-     */
-    readonly end: number;
+        constructor(mime: string, value: unknown, metadata?: Record<string, any>);
+    }
 
-    constructor(start: number, end: number);
-}
-
-export enum NotebookEditorRevealType {
-    /**
-     * The range will be revealed with as little scrolling as possible.
-     */
-    Default = 0,
-    /**
-     * The range will always be revealed in the center of the viewport.
-     */
-    InCenter = 1,
-
-    /**
-     * If the range is outside the viewport, it will be revealed in the center of the viewport.
-     * Otherwise, it will be revealed with as little scrolling as possible.
-     */
-    InCenterIfOutsideViewport = 2,
-
-    /**
-     * The range will always be revealed at the top of the viewport.
-     */
-    AtTop = 3,
-}
-
-export interface NotebookEditor {
-    /**
-     * The document associated with this notebook editor.
-     */
-    readonly document: NotebookDocument;
-
-    /**
-     * The primary selected cell on this notebook editor.
-     */
-    // todo@API should not be undefined, rather a default
-    readonly selection?: NotebookCell;
-
-    /**
-     * todo@API should replace selection
-     * The selections on this notebook editor.
-     *
-     * The primary selection (or focused range) is `selections[0]`. When the document has no cells, the primary selection is empty `{ start: 0, end: 0 }`;
-     */
-    readonly selections: NotebookCellRange[];
-
-    /**
-     * The current visible ranges in the editor (vertically).
-     */
-    readonly visibleRanges: NotebookCellRange[];
-
-    revealRange(range: NotebookCellRange, revealType?: NotebookEditorRevealType): void;
-
-    /**
-     * The column in which this editor shows.
-     */
     // @jrieken
-    // todo@API maybe never undefined because notebooks always show in the editor area (unlike text editors)
-    // maybe for notebook diff editor
-    readonly viewColumn?: ViewColumn;
+    // todo@API think about readonly...
+    //TODO@API add execution count to cell output?
+    export class NotebookCellOutput {
+        readonly id: string;
+        readonly outputs: NotebookCellOutputItem[];
+        readonly metadata?: Record<string, any>;
+
+        constructor(outputs: NotebookCellOutputItem[], metadata?: Record<string, any>);
+
+        constructor(outputs: NotebookCellOutputItem[], id: string, metadata?: Record<string, any>);
+    }
+
+    //#endregion
+
+    //#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorEdit
+
+    export interface WorkspaceEdit {
+        replaceNotebookMetadata(uri: Uri, value: NotebookDocumentMetadata): void;
+
+        // todo@API use NotebookCellRange
+        replaceNotebookCells(
+            uri: Uri,
+            start: number,
+            end: number,
+            cells: NotebookCellData[],
+            metadata?: WorkspaceEditEntryMetadata
+        ): void;
+        replaceNotebookCellMetadata(
+            uri: Uri,
+            index: number,
+            cellMetadata: NotebookCellMetadata,
+            metadata?: WorkspaceEditEntryMetadata
+        ): void;
+
+        replaceNotebookCellOutput(
+            uri: Uri,
+            index: number,
+            outputs: NotebookCellOutput[],
+            metadata?: WorkspaceEditEntryMetadata
+        ): void;
+        appendNotebookCellOutput(
+            uri: Uri,
+            index: number,
+            outputs: NotebookCellOutput[],
+            metadata?: WorkspaceEditEntryMetadata
+        ): void;
+
+        // TODO@api
+        // https://jupyter-protocol.readthedocs.io/en/latest/messaging.html#update-display-data
+        replaceNotebookCellOutputItems(
+            uri: Uri,
+            index: number,
+            outputId: string,
+            items: NotebookCellOutputItem[],
+            metadata?: WorkspaceEditEntryMetadata
+        ): void;
+        appendNotebookCellOutputItems(
+            uri: Uri,
+            index: number,
+            outputId: string,
+            items: NotebookCellOutputItem[],
+            metadata?: WorkspaceEditEntryMetadata
+        ): void;
+    }
+
+    export interface NotebookEditorEdit {
+        replaceMetadata(value: NotebookDocumentMetadata): void;
+        replaceCells(start: number, end: number, cells: NotebookCellData[]): void;
+        replaceCellOutput(index: number, outputs: NotebookCellOutput[]): void;
+        replaceCellMetadata(index: number, metadata: NotebookCellMetadata): void;
+    }
+
+    export interface NotebookEditor {
+        /**
+         * Perform an edit on the notebook associated with this notebook editor.
+         *
+         * The given callback-function is invoked with an [edit-builder](#NotebookEditorEdit) which must
+         * be used to make edits. Note that the edit-builder is only valid while the
+         * callback executes.
+         *
+         * @param callback A function which can create edits using an [edit-builder](#NotebookEditorEdit).
+         * @return A promise that resolves with a value indicating if the edits could be applied.
+         */
+        // @jrieken REMOVE maybe
+        edit(callback: (editBuilder: NotebookEditorEdit) => void): Thenable<boolean>;
+    }
+
+    //#endregion
+
+    //#region https://github.com/microsoft/vscode/issues/106744, NotebookContentProvider
+
+    interface NotebookDocumentBackup {
+        /**
+         * Unique identifier for the backup.
+         *
+         * This id is passed back to your extension in `openNotebook` when opening a notebook editor from a backup.
+         */
+        readonly id: string;
+
+        /**
+         * Delete the current backup.
+         *
+         * This is called by VS Code when it is clear the current backup is no longer needed, such as when a new backup
+         * is made or when the file is saved.
+         */
+        delete(): void;
+    }
+
+    interface NotebookDocumentBackupContext {
+        readonly destination: Uri;
+    }
+
+    interface NotebookDocumentOpenContext {
+        readonly backupId?: string;
+    }
+
+    export interface NotebookContentProvider {
+        readonly options?: NotebookDocumentContentOptions;
+        readonly onDidChangeNotebookContentOptions?: Event<NotebookDocumentContentOptions>;
+        /**
+         * Content providers should always use [file system providers](#FileSystemProvider) to
+         * resolve the raw content for `uri` as the resouce is not necessarily a file on disk.
+         */
+        openNotebook(uri: Uri, openContext: NotebookDocumentOpenContext): NotebookData | Thenable<NotebookData>;
+        resolveNotebook(document: NotebookDocument, webview: NotebookCommunication): Thenable<void>;
+        saveNotebook(document: NotebookDocument, cancellation: CancellationToken): Thenable<void>;
+        saveNotebookAs(
+            targetResource: Uri,
+            document: NotebookDocument,
+            cancellation: CancellationToken
+        ): Thenable<void>;
+        backupNotebook(
+            document: NotebookDocument,
+            context: NotebookDocumentBackupContext,
+            cancellation: CancellationToken
+        ): Thenable<NotebookDocumentBackup>;
+
+        // ???
+        // provideKernels(document: NotebookDocument, token: CancellationToken): ProviderResult<T[]>;
+    }
+
+    export namespace notebook {
+        // TODO@api use NotebookDocumentFilter instead of just notebookType:string?
+        // TODO@API options duplicates the more powerful variant on NotebookContentProvider
+        export function registerNotebookContentProvider(
+            notebookType: string,
+            provider: NotebookContentProvider,
+            options?: NotebookDocumentContentOptions & {
+                /**
+                 * Not ready for production or development use yet.
+                 */
+                viewOptions?: {
+                    displayName: string;
+                    filenamePattern: NotebookFilenamePattern[];
+                    exclusive?: boolean;
+                };
+            }
+        ): Disposable;
+    }
+
+    //#endregion
+
+    //#region https://github.com/microsoft/vscode/issues/106744, NotebookKernel
+
+    // todo@API use the NotebookCellExecution-object as a container to model and enforce
+    // the flow of a cell execution
+
+    // kernel -> execute_info
+    // ext -> createNotebookCellExecution(cell)
+    // kernel -> done
+    // exec.dispose();
+
+    // export interface NotebookCellExecution {
+    // 	dispose(): void;
+    // 	clearOutput(): void;
+    // 	appendOutput(out: NotebookCellOutput): void;
+    // 	replaceOutput(out: NotebookCellOutput): void;
+    //  appendOutputItems(output:string, items: NotebookCellOutputItem[]):void;
+    //  replaceOutputItems(output:string, items: NotebookCellOutputItem[]):void;
+    // }
+
+    // export function createNotebookCellExecution(cell: NotebookCell, startTime?: number): NotebookCellExecution;
+    // export const onDidStartNotebookCellExecution: Event<any>;
+    // export const onDidStopNotebookCellExecution: Event<any>;
+
+    export interface NotebookKernel {
+        // todo@API make this mandatory?
+        readonly id?: string;
+
+        label: string;
+        description?: string;
+        detail?: string;
+        isPreferred?: boolean;
+
+        // todo@API is this maybe an output property?
+        preloads?: Uri[];
+
+        /**
+         * languages supported by kernel
+         * - first is preferred
+         * - `undefined` means all languages available in the editor
+         */
+        supportedLanguages?: string[];
+
+        // todo@API kernel updating itself
+        // fired when properties like the supported languages etc change
+        // onDidChangeProperties?: Event<void>
+
+        // @roblourens
+        // todo@API change to `executeCells(document: NotebookDocument, cells: NotebookCellRange[], context:{isWholeNotebooke: boolean}, token: CancelationToken): void;`
+        // todo@API interrupt vs cancellation, https://github.com/microsoft/vscode/issues/106741
+        // interrupt?():void;
+        executeCell(document: NotebookDocument, cell: NotebookCell): void;
+        cancelCellExecution(document: NotebookDocument, cell: NotebookCell): void;
+        executeAllCells(document: NotebookDocument): void;
+        cancelAllCellsExecution(document: NotebookDocument): void;
+    }
+
+    export type NotebookFilenamePattern = GlobPattern | { include: GlobPattern; exclude: GlobPattern };
+
+    // todo@API why not for NotebookContentProvider?
+    export interface NotebookDocumentFilter {
+        viewType?: string | string[];
+        filenamePattern?: NotebookFilenamePattern;
+    }
+
+    // todo@API very unclear, provider MUST not return alive object but only data object
+    // todo@API unclear how the flow goes
+    export interface NotebookKernelProvider<T extends NotebookKernel = NotebookKernel> {
+        onDidChangeKernels?: Event<NotebookDocument | undefined>;
+        provideKernels(document: NotebookDocument, token: CancellationToken): ProviderResult<T[]>;
+        resolveKernel?(
+            kernel: T,
+            document: NotebookDocument,
+            webview: NotebookCommunication,
+            token: CancellationToken
+        ): ProviderResult<void>;
+    }
+
+    export interface NotebookEditor {
+        /**
+         * Active kernel used in the editor
+         */
+        // todo@API unsure about that
+        // kernel, kernel selection, kernel provider
+        readonly kernel?: NotebookKernel;
+    }
+
+    export namespace notebook {
+        export const onDidChangeActiveNotebookKernel: Event<{
+            document: NotebookDocument;
+            kernel: NotebookKernel | undefined;
+        }>;
+
+        export function registerNotebookKernelProvider(
+            selector: NotebookDocumentFilter,
+            provider: NotebookKernelProvider
+        ): Disposable;
+    }
+
+    //#endregion
+
+    //#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorDecorationType
+
+    export interface NotebookEditor {
+        setDecorations(decorationType: NotebookEditorDecorationType, range: NotebookCellRange): void;
+    }
+
+    export interface NotebookDecorationRenderOptions {
+        backgroundColor?: string | ThemeColor;
+        borderColor?: string | ThemeColor;
+        top: ThemableDecorationAttachmentRenderOptions;
+    }
+
+    export interface NotebookEditorDecorationType {
+        readonly key: string;
+        dispose(): void;
+    }
+
+    export namespace notebook {
+        export function createNotebookEditorDecorationType(
+            options: NotebookDecorationRenderOptions
+        ): NotebookEditorDecorationType;
+    }
+
+    //#endregion
+
+    //#region https://github.com/microsoft/vscode/issues/106744, NotebookCellStatusBarItem
 
     /**
-     * Fired when the panel is disposed.
+     * Represents the alignment of status bar items.
      */
-    // @rebornix REMOVE/REplace NotebookCommunication
-    // todo@API fishy? notebooks are public objects, there should be a "global" events for this
-    readonly onDidDispose: Event<void>;
-}
-
-export interface NotebookDocumentMetadataChangeEvent {
-    readonly document: NotebookDocument;
-}
-
-export interface NotebookCellsChangeData {
-    readonly start: number;
-    readonly deletedCount: number;
-    readonly deletedItems: NotebookCell[];
-    readonly items: NotebookCell[];
-}
-
-export interface NotebookCellsChangeEvent {
-    /**
-     * The affected document.
-     */
-    readonly document: NotebookDocument;
-    readonly changes: ReadonlyArray<NotebookCellsChangeData>;
-}
-
-export interface NotebookCellOutputsChangeEvent {
-    /**
-     * The affected document.
-     */
-    readonly document: NotebookDocument;
-    readonly cells: NotebookCell[];
-}
-
-export interface NotebookCellLanguageChangeEvent {
-    /**
-     * The affected document.
-     */
-    readonly document: NotebookDocument;
-    readonly cell: NotebookCell;
-    readonly language: string;
-}
-
-export interface NotebookCellMetadataChangeEvent {
-    readonly document: NotebookDocument;
-    readonly cell: NotebookCell;
-}
-
-export interface NotebookEditorSelectionChangeEvent {
-    readonly notebookEditor: NotebookEditor;
-    readonly selections: ReadonlyArray<NotebookCellRange>;
-}
-
-export interface NotebookEditorVisibleRangesChangeEvent {
-    readonly notebookEditor: NotebookEditor;
-    readonly visibleRanges: ReadonlyArray<NotebookCellRange>;
-}
-
-// todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
-export class NotebookCellData {
-    kind: NotebookCellKind;
-    // todo@API better names: value? text?
-    source: string;
-    // todo@API how does language and MD relate?
-    language: string;
-    outputs?: NotebookCellOutput[];
-    metadata?: NotebookCellMetadata;
-    constructor(
-        kind: NotebookCellKind,
-        source: string,
-        language: string,
-        outputs?: NotebookCellOutput[],
-        metadata?: NotebookCellMetadata,
-    );
-}
-
-export class NotebookData {
-    cells: NotebookCellData[];
-    metadata?: NotebookDocumentMetadata;
-    constructor(cells: NotebookCellData[], metadata?: NotebookDocumentMetadata);
-}
-
-/**
- * Communication object passed to the {@link NotebookContentProvider} and
- * {@link NotebookOutputRenderer} to communicate with the webview.
- */
-export interface NotebookCommunication {
-    /**
-     * ID of the editor this object communicates with. A single notebook
-     * document can have multiple attached webviews and editors, when the
-     * notebook is split for instance. The editor ID lets you differentiate
-     * between them.
-     */
-    readonly editorId: string;
-
-    /**
-     * Fired when the output hosting webview posts a message.
-     */
-    readonly onDidReceiveMessage: Event<any>;
-    /**
-     * Post a message to the output hosting webview.
-     *
-     * Messages are only delivered if the editor is live.
-     *
-     * @param message Body of the message. This must be a string or other json serializable object.
-     */
-    postMessage(message: any): Thenable<boolean>;
-
-    /**
-     * Convert a uri for the local file system to one that can be used inside outputs webview.
-     */
-    asWebviewUri(localResource: Uri): Uri;
-
-    // @rebornix
-    // readonly onDidDispose: Event<void>;
-}
-
-// export function registerNotebookKernel(selector: string, kernel: NotebookKernel): Disposable;
-
-export interface NotebookDocumentShowOptions {
-    viewColumn?: ViewColumn;
-    preserveFocus?: boolean;
-    preview?: boolean;
-    selection?: NotebookCellRange;
-}
-
-export namespace notebook {
-    // todo@API should we really support to pass the viewType? We do NOT support
-    // to open the same file with different viewTypes at the same time
-    export function openNotebookDocument(uri: Uri, viewType?: string): Thenable<NotebookDocument>;
-    export const onDidOpenNotebookDocument: Event<NotebookDocument>;
-    export const onDidCloseNotebookDocument: Event<NotebookDocument>;
-
-    export const onDidSaveNotebookDocument: Event<NotebookDocument>;
-
-    /**
-     * All currently known notebook documents.
-     */
-    export const notebookDocuments: ReadonlyArray<NotebookDocument>;
-    export const onDidChangeNotebookDocumentMetadata: Event<NotebookDocumentMetadataChangeEvent>;
-    export const onDidChangeNotebookCells: Event<NotebookCellsChangeEvent>;
-    export const onDidChangeCellOutputs: Event<NotebookCellOutputsChangeEvent>;
-
-    // todo@API we send document close and open events when the language of a document changes and
-    // I believe we should stick that for cells as well
-    export const onDidChangeCellLanguage: Event<NotebookCellLanguageChangeEvent>;
-    export const onDidChangeCellMetadata: Event<NotebookCellMetadataChangeEvent>;
-}
-
-export namespace window {
-    export const visibleNotebookEditors: NotebookEditor[];
-    export const onDidChangeVisibleNotebookEditors: Event<NotebookEditor[]>;
-    export const activeNotebookEditor: NotebookEditor | undefined;
-    export const onDidChangeActiveNotebookEditor: Event<NotebookEditor | undefined>;
-    export const onDidChangeNotebookEditorSelection: Event<NotebookEditorSelectionChangeEvent>;
-    export const onDidChangeNotebookEditorVisibleRanges: Event<NotebookEditorVisibleRangesChangeEvent>;
-
-    export function showNotebookDocument(uri: Uri, options?: NotebookDocumentShowOptions): Thenable<NotebookEditor>;
-    export function showNotebookDocument(
-        document: NotebookDocument,
-        options?: NotebookDocumentShowOptions,
-    ): Thenable<NotebookEditor>;
-}
-
-//#endregion
-
-//#region https://github.com/microsoft/vscode/issues/106744, NotebookCellOutput
-
-// code specific mime types
-// application/x.notebook.error-traceback
-// application/x.notebook.stream
-export class NotebookCellOutputItem {
-    // todo@API
-    // add factory functions for common mime types
-    // static textplain(value:string): NotebookCellOutputItem;
-    // static errortrace(value:any): NotebookCellOutputItem;
-
-    readonly mime: string;
-    readonly value: unknown;
-    readonly metadata?: Record<string, any>;
-
-    constructor(mime: string, value: unknown, metadata?: Record<string, any>);
-}
-
-// @jrieken
-// todo@API think about readonly...
-//TODO@API add execution count to cell output?
-export class NotebookCellOutput {
-    readonly id: string;
-    readonly outputs: NotebookCellOutputItem[];
-    readonly metadata?: Record<string, any>;
-
-    constructor(outputs: NotebookCellOutputItem[], metadata?: Record<string, any>);
-
-    constructor(outputs: NotebookCellOutputItem[], id: string, metadata?: Record<string, any>);
-}
-
-//#endregion
-
-//#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorEdit
-
-export interface WorkspaceEdit {
-    replaceNotebookMetadata(uri: Uri, value: NotebookDocumentMetadata): void;
-
-    // todo@API use NotebookCellRange
-    replaceNotebookCells(
-        uri: Uri,
-        start: number,
-        end: number,
-        cells: NotebookCellData[],
-        metadata?: WorkspaceEditEntryMetadata,
-    ): void;
-    replaceNotebookCellMetadata(
-        uri: Uri,
-        index: number,
-        cellMetadata: NotebookCellMetadata,
-        metadata?: WorkspaceEditEntryMetadata,
-    ): void;
-
-    replaceNotebookCellOutput(
-        uri: Uri,
-        index: number,
-        outputs: NotebookCellOutput[],
-        metadata?: WorkspaceEditEntryMetadata,
-    ): void;
-    appendNotebookCellOutput(
-        uri: Uri,
-        index: number,
-        outputs: NotebookCellOutput[],
-        metadata?: WorkspaceEditEntryMetadata,
-    ): void;
-
-    // TODO@api
-    // https://jupyter-protocol.readthedocs.io/en/latest/messaging.html#update-display-data
-    replaceNotebookCellOutputItems(
-        uri: Uri,
-        index: number,
-        outputId: string,
-        items: NotebookCellOutputItem[],
-        metadata?: WorkspaceEditEntryMetadata,
-    ): void;
-    appendNotebookCellOutputItems(
-        uri: Uri,
-        index: number,
-        outputId: string,
-        items: NotebookCellOutputItem[],
-        metadata?: WorkspaceEditEntryMetadata,
-    ): void;
-}
-
-export interface NotebookEditorEdit {
-    replaceMetadata(value: NotebookDocumentMetadata): void;
-    replaceCells(start: number, end: number, cells: NotebookCellData[]): void;
-    replaceCellOutput(index: number, outputs: NotebookCellOutput[]): void;
-    replaceCellMetadata(index: number, metadata: NotebookCellMetadata): void;
-}
-
-export interface NotebookEditor {
-    /**
-     * Perform an edit on the notebook associated with this notebook editor.
-     *
-     * The given callback-function is invoked with an [edit-builder](#NotebookEditorEdit) which must
-     * be used to make edits. Note that the edit-builder is only valid while the
-     * callback executes.
-     *
-     * @param callback A function which can create edits using an [edit-builder](#NotebookEditorEdit).
-     * @return A promise that resolves with a value indicating if the edits could be applied.
-     */
-    // @jrieken REMOVE maybe
-    edit(callback: (editBuilder: NotebookEditorEdit) => void): Thenable<boolean>;
-}
-
-//#endregion
-
-//#region https://github.com/microsoft/vscode/issues/106744, NotebookContentProvider
-
-interface NotebookDocumentBackup {
-    /**
-     * Unique identifier for the backup.
-     *
-     * This id is passed back to your extension in `openNotebook` when opening a notebook editor from a backup.
-     */
-    readonly id: string;
-
-    /**
-     * Delete the current backup.
-     *
-     * This is called by VS Code when it is clear the current backup is no longer needed, such as when a new backup
-     * is made or when the file is saved.
-     */
-    delete(): void;
-}
-
-interface NotebookDocumentBackupContext {
-    readonly destination: Uri;
-}
-
-interface NotebookDocumentOpenContext {
-    readonly backupId?: string;
-}
-
-export interface NotebookContentProvider {
-    readonly options?: NotebookDocumentContentOptions;
-    readonly onDidChangeNotebookContentOptions?: Event<NotebookDocumentContentOptions>;
-    /**
-     * Content providers should always use [file system providers](#FileSystemProvider) to
-     * resolve the raw content for `uri` as the resouce is not necessarily a file on disk.
-     */
-    openNotebook(uri: Uri, openContext: NotebookDocumentOpenContext): NotebookData | Thenable<NotebookData>;
-    resolveNotebook(document: NotebookDocument, webview: NotebookCommunication): Thenable<void>;
-    saveNotebook(document: NotebookDocument, cancellation: CancellationToken): Thenable<void>;
-    saveNotebookAs(targetResource: Uri, document: NotebookDocument, cancellation: CancellationToken): Thenable<void>;
-    backupNotebook(
-        document: NotebookDocument,
-        context: NotebookDocumentBackupContext,
-        cancellation: CancellationToken,
-    ): Thenable<NotebookDocumentBackup>;
-
-    // ???
-    // provideKernels(document: NotebookDocument, token: CancellationToken): ProviderResult<T[]>;
-}
-
-export namespace notebook {
-    // TODO@api use NotebookDocumentFilter instead of just notebookType:string?
-    // TODO@API options duplicates the more powerful variant on NotebookContentProvider
-    export function registerNotebookContentProvider(
-        notebookType: string,
-        provider: NotebookContentProvider,
-        options?: NotebookDocumentContentOptions & {
-            /**
-             * Not ready for production or development use yet.
-             */
-            viewOptions?: {
-                displayName: string;
-                filenamePattern: NotebookFilenamePattern[];
-                exclusive?: boolean;
-            };
-        },
-    ): Disposable;
-}
-
-//#endregion
-
-//#region https://github.com/microsoft/vscode/issues/106744, NotebookKernel
-
-// todo@API use the NotebookCellExecution-object as a container to model and enforce
-// the flow of a cell execution
-
-// kernel -> execute_info
-// ext -> createNotebookCellExecution(cell)
-// kernel -> done
-// exec.dispose();
-
-// export interface NotebookCellExecution {
-// 	dispose(): void;
-// 	clearOutput(): void;
-// 	appendOutput(out: NotebookCellOutput): void;
-// 	replaceOutput(out: NotebookCellOutput): void;
-//  appendOutputItems(output:string, items: NotebookCellOutputItem[]):void;
-//  replaceOutputItems(output:string, items: NotebookCellOutputItem[]):void;
-// }
-
-// export function createNotebookCellExecution(cell: NotebookCell, startTime?: number): NotebookCellExecution;
-// export const onDidStartNotebookCellExecution: Event<any>;
-// export const onDidStopNotebookCellExecution: Event<any>;
-
-export interface NotebookKernel {
-    // todo@API make this mandatory?
-    readonly id?: string;
-
-    label: string;
-    description?: string;
-    detail?: string;
-    isPreferred?: boolean;
-
-    // todo@API is this maybe an output property?
-    preloads?: Uri[];
-
-    /**
-     * languages supported by kernel
-     * - first is preferred
-     * - `undefined` means all languages available in the editor
-     */
-    supportedLanguages?: string[];
-
-    // todo@API kernel updating itself
-    // fired when properties like the supported languages etc change
-    // onDidChangeProperties?: Event<void>
-
-    // @roblourens
-    // todo@API change to `executeCells(document: NotebookDocument, cells: NotebookCellRange[], context:{isWholeNotebooke: boolean}, token: CancelationToken): void;`
-    // todo@API interrupt vs cancellation, https://github.com/microsoft/vscode/issues/106741
-    // interrupt?():void;
-    executeCell(document: NotebookDocument, cell: NotebookCell): void;
-    cancelCellExecution(document: NotebookDocument, cell: NotebookCell): void;
-    executeAllCells(document: NotebookDocument): void;
-    cancelAllCellsExecution(document: NotebookDocument): void;
-}
-
-export type NotebookFilenamePattern = GlobPattern | { include: GlobPattern; exclude: GlobPattern };
-
-// todo@API why not for NotebookContentProvider?
-export interface NotebookDocumentFilter {
-    viewType?: string | string[];
-    filenamePattern?: NotebookFilenamePattern;
-}
-
-// todo@API very unclear, provider MUST not return alive object but only data object
-// todo@API unclear how the flow goes
-export interface NotebookKernelProvider<T extends NotebookKernel = NotebookKernel> {
-    onDidChangeKernels?: Event<NotebookDocument | undefined>;
-    provideKernels(document: NotebookDocument, token: CancellationToken): ProviderResult<T[]>;
-    resolveKernel?(
-        kernel: T,
-        document: NotebookDocument,
-        webview: NotebookCommunication,
-        token: CancellationToken,
-    ): ProviderResult<void>;
-}
-
-export interface NotebookEditor {
-    /**
-     * Active kernel used in the editor
-     */
-    // todo@API unsure about that
-    // kernel, kernel selection, kernel provider
-    readonly kernel?: NotebookKernel;
-}
-
-export namespace notebook {
-    export const onDidChangeActiveNotebookKernel: Event<{
-        document: NotebookDocument;
-        kernel: NotebookKernel | undefined;
-    }>;
-
-    export function registerNotebookKernelProvider(
-        selector: NotebookDocumentFilter,
-        provider: NotebookKernelProvider,
-    ): Disposable;
-}
-
-//#endregion
-
-//#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorDecorationType
-
-export interface NotebookEditor {
-    setDecorations(decorationType: NotebookEditorDecorationType, range: NotebookCellRange): void;
-}
-
-export interface NotebookDecorationRenderOptions {
-    backgroundColor?: string | ThemeColor;
-    borderColor?: string | ThemeColor;
-    top: ThemableDecorationAttachmentRenderOptions;
-}
-
-export interface NotebookEditorDecorationType {
-    readonly key: string;
-    dispose(): void;
-}
-
-export namespace notebook {
-    export function createNotebookEditorDecorationType(
-        options: NotebookDecorationRenderOptions,
-    ): NotebookEditorDecorationType;
-}
-
-//#endregion
-
-//#region https://github.com/microsoft/vscode/issues/106744, NotebookCellStatusBarItem
-
-/**
- * Represents the alignment of status bar items.
- */
-export enum NotebookCellStatusBarAlignment {
-    /**
-     * Aligned to the left side.
-     */
-    Left = 1,
-
-    /**
-     * Aligned to the right side.
-     */
-    Right = 2,
-}
-
-export interface NotebookCellStatusBarItem {
-    readonly cell: NotebookCell;
-    readonly alignment: NotebookCellStatusBarAlignment;
-    readonly priority?: number;
-    text: string;
-    tooltip: string | undefined;
-    command: string | Command | undefined;
-    accessibilityInformation?: AccessibilityInformation;
-    show(): void;
-    hide(): void;
-    dispose(): void;
-}
-
-export namespace notebook {
-    /**
-     * Creates a notebook cell status bar [item](#NotebookCellStatusBarItem).
-     * It will be disposed automatically when the notebook document is closed or the cell is deleted.
-     *
-     * @param cell The cell on which this item should be shown.
-     * @param alignment The alignment of the item.
-     * @param priority The priority of the item. Higher values mean the item should be shown more to the left.
-     * @return A new status bar item.
-     */
-    // @roblourens
-    // todo@API this should be a provider, https://github.com/microsoft/vscode/issues/105809
-    export function createCellStatusBarItem(
-        cell: NotebookCell,
-        alignment?: NotebookCellStatusBarAlignment,
-        priority?: number,
-    ): NotebookCellStatusBarItem;
-}
-
-//#endregion
-
-//#region https://github.com/microsoft/vscode/issues/106744, NotebookConcatTextDocument
-
-export namespace notebook {
-    /**
-     * Create a document that is the concatenation of all  notebook cells. By default all code-cells are included
-     * but a selector can be provided to narrow to down the set of cells.
-     *
-     * @param notebook
-     * @param selector
-     */
-    // @jrieken REMOVE. p_never
-    // todo@API really needed? we didn't find a user here
-    export function createConcatTextDocument(
-        notebook: NotebookDocument,
-        selector?: DocumentSelector,
-    ): NotebookConcatTextDocument;
-}
-
-export interface NotebookConcatTextDocument {
-    uri: Uri;
-    isClosed: boolean;
-    dispose(): void;
-    onDidChange: Event<void>;
-    version: number;
-    getText(): string;
-    getText(range: Range): string;
-
-    offsetAt(position: Position): number;
-    positionAt(offset: number): Position;
-    validateRange(range: Range): Range;
-    validatePosition(position: Position): Position;
-
-    locationAt(positionOrRange: Position | Range): Location;
-    positionAt(location: Location): Position;
-    contains(uri: Uri): boolean;
-}
-
-//#endregion
+    export enum NotebookCellStatusBarAlignment {
+        /**
+         * Aligned to the left side.
+         */
+        Left = 1,
+
+        /**
+         * Aligned to the right side.
+         */
+        Right = 2
+    }
+
+    export interface NotebookCellStatusBarItem {
+        readonly cell: NotebookCell;
+        readonly alignment: NotebookCellStatusBarAlignment;
+        readonly priority?: number;
+        text: string;
+        tooltip: string | undefined;
+        command: string | Command | undefined;
+        accessibilityInformation?: AccessibilityInformation;
+        show(): void;
+        hide(): void;
+        dispose(): void;
+    }
+
+    export namespace notebook {
+        /**
+         * Creates a notebook cell status bar [item](#NotebookCellStatusBarItem).
+         * It will be disposed automatically when the notebook document is closed or the cell is deleted.
+         *
+         * @param cell The cell on which this item should be shown.
+         * @param alignment The alignment of the item.
+         * @param priority The priority of the item. Higher values mean the item should be shown more to the left.
+         * @return A new status bar item.
+         */
+        // @roblourens
+        // todo@API this should be a provider, https://github.com/microsoft/vscode/issues/105809
+        export function createCellStatusBarItem(
+            cell: NotebookCell,
+            alignment?: NotebookCellStatusBarAlignment,
+            priority?: number
+        ): NotebookCellStatusBarItem;
+    }
+
+    //#endregion
+
+    //#region https://github.com/microsoft/vscode/issues/106744, NotebookConcatTextDocument
+
+    export namespace notebook {
+        /**
+         * Create a document that is the concatenation of all  notebook cells. By default all code-cells are included
+         * but a selector can be provided to narrow to down the set of cells.
+         *
+         * @param notebook
+         * @param selector
+         */
+        // @jrieken REMOVE. p_never
+        // todo@API really needed? we didn't find a user here
+        export function createConcatTextDocument(
+            notebook: NotebookDocument,
+            selector?: DocumentSelector
+        ): NotebookConcatTextDocument;
+    }
+
+    export interface NotebookConcatTextDocument {
+        uri: Uri;
+        isClosed: boolean;
+        dispose(): void;
+        onDidChange: Event<void>;
+        version: number;
+        getText(): string;
+        getText(range: Range): string;
+
+        offsetAt(position: Position): number;
+        positionAt(offset: number): Position;
+        validateRange(range: Range): Range;
+        validatePosition(position: Position): Position;
+
+        locationAt(positionOrRange: Position | Range): Location;
+        positionAt(location: Location): Position;
+        contains(uri: Uri): boolean;
+    }
+
+    //#endregion

--- a/typings/vscode-proposed/index.d.ts
+++ b/typings/vscode-proposed/index.d.ts
@@ -23,809 +23,814 @@ import {
     ThemeColor,
 } from 'vscode';
 
-    //#region https://github.com/microsoft/vscode/issues/106744, Notebooks (misc)
+//#region https://github.com/microsoft/vscode/issues/106744, Notebooks (misc)
 
-    export enum NotebookCellKind {
-        Markdown = 1,
-        Code = 2
-    }
+export enum NotebookCellKind {
+    Markdown = 1,
+    Code = 2
+}
 
-    export enum NotebookCellRunState {
-        Running = 1,
-        Idle = 2,
-        Success = 3,
-        Error = 4
-    }
+export enum NotebookCellRunState {
+    Running = 1,
+    Idle = 2,
+    Success = 3,
+    Error = 4
+}
 
-    export enum NotebookRunState {
-        Running = 1,
-        Idle = 2
-    }
+export enum NotebookRunState {
+    Running = 1,
+    Idle = 2
+}
 
-    export class NotebookCellMetadata {
-        /**
-         * Controls whether a cell's editor is editable/readonly.
-         */
-        readonly editable?: boolean;
-        /**
-         * Controls if the cell has a margin to support the breakpoint UI.
-         * This metadata is ignored for markdown cell.
-         */
-        readonly breakpointMargin?: boolean;
-        /**
-         * Whether a code cell's editor is collapsed
-         */
-        readonly outputCollapsed?: boolean;
-        /**
-         * Whether a code cell's outputs are collapsed
-         */
-        readonly inputCollapsed?: boolean;
-        /**
-         * Additional attributes of a cell metadata.
-         */
-        readonly custom?: Record<string, any>;
+export class NotebookCellMetadata {
+    /**
+     * Controls whether a cell's editor is editable/readonly.
+     */
+    readonly editable?: boolean;
+    /**
+     * Controls if the cell has a margin to support the breakpoint UI.
+     * This metadata is ignored for markdown cell.
+     */
+    readonly breakpointMargin?: boolean;
+    /**
+     * Whether a code cell's editor is collapsed
+     */
+    readonly outputCollapsed?: boolean;
+    /**
+     * Whether a code cell's outputs are collapsed
+     */
+    readonly inputCollapsed?: boolean;
+    /**
+     * Additional attributes of a cell metadata.
+     */
+    readonly custom?: Record<string, any>;
 
-        // todo@API duplicates status bar API
-        readonly statusMessage?: string;
+    // todo@API duplicates status bar API
+    readonly statusMessage?: string;
 
-        // run related API, will be removed
-        readonly runnable?: boolean;
-        readonly hasExecutionOrder?: boolean;
-        readonly executionOrder?: number;
-        readonly runState?: NotebookCellRunState;
-        readonly runStartTime?: number;
-        readonly lastRunDuration?: number;
+    // run related API, will be removed
+    readonly hasExecutionOrder?: boolean;
+    readonly executionOrder?: number;
+    readonly runState?: NotebookCellRunState;
+    readonly runStartTime?: number;
+    readonly lastRunDuration?: number;
 
-        constructor(
-            editable?: boolean,
-            breakpointMargin?: boolean,
-            runnable?: boolean,
-            hasExecutionOrder?: boolean,
-            executionOrder?: number,
-            runState?: NotebookCellRunState,
-            runStartTime?: number,
-            statusMessage?: string,
-            lastRunDuration?: number,
-            inputCollapsed?: boolean,
-            outputCollapsed?: boolean,
-            custom?: Record<string, any>
-        );
+    constructor(
+        editable?: boolean,
+        breakpointMargin?: boolean,
+        hasExecutionOrder?: boolean,
+        executionOrder?: number,
+        runState?: NotebookCellRunState,
+        runStartTime?: number,
+        statusMessage?: string,
+        lastRunDuration?: number,
+        inputCollapsed?: boolean,
+        outputCollapsed?: boolean,
+        custom?: Record<string, any>
+    );
 
-        with(change: {
-            editable?: boolean | null;
-            breakpointMargin?: boolean | null;
-            runnable?: boolean | null;
-            hasExecutionOrder?: boolean | null;
-            executionOrder?: number | null;
-            runState?: NotebookCellRunState | null;
-            runStartTime?: number | null;
-            statusMessage?: string | null;
-            lastRunDuration?: number | null;
-            inputCollapsed?: boolean | null;
-            outputCollapsed?: boolean | null;
-            custom?: Record<string, any> | null;
-        }): NotebookCellMetadata;
-    }
+    with(change: {
+        editable?: boolean | null;
+        breakpointMargin?: boolean | null;
+        hasExecutionOrder?: boolean | null;
+        executionOrder?: number | null;
+        runState?: NotebookCellRunState | null;
+        runStartTime?: number | null;
+        statusMessage?: string | null;
+        lastRunDuration?: number | null;
+        inputCollapsed?: boolean | null;
+        outputCollapsed?: boolean | null;
+        custom?: Record<string, any> | null;
+    }): NotebookCellMetadata;
+}
 
-    // todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
-    export interface NotebookCell {
-        readonly index: number;
-        readonly notebook: NotebookDocument;
-        readonly cellKind: NotebookCellKind;
-        // todo@API duplicates #document.uri
-        readonly uri: Uri;
-        // todo@API duplicates #document.languageId
-        readonly language: string;
-        readonly document: TextDocument;
-        readonly outputs: readonly NotebookCellOutput[];
-        readonly metadata: NotebookCellMetadata;
-    }
+// todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
+export interface NotebookCell {
+    readonly index: number;
+    readonly notebook: NotebookDocument;
+    readonly kind: NotebookCellKind;
+    readonly document: TextDocument;
+    readonly metadata: NotebookCellMetadata;
+    readonly outputs: ReadonlyArray<NotebookCellOutput>;
+}
 
-    export class NotebookDocumentMetadata {
-        /**
-         * Controls if users can add or delete cells
-         * Defaults to true
-         */
-        readonly editable: boolean;
-        /**
-         * Default value for [cell editable metadata](#NotebookCellMetadata.editable).
-         * Defaults to true.
-         */
-        readonly cellEditable: boolean;
-        /**
-         * Additional attributes of the document metadata.
-         */
-        readonly custom: { [key: string]: any };
-        /**
-         * Whether the document is trusted, default to true
-         * When false, insecure outputs like HTML, JavaScript, SVG will not be rendered.
-         */
-        readonly trusted: boolean;
+export class NotebookDocumentMetadata {
+    /**
+     * Controls if users can add or delete cells
+     * Defaults to true
+     */
+    readonly editable: boolean;
+    /**
+     * Default value for [cell editable metadata](#NotebookCellMetadata.editable).
+     * Defaults to true.
+     */
+    readonly cellEditable: boolean;
+    /**
+     * Additional attributes of the document metadata.
+     */
+    readonly custom: { [key: string]: any };
+    /**
+     * Whether the document is trusted, default to true
+     * When false, insecure outputs like HTML, JavaScript, SVG will not be rendered.
+     */
+    readonly trusted: boolean;
 
-        // todo@API is this a kernel property?
-        readonly cellHasExecutionOrder: boolean;
+    // todo@API is this a kernel property?
+    readonly cellHasExecutionOrder: boolean;
 
-        // run related, remove infer from kernel, exec
-        // todo@API infer from kernel
-        // todo@API remove
-        readonly runnable: boolean;
-        readonly cellRunnable: boolean;
-        readonly runState: NotebookRunState;
+    // todo@API remove
+    readonly runState: NotebookRunState;
 
-        constructor(
-            editable?: boolean,
-            runnable?: boolean,
-            cellEditable?: boolean,
-            cellRunnable?: boolean,
-            cellHasExecutionOrder?: boolean,
-            custom?: { [key: string]: any },
-            runState?: NotebookRunState,
-            trusted?: boolean
-        );
+    constructor(
+        editable?: boolean,
+        cellEditable?: boolean,
+        cellHasExecutionOrder?: boolean,
+        custom?: { [key: string]: any },
+        runState?: NotebookRunState,
+        trusted?: boolean
+    );
 
-        with(change: {
-            editable?: boolean | null;
-            runnable?: boolean | null;
-            cellEditable?: boolean | null;
-            cellRunnable?: boolean | null;
-            cellHasExecutionOrder?: boolean | null;
-            custom?: { [key: string]: any } | null;
-            runState?: NotebookRunState | null;
-            trusted?: boolean | null;
-        }): NotebookDocumentMetadata;
-    }
+    with(change: {
+        editable?: boolean | null;
+        cellEditable?: boolean | null;
+        cellHasExecutionOrder?: boolean | null;
+        custom?: { [key: string]: any } | null;
+        runState?: NotebookRunState | null;
+        trusted?: boolean | null;
+    }): NotebookDocumentMetadata;
+}
 
-    export interface NotebookDocumentContentOptions {
-        /**
-         * Controls if outputs change will trigger notebook document content change and if it will be used in the diff editor
-         * Default to false. If the content provider doesn't persisit the outputs in the file document, this should be set to true.
-         */
-        transientOutputs: boolean;
-
-        /**
-         * Controls if a meetadata property change will trigger notebook document content change and if it will be used in the diff editor
-         * Default to false. If the content provider doesn't persisit a metadata property in the file document, it should be set to true.
-         */
-        transientMetadata: { [K in keyof NotebookCellMetadata]?: boolean };
-    }
-
-    export interface NotebookDocument {
-        readonly uri: Uri;
-        readonly version: number;
-        // todo@API don't have this...
-        readonly fileName: string;
-        // todo@API should we really expose this?
-        readonly viewType: string;
-        readonly isDirty: boolean;
-        readonly isUntitled: boolean;
-        readonly cells: ReadonlyArray<NotebookCell>;
-        readonly contentOptions: NotebookDocumentContentOptions;
-        readonly metadata: NotebookDocumentMetadata;
-
-        /**
-         * Save the document. The saving will be handled by the corresponding content provider
-         *
-         * @return A promise that will resolve to true when the document
-         * has been saved. If the file was not dirty or the save failed,
-         * will return false.
-         */
-        save(): Thenable<boolean>;
-    }
-
-    // todo@API maybe have a NotebookCellPosition sibling
-    export class NotebookCellRange {
-        readonly start: number;
-        /**
-         * exclusive
-         */
-        readonly end: number;
-
-        constructor(start: number, end: number);
-    }
-
-    export enum NotebookEditorRevealType {
-        /**
-         * The range will be revealed with as little scrolling as possible.
-         */
-        Default = 0,
-        /**
-         * The range will always be revealed in the center of the viewport.
-         */
-        InCenter = 1,
-
-        /**
-         * If the range is outside the viewport, it will be revealed in the center of the viewport.
-         * Otherwise, it will be revealed with as little scrolling as possible.
-         */
-        InCenterIfOutsideViewport = 2,
-
-        /**
-         * The range will always be revealed at the top of the viewport.
-         */
-        AtTop = 3
-    }
-
-    export interface NotebookEditor {
-        /**
-         * The document associated with this notebook editor.
-         */
-        readonly document: NotebookDocument;
-
-        /**
-         * The primary selected cell on this notebook editor.
-         */
-        // todo@API should not be undefined, rather a default
-        readonly selection?: NotebookCell;
-
-        /**
-         * todo@API should replace selection
-         * The selections on this notebook editor.
-         *
-         * The primary selection (or focused range) is `selections[0]`. When the document has no cells, the primary selection is empty `{ start: 0, end: 0 }`;
-         */
-        readonly selections: NotebookCellRange[];
-
-        /**
-         * The current visible ranges in the editor (vertically).
-         */
-        readonly visibleRanges: NotebookCellRange[];
-
-        revealRange(range: NotebookCellRange, revealType?: NotebookEditorRevealType): void;
-
-        /**
-         * The column in which this editor shows.
-         */
-        // @jrieken
-        // todo@API maybe never undefined because notebooks always show in the editor area (unlike text editors)
-        // maybe for notebook diff editor
-        readonly viewColumn?: ViewColumn;
-
-        /**
-         * Fired when the panel is disposed.
-         */
-        // @rebornix REMOVE/REplace NotebookCommunication
-        // todo@API fishy? notebooks are public objects, there should be a "global" events for this
-        readonly onDidDispose: Event<void>;
-    }
-
-    export interface NotebookDocumentMetadataChangeEvent {
-        readonly document: NotebookDocument;
-    }
-
-    export interface NotebookCellsChangeData {
-        readonly start: number;
-        readonly deletedCount: number;
-        readonly deletedItems: NotebookCell[];
-        readonly items: NotebookCell[];
-    }
-
-    export interface NotebookCellsChangeEvent {
-        /**
-         * The affected document.
-         */
-        readonly document: NotebookDocument;
-        readonly changes: ReadonlyArray<NotebookCellsChangeData>;
-    }
-
-    export interface NotebookCellOutputsChangeEvent {
-        /**
-         * The affected document.
-         */
-        readonly document: NotebookDocument;
-        readonly cells: NotebookCell[];
-    }
-
-    export interface NotebookCellMetadataChangeEvent {
-        readonly document: NotebookDocument;
-        readonly cell: NotebookCell;
-    }
-
-    export interface NotebookEditorSelectionChangeEvent {
-        readonly notebookEditor: NotebookEditor;
-        readonly selections: ReadonlyArray<NotebookCellRange>;
-    }
-
-    export interface NotebookEditorVisibleRangesChangeEvent {
-        readonly notebookEditor: NotebookEditor;
-        readonly visibleRanges: ReadonlyArray<NotebookCellRange>;
-    }
-
-    // todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
-    export class NotebookCellData {
-        kind: NotebookCellKind;
-        // todo@API better names: value? text?
-        source: string;
-        // todo@API how does language and MD relate?
-        language: string;
-        outputs?: NotebookCellOutput[];
-        metadata?: NotebookCellMetadata;
-        constructor(
-            kind: NotebookCellKind,
-            source: string,
-            language: string,
-            outputs?: NotebookCellOutput[],
-            metadata?: NotebookCellMetadata
-        );
-    }
-
-    export class NotebookData {
-        cells: NotebookCellData[];
-        metadata?: NotebookDocumentMetadata;
-        constructor(cells: NotebookCellData[], metadata?: NotebookDocumentMetadata);
-    }
+export interface NotebookDocumentContentOptions {
+    /**
+     * Controls if outputs change will trigger notebook document content change and if it will be used in the diff editor
+     * Default to false. If the content provider doesn't persisit the outputs in the file document, this should be set to true.
+     */
+    transientOutputs: boolean;
 
     /**
-     * Communication object passed to the {@link NotebookContentProvider} and
-     * {@link NotebookOutputRenderer} to communicate with the webview.
+     * Controls if a meetadata property change will trigger notebook document content change and if it will be used in the diff editor
+     * Default to false. If the content provider doesn't persisit a metadata property in the file document, it should be set to true.
      */
-    export interface NotebookCommunication {
-        /**
-         * ID of the editor this object communicates with. A single notebook
-         * document can have multiple attached webviews and editors, when the
-         * notebook is split for instance. The editor ID lets you differentiate
-         * between them.
-         */
-        readonly editorId: string;
+    transientMetadata: { [K in keyof NotebookCellMetadata]?: boolean };
+}
 
-        /**
-         * Fired when the output hosting webview posts a message.
-         */
-        readonly onDidReceiveMessage: Event<any>;
-        /**
-         * Post a message to the output hosting webview.
-         *
-         * Messages are only delivered if the editor is live.
-         *
-         * @param message Body of the message. This must be a string or other json serializable object.
-         */
-        postMessage(message: any): Thenable<boolean>;
+export interface NotebookDocument {
+    readonly uri: Uri;
+    readonly version: number;
 
-        /**
-         * Convert a uri for the local file system to one that can be used inside outputs webview.
-         */
-        asWebviewUri(localResource: Uri): Uri;
+    // todo@API don't have this...
+    readonly fileName: string;
 
-        // @rebornix
-        // readonly onDidDispose: Event<void>;
-    }
+    readonly isDirty: boolean;
+    readonly isUntitled: boolean;
+    readonly cells: ReadonlyArray<NotebookCell>;
 
-    // export function registerNotebookKernel(selector: string, kernel: NotebookKernel): Disposable;
+    readonly metadata: NotebookDocumentMetadata;
 
-    export interface NotebookDocumentShowOptions {
-        viewColumn?: ViewColumn;
-        preserveFocus?: boolean;
-        preview?: boolean;
-        selection?: NotebookCellRange;
-    }
+    // todo@API should we really expose this?
+    readonly viewType: string;
 
-    export namespace notebook {
-        // todo@API should we really support to pass the viewType? We do NOT support
-        // to open the same file with different viewTypes at the same time
-        export function openNotebookDocument(uri: Uri, viewType?: string): Thenable<NotebookDocument>;
-        export const onDidOpenNotebookDocument: Event<NotebookDocument>;
-        export const onDidCloseNotebookDocument: Event<NotebookDocument>;
+    /**
+     * Save the document. The saving will be handled by the corresponding content provider
+     *
+     * @return A promise that will resolve to true when the document
+     * has been saved. If the file was not dirty or the save failed,
+     * will return false.
+     */
+    save(): Thenable<boolean>;
+}
 
-        export const onDidSaveNotebookDocument: Event<NotebookDocument>;
+// todo@API maybe have a NotebookCellPosition sibling
+export class NotebookCellRange {
+    readonly start: number;
+    /**
+     * exclusive
+     */
+    readonly end: number;
 
-        /**
-         * All currently known notebook documents.
-         */
-        export const notebookDocuments: ReadonlyArray<NotebookDocument>;
-        export const onDidChangeNotebookDocumentMetadata: Event<NotebookDocumentMetadataChangeEvent>;
-        export const onDidChangeNotebookCells: Event<NotebookCellsChangeEvent>;
-        export const onDidChangeCellOutputs: Event<NotebookCellOutputsChangeEvent>;
-        export const onDidChangeCellMetadata: Event<NotebookCellMetadataChangeEvent>;
-    }
+    isEmpty: boolean;
 
-    export namespace window {
-        export const visibleNotebookEditors: NotebookEditor[];
-        export const onDidChangeVisibleNotebookEditors: Event<NotebookEditor[]>;
-        export const activeNotebookEditor: NotebookEditor | undefined;
-        export const onDidChangeActiveNotebookEditor: Event<NotebookEditor | undefined>;
-        export const onDidChangeNotebookEditorSelection: Event<NotebookEditorSelectionChangeEvent>;
-        export const onDidChangeNotebookEditorVisibleRanges: Event<NotebookEditorVisibleRangesChangeEvent>;
+    constructor(start: number, end: number);
+}
 
-        export function showNotebookDocument(uri: Uri, options?: NotebookDocumentShowOptions): Thenable<NotebookEditor>;
-        export function showNotebookDocument(
-            document: NotebookDocument,
-            options?: NotebookDocumentShowOptions
-        ): Thenable<NotebookEditor>;
-    }
+export enum NotebookEditorRevealType {
+    /**
+     * The range will be revealed with as little scrolling as possible.
+     */
+    Default = 0,
+    /**
+     * The range will always be revealed in the center of the viewport.
+     */
+    InCenter = 1,
 
-    //#endregion
+    /**
+     * If the range is outside the viewport, it will be revealed in the center of the viewport.
+     * Otherwise, it will be revealed with as little scrolling as possible.
+     */
+    InCenterIfOutsideViewport = 2,
 
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookCellOutput
+    /**
+     * The range will always be revealed at the top of the viewport.
+     */
+    AtTop = 3
+}
 
-    // code specific mime types
-    // application/x.notebook.error-traceback
-    // application/x.notebook.stream
-    export class NotebookCellOutputItem {
-        // todo@API
-        // add factory functions for common mime types
-        // static textplain(value:string): NotebookCellOutputItem;
-        // static errortrace(value:any): NotebookCellOutputItem;
+export interface NotebookEditor {
+    /**
+     * The document associated with this notebook editor.
+     */
+    readonly document: NotebookDocument;
 
-        readonly mime: string;
-        readonly value: unknown;
-        readonly metadata?: Record<string, any>;
+    /**
+     * The primary selected cell on this notebook editor.
+     */
+    // todo@API should not be undefined, rather a default
+    readonly selection?: NotebookCell;
 
-        constructor(mime: string, value: unknown, metadata?: Record<string, any>);
-    }
+    /**
+     * todo@API should replace selection
+     * The selections on this notebook editor.
+     *
+     * The primary selection (or focused range) is `selections[0]`. When the document has no cells, the primary selection is empty `{ start: 0, end: 0 }`;
+     */
+    readonly selections: NotebookCellRange[];
 
+    /**
+     * The current visible ranges in the editor (vertically).
+     */
+    readonly visibleRanges: NotebookCellRange[];
+
+    revealRange(range: NotebookCellRange, revealType?: NotebookEditorRevealType): void;
+
+    /**
+     * The column in which this editor shows.
+     */
     // @jrieken
-    // todo@API think about readonly...
-    //TODO@API add execution count to cell output?
-    export class NotebookCellOutput {
-        readonly id: string;
-        readonly outputs: NotebookCellOutputItem[];
-        readonly metadata?: Record<string, any>;
-
-        constructor(outputs: NotebookCellOutputItem[], metadata?: Record<string, any>);
-
-        constructor(outputs: NotebookCellOutputItem[], id: string, metadata?: Record<string, any>);
-    }
-
-    //#endregion
-
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorEdit
-
-    export interface WorkspaceEdit {
-        replaceNotebookMetadata(uri: Uri, value: NotebookDocumentMetadata): void;
-
-        // todo@API use NotebookCellRange
-        replaceNotebookCells(
-            uri: Uri,
-            start: number,
-            end: number,
-            cells: NotebookCellData[],
-            metadata?: WorkspaceEditEntryMetadata
-        ): void;
-        replaceNotebookCellMetadata(
-            uri: Uri,
-            index: number,
-            cellMetadata: NotebookCellMetadata,
-            metadata?: WorkspaceEditEntryMetadata
-        ): void;
-
-        replaceNotebookCellOutput(
-            uri: Uri,
-            index: number,
-            outputs: NotebookCellOutput[],
-            metadata?: WorkspaceEditEntryMetadata
-        ): void;
-        appendNotebookCellOutput(
-            uri: Uri,
-            index: number,
-            outputs: NotebookCellOutput[],
-            metadata?: WorkspaceEditEntryMetadata
-        ): void;
-
-        // TODO@api
-        // https://jupyter-protocol.readthedocs.io/en/latest/messaging.html#update-display-data
-        replaceNotebookCellOutputItems(
-            uri: Uri,
-            index: number,
-            outputId: string,
-            items: NotebookCellOutputItem[],
-            metadata?: WorkspaceEditEntryMetadata
-        ): void;
-        appendNotebookCellOutputItems(
-            uri: Uri,
-            index: number,
-            outputId: string,
-            items: NotebookCellOutputItem[],
-            metadata?: WorkspaceEditEntryMetadata
-        ): void;
-    }
-
-    export interface NotebookEditorEdit {
-        replaceMetadata(value: NotebookDocumentMetadata): void;
-        replaceCells(start: number, end: number, cells: NotebookCellData[]): void;
-        replaceCellOutput(index: number, outputs: NotebookCellOutput[]): void;
-        replaceCellMetadata(index: number, metadata: NotebookCellMetadata): void;
-    }
-
-    export interface NotebookEditor {
-        /**
-         * Perform an edit on the notebook associated with this notebook editor.
-         *
-         * The given callback-function is invoked with an [edit-builder](#NotebookEditorEdit) which must
-         * be used to make edits. Note that the edit-builder is only valid while the
-         * callback executes.
-         *
-         * @param callback A function which can create edits using an [edit-builder](#NotebookEditorEdit).
-         * @return A promise that resolves with a value indicating if the edits could be applied.
-         */
-        // @jrieken REMOVE maybe
-        edit(callback: (editBuilder: NotebookEditorEdit) => void): Thenable<boolean>;
-    }
-
-    //#endregion
-
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookContentProvider
-
-    interface NotebookDocumentBackup {
-        /**
-         * Unique identifier for the backup.
-         *
-         * This id is passed back to your extension in `openNotebook` when opening a notebook editor from a backup.
-         */
-        readonly id: string;
-
-        /**
-         * Delete the current backup.
-         *
-         * This is called by VS Code when it is clear the current backup is no longer needed, such as when a new backup
-         * is made or when the file is saved.
-         */
-        delete(): void;
-    }
-
-    interface NotebookDocumentBackupContext {
-        readonly destination: Uri;
-    }
-
-    interface NotebookDocumentOpenContext {
-        readonly backupId?: string;
-    }
-
-    export interface NotebookContentProvider {
-        readonly options?: NotebookDocumentContentOptions;
-        readonly onDidChangeNotebookContentOptions?: Event<NotebookDocumentContentOptions>;
-        /**
-         * Content providers should always use [file system providers](#FileSystemProvider) to
-         * resolve the raw content for `uri` as the resouce is not necessarily a file on disk.
-         */
-        openNotebook(uri: Uri, openContext: NotebookDocumentOpenContext): NotebookData | Thenable<NotebookData>;
-        resolveNotebook(document: NotebookDocument, webview: NotebookCommunication): Thenable<void>;
-        saveNotebook(document: NotebookDocument, cancellation: CancellationToken): Thenable<void>;
-        saveNotebookAs(
-            targetResource: Uri,
-            document: NotebookDocument,
-            cancellation: CancellationToken
-        ): Thenable<void>;
-        backupNotebook(
-            document: NotebookDocument,
-            context: NotebookDocumentBackupContext,
-            cancellation: CancellationToken
-        ): Thenable<NotebookDocumentBackup>;
-
-        // ???
-        // provideKernels(document: NotebookDocument, token: CancellationToken): ProviderResult<T[]>;
-    }
-
-    export namespace notebook {
-        // TODO@api use NotebookDocumentFilter instead of just notebookType:string?
-        // TODO@API options duplicates the more powerful variant on NotebookContentProvider
-        export function registerNotebookContentProvider(
-            notebookType: string,
-            provider: NotebookContentProvider,
-            options?: NotebookDocumentContentOptions & {
-                /**
-                 * Not ready for production or development use yet.
-                 */
-                viewOptions?: {
-                    displayName: string;
-                    filenamePattern: NotebookFilenamePattern[];
-                    exclusive?: boolean;
-                };
-            }
-        ): Disposable;
-    }
-
-    //#endregion
-
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookKernel
-
-    // todo@API use the NotebookCellExecution-object as a container to model and enforce
-    // the flow of a cell execution
-
-    // kernel -> execute_info
-    // ext -> createNotebookCellExecution(cell)
-    // kernel -> done
-    // exec.dispose();
-
-    // export interface NotebookCellExecution {
-    // 	dispose(): void;
-    // 	clearOutput(): void;
-    // 	appendOutput(out: NotebookCellOutput): void;
-    // 	replaceOutput(out: NotebookCellOutput): void;
-    //  appendOutputItems(output:string, items: NotebookCellOutputItem[]):void;
-    //  replaceOutputItems(output:string, items: NotebookCellOutputItem[]):void;
-    // }
-
-    // export function createNotebookCellExecution(cell: NotebookCell, startTime?: number): NotebookCellExecution;
-    // export const onDidStartNotebookCellExecution: Event<any>;
-    // export const onDidStopNotebookCellExecution: Event<any>;
-
-    export interface NotebookKernel {
-        // todo@API make this mandatory?
-        readonly id?: string;
-
-        label: string;
-        description?: string;
-        detail?: string;
-        isPreferred?: boolean;
-
-        // todo@API is this maybe an output property?
-        preloads?: Uri[];
-
-        /**
-         * languages supported by kernel
-         * - first is preferred
-         * - `undefined` means all languages available in the editor
-         */
-        supportedLanguages?: string[];
-
-        // todo@API kernel updating itself
-        // fired when properties like the supported languages etc change
-        // onDidChangeProperties?: Event<void>
-
-        // @roblourens
-        // todo@API change to `executeCells(document: NotebookDocument, cells: NotebookCellRange[], context:{isWholeNotebooke: boolean}, token: CancelationToken): void;`
-        // todo@API interrupt vs cancellation, https://github.com/microsoft/vscode/issues/106741
-        // interrupt?():void;
-        executeCell(document: NotebookDocument, cell: NotebookCell): void;
-        cancelCellExecution(document: NotebookDocument, cell: NotebookCell): void;
-        executeAllCells(document: NotebookDocument): void;
-        cancelAllCellsExecution(document: NotebookDocument): void;
-    }
-
-    export type NotebookFilenamePattern = GlobPattern | { include: GlobPattern; exclude: GlobPattern };
-
-    // todo@API why not for NotebookContentProvider?
-    export interface NotebookDocumentFilter {
-        viewType?: string | string[];
-        filenamePattern?: NotebookFilenamePattern;
-    }
-
-    // todo@API very unclear, provider MUST not return alive object but only data object
-    // todo@API unclear how the flow goes
-    export interface NotebookKernelProvider<T extends NotebookKernel = NotebookKernel> {
-        onDidChangeKernels?: Event<NotebookDocument | undefined>;
-        provideKernels(document: NotebookDocument, token: CancellationToken): ProviderResult<T[]>;
-        resolveKernel?(
-            kernel: T,
-            document: NotebookDocument,
-            webview: NotebookCommunication,
-            token: CancellationToken
-        ): ProviderResult<void>;
-    }
-
-    export interface NotebookEditor {
-        /**
-         * Active kernel used in the editor
-         */
-        // todo@API unsure about that
-        // kernel, kernel selection, kernel provider
-        readonly kernel?: NotebookKernel;
-    }
-
-    export namespace notebook {
-        export const onDidChangeActiveNotebookKernel: Event<{
-            document: NotebookDocument;
-            kernel: NotebookKernel | undefined;
-        }>;
-
-        export function registerNotebookKernelProvider(
-            selector: NotebookDocumentFilter,
-            provider: NotebookKernelProvider
-        ): Disposable;
-    }
-
-    //#endregion
-
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorDecorationType
-
-    export interface NotebookEditor {
-        setDecorations(decorationType: NotebookEditorDecorationType, range: NotebookCellRange): void;
-    }
-
-    export interface NotebookDecorationRenderOptions {
-        backgroundColor?: string | ThemeColor;
-        borderColor?: string | ThemeColor;
-        top: ThemableDecorationAttachmentRenderOptions;
-    }
-
-    export interface NotebookEditorDecorationType {
-        readonly key: string;
-        dispose(): void;
-    }
-
-    export namespace notebook {
-        export function createNotebookEditorDecorationType(
-            options: NotebookDecorationRenderOptions
-        ): NotebookEditorDecorationType;
-    }
-
-    //#endregion
-
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookCellStatusBarItem
+    // this is not implemented...
+    readonly viewColumn?: ViewColumn;
 
     /**
-     * Represents the alignment of status bar items.
+     * Fired when the panel is disposed.
      */
-    export enum NotebookCellStatusBarAlignment {
-        /**
-         * Aligned to the left side.
-         */
-        Left = 1,
+    // @rebornix REMOVE/REplace NotebookCommunication
+    // todo@API fishy? notebooks are public objects, there should be a "global" events for this
+    readonly onDidDispose: Event<void>;
+}
 
-        /**
-         * Aligned to the right side.
-         */
-        Right = 2
-    }
+export interface NotebookDocumentMetadataChangeEvent {
+    readonly document: NotebookDocument;
+}
 
-    export interface NotebookCellStatusBarItem {
-        readonly cell: NotebookCell;
-        readonly alignment: NotebookCellStatusBarAlignment;
-        readonly priority?: number;
-        text: string;
-        tooltip: string | undefined;
-        command: string | Command | undefined;
-        accessibilityInformation?: AccessibilityInformation;
-        show(): void;
-        hide(): void;
-        dispose(): void;
-    }
+export interface NotebookCellsChangeData {
+    readonly start: number;
+    readonly deletedCount: number;
+    readonly deletedItems: NotebookCell[];
+    readonly items: NotebookCell[];
+}
 
-    export namespace notebook {
-        /**
-         * Creates a notebook cell status bar [item](#NotebookCellStatusBarItem).
-         * It will be disposed automatically when the notebook document is closed or the cell is deleted.
-         *
-         * @param cell The cell on which this item should be shown.
-         * @param alignment The alignment of the item.
-         * @param priority The priority of the item. Higher values mean the item should be shown more to the left.
-         * @return A new status bar item.
-         */
-        // @roblourens
-        // todo@API this should be a provider, https://github.com/microsoft/vscode/issues/105809
-        export function createCellStatusBarItem(
-            cell: NotebookCell,
-            alignment?: NotebookCellStatusBarAlignment,
-            priority?: number
-        ): NotebookCellStatusBarItem;
-    }
+export interface NotebookCellsChangeEvent {
+    /**
+     * The affected document.
+     */
+    readonly document: NotebookDocument;
+    readonly changes: ReadonlyArray<NotebookCellsChangeData>;
+}
 
-    //#endregion
+export interface NotebookCellOutputsChangeEvent {
+    /**
+     * The affected document.
+     */
+    readonly document: NotebookDocument;
+    readonly cells: NotebookCell[];
+}
 
-    //#region https://github.com/microsoft/vscode/issues/106744, NotebookConcatTextDocument
+export interface NotebookCellLanguageChangeEvent {
+    /**
+     * The affected document.
+     */
+    readonly document: NotebookDocument;
+    readonly cell: NotebookCell;
+    readonly language: string;
+}
 
-    export namespace notebook {
-        /**
-         * Create a document that is the concatenation of all  notebook cells. By default all code-cells are included
-         * but a selector can be provided to narrow to down the set of cells.
-         *
-         * @param notebook
-         * @param selector
-         */
-        // @jrieken REMOVE. p_never
-        // todo@API really needed? we didn't find a user here
-        export function createConcatTextDocument(
-            notebook: NotebookDocument,
-            selector?: DocumentSelector
-        ): NotebookConcatTextDocument;
-    }
+export interface NotebookCellMetadataChangeEvent {
+    readonly document: NotebookDocument;
+    readonly cell: NotebookCell;
+}
 
-    export interface NotebookConcatTextDocument {
-        uri: Uri;
-        isClosed: boolean;
-        dispose(): void;
-        onDidChange: Event<void>;
-        version: number;
-        getText(): string;
-        getText(range: Range): string;
+export interface NotebookEditorSelectionChangeEvent {
+    readonly notebookEditor: NotebookEditor;
+    readonly selections: ReadonlyArray<NotebookCellRange>;
+}
 
-        offsetAt(position: Position): number;
-        positionAt(offset: number): Position;
-        validateRange(range: Range): Range;
-        validatePosition(position: Position): Position;
+export interface NotebookEditorVisibleRangesChangeEvent {
+    readonly notebookEditor: NotebookEditor;
+    readonly visibleRanges: ReadonlyArray<NotebookCellRange>;
+}
 
-        locationAt(positionOrRange: Position | Range): Location;
-        positionAt(location: Location): Position;
-        contains(uri: Uri): boolean;
-    }
+// todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
+export class NotebookCellData {
+    kind: NotebookCellKind;
+    // todo@API better names: value? text?
+    source: string;
+    // todo@API how does language and MD relate?
+    language: string;
+    outputs?: NotebookCellOutput[];
+    metadata?: NotebookCellMetadata;
+    constructor(
+        kind: NotebookCellKind,
+        source: string,
+        language: string,
+        outputs?: NotebookCellOutput[],
+        metadata?: NotebookCellMetadata
+    );
+}
 
-    //#endregion
+export class NotebookData {
+    cells: NotebookCellData[];
+    metadata?: NotebookDocumentMetadata;
+    constructor(cells: NotebookCellData[], metadata?: NotebookDocumentMetadata);
+}
+
+/**
+ * Communication object passed to the {@link NotebookContentProvider} and
+ * {@link NotebookOutputRenderer} to communicate with the webview.
+ */
+export interface NotebookCommunication {
+    /**
+     * ID of the editor this object communicates with. A single notebook
+     * document can have multiple attached webviews and editors, when the
+     * notebook is split for instance. The editor ID lets you differentiate
+     * between them.
+     */
+    readonly editorId: string;
+
+    /**
+     * Fired when the output hosting webview posts a message.
+     */
+    readonly onDidReceiveMessage: Event<any>;
+    /**
+     * Post a message to the output hosting webview.
+     *
+     * Messages are only delivered if the editor is live.
+     *
+     * @param message Body of the message. This must be a string or other json serializable object.
+     */
+    postMessage(message: any): Thenable<boolean>;
+
+    /**
+     * Convert a uri for the local file system to one that can be used inside outputs webview.
+     */
+    asWebviewUri(localResource: Uri): Uri;
+
+    // @rebornix
+    // readonly onDidDispose: Event<void>;
+}
+
+// export function registerNotebookKernel(selector: string, kernel: NotebookKernel): Disposable;
+
+export interface NotebookDocumentShowOptions {
+    viewColumn?: ViewColumn;
+    preserveFocus?: boolean;
+    preview?: boolean;
+    selection?: NotebookCellRange;
+}
+
+export namespace notebook {
+    export function openNotebookDocument(uri: Uri): Thenable<NotebookDocument>;
+
+    export const onDidOpenNotebookDocument: Event<NotebookDocument>;
+    export const onDidCloseNotebookDocument: Event<NotebookDocument>;
+
+    export const onDidSaveNotebookDocument: Event<NotebookDocument>;
+
+    /**
+     * All currently known notebook documents.
+     */
+    export const notebookDocuments: ReadonlyArray<NotebookDocument>;
+    export const onDidChangeNotebookDocumentMetadata: Event<NotebookDocumentMetadataChangeEvent>;
+    export const onDidChangeNotebookCells: Event<NotebookCellsChangeEvent>;
+    export const onDidChangeCellOutputs: Event<NotebookCellOutputsChangeEvent>;
+
+    export const onDidChangeCellMetadata: Event<NotebookCellMetadataChangeEvent>;
+}
+
+export namespace window {
+    export const visibleNotebookEditors: NotebookEditor[];
+    export const onDidChangeVisibleNotebookEditors: Event<NotebookEditor[]>;
+    export const activeNotebookEditor: NotebookEditor | undefined;
+    export const onDidChangeActiveNotebookEditor: Event<NotebookEditor | undefined>;
+    export const onDidChangeNotebookEditorSelection: Event<NotebookEditorSelectionChangeEvent>;
+    export const onDidChangeNotebookEditorVisibleRanges: Event<NotebookEditorVisibleRangesChangeEvent>;
+
+    export function showNotebookDocument(uri: Uri, options?: NotebookDocumentShowOptions): Thenable<NotebookEditor>;
+    export function showNotebookDocument(
+        document: NotebookDocument,
+        options?: NotebookDocumentShowOptions
+    ): Thenable<NotebookEditor>;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookCellOutput
+
+// code specific mime types
+// application/x.notebook.error-traceback
+// application/x.notebook.stream
+export class NotebookCellOutputItem {
+    // todo@API
+    // add factory functions for common mime types
+    // static textplain(value:string): NotebookCellOutputItem;
+    // static errortrace(value:any): NotebookCellOutputItem;
+
+    readonly mime: string;
+    readonly value: unknown;
+    readonly metadata?: Record<string, any>;
+
+    constructor(mime: string, value: unknown, metadata?: Record<string, any>);
+}
+
+// @jrieken
+// todo@API think about readonly...
+//TODO@API add execution count to cell output?
+export class NotebookCellOutput {
+    readonly id: string;
+    readonly outputs: NotebookCellOutputItem[];
+    readonly metadata?: Record<string, any>;
+
+    constructor(outputs: NotebookCellOutputItem[], metadata?: Record<string, any>);
+
+    constructor(outputs: NotebookCellOutputItem[], id: string, metadata?: Record<string, any>);
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorEdit
+
+export interface WorkspaceEdit {
+    replaceNotebookMetadata(uri: Uri, value: NotebookDocumentMetadata): void;
+
+    // todo@API use NotebookCellRange
+    replaceNotebookCells(
+        uri: Uri,
+        start: number,
+        end: number,
+        cells: NotebookCellData[],
+        metadata?: WorkspaceEditEntryMetadata
+    ): void;
+    replaceNotebookCellMetadata(
+        uri: Uri,
+        index: number,
+        cellMetadata: NotebookCellMetadata,
+        metadata?: WorkspaceEditEntryMetadata
+    ): void;
+
+    replaceNotebookCellOutput(
+        uri: Uri,
+        index: number,
+        outputs: NotebookCellOutput[],
+        metadata?: WorkspaceEditEntryMetadata
+    ): void;
+    appendNotebookCellOutput(
+        uri: Uri,
+        index: number,
+        outputs: NotebookCellOutput[],
+        metadata?: WorkspaceEditEntryMetadata
+    ): void;
+
+    // TODO@api
+    // https://jupyter-protocol.readthedocs.io/en/latest/messaging.html#update-display-data
+    replaceNotebookCellOutputItems(
+        uri: Uri,
+        index: number,
+        outputId: string,
+        items: NotebookCellOutputItem[],
+        metadata?: WorkspaceEditEntryMetadata
+    ): void;
+    appendNotebookCellOutputItems(
+        uri: Uri,
+        index: number,
+        outputId: string,
+        items: NotebookCellOutputItem[],
+        metadata?: WorkspaceEditEntryMetadata
+    ): void;
+}
+
+export interface NotebookEditorEdit {
+    replaceMetadata(value: NotebookDocumentMetadata): void;
+    replaceCells(start: number, end: number, cells: NotebookCellData[]): void;
+    replaceCellOutput(index: number, outputs: NotebookCellOutput[]): void;
+    replaceCellMetadata(index: number, metadata: NotebookCellMetadata): void;
+}
+
+export interface NotebookEditor {
+    /**
+     * Perform an edit on the notebook associated with this notebook editor.
+     *
+     * The given callback-function is invoked with an [edit-builder](#NotebookEditorEdit) which must
+     * be used to make edits. Note that the edit-builder is only valid while the
+     * callback executes.
+     *
+     * @param callback A function which can create edits using an [edit-builder](#NotebookEditorEdit).
+     * @return A promise that resolves with a value indicating if the edits could be applied.
+     */
+    // @jrieken REMOVE maybe
+    edit(callback: (editBuilder: NotebookEditorEdit) => void): Thenable<boolean>;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookContentProvider
+
+interface NotebookDocumentBackup {
+    /**
+     * Unique identifier for the backup.
+     *
+     * This id is passed back to your extension in `openNotebook` when opening a notebook editor from a backup.
+     */
+    readonly id: string;
+
+    /**
+     * Delete the current backup.
+     *
+     * This is called by VS Code when it is clear the current backup is no longer needed, such as when a new backup
+     * is made or when the file is saved.
+     */
+    delete(): void;
+}
+
+interface NotebookDocumentBackupContext {
+    readonly destination: Uri;
+}
+
+interface NotebookDocumentOpenContext {
+    readonly backupId?: string;
+    readonly untitledDocumentData?: Uint8Array;
+}
+
+// todo@API use openNotebookDOCUMENT to align with openCustomDocument etc?
+// todo@API rename to NotebookDocumentContentProvider
+export interface NotebookContentProvider {
+    readonly options?: NotebookDocumentContentOptions;
+    readonly onDidChangeNotebookContentOptions?: Event<NotebookDocumentContentOptions>;
+
+    // todo@API remove! against separation of data provider and renderer
+    // eslint-disable-next-line vscode-dts-cancellation
+    resolveNotebook(document: NotebookDocument, webview: NotebookCommunication): Thenable<void>;
+
+    /**
+     * Content providers should always use [file system providers](#FileSystemProvider) to
+     * resolve the raw content for `uri` as the resouce is not necessarily a file on disk.
+     */
+    openNotebook(
+        uri: Uri,
+        openContext: NotebookDocumentOpenContext,
+        token: CancellationToken
+    ): NotebookData | Thenable<NotebookData>;
+
+    saveNotebook(document: NotebookDocument, token: CancellationToken): Thenable<void>;
+
+    saveNotebookAs(targetResource: Uri, document: NotebookDocument, token: CancellationToken): Thenable<void>;
+
+    backupNotebook(
+        document: NotebookDocument,
+        context: NotebookDocumentBackupContext,
+        token: CancellationToken
+    ): Thenable<NotebookDocumentBackup>;
+}
+
+export namespace notebook {
+    // TODO@api use NotebookDocumentFilter instead of just notebookType:string?
+    // TODO@API options duplicates the more powerful variant on NotebookContentProvider
+    export function registerNotebookContentProvider(
+        notebookType: string,
+        provider: NotebookContentProvider,
+        options?: NotebookDocumentContentOptions & {
+            /**
+             * Not ready for production or development use yet.
+             */
+            viewOptions?: {
+                displayName: string;
+                filenamePattern: NotebookFilenamePattern[];
+                exclusive?: boolean;
+            };
+        }
+    ): Disposable;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookKernel
+
+// todo@API use the NotebookCellExecution-object as a container to model and enforce
+// the flow of a cell execution
+
+// kernel -> execute_info
+// ext -> createNotebookCellExecution(cell)
+// kernel -> done
+// exec.dispose();
+
+// export interface NotebookCellExecution {
+// 	dispose(): void;
+// 	clearOutput(): void;
+// 	appendOutput(out: NotebookCellOutput): void;
+// 	replaceOutput(out: NotebookCellOutput): void;
+//  appendOutputItems(output:string, items: NotebookCellOutputItem[]):void;
+//  replaceOutputItems(output:string, items: NotebookCellOutputItem[]):void;
+// }
+
+// export function createNotebookCellExecution(cell: NotebookCell, startTime?: number): NotebookCellExecution;
+// export const onDidStartNotebookCellExecution: Event<any>;
+// export const onDidStopNotebookCellExecution: Event<any>;
+
+export interface NotebookKernel {
+    // todo@API make this mandatory?
+    readonly id?: string;
+
+    label: string;
+    description?: string;
+    detail?: string;
+    isPreferred?: boolean;
+
+    // todo@API is this maybe an output property?
+    preloads?: Uri[];
+
+    /**
+     * languages supported by kernel
+     * - first is preferred
+     * - `undefined` means all languages available in the editor
+     */
+    supportedLanguages?: string[];
+
+    // todo@API kernel updating itself
+    // fired when properties like the supported languages etc change
+    // onDidChangeProperties?: Event<void>
+
+    // @roblourens
+    // todo@API change to `executeCells(document: NotebookDocument, cells: NotebookCellRange[], context:{isWholeNotebooke: boolean}, token: CancelationToken): void;`
+    // todo@API interrupt vs cancellation, https://github.com/microsoft/vscode/issues/106741
+    // interrupt?():void;
+    executeCell(document: NotebookDocument, cell: NotebookCell): void;
+    cancelCellExecution(document: NotebookDocument, cell: NotebookCell): void;
+    executeAllCells(document: NotebookDocument): void;
+    cancelAllCellsExecution(document: NotebookDocument): void;
+}
+
+export type NotebookFilenamePattern = GlobPattern | { include: GlobPattern; exclude: GlobPattern };
+
+// todo@API why not for NotebookContentProvider?
+export interface NotebookDocumentFilter {
+    viewType?: string | string[];
+    filenamePattern?: NotebookFilenamePattern;
+}
+
+// todo@API very unclear, provider MUST not return alive object but only data object
+// todo@API unclear how the flow goes
+export interface NotebookKernelProvider<T extends NotebookKernel = NotebookKernel> {
+    onDidChangeKernels?: Event<NotebookDocument | undefined>;
+    provideKernels(document: NotebookDocument, token: CancellationToken): ProviderResult<T[]>;
+    resolveKernel?(
+        kernel: T,
+        document: NotebookDocument,
+        webview: NotebookCommunication,
+        token: CancellationToken
+    ): ProviderResult<void>;
+}
+
+export interface NotebookEditor {
+    /**
+     * Active kernel used in the editor
+     */
+    // todo@API unsure about that
+    // kernel, kernel selection, kernel provider
+    readonly kernel?: NotebookKernel;
+}
+
+export namespace notebook {
+    export const onDidChangeActiveNotebookKernel: Event<{
+        document: NotebookDocument;
+        kernel: NotebookKernel | undefined;
+    }>;
+
+    export function registerNotebookKernelProvider(
+        selector: NotebookDocumentFilter,
+        provider: NotebookKernelProvider
+    ): Disposable;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorDecorationType
+
+export interface NotebookEditor {
+    setDecorations(decorationType: NotebookEditorDecorationType, range: NotebookCellRange): void;
+}
+
+export interface NotebookDecorationRenderOptions {
+    backgroundColor?: string | ThemeColor;
+    borderColor?: string | ThemeColor;
+    top: ThemableDecorationAttachmentRenderOptions;
+}
+
+export interface NotebookEditorDecorationType {
+    readonly key: string;
+    dispose(): void;
+}
+
+export namespace notebook {
+    export function createNotebookEditorDecorationType(
+        options: NotebookDecorationRenderOptions
+    ): NotebookEditorDecorationType;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookCellStatusBarItem
+
+/**
+ * Represents the alignment of status bar items.
+ */
+export enum NotebookCellStatusBarAlignment {
+    /**
+     * Aligned to the left side.
+     */
+    Left = 1,
+
+    /**
+     * Aligned to the right side.
+     */
+    Right = 2
+}
+
+export interface NotebookCellStatusBarItem {
+    readonly cell: NotebookCell;
+    readonly alignment: NotebookCellStatusBarAlignment;
+    readonly priority?: number;
+    text: string;
+    tooltip: string | undefined;
+    command: string | Command | undefined;
+    accessibilityInformation?: AccessibilityInformation;
+    show(): void;
+    hide(): void;
+    dispose(): void;
+}
+
+export namespace notebook {
+    /**
+     * Creates a notebook cell status bar [item](#NotebookCellStatusBarItem).
+     * It will be disposed automatically when the notebook document is closed or the cell is deleted.
+     *
+     * @param cell The cell on which this item should be shown.
+     * @param alignment The alignment of the item.
+     * @param priority The priority of the item. Higher values mean the item should be shown more to the left.
+     * @return A new status bar item.
+     */
+    // @roblourens
+    // todo@API this should be a provider, https://github.com/microsoft/vscode/issues/105809
+    export function createCellStatusBarItem(
+        cell: NotebookCell,
+        alignment?: NotebookCellStatusBarAlignment,
+        priority?: number
+    ): NotebookCellStatusBarItem;
+}
+
+//#endregion
+
+//#region https://github.com/microsoft/vscode/issues/106744, NotebookConcatTextDocument
+
+export namespace notebook {
+    /**
+     * Create a document that is the concatenation of all  notebook cells. By default all code-cells are included
+     * but a selector can be provided to narrow to down the set of cells.
+     *
+     * @param notebook
+     * @param selector
+     */
+    // @jrieken REMOVE. p_never
+    // todo@API really needed? we didn't find a user here
+    export function createConcatTextDocument(
+        notebook: NotebookDocument,
+        selector?: DocumentSelector
+    ): NotebookConcatTextDocument;
+}
+
+export interface NotebookConcatTextDocument {
+    uri: Uri;
+    isClosed: boolean;
+    dispose(): void;
+    onDidChange: Event<void>;
+    version: number;
+    getText(): string;
+    getText(range: Range): string;
+
+    offsetAt(position: Position): number;
+    positionAt(offset: number): Position;
+    validateRange(range: Range): Range;
+    validatePosition(position: Position): Position;
+
+    locationAt(positionOrRange: Position | Range): Location;
+    positionAt(location: Location): Position;
+    contains(uri: Uri): boolean;
+}
+
+//#endregion


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/15638
* Updates to the notebook API

This PR is safe for the release, in fact I would highly recommend it for the VS Code Insider users & for the next VS Code release.
* The changes will work with current stable & the VS Code insiders.
* Removed unnecessary code that was in python extension (unblocks Insiders)
* Using the cell document language instead of language in cell (the document.languageId always existed, hence this change will work in current vs code stable)
* Using the cell document uri instead of uri in cell (the document.uri always existed, hence this change will work in current vs code stable)