### PR TITLE
Correct the vsix artifact name to be uploaded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         shell: python
     outputs:
       vsix_name: ${{ steps.vsix_names.outputs.vsix_name }}
-      vsix_artifact_name: $ {{ steps.vsix_names.outputs.vsix_artifact_name }}
+      vsix_artifact_name: ${{ steps.vsix_names.outputs.vsix_artifact_name }}
     steps:
       - name: VSIX names
         id: vsix_names


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python-internalbacklog/issues/196

See https://github.com/microsoft/vscode-python/actions/runs/811168374, The artifact uploaded is named `$ {{ steps.vsix_names.outputs.vsix_artifact_name }}` instead of `ms-python-insiders-vsix`. That is probably because of the space character after `$`.

I expect this to fix the smoke tests.