### PR TITLE
Automatically fill data in report issue

### DIFF
--- a/resources/report_issue_template.md
+++ b/resources/report_issue_template.md
@@ -28,9 +28,9 @@ You can attach such things **after** you create your issue on GitHub.
 
 # Diagnostic data
 
--   Python version (& distribution if applicable, e.g. Anaconda): XXX
--   Type of virtual environment used (e.g. conda, venv, virtualenv, etc.): XXX
--   Value of the `python.languageServer` setting: XXX
+-   Python version (& distribution if applicable, e.g. Anaconda): {0}
+-   Type of virtual environment used (e.g. conda, venv, virtualenv, etc.): {1}
+-   Value of the `python.languageServer` setting: {2}
 
 <details>
 

--- a/src/client/common/application/commands/reportIssueCommand.ts
+++ b/src/client/common/application/commands/reportIssueCommand.ts
@@ -32,7 +32,7 @@ export class ReportIssueCommandHandler implements IExtensionSingleActivationServ
 
     public async openReportIssue(): Promise<void> {
         const template = await fs.readFile(this.templatePath, 'utf8');
-        const interpreterPath = (await this.interpreterService.getActiveInterpreter())?.path || 'python';
+        const interpreterPath = (await this.interpreterService.getActiveInterpreter())?.path || 'not-selected';
         const pythonVersion = await this.interpreterVersionService.getVersion(interpreterPath, '');
         const languageServer =
             this.workspaceService.getConfiguration('python').get<string>('languageServer') || 'Not Found';

--- a/src/client/common/application/commands/reportIssueCommand.ts
+++ b/src/client/common/application/commands/reportIssueCommand.ts
@@ -3,19 +3,17 @@
 
 'use strict';
 
-import * as vscode from 'vscode';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-
 import { inject, injectable } from 'inversify';
 import { IExtensionSingleActivationService } from '../../../activation/types';
 import { ICommandManager, IWorkspaceService } from '../types';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
 import { IInterpreterVersionService } from '../../../interpreter/contracts';
 import { PYTHON_PATH } from '../../../../test/common';
-import { getVirtualEnvKind } from '../../../pythonEnvironments/discovery/locators/services/customVirtualEnvLocator';
 import { IInterpreterPathService } from '../../types';
 import { RESOURCE } from '../../../../test/testing/helper';
+import { identifyEnvironment } from '../../../pythonEnvironments/common/environmentIdentifier';
 
 /**
  * Allows the user to report an issue related to the Python extension using our template.
@@ -38,13 +36,13 @@ export class ReportIssueCommandHandler implements IExtensionSingleActivationServ
     public async openReportIssue(): Promise<void> {
         const pythonVersion = await this.interpreterVersionService.getVersion(PYTHON_PATH, '');
         const languageServer = this.workspaceService.getConfiguration('python').get<string>('languageServer');
-        const path2 = this.interpreterPathService.get(RESOURCE);
-        const virtualEnv = await getVirtualEnvKind(path2);
+        const interpretherPath = this.interpreterPathService.get(RESOURCE);
+        const virtualEnv = await identifyEnvironment(interpretherPath);
         const templ = this.getIssueTemplate();
 
-        vscode.commands.executeCommand('workbench.action.openIssueReporter', {
+        this.commandManager.executeCommand('workbench.action.openIssueReporter', {
             extensionId: 'ms-python.python',
-            issueBody: templ.format(pythonVersion, virtualEnv, languageServer || ''),
+            issueBody: templ.format(pythonVersion, virtualEnv, languageServer.globalValue),
         });
     }
 

--- a/src/client/common/application/commands/reportIssueCommand.ts
+++ b/src/client/common/application/commands/reportIssueCommand.ts
@@ -7,10 +7,9 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import { inject, injectable } from 'inversify';
 import { IExtensionSingleActivationService } from '../../../activation/types';
-import { IActiveResourceService, ICommandManager, IWorkspaceService } from '../types';
+import { ICommandManager, IWorkspaceService } from '../types';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
-import { IInterpreterVersionService } from '../../../interpreter/contracts';
-import { IInterpreterPathService } from '../../types';
+import { IInterpreterService, IInterpreterVersionService } from '../../../interpreter/contracts';
 import { identifyEnvironment } from '../../../pythonEnvironments/common/environmentIdentifier';
 
 /**
@@ -21,9 +20,8 @@ export class ReportIssueCommandHandler implements IExtensionSingleActivationServ
     constructor(
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
-        @inject(IInterpreterPathService) private readonly interpreterPathService: IInterpreterPathService,
+        @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IInterpreterVersionService) private readonly interpreterVersionService: IInterpreterVersionService,
-        @inject(IActiveResourceService) private readonly activeResourceService: IActiveResourceService,
     ) {}
 
     public async activate(): Promise<void> {
@@ -34,7 +32,7 @@ export class ReportIssueCommandHandler implements IExtensionSingleActivationServ
 
     public async openReportIssue(): Promise<void> {
         const template = await fs.readFile(this.templatePath, 'utf8');
-        const interpreterPath = this.interpreterPathService.get(this.activeResourceService.getActiveResource());
+        const interpreterPath = (await this.interpreterService.getActiveInterpreter())?.path || 'python';
         const pythonVersion = await this.interpreterVersionService.getVersion(interpreterPath, '');
         const languageServer =
             this.workspaceService.getConfiguration('python').get<string>('languageServer') || 'Not Found';

--- a/src/client/common/application/commands/reportIssueCommand.ts
+++ b/src/client/common/application/commands/reportIssueCommand.ts
@@ -34,20 +34,17 @@ export class ReportIssueCommandHandler implements IExtensionSingleActivationServ
     private templatePath = path.join(EXTENSION_ROOT_DIR, 'resources', 'report_issue_template.md');
 
     public async openReportIssue(): Promise<void> {
+        const template = await fs.readFile(this.templatePath, 'utf8');
+
         const pythonVersion = await this.interpreterVersionService.getVersion(PYTHON_PATH, '');
-        const languageServer = this.workspaceService.getConfiguration('python').get<string>('languageServer');
-        const interpretherPath = this.interpreterPathService.get(RESOURCE);
-        const virtualEnv = await identifyEnvironment(interpretherPath);
-        const templ = this.getIssueTemplate();
+        const languageServer =
+            this.workspaceService.getConfiguration('python').get<string>('languageServer') || 'Not Found';
+        const interpreterPath = this.interpreterPathService.get(RESOURCE);
+        const virtualEnv = await identifyEnvironment(interpreterPath);
 
         this.commandManager.executeCommand('workbench.action.openIssueReporter', {
             extensionId: 'ms-python.python',
-            issueBody: templ.format(pythonVersion, virtualEnv, languageServer.globalValue),
+            issueBody: template.format(pythonVersion, virtualEnv, languageServer),
         });
-    }
-
-    public getIssueTemplate(): string {
-        const templ = fs.readFileSync(this.templatePath, 'utf8');
-        return templ;
     }
 }

--- a/src/client/common/application/commands/reportIssueCommand.ts
+++ b/src/client/common/application/commands/reportIssueCommand.ts
@@ -9,15 +9,25 @@ import * as path from 'path';
 
 import { inject, injectable } from 'inversify';
 import { IExtensionSingleActivationService } from '../../../activation/types';
-import { ICommandManager } from '../types';
+import { ICommandManager, IWorkspaceService } from '../types';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
+import { IInterpreterVersionService } from '../../../interpreter/contracts';
+import { PYTHON_PATH } from '../../../../test/common';
+import { getVirtualEnvKind } from '../../../pythonEnvironments/discovery/locators/services/customVirtualEnvLocator';
+import { IInterpreterPathService } from '../../types';
+import { RESOURCE } from '../../../../test/testing/helper';
 
 /**
  * Allows the user to report an issue related to the Python extension using our template.
  */
 @injectable()
 export class ReportIssueCommandHandler implements IExtensionSingleActivationService {
-    constructor(@inject(ICommandManager) private readonly commandManager: ICommandManager) {}
+    constructor(
+        @inject(ICommandManager) private readonly commandManager: ICommandManager,
+        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
+        @inject(IInterpreterPathService) private readonly interpreterPathService: IInterpreterPathService,
+        @inject(IInterpreterVersionService) private readonly interpreterVersionService: IInterpreterVersionService,
+    ) {}
 
     public async activate(): Promise<void> {
         this.commandManager.registerCommand('python.reportIssue', this.openReportIssue, this);
@@ -25,11 +35,16 @@ export class ReportIssueCommandHandler implements IExtensionSingleActivationServ
 
     private templatePath = path.join(EXTENSION_ROOT_DIR, 'resources', 'report_issue_template.md');
 
-    public openReportIssue(): void {
+    public async openReportIssue(): Promise<void> {
+        const pythonVersion = await this.interpreterVersionService.getVersion(PYTHON_PATH, '');
+        const languageServer = this.workspaceService.getConfiguration('python').get<string>('languageServer');
+        const path2 = this.interpreterPathService.get(RESOURCE);
+        const virtualEnv = await getVirtualEnvKind(path2);
         const templ = this.getIssueTemplate();
+
         vscode.commands.executeCommand('workbench.action.openIssueReporter', {
             extensionId: 'ms-python.python',
-            issueBody: templ,
+            issueBody: templ.format(pythonVersion, virtualEnv, languageServer || ''),
         });
     }
 

--- a/src/client/pythonEnvironments/discovery/locators/services/customVirtualEnvLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/customVirtualEnvLocator.ts
@@ -61,7 +61,7 @@ async function getCustomVirtualEnvDirs(): Promise<string[]> {
  * and virtualenvwrapper based environments.
  * @param interpreterPath: Absolute path to the interpreter paths.
  */
-export async function getVirtualEnvKind(interpreterPath: string): Promise<PythonEnvKind> {
+async function getVirtualEnvKind(interpreterPath: string): Promise<PythonEnvKind> {
     if (await isPipenvEnvironment(interpreterPath)) {
         return PythonEnvKind.Pipenv;
     }

--- a/src/client/pythonEnvironments/discovery/locators/services/customVirtualEnvLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/customVirtualEnvLocator.ts
@@ -61,7 +61,7 @@ async function getCustomVirtualEnvDirs(): Promise<string[]> {
  * and virtualenvwrapper based environments.
  * @param interpreterPath: Absolute path to the interpreter paths.
  */
-async function getVirtualEnvKind(interpreterPath: string): Promise<PythonEnvKind> {
+export async function getVirtualEnvKind(interpreterPath: string): Promise<PythonEnvKind> {
     if (await isPipenvEnvironment(interpreterPath)) {
         return PythonEnvKind.Pipenv;
     }

--- a/src/test/common/application/commands/issueTemplateVenv1.md
+++ b/src/test/common/application/commands/issueTemplateVenv1.md
@@ -1,0 +1,47 @@
+<!-- Please search existing issues to avoid creating duplicates;
+     https://github.com/microsoft/vscode-python/issues?q=is%3Aopen+is%3Aissue+label%3Atype-bug
+-->
+
+# Behaviour
+
+[**NOTE**: If you suspect that your issue is related to the Microsoft Python Language Server (`python.languageServer: 'Microsoft'`), please download our new language server [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) from the VS Code marketplace to see if that fixes your issue]
+
+
+## Expected
+
+XXX
+
+## Actual
+
+XXX
+
+## Steps to reproduce:
+
+[**NOTE**: Self-contained, minimal reproducing code samples are **extremely** helpful and will expedite addressing your issue]
+
+1.
+
+<!--
+Note: If you think a GIF of what is happening would be helpful, consider tools like https://www.cockos.com/licecap/, https://github.com/phw/peek or https://www.screentogif.com/ .
+You can attach such things **after** you create your issue on GitHub.
+-->
+
+# Diagnostic data
+
+-   Python version (& distribution if applicable, e.g. Anaconda): 3.9.0
+-   Type of virtual environment used (e.g. conda, venv, virtualenv, etc.): virt-venv
+-   Value of the `python.languageServer` setting: Pylance
+
+<details>
+
+<summary>"Python" channel in the OUTPUT panel</summary>
+
+<p>
+
+<!-- Run the "Python: Show Output" command to see the requested output. --->
+```
+XXX
+```
+
+</p>
+</details>

--- a/src/test/common/application/commands/reportIssueCommand.unit.test.ts
+++ b/src/test/common/application/commands/reportIssueCommand.unit.test.ts
@@ -11,7 +11,11 @@ import { expect } from 'chai';
 import { LanguageServerType } from '../../../../client/activation/types';
 import { CommandManager } from '../../../../client/common/application/commandManager';
 import { ReportIssueCommandHandler } from '../../../../client/common/application/commands/reportIssueCommand';
-import { ICommandManager, IWorkspaceService } from '../../../../client/common/application/types';
+import {
+    IActiveResourceService,
+    ICommandManager,
+    IWorkspaceService,
+} from '../../../../client/common/application/types';
 import { WorkspaceService } from '../../../../client/common/application/workspace';
 import { InterpreterPathService } from '../../../../client/common/interpreterPathService';
 import { IInterpreterPathService } from '../../../../client/common/types';
@@ -21,6 +25,8 @@ import { PythonEnvKind } from '../../../../client/pythonEnvironments/base/info';
 import * as EnvIdentifier from '../../../../client/pythonEnvironments/common/environmentIdentifier';
 import { MockWorkspaceConfiguration } from '../../../startPage/mockWorkspaceConfig';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../../constants';
+import { ActiveResourceService } from '../../../../client/common/application/activeResource';
+import { RESOURCE } from '../../../testing/helper';
 
 suite('Report Issue Command', () => {
     let reportIssueCommandHandler: ReportIssueCommandHandler;
@@ -29,14 +35,17 @@ suite('Report Issue Command', () => {
     let interpreterVersionService: IInterpreterVersionService;
     let interpreterPathService: IInterpreterPathService;
     let identifyEnvironmentStub: sinon.SinonStub;
+    let activeResourceService: IActiveResourceService;
 
     setup(async () => {
         interpreterVersionService = mock(InterpreterVersionService);
         workspaceService = mock(WorkspaceService);
         cmdManager = mock(CommandManager);
         interpreterPathService = mock(InterpreterPathService);
+        activeResourceService = mock(ActiveResourceService);
 
         when(interpreterVersionService.getVersion(anything(), anything())).thenResolve('3.9.0');
+        when(activeResourceService.getActiveResource()).thenReturn(RESOURCE);
         when(workspaceService.getConfiguration('python')).thenReturn(
             new MockWorkspaceConfiguration({
                 languageServer: LanguageServerType.Node,
@@ -52,6 +61,7 @@ suite('Report Issue Command', () => {
             instance(workspaceService),
             instance(interpreterPathService),
             instance(interpreterVersionService),
+            instance(activeResourceService),
         );
 
         when(cmdManager.executeCommand(anyString(), anything())).thenResolve();

--- a/src/test/common/application/commands/reportIssueCommand.unit.test.ts
+++ b/src/test/common/application/commands/reportIssueCommand.unit.test.ts
@@ -3,29 +3,80 @@
 
 'use strict';
 
-import { anything, instance, mock, verify, when } from 'ts-mockito';
+import * as sinon from 'sinon';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
+import { expect } from 'chai';
+import { LanguageServerType } from '../../../../client/activation/types';
 import { CommandManager } from '../../../../client/common/application/commandManager';
 import { ReportIssueCommandHandler } from '../../../../client/common/application/commands/reportIssueCommand';
 import { ICommandManager, IWorkspaceService } from '../../../../client/common/application/types';
+import { WorkspaceService } from '../../../../client/common/application/workspace';
+import { InterpreterPathService } from '../../../../client/common/interpreterPathService';
+import { IInterpreterPathService } from '../../../../client/common/types';
 import { IInterpreterVersionService } from '../../../../client/interpreter/contracts';
+import { InterpreterVersionService } from '../../../../client/interpreter/interpreterVersion';
+import { PythonEnvKind } from '../../../../client/pythonEnvironments/base/info';
+import * as EnvIdentifier from '../../../../client/pythonEnvironments/common/environmentIdentifier';
+import { MockWorkspaceConfiguration } from '../../../startPage/mockWorkspaceConfig';
+import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../../constants';
 
 suite('Report Issue Command', () => {
     let reportIssueCommandHandler: ReportIssueCommandHandler;
     let cmdManager: ICommandManager;
     let workspaceService: IWorkspaceService;
     let interpreterVersionService: IInterpreterVersionService;
+    let interpreterPathService: IInterpreterPathService;
+    let identifyEnvironmentStub: sinon.SinonStub;
+
     setup(async () => {
+        interpreterVersionService = mock(InterpreterVersionService);
+        workspaceService = mock(WorkspaceService);
+        cmdManager = mock(CommandManager);
+        interpreterPathService = mock(InterpreterPathService);
+
+        when(interpreterVersionService.getVersion(anything(), anything())).thenResolve('3.9.0');
+        when(workspaceService.getConfiguration('python')).thenReturn(
+            new MockWorkspaceConfiguration({
+                languageServer: { globalValue: LanguageServerType.Node },
+            }),
+        );
+        when(interpreterPathService.get(anything())).thenReturn('python');
+        identifyEnvironmentStub = sinon.stub(EnvIdentifier, 'identifyEnvironment');
+        identifyEnvironmentStub.resolves(PythonEnvKind.Venv);
+
         cmdManager = mock(CommandManager);
         reportIssueCommandHandler = new ReportIssueCommandHandler(
             instance(cmdManager),
             instance(workspaceService),
+            instance(interpreterPathService),
             instance(interpreterVersionService),
         );
+
         when(cmdManager.executeCommand(anything())).thenResolve();
         await reportIssueCommandHandler.activate();
     });
 
+    teardown(() => {
+        identifyEnvironmentStub.restore();
+    });
+
     test('Confirm command handler is added', async () => {
+        await reportIssueCommandHandler.openReportIssue();
+        const templatePath = path.join(
+            EXTENSION_ROOT_DIR_FOR_TESTS,
+            'src',
+            'test',
+            'common',
+            'application',
+            'commands',
+            'issueTemplateVenv1.md',
+        );
+        const templ = fs.readFileSync(templatePath, 'utf8');
+        const args = capture(cmdManager.executeCommand).last();
         verify(cmdManager.registerCommand('python.reportIssue', anything(), anything())).once();
+        verify(cmdManager.executeCommand('workbench.action.openIssueReporter', anything())).once();
+        expect(args[1].issueBody).to.be.equal(templ);
     });
 });

--- a/src/test/common/application/commands/reportIssueCommand.unit.test.ts
+++ b/src/test/common/application/commands/reportIssueCommand.unit.test.ts
@@ -6,14 +6,21 @@
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { CommandManager } from '../../../../client/common/application/commandManager';
 import { ReportIssueCommandHandler } from '../../../../client/common/application/commands/reportIssueCommand';
-import { ICommandManager } from '../../../../client/common/application/types';
+import { ICommandManager, IWorkspaceService } from '../../../../client/common/application/types';
+import { IInterpreterVersionService } from '../../../../client/interpreter/contracts';
 
 suite('Report Issue Command', () => {
     let reportIssueCommandHandler: ReportIssueCommandHandler;
     let cmdManager: ICommandManager;
+    let workspaceService: IWorkspaceService;
+    let interpreterVersionService: IInterpreterVersionService;
     setup(async () => {
         cmdManager = mock(CommandManager);
-        reportIssueCommandHandler = new ReportIssueCommandHandler(instance(cmdManager));
+        reportIssueCommandHandler = new ReportIssueCommandHandler(
+            instance(cmdManager),
+            instance(workspaceService),
+            instance(interpreterVersionService),
+        );
         when(cmdManager.executeCommand(anything())).thenResolve();
         await reportIssueCommandHandler.activate();
     });

--- a/src/test/common/application/commands/reportIssueCommand.unit.test.ts
+++ b/src/test/common/application/commands/reportIssueCommand.unit.test.ts
@@ -11,47 +11,37 @@ import { expect } from 'chai';
 import { LanguageServerType } from '../../../../client/activation/types';
 import { CommandManager } from '../../../../client/common/application/commandManager';
 import { ReportIssueCommandHandler } from '../../../../client/common/application/commands/reportIssueCommand';
-import {
-    IActiveResourceService,
-    ICommandManager,
-    IWorkspaceService,
-} from '../../../../client/common/application/types';
+import { ICommandManager, IWorkspaceService } from '../../../../client/common/application/types';
 import { WorkspaceService } from '../../../../client/common/application/workspace';
-import { InterpreterPathService } from '../../../../client/common/interpreterPathService';
-import { IInterpreterPathService } from '../../../../client/common/types';
-import { IInterpreterVersionService } from '../../../../client/interpreter/contracts';
+import { IInterpreterService, IInterpreterVersionService } from '../../../../client/interpreter/contracts';
 import { InterpreterVersionService } from '../../../../client/interpreter/interpreterVersion';
 import { PythonEnvKind } from '../../../../client/pythonEnvironments/base/info';
 import * as EnvIdentifier from '../../../../client/pythonEnvironments/common/environmentIdentifier';
 import { MockWorkspaceConfiguration } from '../../../startPage/mockWorkspaceConfig';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../../constants';
-import { ActiveResourceService } from '../../../../client/common/application/activeResource';
-import { RESOURCE } from '../../../testing/helper';
+import { InterpreterService } from '../../../../client/interpreter/interpreterService';
 
 suite('Report Issue Command', () => {
     let reportIssueCommandHandler: ReportIssueCommandHandler;
     let cmdManager: ICommandManager;
     let workspaceService: IWorkspaceService;
     let interpreterVersionService: IInterpreterVersionService;
-    let interpreterPathService: IInterpreterPathService;
+    let interpreterService: IInterpreterService;
     let identifyEnvironmentStub: sinon.SinonStub;
-    let activeResourceService: IActiveResourceService;
 
     setup(async () => {
         interpreterVersionService = mock(InterpreterVersionService);
         workspaceService = mock(WorkspaceService);
         cmdManager = mock(CommandManager);
-        interpreterPathService = mock(InterpreterPathService);
-        activeResourceService = mock(ActiveResourceService);
+        interpreterService = mock(InterpreterService);
 
         when(interpreterVersionService.getVersion(anything(), anything())).thenResolve('3.9.0');
-        when(activeResourceService.getActiveResource()).thenReturn(RESOURCE);
         when(workspaceService.getConfiguration('python')).thenReturn(
             new MockWorkspaceConfiguration({
                 languageServer: LanguageServerType.Node,
             }),
         );
-        when(interpreterPathService.get(anything())).thenReturn('python');
+        when(interpreterService.getActiveInterpreter(anything())).thenResolve(undefined);
         identifyEnvironmentStub = sinon.stub(EnvIdentifier, 'identifyEnvironment');
         identifyEnvironmentStub.resolves(PythonEnvKind.Venv);
 
@@ -59,9 +49,8 @@ suite('Report Issue Command', () => {
         reportIssueCommandHandler = new ReportIssueCommandHandler(
             instance(cmdManager),
             instance(workspaceService),
-            instance(interpreterPathService),
+            instance(interpreterService),
             instance(interpreterVersionService),
-            instance(activeResourceService),
         );
 
         when(cmdManager.executeCommand(anyString(), anything())).thenResolve();


### PR DESCRIPTION
Automatically add:
* python.languageServer setting. Closed [#153](https://github.com/microsoft/vscode-python-internalbacklog/issues/153).
* Virtual environment. Closed [#152](https://github.com/microsoft/vscode-python-internalbacklog/issues/152).
* Python version data. Closed [#100](https://github.com/microsoft/vscode-python-internalbacklog/issues/100).
