### PR TITLE
Ensure selected interpreter doesn't change when the extension is loading when in experiment

### DIFF
--- a/news/2 Fixes/16291.md
+++ b/news/2 Fixes/16291.md
@@ -1,0 +1,1 @@
+Ensure selected interpreter doesn't change when the extension is starting up and in experiment.

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -619,7 +619,7 @@ export class PythonSettings implements IPythonSettings {
         }
     }
 
-    protected initialize(): void {
+    public initialize(): void {
         const onDidChange = () => {
             const currentConfig = this.workspace.getConfiguration('python', this.workspaceRoot);
             this.update(currentConfig);

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -205,6 +205,7 @@ export interface IPythonSettings {
     readonly logging: ILoggingSettings;
     readonly useIsolation: boolean;
     readonly tensorBoard: ITensorBoardSettings | undefined;
+    initialize(): void;
 }
 
 export interface ITensorBoardSettings {

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -175,6 +175,8 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
     const manager = serviceContainer.get<IExtensionActivationManager>(IExtensionActivationManager);
     context.subscriptions.push(manager);
 
+    // Settings are dependent on Experiment service, so we need to initialize it after experiments are activated.
+    serviceContainer.get<IConfigurationService>(IConfigurationService).getSettings().initialize();
     await interpreterManager
         .refresh(workspaceService.hasWorkspaceFolders ? workspaceService.workspaceFolders![0].uri : undefined)
         .catch((ex) => traceError('Python Extension: interpreterManager.refresh', ex));

--- a/src/test/common/configSettings/configSettings.pythonPath.unit.test.ts
+++ b/src/test/common/configSettings/configSettings.pythonPath.unit.test.ts
@@ -27,7 +27,7 @@ suite('Python Settings - pythonPath', () => {
         protected getPythonExecutable(pythonPath: string) {
             return pythonPath;
         }
-        protected initialize() {
+        public initialize() {
             noop();
         }
     }

--- a/src/test/common/configSettings/configSettings.unit.test.ts
+++ b/src/test/common/configSettings/configSettings.unit.test.ts
@@ -33,7 +33,7 @@ suite('Python Settings', async () => {
         public update(pythonSettings: WorkspaceConfiguration) {
             return super.update(pythonSettings);
         }
-        protected initialize() {
+        public initialize() {
             noop();
         }
     }


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/16291 closes https://github.com/microsoft/vscode-python-internalbacklog/issues/263 Could potentially fix https://github.com/microsoft/vscode-python/issues/16291 and https://github.com/microsoft/vscode-python-internalbacklog/issues/256.

Due to design issues that are not trivial to address, configuration settings are initialized in the constructor when creating the classes, when experiment service is not activated.

We need to initialize it again once experiments service is activated before using it. Only after that we can access the `pythonPath` setting using it, which was the bug.