### PR TITLE
Allow TensorBoard to load despite existing MIME type misconfiguration

### DIFF
--- a/news/2 Fixes/16072.md
+++ b/news/2 Fixes/16072.md
@@ -1,0 +1,1 @@
+Workaround existing MIME type misconfiguration on Windows preventing TensorBoard from loading when starting TensorBoard.

--- a/pythonFiles/tensorboard_launcher.py
+++ b/pythonFiles/tensorboard_launcher.py
@@ -1,17 +1,25 @@
 import time
 import sys
 import os
-from tensorboard import default
+import mimetypes
 from tensorboard import program
 
 
 def main(logdir):
+    # Environment variable for PyTorch profiler TensorBoard plugin
+    # to detect when it's running inside VS Code
     os.environ["VSCODE_TENSORBOARD_LAUNCH"] = "1"
+
+    # Work around incorrectly configured MIME types on Windows
+    mimetypes.add_type("application/javascript", ".js")
+
+    # Start TensorBoard using their Python API
     tb = program.TensorBoard()
     tb.configure(bind_all=False, logdir=logdir)
     url = tb.launch()
     sys.stdout.write("TensorBoard started at %s\n" % (url))
     sys.stdout.flush()
+
     while True:
         try:
             time.sleep(60)


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/16072

This comprehensively solves bugs like https://github.com/microsoft/vscode-python/issues/15636#issuecomment-827535040 without us having to tell users how to delete problematic MIME types from the Windows registry like https://github.com/microsoft/vscode-python/wiki/Troubleshooting-TensorBoard-integration-in-VS-Code#integrated-tensorboard-sessions

In the screenshot below, you can see that even if I've intentionally misconfigured '.js' files to resolve to a MIME type other than 'application/javascript', TensorBoard is still able to load:

![image](https://user-images.githubusercontent.com/30305945/117888252-ab94dc00-b266-11eb-97af-ba9f7e82b163.png)


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
