### PR TITLE
Allow Pylance to be used with Python 2 if explicitly chosen

### DIFF
--- a/news/2 Fixes/16204.md
+++ b/news/2 Fixes/16204.md
@@ -1,0 +1,1 @@
+Allow Pylance to be used with Python 2 if "Pylance" is explicitly set as the language server.

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -212,6 +212,11 @@ export class LanguageServerExtensionActivationService
         return configurationService.getSettings(this.resource).languageServer;
     }
 
+    private getCurrentLanguageServerTypeIsDefault(): boolean {
+        const configurationService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
+        return configurationService.getSettings(this.resource).languageServerIsDefault;
+    }
+
     private async createRefCountedServer(
         resource: Resource,
         interpreter: PythonEnvironment | undefined,
@@ -240,10 +245,14 @@ export class LanguageServerExtensionActivationService
             }
         }
 
-        if (serverType === LanguageServerType.Node && interpreter && interpreter.version) {
-            if (interpreter.version.major < 3) {
-                sendTelemetryEvent(EventName.JEDI_FALLBACK);
-                serverType = LanguageServerType.Jedi;
+        // If "Pylance" was explicitly chosen, use it even though it's not guaranteed to work
+        // properly with Python 2.
+        if (!this.getCurrentLanguageServerTypeIsDefault()) {
+            if (serverType === LanguageServerType.Node && interpreter && interpreter.version) {
+                if (interpreter.version.major < 3) {
+                    sendTelemetryEvent(EventName.JEDI_FALLBACK);
+                    serverType = LanguageServerType.Jedi;
+                }
             }
         }
 

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -144,6 +144,8 @@ export class PythonSettings implements IPythonSettings {
 
     public languageServer: LanguageServerType = LanguageServerType.Microsoft;
 
+    public languageServerIsDefault = true;
+
     public logging: ILoggingSettings = { level: LogLevel.Error };
 
     public useIsolation = true;
@@ -288,20 +290,18 @@ export class PythonSettings implements IPythonSettings {
         let userLS = pythonSettings.get<string>('languageServer');
         userLS = systemVariables.resolveAny(userLS);
 
-        let ls: LanguageServerType;
-
         // Validate the user's input; if invalid, set it to the default.
         if (
             !userLS ||
             userLS === 'Default' ||
             !Object.values(LanguageServerType).includes(userLS as LanguageServerType)
         ) {
-            ls = this.defaultLS?.defaultLSType ?? LanguageServerType.Jedi;
+            this.languageServer = this.defaultLS?.defaultLSType ?? LanguageServerType.Jedi;
+            this.languageServerIsDefault = true;
         } else {
-            ls = userLS as LanguageServerType;
+            this.languageServer = userLS as LanguageServerType;
+            this.languageServerIsDefault = false;
         }
-
-        this.languageServer = ls;
 
         this.jediPath = systemVariables.resolveAny(pythonSettings.get<string>('jediPath'))!;
         if (typeof this.jediPath === 'string' && this.jediPath.length > 0) {

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -200,6 +200,7 @@ export interface IPythonSettings {
     readonly onDidChange: Event<void>;
     readonly experiments: IExperiments;
     readonly languageServer: LanguageServerType;
+    readonly languageServerIsDefault: boolean;
     readonly defaultInterpreterPath: string;
     readonly logging: ILoggingSettings;
     readonly useIsolation: boolean;

--- a/src/test/common/configSettings/configSettings.unit.test.ts
+++ b/src/test/common/configSettings/configSettings.unit.test.ts
@@ -187,7 +187,11 @@ suite('Python Settings', async () => {
         config.verifyAll();
     });
 
-    function testLanguageServer(languageServer: LanguageServerType, expectedValue: LanguageServerType) {
+    function testLanguageServer(
+        languageServer: LanguageServerType,
+        expectedValue: LanguageServerType,
+        isDefault: boolean,
+    ) {
         test(languageServer, () => {
             expected.pythonPath = 'python3';
             expected.languageServer = languageServer;
@@ -200,16 +204,17 @@ suite('Python Settings', async () => {
             settings.update(config.object);
 
             expect(settings.languageServer).to.be.equal(expectedValue);
+            expect(settings.languageServerIsDefault).to.be.equal(isDefault);
             config.verifyAll();
         });
     }
 
     suite('languageServer settings', async () => {
         Object.values(LanguageServerType).forEach(async (languageServer) => {
-            testLanguageServer(languageServer, languageServer);
+            testLanguageServer(languageServer, languageServer, false);
         });
 
-        testLanguageServer('invalid' as LanguageServerType, LanguageServerType.Jedi);
+        testLanguageServer('invalid' as LanguageServerType, LanguageServerType.Jedi, true);
     });
 
     function testExperiments(enabled: boolean) {


### PR DESCRIPTION
For #16204.

I didn't change the logic for jedi, as it will quite literally crash. Pylance doesn't need Python to run, so is safe to use (even if the analysis may not fully understand Python 2).