### PR TITLE
Add workaround for truncated mypy output #13381

### DIFF
--- a/news/2 Fixes/13381-workaround.md
+++ b/news/2 Fixes/13381-workaround.md
@@ -1,0 +1,1 @@
+Update default mypy arguments to avoid truncated messages. (thanks [n4nn31355](https://github.com/n4nn31355))

--- a/package.json
+++ b/package.json
@@ -1388,7 +1388,8 @@
                     "default": [
                         "--ignore-missing-imports",
                         "--follow-imports=silent",
-                        "--show-column-numbers"
+                        "--show-column-numbers",
+                        "--no-pretty"
                     ],
                     "items": {
                         "type": "string"


### PR DESCRIPTION
Workaround for: https://github.com/microsoft/vscode-python/issues/13381

