### PR TITLE
Ensure server process is cleaned up on dispose

### DIFF
--- a/news/2 Fixes/15644.md
+++ b/news/2 Fixes/15644.md
@@ -1,0 +1,1 @@
+Ensure any stray jedi process is terminated on language server dispose.

--- a/src/client/common/process/memory.ts
+++ b/src/client/common/process/memory.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-const pidusageTree = require('pidusage-tree');
+const pidUsageTree = require('pidusage-tree');
 
 /**
  * Calculates number of bytes of memory consumed by the entire process tree with
@@ -10,7 +10,7 @@ const pidusageTree = require('pidusage-tree');
  * @returns : Memory consumed in bytes.
  */
 export async function getMemoryUsage(pid: number): Promise<number> {
-    const result = await pidusageTree(pid);
+    const result = await pidUsageTree(pid);
     let memory = 0;
     if (result) {
         for (const key of Object.keys(result)) {

--- a/src/client/common/process/rawProcessApis.ts
+++ b/src/client/common/process/rawProcessApis.ts
@@ -19,6 +19,8 @@ import {
 } from './types';
 import { noop } from '../utils/misc';
 
+const pidUsageTree = require('pidusage-tree');
+
 export function getDefaultOptions<T extends ShellOptions | SpawnOptions>(
     options: T,
     defaultEnv?: EnvironmentVariables,
@@ -251,6 +253,22 @@ export function killPid(pid: number): void {
             process.kill(pid);
         }
     } catch {
+        // Ignore.
+    }
+}
+
+/**
+ * Kills all processes spawned by `pid` (`pid` inclusive)
+ * @param pid
+ */
+export async function killPidTree(pid: number): Promise<void> {
+    try {
+        // This can fail if the process is already killed
+        const result = await pidUsageTree(pid);
+        for (const key of Object.keys(result)) {
+            killPid(parseInt(key, 10));
+        }
+    } catch (ex) {
         // Ignore.
     }
 }


### PR DESCRIPTION
closes #15644

This is a preventative fix. On language server proxy dispose, we don't know if the server process is actually shutting down after the stop request is sent. So, we send a kill process tree request in all cases so we don't leave behind jedi processes.