### PR TITLE
Fill report issue template with output logs

### DIFF
--- a/resources/report_issue_template.md
+++ b/resources/report_issue_template.md
@@ -40,7 +40,7 @@ You can attach such things **after** you create your issue on GitHub.
 
 <!-- Run the "Python: Show Output" command to see the requested output. --->
 ```
-XXX
+{3}
 ```
 
 </p>

--- a/src/client/common/application/commands/reportIssueCommand.ts
+++ b/src/client/common/application/commands/reportIssueCommand.ts
@@ -7,10 +7,11 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import { inject, injectable } from 'inversify';
 import { IExtensionSingleActivationService } from '../../../activation/types';
-import { ICommandManager, IDocumentManager, IWorkspaceService } from '../types';
+import { ICommandManager, IWorkspaceService } from '../types';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
 import { IInterpreterService, IInterpreterVersionService } from '../../../interpreter/contracts';
 import { identifyEnvironment } from '../../../pythonEnvironments/common/environmentIdentifier';
+import { getPythonOutputChannelContent } from '../../../logging';
 
 /**
  * Allows the user to report an issue related to the Python extension using our template.
@@ -22,7 +23,6 @@ export class ReportIssueCommandHandler implements IExtensionSingleActivationServ
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IInterpreterVersionService) private readonly interpreterVersionService: IInterpreterVersionService,
-        @inject(IDocumentManager) private readonly documentManager: IDocumentManager,
     ) {}
 
     public async activate(): Promise<void> {
@@ -31,33 +31,18 @@ export class ReportIssueCommandHandler implements IExtensionSingleActivationServ
 
     private templatePath = path.join(EXTENSION_ROOT_DIR, 'resources', 'report_issue_template.md');
 
-    private async fillTemplateData(): Promise<void> {
-        return new Promise(() => {
-            setTimeout(async () => {
-                const template = await fs.readFile(this.templatePath, 'utf8');
-                const interpreterPath = (await this.interpreterService.getActiveInterpreter())?.path || 'not-selected';
-                const pythonVersion = await this.interpreterVersionService.getVersion(interpreterPath, '');
-                const languageServer =
-                    this.workspaceService.getConfiguration('python').get<string>('languageServer') || 'Not Found';
-                const virtualEnv = await identifyEnvironment(interpreterPath);
-
-                // Assumes caller has shown the Python Output window so that textDocuments is populated with our Log file
-                let pythonLogs = '';
-                const doc = this.documentManager.textDocuments.find((td) => td.languageId === 'Log');
-                if (doc) {
-                    pythonLogs = doc.getText();
-                }
-
-                this.commandManager.executeCommand('workbench.action.openIssueReporter', {
-                    extensionId: 'ms-python.python',
-                    issueBody: template.format(pythonVersion, virtualEnv, languageServer, pythonLogs),
-                });
-            }, 1000);
-        });
-    }
-
     public async openReportIssue(): Promise<void> {
-        await this.commandManager.executeCommand('python.viewOutput');
-        return this.fillTemplateData();
+        const pythonLogs = await getPythonOutputChannelContent();
+        const template = await fs.readFile(this.templatePath, 'utf8');
+        const interpreterPath = (await this.interpreterService.getActiveInterpreter())?.path || 'not-selected';
+        const pythonVersion = await this.interpreterVersionService.getVersion(interpreterPath, '');
+        const languageServer =
+            this.workspaceService.getConfiguration('python').get<string>('languageServer') || 'Not Found';
+        const virtualEnv = await identifyEnvironment(interpreterPath);
+
+        this.commandManager.executeCommand('workbench.action.openIssueReporter', {
+            extensionId: 'ms-python.python',
+            issueBody: template.format(pythonVersion, virtualEnv, languageServer, pythonLogs),
+        });
     }
 }

--- a/src/client/common/application/commands/reportIssueCommand.ts
+++ b/src/client/common/application/commands/reportIssueCommand.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import { inject, injectable } from 'inversify';
 import { IExtensionSingleActivationService } from '../../../activation/types';
-import { ICommandManager, IWorkspaceService } from '../types';
+import { ICommandManager, IDocumentManager, IWorkspaceService } from '../types';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
 import { IInterpreterService, IInterpreterVersionService } from '../../../interpreter/contracts';
 import { identifyEnvironment } from '../../../pythonEnvironments/common/environmentIdentifier';
@@ -22,6 +22,7 @@ export class ReportIssueCommandHandler implements IExtensionSingleActivationServ
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IInterpreterVersionService) private readonly interpreterVersionService: IInterpreterVersionService,
+        @inject(IDocumentManager) private readonly documentManager: IDocumentManager,
     ) {}
 
     public async activate(): Promise<void> {
@@ -30,17 +31,33 @@ export class ReportIssueCommandHandler implements IExtensionSingleActivationServ
 
     private templatePath = path.join(EXTENSION_ROOT_DIR, 'resources', 'report_issue_template.md');
 
-    public async openReportIssue(): Promise<void> {
-        const template = await fs.readFile(this.templatePath, 'utf8');
-        const interpreterPath = (await this.interpreterService.getActiveInterpreter())?.path || 'not-selected';
-        const pythonVersion = await this.interpreterVersionService.getVersion(interpreterPath, '');
-        const languageServer =
-            this.workspaceService.getConfiguration('python').get<string>('languageServer') || 'Not Found';
-        const virtualEnv = await identifyEnvironment(interpreterPath);
+    private async fillTemplateData(): Promise<void> {
+        return new Promise(() => {
+            setTimeout(async () => {
+                const template = await fs.readFile(this.templatePath, 'utf8');
+                const interpreterPath = (await this.interpreterService.getActiveInterpreter())?.path || 'not-selected';
+                const pythonVersion = await this.interpreterVersionService.getVersion(interpreterPath, '');
+                const languageServer =
+                    this.workspaceService.getConfiguration('python').get<string>('languageServer') || 'Not Found';
+                const virtualEnv = await identifyEnvironment(interpreterPath);
 
-        this.commandManager.executeCommand('workbench.action.openIssueReporter', {
-            extensionId: 'ms-python.python',
-            issueBody: template.format(pythonVersion, virtualEnv, languageServer),
+                // Assumes caller has shown the Python Output window so that textDocuments is populated with our Log file
+                let pythonLogs = '';
+                const doc = this.documentManager.textDocuments.find((td) => td.languageId === 'Log');
+                if (doc) {
+                    pythonLogs = doc.getText();
+                }
+
+                this.commandManager.executeCommand('workbench.action.openIssueReporter', {
+                    extensionId: 'ms-python.python',
+                    issueBody: template.format(pythonVersion, virtualEnv, languageServer, pythonLogs),
+                });
+            }, 1000);
         });
+    }
+
+    public async openReportIssue(): Promise<void> {
+        await this.commandManager.executeCommand('python.viewOutput');
+        return this.fillTemplateData();
     }
 }

--- a/src/client/logging/_global.ts
+++ b/src/client/logging/_global.ts
@@ -9,10 +9,11 @@ import { getFormatter } from './formatters';
 import { LogLevel, resolveLevelName } from './levels';
 import { configureLogger, createLogger, getPreDefinedConfiguration, logToAll } from './logger';
 import { createTracingDecorator, LogInfo, TraceOptions, tracing as _tracing } from './trace';
-import { getPythonOutputChannelTransport } from './transports';
+import { getPythonOutputChannelTransport, IPythonOutputChannelContent } from './transports';
 import { Arguments } from './util';
 
 const globalLogger = createLogger();
+let _globalLoggerContent: IPythonOutputChannelContent;
 initialize();
 
 /**
@@ -61,7 +62,12 @@ export function setLoggingLevel(level: LogLevel | 'off') {
 export function addOutputChannelLogging(channel: IOutputChannel) {
     const formatter = getFormatter();
     const transport = getPythonOutputChannelTransport(channel, formatter);
+    _globalLoggerContent = transport;
     globalLogger.add(transport);
+}
+
+export function getPythonOutputChannelContent(): Promise<string> {
+    return _globalLoggerContent?.getContent() ?? '';
 }
 
 // Emit a log message derived from the args to all enabled transports.

--- a/src/client/logging/index.ts
+++ b/src/client/logging/index.ts
@@ -11,5 +11,6 @@ export {
     logInfo,
     logVerbose,
     logWarning,
+    getPythonOutputChannelContent,
     traceDecorators,
 } from './_global';

--- a/src/test/common/application/commands/issueTemplateVenv1.md
+++ b/src/test/common/application/commands/issueTemplateVenv1.md
@@ -40,7 +40,7 @@ You can attach such things **after** you create your issue on GitHub.
 
 <!-- Run the "Python: Show Output" command to see the requested output. --->
 ```
-XXX
+Python Output
 ```
 
 </p>

--- a/src/test/common/application/commands/reportIssueCommand.unit.test.ts
+++ b/src/test/common/application/commands/reportIssueCommand.unit.test.ts
@@ -6,14 +6,12 @@
 import * as sinon from 'sinon';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import * as TypeMoq from 'typemoq';
-import { TextDocument } from 'vscode';
 import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 import { expect } from 'chai';
 import { LanguageServerType } from '../../../../client/activation/types';
 import { CommandManager } from '../../../../client/common/application/commandManager';
 import { ReportIssueCommandHandler } from '../../../../client/common/application/commands/reportIssueCommand';
-import { ICommandManager, IDocumentManager, IWorkspaceService } from '../../../../client/common/application/types';
+import { ICommandManager, IWorkspaceService } from '../../../../client/common/application/types';
 import { WorkspaceService } from '../../../../client/common/application/workspace';
 import { IInterpreterService, IInterpreterVersionService } from '../../../../client/interpreter/contracts';
 import { InterpreterVersionService } from '../../../../client/interpreter/interpreterVersion';
@@ -22,24 +20,24 @@ import * as EnvIdentifier from '../../../../client/pythonEnvironments/common/env
 import { MockWorkspaceConfiguration } from '../../../startPage/mockWorkspaceConfig';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../../constants';
 import { InterpreterService } from '../../../../client/interpreter/interpreterService';
-import { DocumentManager } from '../../../../client/common/application/documentManager';
+import * as Logging from '../../../../client/logging/_global';
 
 suite('Report Issue Command', () => {
     let reportIssueCommandHandler: ReportIssueCommandHandler;
     let cmdManager: ICommandManager;
     let workspaceService: IWorkspaceService;
     let interpreterVersionService: IInterpreterVersionService;
-    let documentManager: IDocumentManager;
     let interpreterService: IInterpreterService;
     let identifyEnvironmentStub: sinon.SinonStub;
+    let getPythonOutputContentStub: sinon.SinonStub;
 
     setup(async () => {
         interpreterVersionService = mock(InterpreterVersionService);
         workspaceService = mock(WorkspaceService);
         cmdManager = mock(CommandManager);
         interpreterService = mock(InterpreterService);
-        documentManager = mock(DocumentManager);
 
+        when(cmdManager.executeCommand('workbench.action.openIssueReporter', anything())).thenResolve();
         when(interpreterVersionService.getVersion(anything(), anything())).thenResolve('3.9.0');
         when(workspaceService.getConfiguration('python')).thenReturn(
             new MockWorkspaceConfiguration({
@@ -51,49 +49,44 @@ suite('Report Issue Command', () => {
         identifyEnvironmentStub.resolves(PythonEnvKind.Venv);
 
         cmdManager = mock(CommandManager);
+
+        getPythonOutputContentStub = sinon.stub(Logging, 'getPythonOutputChannelContent');
+        getPythonOutputContentStub.resolves('Python Output');
         reportIssueCommandHandler = new ReportIssueCommandHandler(
             instance(cmdManager),
             instance(workspaceService),
             instance(interpreterService),
             instance(interpreterVersionService),
-            instance(documentManager),
         );
-
-        const document = TypeMoq.Mock.ofType<TextDocument>();
-        document.setup((doc) => doc.getText(TypeMoq.It.isAny())).returns(() => 'Python Output');
-        document.setup((d) => d.languageId).returns(() => 'Log');
-        when(documentManager.textDocuments).thenReturn([document.object]);
-
-        when(cmdManager.executeCommand('python.viewOutput')).thenReturn(Promise.resolve());
-        when(cmdManager.executeCommand('workbench.action.openIssueReporter', anything())).thenResolve();
         await reportIssueCommandHandler.activate();
     });
 
     teardown(() => {
         identifyEnvironmentStub.restore();
+        getPythonOutputContentStub.restore();
     });
 
     test('Test if issue body is filled', async () => {
-        reportIssueCommandHandler.openReportIssue().then(() => {
-            const templatePath = path.join(
-                EXTENSION_ROOT_DIR_FOR_TESTS,
-                'src',
-                'test',
-                'common',
-                'application',
-                'commands',
-                'issueTemplateVenv1.md',
-            );
-            const expectedIssueBody = fs.readFileSync(templatePath, 'utf8');
+        await reportIssueCommandHandler.openReportIssue();
 
-            const args: [string, { extensionId: string; issueBody: string }] = capture<
-                string,
-                { extensionId: string; issueBody: string }
-            >(cmdManager.executeCommand).last();
+        const templatePath = path.join(
+            EXTENSION_ROOT_DIR_FOR_TESTS,
+            'src',
+            'test',
+            'common',
+            'application',
+            'commands',
+            'issueTemplateVenv1.md',
+        );
+        const expectedIssueBody = fs.readFileSync(templatePath, 'utf8');
 
-            verify(cmdManager.registerCommand('python.reportIssue', anything(), anything())).once();
-            verify(cmdManager.executeCommand('workbench.action.openIssueReporter', anything())).once();
-            expect(args[1].issueBody).to.be.equal(expectedIssueBody);
-        });
+        const args: [string, { extensionId: string; issueBody: string }] = capture<
+            string,
+            { extensionId: string; issueBody: string }
+        >(cmdManager.executeCommand).last();
+
+        verify(cmdManager.registerCommand('python.reportIssue', anything(), anything())).once();
+        verify(cmdManager.executeCommand('workbench.action.openIssueReporter', anything())).once();
+        expect(args[1].issueBody).to.be.equal(expectedIssueBody);
     });
 });

--- a/src/test/common/application/commands/reportIssueCommand.unit.test.ts
+++ b/src/test/common/application/commands/reportIssueCommand.unit.test.ts
@@ -6,12 +6,14 @@
 import * as sinon from 'sinon';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { anyString, anything, capture, instance, mock, verify, when } from 'ts-mockito';
+import * as TypeMoq from 'typemoq';
+import { TextDocument } from 'vscode';
+import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 import { expect } from 'chai';
 import { LanguageServerType } from '../../../../client/activation/types';
 import { CommandManager } from '../../../../client/common/application/commandManager';
 import { ReportIssueCommandHandler } from '../../../../client/common/application/commands/reportIssueCommand';
-import { ICommandManager, IWorkspaceService } from '../../../../client/common/application/types';
+import { ICommandManager, IDocumentManager, IWorkspaceService } from '../../../../client/common/application/types';
 import { WorkspaceService } from '../../../../client/common/application/workspace';
 import { IInterpreterService, IInterpreterVersionService } from '../../../../client/interpreter/contracts';
 import { InterpreterVersionService } from '../../../../client/interpreter/interpreterVersion';
@@ -20,12 +22,14 @@ import * as EnvIdentifier from '../../../../client/pythonEnvironments/common/env
 import { MockWorkspaceConfiguration } from '../../../startPage/mockWorkspaceConfig';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../../constants';
 import { InterpreterService } from '../../../../client/interpreter/interpreterService';
+import { DocumentManager } from '../../../../client/common/application/documentManager';
 
 suite('Report Issue Command', () => {
     let reportIssueCommandHandler: ReportIssueCommandHandler;
     let cmdManager: ICommandManager;
     let workspaceService: IWorkspaceService;
     let interpreterVersionService: IInterpreterVersionService;
+    let documentManager: IDocumentManager;
     let interpreterService: IInterpreterService;
     let identifyEnvironmentStub: sinon.SinonStub;
 
@@ -34,6 +38,7 @@ suite('Report Issue Command', () => {
         workspaceService = mock(WorkspaceService);
         cmdManager = mock(CommandManager);
         interpreterService = mock(InterpreterService);
+        documentManager = mock(DocumentManager);
 
         when(interpreterVersionService.getVersion(anything(), anything())).thenResolve('3.9.0');
         when(workspaceService.getConfiguration('python')).thenReturn(
@@ -51,9 +56,16 @@ suite('Report Issue Command', () => {
             instance(workspaceService),
             instance(interpreterService),
             instance(interpreterVersionService),
+            instance(documentManager),
         );
 
-        when(cmdManager.executeCommand(anyString(), anything())).thenResolve();
+        const document = TypeMoq.Mock.ofType<TextDocument>();
+        document.setup((doc) => doc.getText(TypeMoq.It.isAny())).returns(() => 'Python Output');
+        document.setup((d) => d.languageId).returns(() => 'Log');
+        when(documentManager.textDocuments).thenReturn([document.object]);
+
+        when(cmdManager.executeCommand('python.viewOutput')).thenReturn(Promise.resolve());
+        when(cmdManager.executeCommand('workbench.action.openIssueReporter', anything())).thenResolve();
         await reportIssueCommandHandler.activate();
     });
 
@@ -62,26 +74,26 @@ suite('Report Issue Command', () => {
     });
 
     test('Test if issue body is filled', async () => {
-        await reportIssueCommandHandler.openReportIssue();
+        reportIssueCommandHandler.openReportIssue().then(() => {
+            const templatePath = path.join(
+                EXTENSION_ROOT_DIR_FOR_TESTS,
+                'src',
+                'test',
+                'common',
+                'application',
+                'commands',
+                'issueTemplateVenv1.md',
+            );
+            const expectedIssueBody = fs.readFileSync(templatePath, 'utf8');
 
-        const templatePath = path.join(
-            EXTENSION_ROOT_DIR_FOR_TESTS,
-            'src',
-            'test',
-            'common',
-            'application',
-            'commands',
-            'issueTemplateVenv1.md',
-        );
-        const expectedIssueBody = fs.readFileSync(templatePath, 'utf8');
+            const args: [string, { extensionId: string; issueBody: string }] = capture<
+                string,
+                { extensionId: string; issueBody: string }
+            >(cmdManager.executeCommand).last();
 
-        const args: [string, { extensionId: string; issueBody: string }] = capture<
-            string,
-            { extensionId: string; issueBody: string }
-        >(cmdManager.executeCommand).last();
-
-        verify(cmdManager.registerCommand('python.reportIssue', anything(), anything())).once();
-        verify(cmdManager.executeCommand('workbench.action.openIssueReporter', anything())).once();
-        expect(args[1].issueBody).to.be.equal(expectedIssueBody);
+            verify(cmdManager.registerCommand('python.reportIssue', anything(), anything())).once();
+            verify(cmdManager.executeCommand('workbench.action.openIssueReporter', anything())).once();
+            expect(args[1].issueBody).to.be.equal(expectedIssueBody);
+        });
     });
 });


### PR DESCRIPTION
Automatically add python output log in issue template. Closed [#187](https://github.com/microsoft/vscode-python-internalbacklog/issues/187).