### PR TITLE
Indent on ``match`` and ``case`` Python 3.10

### DIFF
--- a/news/1 Enhancements/16104.md
+++ b/news/1 Enhancements/16104.md
@@ -1,0 +1,1 @@
+Automatically indent following `match` and `case` statements.

--- a/news/1 Enhancements/16104.md
+++ b/news/1 Enhancements/16104.md
@@ -1,1 +1,1 @@
-Automatically indent following `match` and `case` statements.
+Automatically indent following `match` and `case` statements. (thanks [Marc Mueller](https://github.com/cdce8p))

--- a/src/client/language/languageConfiguration.ts
+++ b/src/client/language/languageConfiguration.ts
@@ -56,7 +56,9 @@ export function getLanguageConfiguration(): LanguageConfiguration {
                                 elif |
                                 while |
                                 with |
-                                async \\s+ with
+                                async \\s+ with |
+                                match |
+                                case
                             )
                             \\b .*
                         ) |

--- a/src/test/language/languageConfiguration.unit.test.ts
+++ b/src/test/language/languageConfiguration.unit.test.ts
@@ -30,6 +30,8 @@ const INDENT_ON_ENTER = [
     /^if\b/,
     /^elif\b/,
     /^else\b/,
+    /^match\b/,
+    /^case\b/,
 ];
 const DEDENT_ON_ENTER = [
     // block-ending statements
@@ -180,6 +182,16 @@ suite('Language Configuration', () => {
             'except TestError:',
             'except :',
             'finally:',
+            'match item:',
+            'case 200:',
+            'case (1, 1):',
+            'case Point(x=0, y=0):',
+            'case [Point(0, 0)]:',
+            'case Point(x, y) if x == y:',
+            'case (Point(x1, y1), Point(x2, y2) as p2):',
+            'case Color.RED:',
+            'case 401 | 403 | 404:',
+            'case _:',
             // simple statemenhts
             'pass',
             'raise Exception(msg)',


### PR DESCRIPTION
Python 3.10 adds pattern matching and the `match` and `case` keywords.
Closes: #16100