### PR TITLE
Use the same "Jupyter is not installed" message everywhere

### DIFF
--- a/src/client/common/application/commandManager.ts
+++ b/src/client/common/application/commandManager.ts
@@ -1,18 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { inject, injectable } from 'inversify';
+import { injectable } from 'inversify';
 import { commands, Disposable, TextEditor, TextEditorEdit } from 'vscode';
-import { IJupyterNotInstalledNotificationHelper, JupyterNotInstalledOrigin } from '../../jupyter/types';
 import { ICommandNameArgumentTypeMapping } from './commands';
 import { ICommandManager } from './types';
 
 @injectable()
 export class CommandManager implements ICommandManager {
-    constructor(
-        @inject(IJupyterNotInstalledNotificationHelper)
-        private jupyterNotInstalledNotificationHelper: IJupyterNotInstalledNotificationHelper,
-    ) {}
+    constructor() {}
 
     /**
      * Registers a command that can be invoked via a keyboard shortcut,
@@ -74,16 +70,7 @@ export class CommandManager implements ICommandManager {
         E extends keyof ICommandNameArgumentTypeMapping,
         U extends ICommandNameArgumentTypeMapping[E]
     >(command: E, ...rest: U): Thenable<T | undefined> {
-        if (
-            command.includes('jupyter') &&
-            !this.jupyterNotInstalledNotificationHelper.shouldShowJupypterExtensionNotInstalledPrompt()
-        ) {
-            return this.jupyterNotInstalledNotificationHelper
-                .showJupyterNotInstalledPrompt(JupyterNotInstalledOrigin.JupyterCommand)
-                .then(() => undefined);
-        } else {
-            return commands.executeCommand<T>(command, ...rest);
-        }
+        return commands.executeCommand<T>(command, ...rest);
     }
 
     /**

--- a/src/client/common/application/types.ts
+++ b/src/client/common/application/types.ts
@@ -488,7 +488,6 @@ export interface ICommandManager {
 export const IJupyterExtensionDependencyManager = Symbol('IJupyterExtensionDependencyManager');
 export interface IJupyterExtensionDependencyManager {
     readonly isJupyterExtensionInstalled: boolean;
-    installJupyterExtension(commandManager: ICommandManager): Promise<undefined>;
 }
 
 export const IDocumentManager = Symbol('IDocumentManager');

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -137,11 +137,6 @@ export namespace Pylance {
 }
 
 export namespace Jupyter {
-    export const jupyterExtensionRequired = localize(
-        'Jupyter.extensionRequired',
-        'The Jupyter extension is required to perform that task. Click Yes to open the Jupyter extension installation page.',
-    );
-
     export const jupyterExtensionNotInstalled = localize(
         'Jupyter.extensionNotInstalled',
         "This feature is available in the Jupyter extension, which isn't currently installed.",

--- a/src/client/jupyter/jupyterExtensionDependencyManager.ts
+++ b/src/client/jupyter/jupyterExtensionDependencyManager.ts
@@ -1,27 +1,13 @@
 import { inject, injectable } from 'inversify';
-import { IApplicationShell, ICommandManager, IJupyterExtensionDependencyManager } from '../common/application/types';
+import { IJupyterExtensionDependencyManager } from '../common/application/types';
 import { JUPYTER_EXTENSION_ID } from '../common/constants';
 import { IExtensions } from '../common/types';
-import { Common, Jupyter } from '../common/utils/localize';
 
 @injectable()
 export class JupyterExtensionDependencyManager implements IJupyterExtensionDependencyManager {
-    constructor(
-        @inject(IExtensions) private extensions: IExtensions,
-        @inject(IApplicationShell) private appShell: IApplicationShell,
-    ) {}
+    constructor(@inject(IExtensions) private extensions: IExtensions) {}
 
     public get isJupyterExtensionInstalled(): boolean {
         return this.extensions.getExtension(JUPYTER_EXTENSION_ID) !== undefined;
-    }
-
-    public async installJupyterExtension(commandManager: ICommandManager): Promise<undefined> {
-        const yes = Common.bannerLabelYes();
-        const no = Common.bannerLabelNo();
-        const answer = await this.appShell.showErrorMessage(Jupyter.jupyterExtensionRequired(), yes, no);
-        if (answer === yes) {
-            commandManager.executeCommand('extension.open', JUPYTER_EXTENSION_ID);
-        }
-        return undefined;
     }
 }

--- a/src/client/jupyter/jupyterNotInstalledNotificationHelper.ts
+++ b/src/client/jupyter/jupyterNotInstalledNotificationHelper.ts
@@ -31,7 +31,7 @@ export class JupyterNotInstalledNotificationHelper implements IJupyterNotInstall
         return !isInstalled;
     }
 
-    public async jupyterNotInstalledPrompt(entrypoint: JupyterNotInstalledOrigin): Promise<void> {
+    public async showJupyterNotInstalledPrompt(entrypoint: JupyterNotInstalledOrigin): Promise<void> {
         sendTelemetryEvent(EventName.JUPYTER_NOT_INSTALLED_NOTIFICATION_DISPLAYED, undefined, { entrypoint });
 
         const prompts = [Common.doNotShowAgain()];

--- a/src/client/jupyter/types.ts
+++ b/src/client/jupyter/types.ts
@@ -57,5 +57,5 @@ export enum JupyterNotInstalledOrigin {
 export const IJupyterNotInstalledNotificationHelper = Symbol('IJupyterNotInstalledNotificationHelper');
 export interface IJupyterNotInstalledNotificationHelper {
     shouldShowJupypterExtensionNotInstalledPrompt(): boolean;
-    jupyterNotInstalledPrompt(entrypoint: JupyterNotInstalledOrigin): Promise<void>;
+    showJupyterNotInstalledPrompt(entrypoint: JupyterNotInstalledOrigin): Promise<void>;
 }

--- a/src/client/jupyter/types.ts
+++ b/src/client/jupyter/types.ts
@@ -52,6 +52,7 @@ export enum JupyterNotInstalledOrigin {
     StartPageCreateJupyterNotebook = 'startpage_create_jupyter_notebook',
     StartPageCreateSampleNotebook = 'startpage_sample_notebook',
     StartPageUseInteractiveWindow = 'startpage_use_interactive_window',
+    JupyterCommand = 'jupyter_command',
 }
 
 export const IJupyterNotInstalledNotificationHelper = Symbol('IJupyterNotInstalledNotificationHelper');

--- a/src/client/jupyter/types.ts
+++ b/src/client/jupyter/types.ts
@@ -52,7 +52,6 @@ export enum JupyterNotInstalledOrigin {
     StartPageCreateJupyterNotebook = 'startpage_create_jupyter_notebook',
     StartPageCreateSampleNotebook = 'startpage_sample_notebook',
     StartPageUseInteractiveWindow = 'startpage_use_interactive_window',
-    JupyterCommand = 'jupyter_command',
 }
 
 export const IJupyterNotInstalledNotificationHelper = Symbol('IJupyterNotInstalledNotificationHelper');

--- a/src/test/jupyter/jupyterNotInstalledNotificationHelper.unit.test.ts
+++ b/src/test/jupyter/jupyterNotInstalledNotificationHelper.unit.test.ts
@@ -110,7 +110,7 @@ suite('Jupyter not installed notification helper', () => {
             ({ createGlobalPersistentState: createGlobalPersistentStateStub } as unknown) as IPersistentStateFactory,
             {} as IJupyterExtensionDependencyManager,
         );
-        await notificationHelper.jupyterNotInstalledPrompt(JupyterNotInstalledOrigin.StartPageCreateBlankNotebook);
+        await notificationHelper.showJupyterNotInstalledPrompt(JupyterNotInstalledOrigin.StartPageCreateBlankNotebook);
 
         sinon.assert.calledOnce(createGlobalPersistentStateStub);
         sinon.assert.calledOnce(showInformationMessageStub);
@@ -142,7 +142,7 @@ suite('Jupyter not installed notification helper', () => {
             ({ createGlobalPersistentState: createGlobalPersistentStateStub } as unknown) as IPersistentStateFactory,
             {} as IJupyterExtensionDependencyManager,
         );
-        await notificationHelper.jupyterNotInstalledPrompt(JupyterNotInstalledOrigin.StartPageCreateBlankNotebook);
+        await notificationHelper.showJupyterNotInstalledPrompt(JupyterNotInstalledOrigin.StartPageCreateBlankNotebook);
 
         const result = notificationHelper.shouldShowJupypterExtensionNotInstalledPrompt();
 


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/16102

This PR does 2 things:
- `jupyterNotInstalledPrompt` -> `showJupyterNotInstalledPrompt` in  `src/client/jupyter/jupyterNotInstalledNotificationHelper.ts` 
- remove `installJupyterExtension` from `src/client/jupyter/jupyterExtensionDependencyManager.ts`
