### PR TITLE
Add hover link to pypi.org for requirements.txt packages

### DIFF
--- a/news/1 Enhancements/14495.md
+++ b/news/1 Enhancements/14495.md
@@ -1,0 +1,1 @@
+Add hover link to pypi.org for requirements.txt packages. (thanks [anttipessa](https://github.com/anttipessa/), [haalto](https://github.com/haalto/), [JeonCD](https://github.com/JeonCD/) and [junskU](https://github.com/junskU))

--- a/src/client/activation/requirements_txt/activator.ts
+++ b/src/client/activation/requirements_txt/activator.ts
@@ -1,0 +1,32 @@
+import { IExtensionSingleActivationService } from '../types';
+import {
+  Hover,
+  languages,
+  TextDocument,
+  Position.
+  WorkspaceEdit,
+} from 'vscode';
+
+export class RequirementsTxtLinkActivator implements IExtensionSingleActivationService {
+
+  public async activate(): Promise<void> {
+    languages.registerHoverProvider({ pattern: '**/requirements.txt'}, {
+      provideHover(
+        document: TextDocument,
+        position: Position,
+      ) {
+        
+        const regex = '^(.*)==';
+
+        const row = document.lineAt(position.line).text;
+        const projectName = row.match(regex);
+        
+        if (projectName) {
+          return new Hover("https://pypi.org/project/" + projectName[0].replace('==', '') + "/");
+        } else {
+          return null;
+        }
+      }
+    });
+  }
+}

--- a/src/client/activation/requirements_txt/activator.ts
+++ b/src/client/activation/requirements_txt/activator.ts
@@ -1,32 +1,25 @@
+import { injectable } from 'inversify';
+import { Hover, languages, TextDocument, Position } from 'vscode';
 import { IExtensionSingleActivationService } from '../types';
-import {
-  Hover,
-  languages,
-  TextDocument,
-  Position.
-  WorkspaceEdit,
-} from 'vscode';
 
+@injectable()
 export class RequirementsTxtLinkActivator implements IExtensionSingleActivationService {
+    public async activate(): Promise<void> {
+        languages.registerHoverProvider(
+            { pattern: '**/requirements.txt' },
+            {
+                provideHover(document: TextDocument, position: Position) {
+                    const regex = '^(.*)==';
 
-  public async activate(): Promise<void> {
-    languages.registerHoverProvider({ pattern: '**/requirements.txt'}, {
-      provideHover(
-        document: TextDocument,
-        position: Position,
-      ) {
-        
-        const regex = '^(.*)==';
+                    const row = document.lineAt(position.line).text;
+                    const projectName = row.match(regex);
 
-        const row = document.lineAt(position.line).text;
-        const projectName = row.match(regex);
-        
-        if (projectName) {
-          return new Hover("https://pypi.org/project/" + projectName[0].replace('==', '') + "/");
-        } else {
-          return null;
-        }
-      }
-    });
-  }
+                    if (projectName) {
+                        return new Hover(`https://pypi.org/project/${projectName[0].replace('==', '')}/`);
+                    }
+                    return null;
+                },
+            },
+        );
+    }
 }

--- a/src/client/activation/requirements_txt/activator.ts
+++ b/src/client/activation/requirements_txt/activator.ts
@@ -4,6 +4,7 @@ import { IExtensionSingleActivationService } from '../types';
 
 @injectable()
 export class RequirementsTxtLinkActivator implements IExtensionSingleActivationService {
+    // eslint-disable-next-line class-methods-use-this
     public async activate(): Promise<void> {
         languages.registerHoverProvider(
             { pattern: '**/requirements.txt' },

--- a/src/client/activation/requirements_txt/activator.ts
+++ b/src/client/activation/requirements_txt/activator.ts
@@ -15,7 +15,7 @@ export class RequirementsTxtLinkActivator implements IExtensionSingleActivationS
                     const projectName = row.match(regex);
 
                     if (projectName) {
-                        return new Hover(`https://pypi.org/project/${projectName[0].replace('==', '')}/`);
+                        return new Hover(`https://pypi.org/project/${projectName[1]}/`);
                     }
                     return null;
                 },

--- a/src/client/activation/serviceRegistry.ts
+++ b/src/client/activation/serviceRegistry.ts
@@ -12,6 +12,7 @@ import { DownloadBetaChannelRule, DownloadDailyChannelRule } from './common/down
 import { LanguageServerDownloader } from './common/downloader';
 import { LanguageServerDownloadChannel } from './common/packageRepository';
 import { ExtensionSurveyPrompt } from './extensionSurvey';
+import { RequirementsTxtLinkActivator } from './requirements_txt/activator';
 import { JediExtensionActivator } from './jedi';
 import { JediLanguageServerAnalysisOptions } from './jedi/analysisOptions';
 import { JediLanguageClientFactory } from './jedi/languageClientFactory';
@@ -67,6 +68,11 @@ export function registerTypes(serviceManager: IServiceManager, languageServerTyp
     serviceManager.addBinding(ILanguageServerCache, IExtensionActivationService);
     serviceManager.addSingleton<ILanguageServerExtension>(ILanguageServerExtension, LanguageServerExtension);
     serviceManager.add<IExtensionActivationManager>(IExtensionActivationManager, ExtensionActivationManager);
+
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        RequirementsTxtLinkActivator,
+    );
 
     serviceManager.addSingleton<IPythonExtensionBanner>(
         IPythonExtensionBanner,

--- a/src/client/activation/serviceRegistry.ts
+++ b/src/client/activation/serviceRegistry.ts
@@ -69,15 +69,15 @@ export function registerTypes(serviceManager: IServiceManager, languageServerTyp
     serviceManager.addSingleton<ILanguageServerExtension>(ILanguageServerExtension, LanguageServerExtension);
     serviceManager.add<IExtensionActivationManager>(IExtensionActivationManager, ExtensionActivationManager);
 
-    serviceManager.addSingleton<IExtensionSingleActivationService>(
-        IExtensionSingleActivationService,
-        RequirementsTxtLinkActivator,
-    );
-
     serviceManager.addSingleton<IPythonExtensionBanner>(
         IPythonExtensionBanner,
         ProposePylanceBanner,
         BANNER_NAME_PROPOSE_LS,
+    );
+
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        RequirementsTxtLinkActivator,
     );
 
     if (languageServerType === LanguageServerType.Microsoft) {

--- a/src/test/activation/serviceRegistry.unit.test.ts
+++ b/src/test/activation/serviceRegistry.unit.test.ts
@@ -25,6 +25,7 @@ import { DotNetLanguageServerProxy } from '../../client/activation/languageServe
 import { DotNetLanguageServerManager } from '../../client/activation/languageServer/manager';
 import { LanguageServerOutputChannel } from '../../client/activation/languageServer/outputChannel';
 import { PlatformData } from '../../client/activation/languageServer/platformData';
+import { RequirementsTxtLinkActivator } from '../../client/activation/requirements_txt/activator';
 import { registerTypes } from '../../client/activation/serviceRegistry';
 import {
     IDownloadChannelRule,
@@ -180,6 +181,12 @@ suite('Unit Tests - Language Server Activation Service Registry', () => {
             serviceManager.addSingleton<IExtensionSingleActivationService>(
                 IExtensionSingleActivationService,
                 ExtensionSurveyPrompt,
+            ),
+        ).once();
+        verify(
+            serviceManager.addSingleton<IExtensionSingleActivationService>(
+                IExtensionSingleActivationService,
+                RequirementsTxtLinkActivator,
             ),
         ).once();
     });


### PR DESCRIPTION
For #14495

![img](https://user-images.githubusercontent.com/33652286/114303288-01465f00-9ad6-11eb-8337-a8d46045a9d2.png)


We created a rough implementation for this feature using HoverProvider. This produces the wanted functionality, but we are not sure if this is the correct way to implement this. We are also not quite sure where to activate this, currently we are activating it in the serviceRegistry and its at least working 😄 

BTW we did this during a university course, where we are learning how to contribute to OSS-projects.