### PR TITLE
Handle both API versions

### DIFF
--- a/src/client/jupyter/languageserver/notebookConcatDocument.ts
+++ b/src/client/jupyter/languageserver/notebookConcatDocument.ts
@@ -120,12 +120,14 @@ export class NotebookConcatDocument implements TextDocument, IDisposable {
 
     private _notebook: SafeNotebookDocument;
 
-    // constructor(public notebook: NotebookDocument, notebookApi: IVSCodeNotebook, selector: DocumentSelector) {
     constructor(notebook: NotebookDocument, notebookApi: IVSCodeNotebook, selector: DocumentSelector) {
         const dir = path.dirname(notebook.uri.fsPath);
+        // Create a safe notebook document so that we can handle both >= 1.56 vscode API and < 1.56
+        // when vscode stable is 1.56 and both Python release and insiders can update to that engine version we
+        // can remove this and just use NotebookDocument directly
+        this._notebook = new SafeNotebookDocument(notebook);
         // Note: Has to be different than the prefix for old notebook editor (HiddenFileFormat) so
         // that the caller doesn't remove diagnostics for this document.
-        this._notebook = new SafeNotebookDocument(notebook);
         this.dummyFilePath = path.join(dir, `${NotebookConcatPrefix}${uuid().replace(/-/g, '')}.py`);
         this.dummyUri = Uri.file(this.dummyFilePath);
         this.concatDocument = notebookApi.createConcatTextDocument(notebook, selector);

--- a/src/client/jupyter/languageserver/safeNotebookDocument.ts
+++ b/src/client/jupyter/languageserver/safeNotebookDocument.ts
@@ -1,0 +1,80 @@
+import { NotebookCell, NotebookCellRange, NotebookDocumentMetadata, Uri } from 'vscode';
+import { NotebookDocument } from 'vscode-proposed';
+
+export interface ISafeNotebookDocument extends NotebookDocument {}
+
+// The old API for NotebookDocument
+interface IOldNotebookDocument {
+    readonly cells: ReadonlyArray<NotebookCell>;
+}
+
+// In the Python extension we often need to support different changing
+// VS Code api versions. This class adds a layer of indirection so that we
+// can handle changes to the NotebookDocument class in the API
+export class SafeNotebookDocument implements ISafeNotebookDocument {
+    constructor(private notebook: NotebookDocument) {}
+
+    // Functions changed to handle multiple APIs
+    public getCells(range?: NotebookCellRange): ReadonlyArray<NotebookCell> {
+        if ('getCells' in this.notebook) {
+            return this.notebook.getCells(range);
+        }
+        // Old API with .cells
+        return (this.notebook as IOldNotebookDocument).cells;
+    }
+
+    public cellAt(index: number): NotebookCell {
+        if ('cellAt' in this.notebook) {
+            return this.notebook.cellAt(index);
+        }
+
+        // Old API with .cells
+        return (this.notebook as IOldNotebookDocument).cells[index];
+    }
+
+    public get cellCount(): number {
+        if ('cellCount' in this.notebook) {
+            return this.notebook.cellCount;
+        }
+
+        // Old API with .cells
+        return (this.notebook as IOldNotebookDocument).cells.length;
+    }
+
+    // Functions directly implemented by NotebookDocument
+    public get uri(): Uri {
+        return this.notebook.uri;
+    }
+
+    public get version(): number {
+        return this.notebook.version;
+    }
+
+    public get fileName(): string {
+        return this.notebook.fileName;
+    }
+
+    public get isDirty(): boolean {
+        return this.notebook.isDirty;
+    }
+
+    public get isUntitled(): boolean {
+        return this.notebook.isUntitled;
+    }
+
+    public get isClosed(): boolean {
+        return this.notebook.isClosed;
+    }
+
+    public get metadata(): NotebookDocumentMetadata {
+        return this.notebook.metadata;
+    }
+
+    public get viewType(): string {
+        return this.notebook.viewType;
+    }
+
+    public save(): Thenable<boolean> {
+        return this.notebook.save();
+    }
+}

--- a/src/client/jupyter/languageserver/safeNotebookDocument.ts
+++ b/src/client/jupyter/languageserver/safeNotebookDocument.ts
@@ -1,9 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 import { NotebookCell, NotebookCellRange, NotebookDocumentMetadata, Uri } from 'vscode';
 import { NotebookDocument } from 'vscode-proposed';
 
 export interface ISafeNotebookDocument extends NotebookDocument {}
 
-// The old API for NotebookDocument
+// The old API for NotebookDocument for vscode engine version < 1.56
 interface IOldNotebookDocument {
     readonly cells: ReadonlyArray<NotebookCell>;
 }
@@ -11,6 +13,8 @@ interface IOldNotebookDocument {
 // In the Python extension we often need to support different changing
 // VS Code api versions. This class adds a layer of indirection so that we
 // can handle changes to the NotebookDocument class in the API
+// When python extension ships with engine version 1.56 for stable and insiders we can remove
+// this class and just use NotebookDocument directly
 export class SafeNotebookDocument implements ISafeNotebookDocument {
     constructor(private notebook: NotebookDocument) {}
 


### PR DESCRIPTION
Change the Notebook Language service code to handle either API >=1.56 and <1.56 so that python insiders will work on current stable vscode. Also will port to the release branch so that python extension can release without having to wait for vscode 1.56 to release to stable.