### PR TITLE
Flag that we don't support virtual workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "capabilities": {
         "untrustedWorkspaces": {
             "supported": false
-        }
+        },
+        "virtualWorkspaces": false
     },
     "languageServerVersion": "0.5.30",
     "publisher": "ms-python",


### PR DESCRIPTION
We are already on a blocklist that ships with VS Code, so this just makes the block under our control.

Details about virtual workspaces can be found at https://github.com/microsoft/vscode/wiki/Virtual-Workspaces.

Fixes #16177