### PR TITLE
Add telemetry to sign up to mailing list on start page

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -220,6 +220,7 @@
     "StartPage.openInteractiveWindow": "Use the Interactive Window to develop Python Scripts",
     "StartPage.interactiveWindowDesc": "- You can create cells on a Python file by typing \"#%%\" <br /> - Use \"<div class=\"italics\">Shift + Enter</div> \" to run a cell, the output will be shown in the interactive window",
     "StartPage.releaseNotes": "Take a look at our <a class=\"link\" href={0}>Release Notes</a> to learn more about the latest features.",
+    "StartPage.mailingList": "<a class=\"link\" href={0}>Sign up</a> for tips and tutorials through our mailing list.",
     "StartPage.tutorialAndDoc": "Explore more features in our <a class=\"link\" href={0}>Tutorials</a> or check <a class=\"link\" href={1}>Documentation</a> for tips and troubleshooting.",
     "StartPage.dontShowAgain": "Don't show this page again",
     "StartPage.helloWorld": "Hello world",

--- a/src/client/common/startPage/constants.ts
+++ b/src/client/common/startPage/constants.ts
@@ -32,4 +32,5 @@ export enum Telemetry {
     StartPageOpenFileBrowser = 'DATASCIENCE.STARTPAGE_OPEN_FILE_BROWSER',
     StartPageOpenFolder = 'DATASCIENCE.STARTPAGE_OPEN_FOLDER',
     StartPageOpenWorkspace = 'DATASCIENCE.STARTPAGE_OPEN_WORKSPACE',
+    StartPageJoinMailingList = 'JOIN_MAILING_LIST_FROM_START_PAGE',
 }

--- a/src/client/common/startPage/startPage.ts
+++ b/src/client/common/startPage/startPage.ts
@@ -205,6 +205,10 @@ export class StartPage extends WebviewPanelHost<IStartPageMapping>
                 this.setTelemetryFlags();
                 this.commandManager.executeCommand('workbench.action.openWorkspace');
                 break;
+            case StartPageMessages.MailingList:
+                sendTelemetryEvent(Telemetry.StartPageJoinMailingList);
+                this.setTelemetryFlags();
+                break;
             case StartPageMessages.UpdateSettings:
                 if (payload === false) {
                     sendTelemetryEvent(Telemetry.StartPageClickedDontShowAgain);

--- a/src/client/common/startPage/types.ts
+++ b/src/client/common/startPage/types.ts
@@ -32,6 +32,7 @@ export namespace StartPageMessages {
     export const OpenFileBrowser = 'OpenFileBrowser';
     export const OpenFolder = 'OpenFolder';
     export const OpenWorkspace = 'OpenWorkspace';
+    export const MailingList = 'MailingList';
 }
 
 export class IStartPageMapping {
@@ -48,6 +49,7 @@ export class IStartPageMapping {
     public [StartPageMessages.OpenFileBrowser]: never | undefined;
     public [StartPageMessages.OpenFolder]: never | undefined;
     public [StartPageMessages.OpenWorkspace]: never | undefined;
+    public [StartPageMessages.MailingList]: never | undefined;
 }
 
 type WebViewViewState = {

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -435,6 +435,10 @@ export namespace StartPage {
         'StartPage.tutorialAndDoc',
         'Explore more features in our <a class="link" href={0}>Tutorials</a> or check <a class="link" href={1}>Documentation</a> for tips and troubleshooting.',
     );
+    export const mailingList = localize(
+        'StartPage.mailingList',
+        '<a class="link" href={0}>Sign up</a> for tips and tutorials through our mailing list.',
+    );
     export const dontShowAgain = localize('StartPage.dontShowAgain', "Don't show this page again");
     export const helloWorld = localize('StartPage.helloWorld', 'Hello world');
     // When localizing sampleNotebook, the translated notebook must also be included in

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -1722,6 +1722,7 @@ export interface IEventNamePropertyMapping {
     [Telemetry.StartPageOpenFileBrowser]: never | undefined;
     [Telemetry.StartPageOpenFolder]: never | undefined;
     [Telemetry.StartPageOpenWorkspace]: never | undefined;
+    [Telemetry.StartPageJoinMailingList]: never | undefined;
 
     // TensorBoard integration events
     /**

--- a/src/startPage-ui/startPage/startPage.tsx
+++ b/src/startPage-ui/startPage/startPage.tsx
@@ -49,6 +49,7 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
         (window as any).openCommandPalette = this.openCommandPalette.bind(this);
         (window as any).openCommandPaletteWithSelection = this.openCommandPaletteWithSelection.bind(this);
         (window as any).openSampleNotebook = this.openSampleNotebook.bind(this);
+        (window as any).openMailingListForm  = this.openMailingListForm.bind(this);
     }
 
     public render() {
@@ -264,6 +265,7 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
     }
 
     private renderMailingList(): JSX.Element {
+        this.postOffice.sendMessage<IStartPageMapping>(StartPageMessages.MailingList);
         return (
             <div
                 className="paragraph"

--- a/src/startPage-ui/startPage/startPage.tsx
+++ b/src/startPage-ui/startPage/startPage.tsx
@@ -49,7 +49,7 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
         (window as any).openCommandPalette = this.openCommandPalette.bind(this);
         (window as any).openCommandPaletteWithSelection = this.openCommandPaletteWithSelection.bind(this);
         (window as any).openSampleNotebook = this.openSampleNotebook.bind(this);
-        (window as any).openMailingListForm  = this.renderMailingList.bind(this);
+        (window as any).openMailingListForm  = this.openMailingListForm.bind(this);
     }
 
     public render() {
@@ -180,6 +180,10 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
         this.postOffice.sendMessage<IStartPageMapping>(StartPageMessages.OpenWorkspace);
     }
 
+    public openMailingListForm() {
+        this.postOffice.sendMessage<IStartPageMapping>(StartPageMessages.MailingList);
+
+    }
     private renderNotebookDescription(): JSX.Element {
         return (
             <div
@@ -265,7 +269,6 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
     }
 
     private renderMailingList(): JSX.Element {
-        this.postOffice.sendMessage<IStartPageMapping>(StartPageMessages.MailingList);
         return (
             <div
                 className="paragraph"

--- a/src/startPage-ui/startPage/startPage.tsx
+++ b/src/startPage-ui/startPage/startPage.tsx
@@ -273,7 +273,7 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
                         '<a class="link" href={0}>Sign up</a> for tips and tutorials through our mailing list.',
                     ).format('https://aka.ms/AAbopxr'),
                 }}
-                />
+            />
         );
     }
 

--- a/src/startPage-ui/startPage/startPage.tsx
+++ b/src/startPage-ui/startPage/startPage.tsx
@@ -48,8 +48,7 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
         (window as any).openWorkspace = this.openWorkspace.bind(this);
         (window as any).openCommandPalette = this.openCommandPalette.bind(this);
         (window as any).openCommandPaletteWithSelection = this.openCommandPaletteWithSelection.bind(this);
-        (window as any).openSampleNotebook = this.openSampleNotebook.bind(this);
-    }
+        (window as any).openSampleNotebook = this.openSampleNotebook.bind(this);}
 
     public render() {
         return (

--- a/src/startPage-ui/startPage/startPage.tsx
+++ b/src/startPage-ui/startPage/startPage.tsx
@@ -49,7 +49,7 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
         (window as any).openCommandPalette = this.openCommandPalette.bind(this);
         (window as any).openCommandPaletteWithSelection = this.openCommandPaletteWithSelection.bind(this);
         (window as any).openSampleNotebook = this.openSampleNotebook.bind(this);
-        (window as any).openMailingListForm  = this.openMailingListForm.bind(this);
+        (window as any).openMailingListForm  = this.renderMailingList.bind(this);
     }
 
     public render() {

--- a/src/startPage-ui/startPage/startPage.tsx
+++ b/src/startPage-ui/startPage/startPage.tsx
@@ -130,6 +130,7 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
                 <div className="releaseNotesRow">
                     {this.renderReleaseNotesLink()}
                     {this.renderTutorialAndDoc()}
+                    {this.renderMailingList()}
                 </div>
                 <div className="block">
                     <input
@@ -259,6 +260,20 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
                     ).format('https://aka.ms/AA8dqti', 'https://aka.ms/AA8dxwy'),
                 }}
             />
+        );
+    }
+
+    private renderMailingList(): JSX.Element {
+        return (
+            <div
+                className="paragraph"
+                dangerouslySetInnerHTML={{
+                    __html: getLocString(
+                        'StartPage.mailingList',
+                        '<a class="link" href={0}>Sign up</a> for tips and tutorials through our mailing list.',
+                    ).format('https://aka.ms/AAbopxr'),
+                }}
+                />
         );
     }
 

--- a/src/startPage-ui/startPage/startPage.tsx
+++ b/src/startPage-ui/startPage/startPage.tsx
@@ -48,7 +48,8 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
         (window as any).openWorkspace = this.openWorkspace.bind(this);
         (window as any).openCommandPalette = this.openCommandPalette.bind(this);
         (window as any).openCommandPaletteWithSelection = this.openCommandPaletteWithSelection.bind(this);
-        (window as any).openSampleNotebook = this.openSampleNotebook.bind(this);}
+        (window as any).openSampleNotebook = this.openSampleNotebook.bind(this);
+    }
 
     public render() {
         return (


### PR DESCRIPTION
To evaluate success of adding the link to the sign up page for our mailing list through our start page. 