### PR TITLE
completions to use new Jedi get_names method

### DIFF
--- a/news/2 Fixes/15791.md
+++ b/news/2 Fixes/15791.md
@@ -1,0 +1,1 @@
+In completions.py: jedi.api.names has been deprecated, switch to new syntax.

--- a/news/2 Fixes/15791.md
+++ b/news/2 Fixes/15791.md
@@ -1,1 +1,2 @@
 In completions.py: jedi.api.names has been deprecated, switch to new syntax.
+(thanks [moselhy](https://github.com/moselhy)).

--- a/pythonFiles/completion.py
+++ b/pythonFiles/completion.py
@@ -581,11 +581,9 @@ class JediCompletion(object):
 
         if lookup == "names":
             return self._serialize_definitions(
-                jedi.api.names(
-                    source=request.get("source", None),
-                    path=request.get("path", ""),
-                    all_scopes=True,
-                ),
+                jedi.Script(
+                    source=request.get("source", None), path=request.get("path", "")
+                ).get_names(all_scopes=True),
                 request["id"],
             )
 


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/10632

jedi.api.names has been deprecated, use new syntax instead.
* note I could have used the Script object initialized in the lines right below the change, but I went the safe route since the method enclosing the change returns pre-emptively