### PR TITLE
Restore experiment for LS RPC event for old versions

### DIFF
--- a/experiments.json
+++ b/experiments.json
@@ -24,6 +24,18 @@
         "max": 100
     },
     {
+        "name": "CollectNodeLSRequestTiming - experiment",
+        "salt": "CollectNodeLSRequestTiming",
+        "min": 0,
+        "max": 100
+    },
+    {
+        "name": "CollectNodeLSRequestTiming - control",
+        "salt": "CollectNodeLSRequestTiming",
+        "min": 0,
+        "max": 0
+    },
+    {
         "name": "DeprecatePythonPath - experiment",
         "salt": "DeprecatePythonPath",
         "min": 0,


### PR DESCRIPTION
#15570 removed this, and I thought it was safe to do so, but in actuality the code said "oh, the treatment group doesn't exist anymore, so I'm not going to send anything", which is the opposite of what we wanted.

Once old versions are gone, then we can really drop it.