### PR TITLE
Ensure venvPath and venvFolders setting can only be set at User or Remote settings

### DIFF
--- a/news/2 Fixes/15947.md
+++ b/news/2 Fixes/15947.md
@@ -1,0 +1,1 @@
+Ensure venvPath and venvFolders setting can only be set at User or Remote settings.

--- a/package.json
+++ b/package.json
@@ -1791,7 +1791,7 @@
                     "type": "array",
                     "default": [],
                     "description": "Folders in your home directory to look into for virtual environments (supports pyenv, direnv and virtualenvwrapper by default).",
-                    "scope": "resource",
+                    "scope": "machine",
                     "items": {
                         "type": "string"
                     }
@@ -1800,7 +1800,7 @@
                     "type": "string",
                     "default": "",
                     "description": "Path to folder with a list of Virtual Environments (e.g. ~/.pyenv, ~/Envs, ~/.virtualenvs).",
-                    "scope": "resource"
+                    "scope": "machine"
                 },
                 "python.workspaceSymbols.ctagsPath": {
                     "type": "string",


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python-internalbacklog/issues/162 Related https://github.com/microsoft/vscode-python/issues/15788