### PR TITLE
Remove deprecated `NotebookCellData` constructor parameter

### DIFF
--- a/src/test/insiders/languageServer.insiders.test.ts
+++ b/src/test/insiders/languageServer.insiders.test.ts
@@ -101,7 +101,7 @@ suite('Insiders Test: Language Server', () => {
                 expect(activeEditor).not.to.be.equal(undefined, 'Active editor not found in notebook');
                 await activeEditor!.edit((edit) => {
                     edit.replaceCells(0, 0, [
-                        new vscode.NotebookCellData(vscode.NotebookCellKind.Code, PYTHON_LANGUAGE, 'x = 4', []),
+                        new vscode.NotebookCellData(vscode.NotebookCellKind.Code, PYTHON_LANGUAGE, 'x = 4'),
                     ]);
                 });
 
@@ -116,7 +116,7 @@ suite('Insiders Test: Language Server', () => {
                 await activeEditor!.edit((edit) => {
                     edit.replaceCells(0, 1, []);
                     edit.replaceCells(1, 0, [
-                        new vscode.NotebookCellData(vscode.NotebookCellKind.Code, PYTHON_LANGUAGE, 'x = 4', []),
+                        new vscode.NotebookCellData(vscode.NotebookCellKind.Code, PYTHON_LANGUAGE, 'x = 4'),
                     ]);
                 });
 


### PR DESCRIPTION
This is just an update to test code for notebook definitions. This will turn into a compile error when the new VS Code build ships, as the new constructor signature is as follows: https://github.com/microsoft/vscode/blob/4cae67137147e35decd91f4ba6a3e62dc8a62825/src/vs/vscode.d.ts#L11717