### PR TITLE
Bandit has no {col} tag

### DIFF
--- a/src/client/linters/bandit.ts
+++ b/src/client/linters/bandit.ts
@@ -28,7 +28,7 @@ export class Bandit extends BaseLinter {
                 '-f',
                 'custom',
                 '--msg-template',
-                '{line},{col},{severity},{test_id}:{msg}',
+                '{line},0,{severity},{test_id}:{msg}',
                 '-n',
                 '-1',
                 document.uri.fsPath,


### PR DESCRIPTION
The col value is being printed into the output for bandit.

##########Linting Output - bandit##########
102,col,LOW,B101:Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.

![image](https://user-images.githubusercontent.com/9027725/119908765-612b8480-bf21-11eb-97fc-8c8793e759f4.png)


Bandit Documentation
![image](https://user-images.githubusercontent.com/9027725/119908776-6688cf00-bf21-11eb-98ef-df40e2e994ee.png)
