### PR TITLE
Update TensorBoard launcher script to not use deprecated API

### DIFF
--- a/pythonFiles/tensorboard_launcher.py
+++ b/pythonFiles/tensorboard_launcher.py
@@ -7,10 +7,7 @@ from tensorboard import program
 
 def main(logdir):
     os.environ["VSCODE_TENSORBOARD_LAUNCH"] = "1"
-    tb = program.TensorBoard(
-        default.get_plugins(),
-        program.get_default_assets_zip_provider(),
-    )
+    tb = program.TensorBoard()
     tb.configure(bind_all=False, logdir=logdir)
     url = tb.launch()
     sys.stdout.write("TensorBoard started at %s\n" % (url))


### PR DESCRIPTION
This PR addresses these release build failures https://github.com/microsoft/vscode-python/actions/runs/764687765 The failures are happening because [TensorBoard 2.5.0](https://pypi.org/project/tensorboard/#history) was released 4 hours ago and our launcher script uses an API that has been deprecated in the latest release.