### PR TITLE
Fix Pylance Python 2 mistake

### DIFF
--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -250,9 +250,10 @@ export class LanguageServerExtensionActivationService
             }
         }
 
-        // If "Pylance" was explicitly chosen, use it even though it's not guaranteed to work
-        // properly with Python 2.
-        if (!this.getCurrentLanguageServerTypeIsDefault()) {
+        // If Pylance was chosen via the default and the interpreter is Python 2, fall back to
+        // Jedi. If Pylance was explicitly chosen, continue anyway, even if Pylance won't work
+        // as expected, matching pre-default behavior.
+        if (this.getCurrentLanguageServerTypeIsDefault()) {
             if (serverType === LanguageServerType.Node && interpreter && interpreter.version) {
                 if (interpreter.version.major < 3) {
                     sendTelemetryEvent(EventName.JEDI_FALLBACK);


### PR DESCRIPTION
I made a mistake in #16210 by flipping the condition. My comment was right, but the code actually went and applied the rule to people who explicitly set the setting, versus those who did not.

I think I oopsed because in an early revision, I wasn't tracking "is default", but "is explicitly set". Maybe the latter would have made more sense.