### PR TITLE
Correct the vsix artifact name to be downloaded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -367,7 +367,7 @@ jobs:
       - name: Download VSIX
         uses: actions/download-artifact@v2
         with:
-          name: ${{ needs.setup.outputs.vsix_artifactname }}
+          name: ${{ needs.setup.outputs.vsix_artifact_name }}
 
       - name: Prepare for smoke tests
         run: npx tsc -p ./


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python-internalbacklog/issues/196

Part 2 of https://github.com/microsoft/vscode-python/pull/16140. It fixes running smoke tests in my fork.