### PR TITLE
Expand no unused vars rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,7 +32,13 @@
         "@typescript-eslint/no-explicit-any": "error",
         "@typescript-eslint/no-non-null-assertion": "off",
         "no-unused-vars": "off",
-        "@typescript-eslint/no-unused-vars": "error",
+        "@typescript-eslint/no-unused-vars": [
+            "error",
+            {
+                "args": "after-used",
+                "argsIgnorePattern": "^_"
+            }
+        ],
         "no-use-before-define": "off",
         "@typescript-eslint/no-use-before-define": [
             "error",

--- a/src/client/activation/jedi/activator.ts
+++ b/src/client/activation/jedi/activator.ts
@@ -29,7 +29,7 @@ export class JediLanguageServerActivator extends LanguageServerActivatorBase {
         super(manager, workspace, fs, configurationService);
     }
 
-    // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line class-methods-use-this
     public async ensureLanguageServerIsAvailable(_resource: Resource): Promise<void> {
         // Nothing to do here. Jedi language server is shipped with the extension
     }

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -53,12 +53,10 @@ function filterByFileType(
     if (fileType === FileType.Unknown) {
         // FileType.Unknown == 0 so we can't just use bitwise
         // operations blindly here.
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         return files.filter(([_file, ft]) => {
             return ft === FileType.Unknown || ft === (FileType.SymbolicLink & FileType.Unknown);
         });
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     return files.filter(([_file, ft]) => (ft & fileType) > 0);
 }
 
@@ -403,7 +401,6 @@ export class FileSystemUtils implements IFileSystemUtils {
     public async getSubDirectories(dirname: string): Promise<string[]> {
         const files = await this.listdir(dirname);
         const filtered = filterByFileType(files, FileType.Directory);
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         return filtered.map(([filename, _fileType]) => filename);
     }
 
@@ -411,7 +408,6 @@ export class FileSystemUtils implements IFileSystemUtils {
         // Note that only "regular" files are returned.
         const files = await this.listdir(dirname);
         const filtered = filterByFileType(files, FileType.File);
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         return filtered.map(([filename, _fileType]) => filename);
     }
 

--- a/src/client/providers/jediProxy.ts
+++ b/src/client/providers/jediProxy.ts
@@ -901,7 +901,6 @@ export class JediProxyHandler<R extends ICommandResult> implements Disposable {
         }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public sendCommand(cmd: ICommand, _token?: CancellationToken): Promise<R | undefined> {
         const executionCmd = <IExecutionCommand<R>>cmd;
         executionCmd.id = executionCmd.id || this.jediProxy.getNextCommandId();

--- a/src/client/pythonEnvironments/base/locator.ts
+++ b/src/client/pythonEnvironments/base/locator.ts
@@ -194,7 +194,7 @@ abstract class LocatorBase<E extends BasicPythonEnvsChangedEvent = PythonEnvsCha
     // eslint-disable-next-line class-methods-use-this
     public abstract iterEnvs(query?: QueryForEvent<E>): IPythonEnvsIterator;
 
-    // eslint-disable-next-line class-methods-use-this,@typescript-eslint/no-unused-vars
+    // eslint-disable-next-line class-methods-use-this
     public async resolveEnv(_env: string | PythonEnvInfo): Promise<PythonEnvInfo | undefined> {
         return undefined;
     }

--- a/src/client/pythonEnvironments/base/locators/composite/cachingWrapper.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/cachingWrapper.ts
@@ -31,7 +31,6 @@ export class CachingLocatorWrapper extends LazyResourceBasedLocator {
         this.onChanged = this.watcher.onChanged;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     protected async *doIterEnvs(_query?: PythonLocatorQuery): IPythonEnvsIterator {
         yield* this.cache.getEnvs();
     }

--- a/src/client/pythonEnvironments/base/locators/lowLevel/filesLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/lowLevel/filesLocator.ts
@@ -34,7 +34,6 @@ export class FoundFilesLocator implements ILocator {
         this.onChanged = this.watcher.onChanged;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public iterEnvs(_query?: PythonLocatorQuery): IPythonEnvsIterator {
         const executablesPromise = this.getExecutables();
         const emitter = new EventEmitter<PythonEnvUpdatedEvent | null>();

--- a/src/client/pythonEnvironments/discovery/locators/services/cacheableLocatorService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/cacheableLocatorService.ts
@@ -176,7 +176,7 @@ export abstract class CacheableLocatorService implements IInterpreterLocatorServ
         });
     }
 
-    // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line class-methods-use-this
     protected async getInterpreterWatchers(_resource: Uri | undefined): Promise<IInterpreterWatcher[]> {
         return [];
     }

--- a/src/client/pythonEnvironments/discovery/locators/services/condaEnvFileService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaEnvFileService.ts
@@ -48,7 +48,6 @@ export class CondaEnvFileService extends CacheableLocatorService {
      *
      * This is used by CacheableLocatorService.getInterpreters().
      */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     protected getInterpretersImplementation(_resource?: Uri): Promise<PythonEnvironment[]> {
         return this.getSuggestionsFromConda();
     }

--- a/src/client/pythonEnvironments/discovery/locators/services/condaEnvService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaEnvService.ts
@@ -40,7 +40,6 @@ export class CondaEnvService extends CacheableLocatorService {
      *
      * This is used by CacheableLocatorService.getInterpreters().
      */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     protected getInterpretersImplementation(_resource?: Uri): Promise<PythonEnvironment[]> {
         return this.getSuggestionsFromConda();
     }

--- a/src/test/activation/languageServer/downloader.unit.test.ts
+++ b/src/test/activation/languageServer/downloader.unit.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable class-methods-use-this */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable max-classes-per-file */
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.

--- a/src/test/install/channelManager.channels.test.ts
+++ b/src/test/install/channelManager.channels.test.ts
@@ -112,7 +112,6 @@ suite('Installation - installation channels', () => {
                 items = i;
             })
             .returns(
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 () => new Promise<string | undefined>((resolve, _reject) => resolve(undefined)),
             );
 

--- a/src/test/install/channelManager.messages.test.ts
+++ b/src/test/install/channelManager.messages.test.ts
@@ -161,7 +161,6 @@ suite('Installation - channel messages', () => {
         interpreters
             .setup((x) => x.getActiveInterpreter(TypeMoq.It.isAny()))
             .returns(
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 () => new Promise<PythonEnvironment>((resolve, _reject) => resolve(activeInterpreter)),
             );
         const channels = new InstallationChannelManager(serviceContainer);
@@ -176,7 +175,6 @@ suite('Installation - channel messages', () => {
                 search = s;
             })
             .returns(
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 () => new Promise<string>((resolve, _reject) => resolve(search)),
             );
         appShell

--- a/src/test/linters/lint.args.test.ts
+++ b/src/test/linters/lint.args.test.ts
@@ -187,7 +187,7 @@ suite('Linting - Arguments', () => {
                         document.setup((d) => d.uri).returns(() => fileUri);
 
                         let invoked = false;
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
                         (linter as any).run = (args: any[]) => {
                             expect(args[args.length - 1]).to.equal(fileUri.fsPath);
                             invoked = true;

--- a/src/test/mocks/autoSelector.ts
+++ b/src/test/mocks/autoSelector.ts
@@ -15,12 +15,12 @@ import { PythonEnvironment } from '../../client/pythonEnvironments/info';
 @injectable()
 export class MockAutoSelectionService
     implements IInterpreterAutoSelectionService, IInterpreterAutoSelectionProxyService {
-    // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line class-methods-use-this
     public async setWorkspaceInterpreter(_resource: Resource, _interpreter: PythonEnvironment): Promise<void> {
         return Promise.resolve();
     }
 
-    // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+    // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-empty-function
     public async setGlobalInterpreter(_interpreter: PythonEnvironment): Promise<void> {}
 
     // eslint-disable-next-line class-methods-use-this
@@ -28,16 +28,16 @@ export class MockAutoSelectionService
         return new EventEmitter<void>().event;
     }
 
-    // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line class-methods-use-this
     public autoSelectInterpreter(_resource: Resource): Promise<void> {
         return Promise.resolve();
     }
 
-    // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line class-methods-use-this
     public getAutoSelectedInterpreter(_resource: Resource): PythonEnvironment | undefined {
         return undefined;
     }
 
-    // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+    // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-empty-function
     public registerInstance(_instance: IInterpreterAutoSelectionProxyService): void {}
 }

--- a/src/test/mocks/moduleInstaller.ts
+++ b/src/test/mocks/moduleInstaller.ts
@@ -17,12 +17,10 @@ export class MockModuleInstaller extends EventEmitter implements IModuleInstalle
         return 0;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public async installModule(name: string, _resource?: Uri): Promise<void> {
         this.emit('installModule', name);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public async isSupported(_resource?: Uri): Promise<boolean> {
         return this.supported;
     }

--- a/src/test/mocks/process.ts
+++ b/src/test/mocks/process.ts
@@ -12,7 +12,7 @@ import { EnvironmentVariables } from '../../client/common/variables/types';
 export class MockProcess implements ICurrentProcess {
     constructor(public env: EnvironmentVariables = { ...process.env }) {}
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/ban-types
+    // eslint-disable-next-line @typescript-eslint/ban-types
     public on(_event: string | symbol, _listener: Function): this {
         return this;
     }

--- a/src/test/pythonEnvironments/discovery/locators/cacheableLocatorService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/cacheableLocatorService.unit.test.ts
@@ -29,22 +29,18 @@ suite('Interpreters - Cacheable Locator Service', () => {
                 noop();
             }
 
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             protected async getInterpretersImplementation(_resource?: Uri): Promise<PythonEnvironment[]> {
                 return this.mockLocator.getInterpretersImplementation();
             }
 
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             protected getCachedInterpreters(_resource?: Uri): PythonEnvironment[] | undefined {
                 return this.mockLocator.getCachedInterpreters();
             }
 
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             protected async cacheInterpreters(_interpreters: PythonEnvironment[], _resource?: Uri) {
                 return this.mockLocator.cacheInterpreters();
             }
 
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             protected getCacheKey(_resource?: Uri) {
                 return this.mockLocator.getCacheKey();
             }
@@ -82,9 +78,7 @@ suite('Interpreters - Cacheable Locator Service', () => {
             const locator = new (class extends Locator {
                 // eslint-disable-next-line class-methods-use-this
                 protected async addHandlersForInterpreterWatchers(
-                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
                     _cacheKey: string,
-                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
                     _resource: Resource,
                 ): Promise<void> {
                     noop();
@@ -114,11 +108,10 @@ suite('Interpreters - Cacheable Locator Service', () => {
             class Watcher implements IInterpreterWatcher {
                 // eslint-disable-next-line class-methods-use-this
                 public onDidCreate(
-                    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     _listener: (e: Resource) => any,
-                    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     _thisArgs?: any,
-                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
                     _disposables?: Disposable[],
                 ): Disposable {
                     return { dispose: noop };
@@ -127,7 +120,7 @@ suite('Interpreters - Cacheable Locator Service', () => {
             const watcher: IInterpreterWatcher = mock(Watcher);
 
             const locator = new (class extends Locator {
-                // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
+                // eslint-disable-next-line class-methods-use-this
                 protected async getInterpreterWatchers(_resource: Resource): Promise<IInterpreterWatcher[]> {
                     return [instance(watcher)];
                 }
@@ -149,9 +142,8 @@ suite('Interpreters - Cacheable Locator Service', () => {
                 public onDidCreate(
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     listener: (e: Resource) => any,
-                    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     _thisArgs?: any,
-                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
                     _disposables?: Disposable[],
                 ): Disposable {
                     this.listner = listener;
@@ -165,7 +157,7 @@ suite('Interpreters - Cacheable Locator Service', () => {
             const watcher = new Watcher();
 
             const locator = new (class extends Locator {
-                // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
+                // eslint-disable-next-line class-methods-use-this
                 protected async getInterpreterWatchers(_resource: Resource): Promise<IInterpreterWatcher[]> {
                     return [watcher];
                 }
@@ -206,7 +198,7 @@ suite('Interpreters - Cacheable Locator Service', () => {
         test('Ensure locating event is raised', async () => {
             const mockedLocatorForVerification = mock(MockLocator);
             const locator = new (class extends Locator {
-                // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
+                // eslint-disable-next-line class-methods-use-this
                 protected async getInterpreterWatchers(_resource: Resource): Promise<IInterpreterWatcher[]> {
                     return [];
                 }
@@ -236,17 +228,17 @@ suite('Interpreters - Cacheable Locator Service', () => {
                 return super.getCacheKey(resource);
             }
 
-            // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
+            // eslint-disable-next-line class-methods-use-this
             protected async getInterpretersImplementation(_resource?: Uri): Promise<PythonEnvironment[]> {
                 return [];
             }
 
-            // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
+            // eslint-disable-next-line class-methods-use-this
             protected getCachedInterpreters(_resource?: Uri): PythonEnvironment[] | undefined {
                 return [];
             }
 
-            // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
+            // eslint-disable-next-line class-methods-use-this
             protected async cacheInterpreters(_interpreters: PythonEnvironment[], _resource?: Uri) {
                 noop();
             }

--- a/src/test/pythonEnvironments/discovery/locators/workspaceVirtualEnvWatcherService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/workspaceVirtualEnvWatcherService.unit.test.ts
@@ -53,7 +53,7 @@ suite('Interpreters - Workspace VirtualEnv Watcher Service', () => {
         when(platformService.isMac).thenReturn(os === OSType.OSX);
 
         class FSWatcher {
-            // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+            // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-explicit-any
             public onDidCreate(_listener: (e: Uri) => any, _thisArgs?: any, _disposables?: Disposable[]): Disposable {
                 return { dispose: noop };
             }
@@ -112,7 +112,7 @@ suite('Interpreters - Workspace VirtualEnv Watcher Service', () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             private listener?: (e: Uri) => any;
 
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             public onDidCreate(listener: (e: Uri) => any, _thisArgs?: any, _disposables?: Disposable[]): Disposable {
                 this.listener = listener;
                 return { dispose: noop };


### PR DESCRIPTION
Amend the @typescript-eslint/no-unused-vars rule to ignore all unused positional arguments that start with an underscore and are placed after the last used argument (see the description [here](https://eslint.org/docs/2.0.0/rules/no-unused-vars#ignore-identifiers-that-match-specific-patterns)). This also means that we don't need to add an ignore directive for code like this anymore:

```js
function foo(x, _y) {​​​​​​​
    return x + 1;
}​​​​​​​​​​​​​​
```

Cleaned up the 44 `no-unused-vars` ignore comments in the codebase as well.