### PR TITLE
Add pypy compatability to pyvsc-run-isolated.py

### DIFF
--- a/news/2 Fixes/15968.md
+++ b/news/2 Fixes/15968.md
@@ -1,0 +1,1 @@
+Added compatability with pypy3.7 interpreter.

--- a/news/2 Fixes/15968.md
+++ b/news/2 Fixes/15968.md
@@ -1,1 +1,2 @@
 Added compatability with pypy3.7 interpreter.
+(thanks [Oliver Margetts](https://github.com/olliemath)

--- a/pythonFiles/pyvsc-run-isolated.py
+++ b/pythonFiles/pyvsc-run-isolated.py
@@ -17,7 +17,7 @@ def normalize(path):
 # We "isolate" the script/module (sys.argv[1]) by removing current working
 # directory or '' in sys.path and then sending the target on to runpy.
 cwd = normalize(os.getcwd())
-sys.path[:] = (p for p in sys.path if p != "" and normalize(p) != cwd)
+sys.path[:] = [p for p in sys.path if p != "" and normalize(p) != cwd]
 del sys.argv[0]
 module = sys.argv[0]
 if module == "-c":


### PR DESCRIPTION
Assigning a generator to a slice does not work under pypy3.7, causing https://github.com/microsoft/vscode-python/issues/15960

Closes #15960