### PR TITLE
Better logs of failures when installing packages

### DIFF
--- a/news/3 Code Health/15933.md
+++ b/news/3 Code Health/15933.md
@@ -1,0 +1,1 @@
+Better logging (telemetry) when installation of Python packages fail.

--- a/src/client/common/installer/types.ts
+++ b/src/client/common/installer/types.ts
@@ -24,7 +24,24 @@ export interface IModuleInstaller {
      * @memberof IModuleInstaller
      */
     installModule(
-        name: string,
+        product: string,
+        resource?: InterpreterUri,
+        cancel?: CancellationToken,
+        isUpgrade?: boolean,
+    ): Promise<void>;
+    /**
+     * Installs a Product
+     * If a cancellation token is provided, then a cancellable progress message is dispalyed.
+     *  At this point, this method would resolve only after the module has been successfully installed.
+     * If cancellation token is not provided, its not guaranteed that module installation has completed.
+     * @param {string} name
+     * @param {InterpreterUri} [resource]
+     * @param {CancellationToken} [cancel]
+     * @returns {Promise<void>}
+     * @memberof IModuleInstaller
+     */
+    installModule(
+        product: Product,
         resource?: InterpreterUri,
         cancel?: CancellationToken,
         isUpgrade?: boolean,

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -803,10 +803,17 @@ export interface IEventNamePropertyMapping {
     [EventName.PYTHON_INSTALL_PACKAGE]: {
         /**
          * The name of the module. (pipenv, Conda etc.)
-         *
-         * @type {string}
+         * One of the possible values includes `unavailable`, meaning user doesn't have pip, conda, or other tools available that can be used to install a python package.
          */
         installer: string;
+        /**
+         * Name of the corresponding product (package) to be installed.
+         */
+        productName?: string;
+        /**
+         * Whether the product (package) has been installed or not.
+         */
+        isInstalled?: boolean;
     };
     /**
      * Telemetry sent with details immediately after linting a document completes

--- a/src/test/common/installer.test.ts
+++ b/src/test/common/installer.test.ts
@@ -350,9 +350,8 @@ suite('Installer', () => {
         const moduleInstallers = ioc.serviceContainer.getAll<MockModuleInstaller>(IModuleInstaller);
         const moduleInstallerOne = moduleInstallers.find((item) => item.displayName === 'two')!;
 
-        moduleInstallerOne.on('installModule', (moduleName) => {
-            const installName = installer.translateProductToModuleName(product, ModuleNamePurpose.install);
-            if (installName === moduleName) {
+        moduleInstallerOne.on('installModule', (name: Product | string) => {
+            if (product === name) {
                 checkInstalledDef.resolve();
             }
         });

--- a/src/test/common/installer/installer.unit.test.ts
+++ b/src/test/common/installer/installer.unit.test.ts
@@ -42,7 +42,6 @@ import {
     IOutputChannel,
     IPersistentState,
     IPersistentStateFactory,
-    ModuleNamePurpose,
     Product,
     ProductType,
 } from '../../../client/common/types';
@@ -525,15 +524,10 @@ suite('Module Installer only', () => {
                         test(`Ensure resource info is passed into the module installer ${product.name} (${
                             resource ? 'With a resource' : 'without a resource'
                         })`, async () => {
-                            const moduleName = installer.translateProductToModuleName(
-                                product.value,
-                                ModuleNamePurpose.install,
-                            );
-
                             moduleInstaller
                                 .setup((m) =>
                                     m.installModule(
-                                        TypeMoq.It.isValue(moduleName),
+                                        TypeMoq.It.isValue(product.value),
                                         TypeMoq.It.isValue(resource),
                                         TypeMoq.It.isValue(undefined),
                                     ),
@@ -546,7 +540,7 @@ suite('Module Installer only', () => {
                                 moduleInstaller.verify(
                                     (m) =>
                                         m.installModule(
-                                            TypeMoq.It.isValue(moduleName),
+                                            TypeMoq.It.isValue(product.value),
                                             TypeMoq.It.isValue(resource),
                                             TypeMoq.It.isValue(undefined),
                                         ),
@@ -558,15 +552,10 @@ suite('Module Installer only', () => {
                         test(`Return InstallerResponse.Ignore for the module installer ${product.name} (${
                             resource ? 'With a resource' : 'without a resource'
                         }) if installation channel is not defined`, async () => {
-                            const moduleName = installer.translateProductToModuleName(
-                                product.value,
-                                ModuleNamePurpose.install,
-                            );
-
                             moduleInstaller
                                 .setup((m) =>
                                     m.installModule(
-                                        TypeMoq.It.isValue(moduleName),
+                                        TypeMoq.It.isValue(product.value),
                                         TypeMoq.It.isValue(resource),
                                         TypeMoq.It.isValue(undefined),
                                     ),
@@ -586,15 +575,10 @@ suite('Module Installer only', () => {
                         test(`Ensure resource info is passed into the module installer (created using ProductInstaller) ${
                             product.name
                         } (${resource ? 'With a resource' : 'without a resource'})`, async () => {
-                            const moduleName = installer.translateProductToModuleName(
-                                product.value,
-                                ModuleNamePurpose.install,
-                            );
-
                             moduleInstaller
                                 .setup((m) =>
                                     m.installModule(
-                                        TypeMoq.It.isValue(moduleName),
+                                        TypeMoq.It.isValue(product.value),
                                         TypeMoq.It.isValue(resource),
                                         TypeMoq.It.isValue(undefined),
                                     ),
@@ -607,7 +591,7 @@ suite('Module Installer only', () => {
                                 moduleInstaller.verify(
                                     (m) =>
                                         m.installModule(
-                                            TypeMoq.It.isValue(moduleName),
+                                            TypeMoq.It.isValue(product.value),
                                             TypeMoq.It.isValue(resource),
                                             TypeMoq.It.isValue(undefined),
                                         ),

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -353,7 +353,7 @@ suite('Module Installer', () => {
                                     .returns(() => Promise.resolve())
                                     .verifiable(TypeMoq.Times.once());
 
-                                await installer.installModule(moduleName, resource, undefined, isUpgrade);
+                                await installer.installModule(product.value, resource, undefined, isUpgrade);
                                 terminalService.verifyAll();
                             }
 
@@ -470,7 +470,7 @@ suite('Module Installer', () => {
                                             Promise.resolve(true),
                                         );
                                         try {
-                                            await installer.installModule(product.name, resource);
+                                            await installer.installModule(product.value, resource);
                                         } catch (ex) {
                                             noop();
                                         }
@@ -495,7 +495,7 @@ suite('Module Installer', () => {
                                             .returns(() => Promise.resolve())
                                             .verifiable(TypeMoq.Times.once());
                                         try {
-                                            await installer.installModule(product.name, resource);
+                                            await installer.installModule(product.value, resource);
                                         } catch (ex) {
                                             noop();
                                         }
@@ -516,7 +516,7 @@ suite('Module Installer', () => {
                                             .returns(() => Promise.resolve())
                                             .verifiable(TypeMoq.Times.once());
                                         try {
-                                            await installer.installModule(product.name, resource);
+                                            await installer.installModule(product.value, resource);
                                         } catch (ex) {
                                             noop();
                                         }
@@ -542,7 +542,7 @@ suite('Module Installer', () => {
                                         );
 
                                         try {
-                                            await installer.installModule(product.name, resource);
+                                            await installer.installModule(product.value, resource);
                                         } catch (ex) {
                                             noop();
                                         }
@@ -563,7 +563,7 @@ suite('Module Installer', () => {
                                             .verifiable(TypeMoq.Times.once());
                                         try {
                                             await installer.installModule(
-                                                product.name,
+                                                product.value,
                                                 resource,
                                                 new CancellationTokenSource().token,
                                             );
@@ -580,7 +580,7 @@ suite('Module Installer', () => {
                                 test(`Ensure getActiveInterpreter is used in PipInstaller (${product.name})`, async () => {
                                     setActiveInterpreter();
                                     try {
-                                        await installer.installModule(product.name, resource);
+                                        await installer.installModule(product.value, resource);
                                     } catch {
                                         noop();
                                     }

--- a/src/test/mocks/moduleInstaller.ts
+++ b/src/test/mocks/moduleInstaller.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import { Uri } from 'vscode';
 import { IModuleInstaller } from '../../client/common/installer/types';
+import { Product } from '../../client/common/types';
 
 export class MockModuleInstaller extends EventEmitter implements IModuleInstaller {
     constructor(public readonly displayName: string, private supported: boolean) {
@@ -17,7 +18,7 @@ export class MockModuleInstaller extends EventEmitter implements IModuleInstalle
         return 0;
     }
 
-    public async installModule(name: string, _resource?: Uri): Promise<void> {
+    public async installModule(name: Product | string, _resource?: Uri): Promise<void> {
         this.emit('installModule', name);
     }
 


### PR DESCRIPTION
@karthiknadig happy to discuss the changes here
The main problem was Core Extension didn't make a distinction between:
* Cannot install due to missing pip
* vs Installation failed

I'm adding telemetry to help making that discintion.
Filing a separate issue to fix the return value as a long term solution (more meaningful) - https://github.com/microsoft/vscode-python/issues/15935