### PR TITLE
Install dev tools using Poetry when the poetry environment related to current folder is selected

### DIFF
--- a/news/1 Enhancements/15786.md
+++ b/news/1 Enhancements/15786.md
@@ -1,0 +1,1 @@
+Install dev tools using Poetry when the poetry environment related to current folder is selected when in discovery experiment.

--- a/src/client/common/installer/poetryInstaller.ts
+++ b/src/client/common/installer/poetryInstaller.ts
@@ -6,12 +6,16 @@
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { Uri } from 'vscode';
+import { IInterpreterService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
+import { isPoetryEnvironmentRelatedToFolder } from '../../pythonEnvironments/discovery/locators/services/poetry';
+import { EnvironmentType } from '../../pythonEnvironments/info';
 import { IWorkspaceService } from '../application/types';
+import { inDiscoveryExperiment } from '../experiments/helpers';
 import { traceError } from '../logger';
 import { IFileSystem } from '../platform/types';
 import { IProcessServiceFactory } from '../process/types';
-import { ExecutionInfo, IConfigurationService } from '../types';
+import { ExecutionInfo, IConfigurationService, IExperimentService } from '../types';
 import { isResource } from '../utils/misc';
 import { ModuleInstaller } from './moduleInstaller';
 import { InterpreterUri } from './types';
@@ -47,8 +51,28 @@ export class PoetryInstaller extends ModuleInstaller {
     }
 
     public async isSupported(resource?: InterpreterUri): Promise<boolean> {
+        // const execPath = this.configurationService.getSettings(isResource(resource) ? resource : undefined).poetryPath;
         if (!resource) {
             return false;
+        }
+        const experimentService = this.serviceContainer.get<IExperimentService>(IExperimentService);
+        if (await inDiscoveryExperiment(experimentService)) {
+            if (!isResource(resource)) {
+                return false;
+            }
+            const interpreter = await this.serviceContainer
+                .get<IInterpreterService>(IInterpreterService)
+                .getActiveInterpreter(resource);
+            const workspaceFolder = resource ? this.workspaceService.getWorkspaceFolder(resource) : undefined;
+            if (!interpreter || !workspaceFolder || interpreter.envType !== EnvironmentType.Poetry) {
+                return false;
+            }
+            // Install using poetry CLI only if the active poetry environment is related to the current folder.
+            return isPoetryEnvironmentRelatedToFolder(
+                interpreter.path,
+                workspaceFolder.uri.fsPath,
+                this.configurationService.getSettings(resource).poetryPath,
+            );
         }
         const workspaceFolder = this.workspaceService.getWorkspaceFolder(isResource(resource) ? resource : undefined);
         if (!workspaceFolder) {

--- a/src/client/common/installer/poetryInstaller.ts
+++ b/src/client/common/installer/poetryInstaller.ts
@@ -51,7 +51,6 @@ export class PoetryInstaller extends ModuleInstaller {
     }
 
     public async isSupported(resource?: InterpreterUri): Promise<boolean> {
-        // const execPath = this.configurationService.getSettings(isResource(resource) ? resource : undefined).poetryPath;
         if (!resource) {
             return false;
         }

--- a/src/client/pythonEnvironments/discovery/locators/services/poetry.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/poetry.ts
@@ -220,8 +220,12 @@ export class Poetry {
  * @param interpreterPath Absolute path to any python interpreter.
  * @param folder Absolute path to the folder.
  */
-export async function isPoetryEnvironmentRelatedToFolder(interpreterPath: string, folder: string): Promise<boolean> {
-    const poetry = await Poetry.getPoetry();
+export async function isPoetryEnvironmentRelatedToFolder(
+    interpreterPath: string,
+    folder: string,
+    poetryPath?: string,
+): Promise<boolean> {
+    const poetry = poetryPath ? new Poetry(poetryPath) : await Poetry.getPoetry();
     const pathToEnv = await poetry?.getActiveEnvPath(folder);
     if (!pathToEnv) {
         return false;

--- a/src/client/pythonEnvironments/discovery/locators/services/poetry.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/poetry.ts
@@ -219,6 +219,7 @@ export class Poetry {
  * false otherwise.
  * @param interpreterPath Absolute path to any python interpreter.
  * @param folder Absolute path to the folder.
+ * @param poetryPath Poetry command to use to calculate the result.
  */
 export async function isPoetryEnvironmentRelatedToFolder(
     interpreterPath: string,

--- a/src/test/common/installer/poetryInstaller.unit.test.ts
+++ b/src/test/common/installer/poetryInstaller.unit.test.ts
@@ -3,6 +3,8 @@
 
 'use strict';
 
+import * as sinon from 'sinon';
+import * as path from 'path';
 import * as assert from 'assert';
 import { expect } from 'chai';
 import { anything, instance, mock, when } from 'ts-mockito';
@@ -16,9 +18,14 @@ import { FileSystem } from '../../../client/common/platform/fileSystem';
 import { IFileSystem } from '../../../client/common/platform/types';
 import { ProcessService } from '../../../client/common/process/proc';
 import { ProcessServiceFactory } from '../../../client/common/process/processFactory';
-import { IProcessServiceFactory } from '../../../client/common/process/types';
-import { ExecutionInfo, IConfigurationService } from '../../../client/common/types';
+import { ExecutionResult, IProcessServiceFactory, ShellOptions } from '../../../client/common/process/types';
+import { ExecutionInfo, IConfigurationService, IExperimentService } from '../../../client/common/types';
 import { ServiceContainer } from '../../../client/ioc/container';
+import { IInterpreterService } from '../../../client/interpreter/contracts';
+import { TEST_LAYOUT_ROOT } from '../../pythonEnvironments/common/commonTestConstants';
+import * as externalDependencies from '../../../client/pythonEnvironments/common/externalDependencies';
+import { DiscoveryVariants } from '../../../client/common/experiments/groups';
+import { EnvironmentType } from '../../../client/pythonEnvironments/info';
 
 suite('Module Installer - Poetry', () => {
     class TestInstaller extends PoetryInstaller {
@@ -26,17 +33,44 @@ suite('Module Installer - Poetry', () => {
             return super.getExecutionInfo(moduleName, resource);
         }
     }
+    const testPoetryDir = path.join(TEST_LAYOUT_ROOT, 'poetry');
+    const project1 = path.join(testPoetryDir, 'project1');
     let poetryInstaller: TestInstaller;
     let workspaceService: IWorkspaceService;
     let configurationService: IConfigurationService;
     let fileSystem: IFileSystem;
+    let experimentService: IExperimentService;
+    let interpreterService: IInterpreterService;
     let processServiceFactory: IProcessServiceFactory;
+    let serviceContainer: ServiceContainer;
+    let shellExecute: sinon.SinonStub;
+
     setup(() => {
-        const serviceContainer = mock(ServiceContainer);
+        serviceContainer = mock(ServiceContainer);
+        experimentService = mock<IExperimentService>();
+        interpreterService = mock<IInterpreterService>();
+        when(serviceContainer.get<IInterpreterService>(IInterpreterService)).thenReturn(instance(interpreterService));
+        when(serviceContainer.get<IExperimentService>(IExperimentService)).thenReturn(instance(experimentService));
         workspaceService = mock(WorkspaceService);
         configurationService = mock(ConfigurationService);
         fileSystem = mock(FileSystem);
         processServiceFactory = mock(ProcessServiceFactory);
+
+        shellExecute = sinon.stub(externalDependencies, 'shellExecute');
+        shellExecute.callsFake((command: string, options: ShellOptions) => {
+            // eslint-disable-next-line default-case
+            switch (command) {
+                case 'poetry --version':
+                    return Promise.resolve<ExecutionResult<string>>({ stdout: '' });
+                case 'poetry env info -p':
+                    if (options.cwd && externalDependencies.arePathsSame(options.cwd, project1)) {
+                        return Promise.resolve<ExecutionResult<string>>({
+                            stdout: `${path.join(project1, '.venv')} \n`,
+                        });
+                    }
+            }
+            return Promise.reject(new Error('Command failed'));
+        });
 
         poetryInstaller = new TestInstaller(
             instance(serviceContainer),
@@ -45,6 +79,10 @@ suite('Module Installer - Poetry', () => {
             instance(fileSystem),
             instance(processServiceFactory),
         );
+    });
+
+    teardown(() => {
+        shellExecute?.restore();
     });
 
     test('Installer name is poetry', () => {
@@ -151,5 +189,76 @@ suite('Module Installer - Poetry', () => {
             args: ['add', '--dev', 'black', '--allow-prereleases'],
             execPath: 'poetry path',
         });
+    });
+    test('When in experiment, is supported returns true if selected interpreter is related to the workspace', async () => {
+        const uri = Uri.file(project1);
+        const settings = mock(PythonSettings);
+
+        when(experimentService.inExperiment(DiscoveryVariants.discoverWithFileWatching)).thenResolve(true);
+        when(interpreterService.getActiveInterpreter(anything())).thenResolve({
+            path: path.join(project1, '.venv', 'Scripts', 'python.exe'),
+            envType: EnvironmentType.Poetry,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+        when(configurationService.getSettings(anything())).thenReturn(instance(settings));
+        when(settings.poetryPath).thenReturn('poetry');
+        when(workspaceService.getWorkspaceFolder(anything())).thenReturn({ uri, name: '', index: 0 });
+
+        const supported = await poetryInstaller.isSupported(Uri.file(__filename));
+
+        assert.equal(supported, true);
+    });
+
+    test('When in experiment, is supported returns true if no interpreter is selected', async () => {
+        const uri = Uri.file(project1);
+        const settings = mock(PythonSettings);
+
+        when(experimentService.inExperiment(DiscoveryVariants.discoverWithFileWatching)).thenResolve(true);
+        when(interpreterService.getActiveInterpreter(anything())).thenResolve(undefined);
+        when(configurationService.getSettings(anything())).thenReturn(instance(settings));
+        when(settings.poetryPath).thenReturn('poetry');
+        when(workspaceService.getWorkspaceFolder(anything())).thenReturn({ uri, name: '', index: 0 });
+
+        const supported = await poetryInstaller.isSupported(Uri.file(__filename));
+
+        assert.equal(supported, false);
+    });
+
+    test('When in experiment, is supported returns false if selected interpreter is not related to the workspace', async () => {
+        const uri = Uri.file(project1);
+        const settings = mock(PythonSettings);
+
+        when(experimentService.inExperiment(DiscoveryVariants.discoverWithFileWatching)).thenResolve(true);
+        when(interpreterService.getActiveInterpreter(anything())).thenResolve({
+            path: path.join(project1, '.random', 'Scripts', 'python.exe'),
+            envType: EnvironmentType.Poetry,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+        when(configurationService.getSettings(anything())).thenReturn(instance(settings));
+        when(settings.poetryPath).thenReturn('poetry');
+        when(workspaceService.getWorkspaceFolder(anything())).thenReturn({ uri, name: '', index: 0 });
+
+        const supported = await poetryInstaller.isSupported(Uri.file(__filename));
+
+        assert.equal(supported, false);
+    });
+
+    test('When in experiment, is supported returns false if selected interpreter is not of Poetry type', async () => {
+        const uri = Uri.file(project1);
+        const settings = mock(PythonSettings);
+
+        when(experimentService.inExperiment(DiscoveryVariants.discoverWithFileWatching)).thenResolve(true);
+        when(interpreterService.getActiveInterpreter(anything())).thenResolve({
+            path: path.join(project1, '.venv', 'Scripts', 'python.exe'),
+            envType: EnvironmentType.Pipenv,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+        when(configurationService.getSettings(anything())).thenReturn(instance(settings));
+        when(settings.poetryPath).thenReturn('poetry');
+        when(workspaceService.getWorkspaceFolder(anything())).thenReturn({ uri, name: '', index: 0 });
+
+        const supported = await poetryInstaller.isSupported(Uri.file(__filename));
+
+        assert.equal(supported, false);
     });
 });


### PR DESCRIPTION
For #8372 Closes https://github.com/microsoft/vscode-python-internalbacklog/issues/93 
Closes https://github.com/microsoft/vscode-python-internalbacklog/issues/12

Should be merged only after https://github.com/microsoft/vscode-python/pull/15765, otherwise old poetry support for installation will break when in discovery experiment.