### PR TITLE
Add "Default" LS setting, which picks between Jedi/Pylance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1225,13 +1225,14 @@
                 "python.languageServer": {
                     "type": "string",
                     "enum": [
+                        "Default",
                         "Jedi",
                         "JediLSP",
                         "Pylance",
                         "Microsoft",
                         "None"
                     ],
-                    "default": "Jedi",
+                    "default": "Default",
                     "description": "Defines type of the language server.",
                     "scope": "window"
                 },

--- a/src/client/activation/common/defaultlanguageServer.ts
+++ b/src/client/activation/common/defaultlanguageServer.ts
@@ -26,7 +26,6 @@ export async function setDefaultLanguageServer(
     serviceManager: IServiceManager,
 ): Promise<void> {
     const lsType = await getDefaultLanguageServer(experimentService, extensions);
-    console.log(`Default LS will be ${lsType}`);
     serviceManager.addSingletonInstance<IDefaultLanguageServer>(
         IDefaultLanguageServer,
         new DefaultLanguageServer(lsType),

--- a/src/client/activation/common/defaultlanguageServer.ts
+++ b/src/client/activation/common/defaultlanguageServer.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { injectable } from 'inversify';
+import { PYLANCE_EXTENSION_ID } from '../../common/constants';
+import { JediLSP } from '../../common/experiments/groups';
+import { IDefaultLanguageServer, IExperimentService, IExtensions } from '../../common/types';
+import { IServiceManager } from '../../ioc/types';
+import { ILSExtensionApi } from '../node/languageServerFolderService';
+import { LanguageServerType } from '../types';
+
+export type PotentialDefault = LanguageServerType.Jedi | LanguageServerType.JediLSP | LanguageServerType.Node;
+
+@injectable()
+class DefaultLanguageServer implements IDefaultLanguageServer {
+    public readonly defaultLSType: PotentialDefault;
+
+    constructor(defaultServer: PotentialDefault) {
+        this.defaultLSType = defaultServer;
+    }
+}
+
+export async function setDefaultLanguageServer(
+    experimentService: IExperimentService,
+    extensions: IExtensions,
+    serviceManager: IServiceManager,
+): Promise<void> {
+    const lsType = await getDefaultLanguageServer(experimentService, extensions);
+    console.log(`Default LS will be ${lsType}`);
+    serviceManager.addSingletonInstance<IDefaultLanguageServer>(
+        IDefaultLanguageServer,
+        new DefaultLanguageServer(lsType),
+    );
+}
+
+async function getDefaultLanguageServer(
+    experimentService: IExperimentService,
+    extensions: IExtensions,
+): Promise<PotentialDefault> {
+    if (extensions.getExtension<ILSExtensionApi>(PYLANCE_EXTENSION_ID)) {
+        return LanguageServerType.Node;
+    }
+
+    // If Pylance is installed and functional, use it as the default.
+    // TODO: This causes a dependency cycle, as VS Code is trying to wait for python to even start pylance...
+    // console.log('Activating Pylance');
+    // const pylance = await extensions.getExtension<ILSExtensionApi>(PYLANCE_EXTENSION_ID)?.activate();
+    // console.log('Activated Pylance');
+    // if (pylance && Object.keys(pylance).length !== 0) {
+    //     return LanguageServerType.Node;
+    // }
+
+    // Otherwise, use jedi.
+    return (await experimentService.inExperiment(JediLSP.experiment))
+        ? LanguageServerType.JediLSP
+        : LanguageServerType.Jedi;
+}

--- a/src/client/activation/common/defaultlanguageServer.ts
+++ b/src/client/activation/common/defaultlanguageServer.ts
@@ -41,16 +41,6 @@ async function getDefaultLanguageServer(
         return LanguageServerType.Node;
     }
 
-    // If Pylance is installed and functional, use it as the default.
-    // TODO: This causes a dependency cycle, as VS Code is trying to wait for python to even start pylance...
-    // console.log('Activating Pylance');
-    // const pylance = await extensions.getExtension<ILSExtensionApi>(PYLANCE_EXTENSION_ID)?.activate();
-    // console.log('Activated Pylance');
-    // if (pylance && Object.keys(pylance).length !== 0) {
-    //     return LanguageServerType.Node;
-    // }
-
-    // Otherwise, use jedi.
     return (await experimentService.inExperiment(JediLSP.experiment))
         ? LanguageServerType.JediLSP
         : LanguageServerType.Jedi;

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -167,7 +167,7 @@ export class PythonSettings implements IPythonSettings {
         private readonly experimentsManager?: IExperimentsManager,
         private readonly interpreterPathService?: IInterpreterPathService,
         private readonly interpreterSecurityService?: IInterpreterSecurityService,
-        private readonly defaultJedi?: IDefaultLanguageServer,
+        private readonly defaultLS?: IDefaultLanguageServer,
     ) {
         this.workspace = workspace || new WorkspaceService();
         this.workspaceRoot = workspaceFolder;
@@ -181,7 +181,7 @@ export class PythonSettings implements IPythonSettings {
         experimentsManager?: IExperimentsManager,
         interpreterPathService?: IInterpreterPathService,
         interpreterSecurityService?: IInterpreterSecurityService,
-        defaultJedi?: IDefaultLanguageServer,
+        defaultLS?: IDefaultLanguageServer,
     ): PythonSettings {
         workspace = workspace || new WorkspaceService();
         const workspaceFolderUri = PythonSettings.getSettingsUriAndTarget(resource, workspace).uri;
@@ -195,7 +195,7 @@ export class PythonSettings implements IPythonSettings {
                 experimentsManager,
                 interpreterPathService,
                 interpreterSecurityService,
-                defaultJedi,
+                defaultLS,
             );
             PythonSettings.pythonSettings.set(workspaceFolderKey, settings);
             // Pass null to avoid VSC from complaining about not passing in a value.
@@ -284,14 +284,21 @@ export class PythonSettings implements IPythonSettings {
 
         this.useIsolation = systemVariables.resolveAny(pythonSettings.get<boolean>('useIsolation', true))!;
 
-        const defaultServer = this.defaultJedi
-            ? this.defaultJedi.defaultLSType
-            : pythonSettings.get<LanguageServerType>('languageServer');
-        let ls = defaultServer ?? LanguageServerType.Jedi;
-        ls = systemVariables.resolveAny(ls);
-        if (!Object.values(LanguageServerType).includes(ls)) {
-            ls = LanguageServerType.Jedi;
+        // Get as a string and verify; don't just accept.
+        let userLS = pythonSettings.get<string>('languageServer');
+        userLS = systemVariables.resolveAny(userLS);
+
+        let ls: LanguageServerType;
+        if (
+            !userLS ||
+            userLS === 'Default' ||
+            !Object.values(LanguageServerType).includes(userLS as LanguageServerType)
+        ) {
+            ls = this.defaultLS?.defaultLSType ?? LanguageServerType.Jedi;
+        } else {
+            ls = userLS as LanguageServerType;
         }
+
         this.languageServer = ls;
 
         this.jediPath = systemVariables.resolveAny(pythonSettings.get<string>('jediPath'))!;

--- a/src/client/common/configuration/service.ts
+++ b/src/client/common/configuration/service.ts
@@ -37,7 +37,7 @@ export class ConfigurationService implements IConfigurationService {
         const interpreterSecurityService = this.serviceContainer.get<IInterpreterSecurityService>(
             IInterpreterSecurityService,
         );
-        const defaultJedi = this.serviceContainer.tryGet<IDefaultLanguageServer>(IDefaultLanguageServer);
+        const defaultLS = this.serviceContainer.get<IDefaultLanguageServer>(IDefaultLanguageServer);
         return PythonSettings.getInstance(
             resource,
             InterpreterAutoSelectionService,
@@ -45,7 +45,7 @@ export class ConfigurationService implements IConfigurationService {
             experiments,
             interpreterPathService,
             interpreterSecurityService,
-            defaultJedi,
+            defaultLS,
         );
     }
 

--- a/src/client/common/configuration/service.ts
+++ b/src/client/common/configuration/service.ts
@@ -37,7 +37,7 @@ export class ConfigurationService implements IConfigurationService {
         const interpreterSecurityService = this.serviceContainer.get<IInterpreterSecurityService>(
             IInterpreterSecurityService,
         );
-        const defaultLS = this.serviceContainer.get<IDefaultLanguageServer>(IDefaultLanguageServer);
+        const defaultLS = this.serviceContainer.tryGet<IDefaultLanguageServer>(IDefaultLanguageServer);
         return PythonSettings.getInstance(
             resource,
             InterpreterAutoSelectionService,

--- a/src/client/common/experiments/helpers.ts
+++ b/src/client/common/experiments/helpers.ts
@@ -3,12 +3,8 @@
 
 'use strict';
 
-import { injectable } from 'inversify';
-import { LanguageServerType } from '../../activation/types';
-import { IServiceManager } from '../../ioc/types';
-import { IWorkspaceService } from '../application/types';
-import { IDefaultLanguageServer, IExperimentService } from '../types';
-import { DiscoveryVariants, JediLSP } from './groups';
+import { IExperimentService } from '../types';
+import { DiscoveryVariants } from './groups';
 
 export async function inDiscoveryExperiment(experimentService: IExperimentService): Promise<boolean> {
     const results = await Promise.all([
@@ -16,42 +12,4 @@ export async function inDiscoveryExperiment(experimentService: IExperimentServic
         experimentService.inExperiment(DiscoveryVariants.discoveryWithoutFileWatching),
     ]);
     return results.includes(true);
-}
-
-@injectable()
-class DefaultLanguageServer implements IDefaultLanguageServer {
-    public readonly defaultLSType: LanguageServerType.Jedi | LanguageServerType.JediLSP;
-
-    constructor(defaultServer: LanguageServerType.Jedi | LanguageServerType.JediLSP) {
-        this.defaultLSType = defaultServer;
-    }
-}
-
-export async function setDefaultLanguageServerByExperiment(
-    experimentService: IExperimentService,
-    workspaceService: IWorkspaceService,
-    serviceManager: IServiceManager,
-): Promise<void> {
-    const settings = workspaceService.getConfiguration('python');
-    const lsSetting = settings.inspect('languageServer');
-    if (lsSetting) {
-        if (
-            lsSetting.globalValue ||
-            lsSetting.globalLanguageValue ||
-            lsSetting.workspaceFolderValue ||
-            lsSetting.workspaceFolderLanguageValue ||
-            lsSetting.workspaceValue ||
-            lsSetting.workspaceLanguageValue
-        ) {
-            return Promise.resolve();
-        }
-    }
-    const lsType = (await experimentService.inExperiment(JediLSP.experiment))
-        ? LanguageServerType.JediLSP
-        : LanguageServerType.Jedi;
-    serviceManager.addSingletonInstance<IDefaultLanguageServer>(
-        IDefaultLanguageServer,
-        new DefaultLanguageServer(lsType),
-    );
-    return Promise.resolve();
 }

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -26,6 +26,7 @@ import {
     IDisposableRegistry,
     IExperimentService,
     IExperimentsManager,
+    IExtensions,
     IOutputChannel,
 } from './common/types';
 import { noop } from './common/utils/misc';
@@ -61,7 +62,7 @@ import * as pythonEnvironments from './pythonEnvironments';
 
 import { ActivationResult, ExtensionState } from './components';
 import { Components } from './extensionInit';
-import { setDefaultLanguageServerByExperiment } from './common/experiments/helpers';
+import { setDefaultLanguageServer } from './activation/common/defaultlanguageServer';
 
 export async function activateComponents(
     // `ext` is passed to any extra activation funcs.
@@ -131,7 +132,8 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
     await experimentService.activate();
 
     const workspaceService = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
-    await setDefaultLanguageServerByExperiment(experimentService, workspaceService, serviceManager);
+    const extensions = serviceContainer.get<IExtensions>(IExtensions);
+    await setDefaultLanguageServer(experimentService, extensions, serviceManager);
 
     const configuration = serviceManager.get<IConfigurationService>(IConfigurationService);
     // We should start logging using the log level as soon as possible, so set it as soon as we can access the level.

--- a/src/test/activation/defaultLanguageServer.unit.test.ts
+++ b/src/test/activation/defaultLanguageServer.unit.test.ts
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect } from 'chai';
+import { anything, instance, mock, when, verify } from 'ts-mockito';
+import { Extension } from 'vscode';
+import { setDefaultLanguageServer } from '../../client/activation/common/defaultlanguageServer';
+import { LanguageServerType } from '../../client/activation/types';
+import { PYLANCE_EXTENSION_ID } from '../../client/common/constants';
+import { JediLSP } from '../../client/common/experiments/groups';
+import { ExperimentService } from '../../client/common/experiments/service';
+import { IDefaultLanguageServer, IExperimentService, IExtensions } from '../../client/common/types';
+import { ServiceManager } from '../../client/ioc/serviceManager';
+import { IServiceManager } from '../../client/ioc/types';
+
+suite('Activation - setDefaultLanguageServer()', () => {
+    let experimentService: IExperimentService;
+    let extensions: IExtensions;
+    let extension: Extension<unknown>;
+    let serviceManager: IServiceManager;
+    setup(() => {
+        experimentService = mock(ExperimentService);
+        extensions = mock();
+        extension = mock();
+        serviceManager = mock(ServiceManager);
+    });
+
+    test('Pylance not installed and NOT in experiment', async () => {
+        let defaultServerType;
+
+        when(extensions.getExtension(PYLANCE_EXTENSION_ID)).thenReturn(undefined);
+        when(experimentService.inExperiment(JediLSP.experiment)).thenResolve(false);
+        when(serviceManager.addSingletonInstance<IDefaultLanguageServer>(IDefaultLanguageServer, anything())).thenCall(
+            (_symbol, value: IDefaultLanguageServer) => {
+                defaultServerType = value.defaultLSType;
+            },
+        );
+
+        await setDefaultLanguageServer(instance(experimentService), instance(extensions), instance(serviceManager));
+
+        verify(extensions.getExtension(PYLANCE_EXTENSION_ID)).once();
+        verify(experimentService.inExperiment(JediLSP.experiment)).once();
+        verify(serviceManager.addSingletonInstance<IDefaultLanguageServer>(IDefaultLanguageServer, anything())).once();
+        expect(defaultServerType).to.equal(LanguageServerType.Jedi);
+    });
+
+    test('Pylance not installed and in experiment', async () => {
+        let defaultServerType;
+        when(extensions.getExtension(PYLANCE_EXTENSION_ID)).thenReturn(undefined);
+        when(experimentService.inExperiment(JediLSP.experiment)).thenResolve(true);
+        when(serviceManager.addSingletonInstance<IDefaultLanguageServer>(IDefaultLanguageServer, anything())).thenCall(
+            (_symbol, value: IDefaultLanguageServer) => {
+                defaultServerType = value.defaultLSType;
+            },
+        );
+
+        await setDefaultLanguageServer(instance(experimentService), instance(extensions), instance(serviceManager));
+
+        verify(extensions.getExtension(PYLANCE_EXTENSION_ID)).once();
+        verify(experimentService.inExperiment(JediLSP.experiment)).once();
+        verify(serviceManager.addSingletonInstance<IDefaultLanguageServer>(IDefaultLanguageServer, anything())).once();
+        expect(defaultServerType).to.equal(LanguageServerType.JediLSP);
+    });
+
+    test('Pylance installed and NOT in experiment', async () => {
+        let defaultServerType;
+
+        when(extensions.getExtension(PYLANCE_EXTENSION_ID)).thenReturn(instance(extension));
+        when(experimentService.inExperiment(JediLSP.experiment)).thenResolve(false);
+        when(serviceManager.addSingletonInstance<IDefaultLanguageServer>(IDefaultLanguageServer, anything())).thenCall(
+            (_symbol, value: IDefaultLanguageServer) => {
+                defaultServerType = value.defaultLSType;
+            },
+        );
+
+        await setDefaultLanguageServer(instance(experimentService), instance(extensions), instance(serviceManager));
+
+        verify(extensions.getExtension(PYLANCE_EXTENSION_ID)).once();
+        verify(experimentService.inExperiment(JediLSP.experiment)).never();
+        verify(serviceManager.addSingletonInstance<IDefaultLanguageServer>(IDefaultLanguageServer, anything())).once();
+        expect(defaultServerType).to.equal(LanguageServerType.Node);
+    });
+
+    test('Pylance installed and in experiment', async () => {
+        let defaultServerType;
+        when(extensions.getExtension(PYLANCE_EXTENSION_ID)).thenReturn(instance(extension));
+        when(experimentService.inExperiment(JediLSP.experiment)).thenResolve(true);
+        when(serviceManager.addSingletonInstance<IDefaultLanguageServer>(IDefaultLanguageServer, anything())).thenCall(
+            (_symbol, value: IDefaultLanguageServer) => {
+                defaultServerType = value.defaultLSType;
+            },
+        );
+
+        await setDefaultLanguageServer(instance(experimentService), instance(extensions), instance(serviceManager));
+
+        verify(extensions.getExtension(PYLANCE_EXTENSION_ID)).once();
+        verify(experimentService.inExperiment(JediLSP.experiment)).never();
+        verify(serviceManager.addSingletonInstance<IDefaultLanguageServer>(IDefaultLanguageServer, anything())).once();
+        expect(defaultServerType).to.equal(LanguageServerType.Node);
+    });
+});

--- a/src/test/common/experiments/helpers.unit.test.ts
+++ b/src/test/common/experiments/helpers.unit.test.ts
@@ -4,20 +4,11 @@
 'use strict';
 
 import { expect } from 'chai';
-import { anything, instance, mock, when, verify } from 'ts-mockito';
-import { LanguageServerType } from '../../../client/activation/types';
-import { IWorkspaceService } from '../../../client/common/application/types';
-import { WorkspaceService } from '../../../client/common/application/workspace';
-import { DiscoveryVariants, JediLSP } from '../../../client/common/experiments/groups';
-import {
-    inDiscoveryExperiment,
-    setDefaultLanguageServerByExperiment,
-} from '../../../client/common/experiments/helpers';
+import { anything, instance, mock, when } from 'ts-mockito';
+import { DiscoveryVariants } from '../../../client/common/experiments/groups';
+import { inDiscoveryExperiment } from '../../../client/common/experiments/helpers';
 import { ExperimentService } from '../../../client/common/experiments/service';
-import { IDefaultLanguageServer, IExperimentService } from '../../../client/common/types';
-import { ServiceManager } from '../../../client/ioc/serviceManager';
-import { IServiceManager } from '../../../client/ioc/types';
-import { MockWorkspaceConfiguration } from '../../startPage/mockWorkspaceConfig';
+import { IExperimentService } from '../../../client/common/types';
 
 suite('Experiments - inDiscoveryExperiment()', () => {
     let experimentService: IExperimentService;
@@ -41,85 +32,5 @@ suite('Experiments - inDiscoveryExperiment()', () => {
         when(experimentService.inExperiment(anything())).thenResolve(false);
         const result = await inDiscoveryExperiment(instance(experimentService));
         expect(result).to.equal(false);
-    });
-});
-
-suite('Experiments - setDefaultLanguageServerByExperiment()', () => {
-    let experimentService: IExperimentService;
-    let workspaceService: IWorkspaceService;
-    let serviceManager: IServiceManager;
-    setup(() => {
-        experimentService = mock(ExperimentService);
-        workspaceService = mock(WorkspaceService);
-        serviceManager = mock(ServiceManager);
-    });
-
-    test('languageServer set by user', async () => {
-        when(workspaceService.getConfiguration('python')).thenReturn(
-            new MockWorkspaceConfiguration({
-                languageServer: { globalValue: LanguageServerType.Node },
-            }),
-        );
-        await setDefaultLanguageServerByExperiment(
-            instance(experimentService),
-            instance(workspaceService),
-            instance(serviceManager),
-        );
-
-        verify(workspaceService.getConfiguration('python')).once();
-        verify(experimentService.inExperiment(JediLSP.experiment)).never();
-        verify(serviceManager.addSingletonInstance<IDefaultLanguageServer>(IDefaultLanguageServer, anything())).never();
-    });
-
-    test('languageServer NOT set by user and NOT in experiment', async () => {
-        let defaultServerType;
-        when(workspaceService.getConfiguration('python')).thenReturn(
-            new MockWorkspaceConfiguration({
-                languageServer: { defaultValue: LanguageServerType.Jedi },
-            }),
-        );
-        when(experimentService.inExperiment(JediLSP.experiment)).thenResolve(false);
-        when(serviceManager.addSingletonInstance<IDefaultLanguageServer>(IDefaultLanguageServer, anything())).thenCall(
-            (_symbol, value: IDefaultLanguageServer) => {
-                defaultServerType = value.defaultLSType;
-            },
-        );
-
-        await setDefaultLanguageServerByExperiment(
-            instance(experimentService),
-            instance(workspaceService),
-            instance(serviceManager),
-        );
-
-        verify(workspaceService.getConfiguration('python')).once();
-        verify(experimentService.inExperiment(JediLSP.experiment)).once();
-        verify(serviceManager.addSingletonInstance<IDefaultLanguageServer>(IDefaultLanguageServer, anything())).once();
-        expect(defaultServerType).to.equal(LanguageServerType.Jedi);
-    });
-
-    test('languageServer NOT set by user and in experiment', async () => {
-        let defaultServerType;
-        when(workspaceService.getConfiguration('python')).thenReturn(
-            new MockWorkspaceConfiguration({
-                languageServer: { defaultValue: LanguageServerType.Jedi },
-            }),
-        );
-        when(experimentService.inExperiment(JediLSP.experiment)).thenResolve(true);
-        when(serviceManager.addSingletonInstance<IDefaultLanguageServer>(IDefaultLanguageServer, anything())).thenCall(
-            (_symbol, value: IDefaultLanguageServer) => {
-                defaultServerType = value.defaultLSType;
-            },
-        );
-
-        await setDefaultLanguageServerByExperiment(
-            instance(experimentService),
-            instance(workspaceService),
-            instance(serviceManager),
-        );
-
-        verify(workspaceService.getConfiguration('python')).once();
-        verify(experimentService.inExperiment(JediLSP.experiment)).once();
-        verify(serviceManager.addSingletonInstance<IDefaultLanguageServer>(IDefaultLanguageServer, anything())).once();
-        expect(defaultServerType).to.equal(LanguageServerType.JediLSP);
     });
 });


### PR DESCRIPTION
Adds a new "Default" setting, which implies Pylance when Pylance installed, otherwise uses jedi (plus/minus the LSP experiment).

For https://github.com/microsoft/vscode-python-internalbacklog/issues/176.