### PR TITLE
Enable running tests for folders in tests explorer

### DIFF
--- a/news/1 Enhancements/15862.md
+++ b/news/1 Enhancements/15862.md
@@ -1,0 +1,1 @@
+Allow running tests for all files within directories from test explorer

--- a/news/1 Enhancements/15862.md
+++ b/news/1 Enhancements/15862.md
@@ -1,1 +1,2 @@
-Allow running tests for all files within directories from test explorer
+Allow running tests for all files within directories from test explorer.
+(thanks [Vladimir Kotikov](https://github.com/vladimir-kotikov))

--- a/package.json
+++ b/package.json
@@ -600,6 +600,16 @@
                     "command": "python.runTestNode",
                     "when": "view == python_tests && viewItem == suite && !busyTests",
                     "group": "inline@0"
+                },
+                {
+                    "command": "python.debugTestNode",
+                    "when": "view == python_tests && viewItem == folder && !busyTests",
+                    "group": "inline@1"
+                },
+                {
+                    "command": "python.runTestNode",
+                    "when": "view == python_tests && viewItem == folder && !busyTests",
+                    "group": "inline@0"
                 }
             ]
         },

--- a/src/client/testing/common/services/testsStatusService.ts
+++ b/src/client/testing/common/services/testsStatusService.ts
@@ -70,6 +70,7 @@ export class TestsStatusUpdaterService implements ITestsStatusUpdaterService {
             return;
         }
         const itemsRunning = [
+            ...(testsToRun.testFolder || []),
             ...(testsToRun.testFile || []),
             ...(testsToRun.testSuite || []),
             ...(testsToRun.testFunction || []),


### PR DESCRIPTION
This seems to be quite obvious but useful addition which I constantly miss. The support for running tests for folders is already present in test runners, just package.json needs to be slightly tweaked.