### PR TITLE
Make poetry discovery faster

### DIFF
--- a/src/client/common/utils/decorators.ts
+++ b/src/client/common/utils/decorators.ts
@@ -4,6 +4,7 @@ import { traceError, traceVerbose } from '../logger';
 import { createDeferred, Deferred } from './async';
 import { getCacheKeyFromFunctionArgs, getGlobalCacheStore } from './cacheUtils';
 import { TraceInfo, tracing } from './misc';
+import { StopWatch } from './stopWatch';
 
 const _debounce = require('lodash/debounce') as typeof import('lodash/debounce');
 
@@ -121,13 +122,25 @@ export function makeDebounceAsyncDecorator(wait?: number) {
 
 type PromiseFunctionWithAnyArgs = (...any: any) => Promise<any>;
 const cacheStoreForMethods = getGlobalCacheStore();
+
+/**
+ * Extension start up time is considered the duration until extension is likely to keep running commands in background.
+ * It is observed on CI it can take upto 3 minutes, so this is an intelligent guess.
+ */
+const extensionStartUpTime = 200_000;
+/**
+ * Tracks the time since the module was loaded. For caching purposes, we consider this time to approximately signify
+ * how long extension has been active.
+ */
+const moduleLoadWatch = new StopWatch();
 /**
  * Caches function value until a specific duration.
  * @param expiryDurationMs Duration to cache the result for. If set as '-1', the cache will never expire for the session.
  * @param cachePromise If true, cache the promise instead of the promise result.
- * @returns
+ * @param expiryDurationAfterStartUpMs If specified, this is the duration to cache the result for after extension startup (until extension is likely to
+ * keep running commands in background)
  */
-export function cache(expiryDurationMs: number, cachePromise = false) {
+export function cache(expiryDurationMs: number, cachePromise = false, expiryDurationAfterStartUpMs?: number) {
     return function (
         target: Object,
         propertyName: string,
@@ -142,18 +155,20 @@ export function cache(expiryDurationMs: number, cachePromise = false) {
             }
             const key = getCacheKeyFromFunctionArgs(keyPrefix, args);
             const cachedItem = cacheStoreForMethods.get(key);
-            if (cachedItem && (cachedItem.expiry > Date.now() || cachedItem.expiry === -1)) {
+            if (cachedItem && (cachedItem.expiry > Date.now() || expiryDurationMs === -1)) {
                 traceVerbose(`Cached data exists ${key}`);
                 return Promise.resolve(cachedItem.data);
             }
+            const expiryMs =
+                expiryDurationAfterStartUpMs && moduleLoadWatch.elapsedTime > extensionStartUpTime
+                    ? expiryDurationAfterStartUpMs
+                    : expiryDurationMs;
             const promise = originalMethod.apply(this, args) as Promise<any>;
             if (cachePromise) {
-                cacheStoreForMethods.set(key, { data: promise, expiry: Date.now() + expiryDurationMs });
+                cacheStoreForMethods.set(key, { data: promise, expiry: Date.now() + expiryMs });
             } else {
                 promise
-                    .then((result) =>
-                        cacheStoreForMethods.set(key, { data: result, expiry: Date.now() + expiryDurationMs }),
-                    )
+                    .then((result) => cacheStoreForMethods.set(key, { data: result, expiry: Date.now() + expiryMs }))
                     .ignoreErrors();
             }
             return promise;

--- a/src/client/pythonEnvironments/common/externalDependencies.ts
+++ b/src/client/pythonEnvironments/common/externalDependencies.ts
@@ -61,8 +61,16 @@ export function pathExists(absPath: string): Promise<boolean> {
     return fsapi.pathExists(absPath);
 }
 
+export function pathExistsSync(absPath: string): boolean {
+    return fsapi.pathExistsSync(absPath);
+}
+
 export function readFile(filePath: string): Promise<string> {
     return fsapi.readFile(filePath, 'utf-8');
+}
+
+export function readFileSync(filePath: string): string {
+    return fsapi.readFileSync(filePath, 'utf-8');
 }
 
 /**

--- a/src/client/pythonEnvironments/discovery/locators/services/conda.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/conda.ts
@@ -10,6 +10,7 @@ import { parseVersion } from '../../../base/info/pythonVersion';
 import { getRegistryInterpreters } from '../../../common/windowsUtils';
 import { EnvironmentType, PythonEnvironment } from '../../../info';
 import { IDisposable } from '../../../../common/types';
+import { cache } from '../../../../common/utils/decorators';
 
 export const AnacondaCompanyNames = ['Anaconda, Inc.', 'Continuum Analytics, Inc.'];
 
@@ -347,6 +348,7 @@ export class Conda {
      * Retrieves list of Python environments known to this conda.
      * Corresponds to "conda env list --json", but also computes environment names.
      */
+    @cache(20_000)
     public async getEnvList(): Promise<CondaEnvInfo[]> {
         const info = await this.getInfo();
         const { envs } = info;

--- a/src/client/pythonEnvironments/discovery/locators/services/conda.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/conda.ts
@@ -348,7 +348,7 @@ export class Conda {
      * Retrieves list of Python environments known to this conda.
      * Corresponds to "conda env list --json", but also computes environment names.
      */
-    @cache(20_000)
+    @cache(30_000, true, 10_000)
     public async getEnvList(): Promise<CondaEnvInfo[]> {
         const info = await this.getInfo();
         const { envs } = info;

--- a/src/client/pythonEnvironments/discovery/locators/services/poetry.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/poetry.ts
@@ -9,13 +9,14 @@ import { getOSType, getUserHomeDir, OSType } from '../../../../common/utils/plat
 import {
     getPythonSetting,
     isParentPath,
-    pathExists,
-    readFile,
+    pathExistsSync,
+    readFileSync,
     shellExecute,
 } from '../../../common/externalDependencies';
 import { getEnvironmentDirFromPath } from '../../../common/commonUtils';
 import { isVirtualenvEnvironment } from './virtualEnvironmentIdentifier';
 import { StopWatch } from '../../../../common/utils/stopWatch';
+import { cache } from '../../../../common/utils/decorators';
 
 /**
  * Global virtual env dir for a project is named as:
@@ -59,7 +60,7 @@ async function isLocalPoetryEnvironment(interpreterPath: string): Promise<boolea
         return false;
     }
     const project = path.dirname(envDir);
-    if (!(await hasValidPyprojectToml(project))) {
+    if (!hasValidPyprojectToml(project)) {
         return false;
     }
     // The assumption is that we need to be able to run poetry CLI for an environment in order to mark it as poetry.
@@ -112,7 +113,7 @@ export class Poetry {
     }
 
     public static async getPoetry(cwd: string): Promise<Poetry | undefined> {
-        if (!(await hasValidPyprojectToml(cwd))) {
+        if (!hasValidPyprojectToml(cwd)) {
             // This check is not expensive and may change during a session, so we need not cache it.
             return undefined;
         }
@@ -128,7 +129,7 @@ export class Poetry {
      */
     private static async locate(cwd: string): Promise<Poetry | undefined> {
         // Produce a list of candidate binaries to be probed by exec'ing them.
-        async function* getCandidates() {
+        function* getCandidates() {
             const customPoetryPath = getPythonSetting<string>('poetryPath');
             if (customPoetryPath && customPoetryPath !== 'poetry') {
                 // If user has specified a custom poetry path, use it first.
@@ -139,26 +140,21 @@ export class Poetry {
             const home = getUserHomeDir();
             if (home) {
                 const defaultPoetryPath = path.join(home, '.poetry', 'bin', 'poetry');
-                if (await pathExists(defaultPoetryPath)) {
+                if (pathExistsSync(defaultPoetryPath)) {
                     yield defaultPoetryPath;
                 }
             }
         }
 
         // Probe the candidates, and pick the first one that exists and does what we need.
-        for await (const poetryPath of getCandidates()) {
+        for (const poetryPath of getCandidates()) {
             traceVerbose(`Probing poetry binary for ${cwd}: ${poetryPath}`);
             const poetry = new Poetry(poetryPath, cwd);
-            const stopWatch = new StopWatch();
             const virtualenvs = await poetry.getEnvList();
             if (virtualenvs !== undefined) {
                 traceVerbose(`Found poetry via filesystem probing for ${cwd}: ${poetryPath}`);
                 return poetry;
             }
-            traceVerbose(
-                `Time taken to run ${poetryPath} env list --full-path in ms for ${cwd}`,
-                stopWatch.elapsedTime,
-            );
         }
 
         // Didn't find anything.
@@ -176,6 +172,15 @@ export class Poetry {
      * Corresponds to "poetry env list --full-path". Swallows errors if any.
      */
     public async getEnvList(): Promise<string[] | undefined> {
+        return this._getEnvList(this.cwd);
+    }
+
+    /**
+     * Method created to faciliate caching. The caching decorator uses function arguments as cache key,
+     * so pass in cwd on which we need to cache.
+     */
+    @cache(30_000, true)
+    private async _getEnvList(_cwd: string): Promise<string[] | undefined> {
         const result = await this.safeShellExecute(`${this._command} env list --full-path`);
         if (!result) {
             return undefined;
@@ -203,6 +208,18 @@ export class Poetry {
      * Corresponds to "poetry env info -p". Swallows errors if any.
      */
     public async getActiveEnvPath(): Promise<string | undefined> {
+        return this._getActiveEnvPath(this.cwd);
+    }
+
+    /**
+     * Method created to faciliate caching. The caching decorator uses function arguments as cache key,
+     * so pass in cwd on which we need to cache.
+     *
+     * Note this cache has no expiry, this is because we often need this method to decide whether to use
+     * poetry to install a product, after user asks to install something. We need this to be fast always.
+     */
+    @cache(-1, true)
+    private async _getActiveEnvPath(_cwd: string): Promise<string | undefined> {
         const result = await this.safeShellExecute(`${this._command} env info -p`, true);
         if (!result) {
             return undefined;
@@ -288,12 +305,12 @@ export async function isPoetryEnvironmentRelatedToFolder(
  *
  * @param folder Folder to look for pyproject.toml file in.
  */
-async function hasValidPyprojectToml(folder: string): Promise<boolean> {
+function hasValidPyprojectToml(folder: string): boolean {
     const pyprojectToml = path.join(folder, 'pyproject.toml');
-    if (!(await pathExists(pyprojectToml))) {
+    if (!pathExistsSync(pyprojectToml)) {
         return false;
     }
-    const content = await readFile(pyprojectToml);
+    const content = readFileSync(pyprojectToml);
     if (!content.includes('[tool.poetry]')) {
         return false;
     }

--- a/src/client/pythonEnvironments/discovery/locators/services/poetry.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/poetry.ts
@@ -226,7 +226,7 @@ export class Poetry {
      * Note this cache has no expiry, this is because we often need this method to decide whether to use
      * poetry to install a product, after user asks to install something. We need this to be fast.
      */
-    @cache(-1, true)
+    @cache(20_000, true, 10_000)
     private async getActiveEnvPathCached(_cwd: string): Promise<string | undefined> {
         const result = await this.safeShellExecute(`${this._command} env info -p`, true);
         if (!result) {

--- a/src/client/pythonEnvironments/discovery/locators/services/poetry.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/poetry.ts
@@ -112,7 +112,15 @@ export class Poetry {
         this.fixCwd();
     }
 
+    /**
+     * Returns a Poetry instance corresponding to the binary which can be used to run commands for the cwd.
+     *
+     * Poetry commands can be slow and so can be bottleneck to overall discovery time. So trigger command
+     * execution as soon as possible. To do that we need to ensure the operations before the command are
+     * performed synchronously.
+     */
     public static async getPoetry(cwd: string): Promise<Poetry | undefined> {
+        // Following check should be performed synchronously so we trigger poetry execution as soon as possible.
         if (!hasValidPyprojectToml(cwd)) {
             // This check is not expensive and may change during a session, so we need not cache it.
             return undefined;
@@ -124,10 +132,10 @@ export class Poetry {
         return Poetry._poetryPromise.get(cwd);
     }
 
-    /**
-     * Returns a Poetry instance corresponding to the binary.
-     */
     private static async locate(cwd: string): Promise<Poetry | undefined> {
+        // First thing this method awaits on should be poetry command execution, hence perform all operations
+        // before that synchronously.
+
         // Produce a list of candidate binaries to be probed by exec'ing them.
         function* getCandidates() {
             const customPoetryPath = getPythonSetting<string>('poetryPath');

--- a/src/client/pythonEnvironments/discovery/locators/services/poetry.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/poetry.ts
@@ -222,9 +222,6 @@ export class Poetry {
     /**
      * Method created to faciliate caching. The caching decorator uses function arguments as cache key,
      * so pass in cwd on which we need to cache.
-     *
-     * Note this cache has no expiry, this is because we often need this method to decide whether to use
-     * poetry to install a product, after user asks to install something. We need this to be fast.
      */
     @cache(20_000, true, 10_000)
     private async getActiveEnvPathCached(_cwd: string): Promise<string | undefined> {

--- a/src/client/pythonEnvironments/discovery/locators/services/poetry.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/poetry.ts
@@ -187,7 +187,7 @@ export class Poetry {
      * Method created to faciliate caching. The caching decorator uses function arguments as cache key,
      * so pass in cwd on which we need to cache.
      */
-    @cache(30_000, true)
+    @cache(30_000, true, 10_000)
     private async getEnvListCached(_cwd: string): Promise<string[] | undefined> {
         const result = await this.safeShellExecute(`${this._command} env list --full-path`);
         if (!result) {

--- a/src/client/pythonEnvironments/discovery/locators/services/poetry.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/poetry.ts
@@ -180,7 +180,7 @@ export class Poetry {
      * Corresponds to "poetry env list --full-path". Swallows errors if any.
      */
     public async getEnvList(): Promise<string[] | undefined> {
-        return this._getEnvList(this.cwd);
+        return this.getEnvListCached(this.cwd);
     }
 
     /**
@@ -188,7 +188,7 @@ export class Poetry {
      * so pass in cwd on which we need to cache.
      */
     @cache(30_000, true)
-    private async _getEnvList(_cwd: string): Promise<string[] | undefined> {
+    private async getEnvListCached(_cwd: string): Promise<string[] | undefined> {
         const result = await this.safeShellExecute(`${this._command} env list --full-path`);
         if (!result) {
             return undefined;
@@ -216,7 +216,7 @@ export class Poetry {
      * Corresponds to "poetry env info -p". Swallows errors if any.
      */
     public async getActiveEnvPath(): Promise<string | undefined> {
-        return this._getActiveEnvPath(this.cwd);
+        return this.getActiveEnvPathCached(this.cwd);
     }
 
     /**
@@ -224,10 +224,10 @@ export class Poetry {
      * so pass in cwd on which we need to cache.
      *
      * Note this cache has no expiry, this is because we often need this method to decide whether to use
-     * poetry to install a product, after user asks to install something. We need this to be fast always.
+     * poetry to install a product, after user asks to install something. We need this to be fast.
      */
     @cache(-1, true)
-    private async _getActiveEnvPath(_cwd: string): Promise<string | undefined> {
+    private async getActiveEnvPathCached(_cwd: string): Promise<string | undefined> {
         const result = await this.safeShellExecute(`${this._command} env info -p`, true);
         if (!result) {
             return undefined;

--- a/src/test/pythonEnvironments/discovery/locators/lowLevel/poetry.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/lowLevel/poetry.unit.test.ts
@@ -94,7 +94,6 @@ suite('isPoetryEnvironment Tests', () => {
 suite('Poetry binary is located correctly', async () => {
     let shellExecute: sinon.SinonStub;
     let getPythonSetting: sinon.SinonStub;
-    let pathExists: sinon.SinonStub;
 
     suiteSetup(() => {
         Poetry._poetryPromise = new Map();
@@ -175,9 +174,9 @@ suite('Poetry binary is located correctly', async () => {
             return;
         }
         const defaultPoetry = path.join(home, '.poetry', 'bin', 'poetry');
-        pathExists = sinon.stub(externalDependencies, 'pathExists');
-        pathExists.withArgs(defaultPoetry).resolves(true);
-        pathExists.callThrough();
+        const pathExistsSync = sinon.stub(externalDependencies, 'pathExistsSync');
+        pathExistsSync.withArgs(defaultPoetry).returns(true);
+        pathExistsSync.callThrough();
         getPythonSetting.returns('poetry');
         shellExecute.callsFake((command: string, options: ShellOptions) => {
             if (


### PR DESCRIPTION
For #8372 Closes https://github.com/microsoft/vscode-python-internalbacklog/issues/125

- Add caching to command output in discovery component. When the extension is starting up sometimes the same commands are run again and again, hence cache for more duration during startup.
- Poetry commands can be slow and so can be bottleneck to overall discovery time. So trigger command execution as soon as possible. To do that we need to ensure the operations before the command are performed synchronously.
- Get python executables using `getInterpreterPathFromDir` instead of finding interpreters in all directories.