### PR TITLE
Support `~` in WORKON_HOME and venvPath setting when in discovery experiment

### DIFF
--- a/news/2 Fixes/15788.md
+++ b/news/2 Fixes/15788.md
@@ -1,0 +1,1 @@
+Support `~` in WORKON_HOME and venvPath setting when in discovery experiment.

--- a/src/client/pythonEnvironments/common/externalDependencies.ts
+++ b/src/client/pythonEnvironments/common/externalDependencies.ts
@@ -73,6 +73,9 @@ export function readFileSync(filePath: string): string {
     return fsapi.readFileSync(filePath, 'utf-8');
 }
 
+// eslint-disable-next-line global-require
+export const untildify: (value: string) => string = require('untildify');
+
 /**
  * Returns true if given file path exists within the given parent directory, false otherwise.
  * @param filePath File path to check for

--- a/src/client/pythonEnvironments/discovery/locators/services/customVirtualEnvLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/customVirtualEnvLocator.ts
@@ -21,6 +21,7 @@ import {
     getPythonSetting,
     onDidChangePythonSetting,
     pathExists,
+    untildify,
 } from '../../../common/externalDependencies';
 import { isPipenvEnvironment } from './pipEnvHelper';
 import {
@@ -44,7 +45,7 @@ async function getCustomVirtualEnvDirs(): Promise<string[]> {
     const venvDirs: string[] = [];
     const venvPath = getPythonSetting<string>(VENVPATH_SETTING_KEY);
     if (venvPath) {
-        venvDirs.push(venvPath);
+        venvDirs.push(untildify(venvPath));
     }
     const venvFolders = getPythonSetting<string[]>(VENVFOLDERS_SETTING_KEY) ?? [];
     const homeDir = getUserHomeDir();

--- a/src/client/pythonEnvironments/discovery/locators/services/globalVirtualEnvronmentLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/globalVirtualEnvronmentLocator.ts
@@ -16,7 +16,7 @@ import {
     getPythonVersionFromPath,
     looksLikeBasicVirtualPython,
 } from '../../../common/commonUtils';
-import { getFileInfo, pathExists } from '../../../common/externalDependencies';
+import { getFileInfo, pathExists, untildify } from '../../../common/externalDependencies';
 import { isPipenvEnvironment } from './pipEnvHelper';
 import {
     isVenvEnvironment,
@@ -34,9 +34,12 @@ const DEFAULT_SEARCH_DEPTH = 2;
 async function getGlobalVirtualEnvDirs(): Promise<string[]> {
     const venvDirs: string[] = [];
 
-    const workOnHome = getEnvironmentVariable('WORKON_HOME');
-    if (workOnHome && (await pathExists(workOnHome))) {
-        venvDirs.push(workOnHome);
+    let workOnHome = getEnvironmentVariable('WORKON_HOME');
+    if (workOnHome) {
+        workOnHome = untildify(workOnHome);
+        if (await pathExists(workOnHome)) {
+            venvDirs.push(workOnHome);
+        }
     }
 
     const homeDir = getUserHomeDir();


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/15788 closes https://github.com/microsoft/vscode-python-internalbacklog/issues/131