### PR TITLE
Format files using Black 21.4b0

### DIFF
--- a/pythonFiles/refactor.py
+++ b/pythonFiles/refactor.py
@@ -52,7 +52,7 @@ class ChangeType:
 
 
 class Change:
-    """"""
+    """ """
 
     EDIT = 0
     NEW = 1


### PR DESCRIPTION
Black updated to 21.4b0, this caused a linting error in [refactor.py](https://github.com/microsoft/vscode-python/pull/16047/checks?check_run_id=2435534425).