### PR TITLE
Add an "enumDescriptions" key to describe all language server options

### DIFF
--- a/news/1 Enhancements/16141.md
+++ b/news/1 Enhancements/16141.md
@@ -1,0 +1,1 @@
+Add an `enumDescriptions` key under the `python.languageServer` setting to describe all language server options.

--- a/package.json
+++ b/package.json
@@ -1257,6 +1257,14 @@
                         "Microsoft",
                         "None"
                     ],
+                    "enumDescriptions": [
+                        "Automatically select a language server: Pylance if installed and available, otherwise fallback to Jedi.",
+                        "Use Jedi as a language server.",
+                        "Use Jedi behind the Language Server Protocol (LSP) as a language server.",
+                        "Use Pylance as a language server.",
+                        "Use the Microsoft Python Language Server (MPLS) as a language server. (legacy)",
+                        "Disable language server capabilities."
+                    ],
                     "default": "Default",
                     "description": "Defines type of the language server.",
                     "scope": "window"


### PR DESCRIPTION
Closes #16141

Preview:

<img width="329" alt="Screen Shot 2021-05-13 at 9 24 42 AM" src="https://user-images.githubusercontent.com/51720070/118161849-eb79d180-b3d4-11eb-9d32-3833a58fe114.png">
