### PR TITLE
Parse pypy versions on windows

### DIFF
--- a/src/client/pythonEnvironments/discovery/locators/services/pyenvLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/pyenvLocator.ts
@@ -169,11 +169,15 @@ function getKnownPyenvVersionParsers(): Map<string, (path: string) => Promise<IP
 
         if (
             parts.length === 3 &&
-            (parts[2].startsWith('src') || parts[2].startsWith('beta') || parts[2].startsWith('alpha'))
+            (parts[2].startsWith('src') ||
+                parts[2].startsWith('beta') ||
+                parts[2].startsWith('alpha') ||
+                parts[2].startsWith('win64'))
         ) {
+            const part1 = parts[1].startsWith('v') ? parts[1].substr(1) : parts[1];
             return Promise.resolve({
                 pythonVer,
-                distroVer: `${parts[1]}-${parts[2]}`,
+                distroVer: `${part1}-${parts[2]}`,
                 distro: 'pypy',
             });
         }

--- a/src/test/pythonEnvironments/discovery/locators/pyenvLocator.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/pyenvLocator.unit.test.ts
@@ -249,6 +249,14 @@ suite('Pyenv Versions Parser Test', () => {
         { input: 'pypy3.6-7.3.1-src', expectedOutput: { pythonVer: '3.6', distro: 'pypy', distroVer: '7.3.1-src' } },
         { input: 'pypy3.6-7.3.1', expectedOutput: { pythonVer: '3.6', distro: 'pypy', distroVer: '7.3.1' } },
         {
+            input: 'pypy3.7-v7.3.5rc3-win64',
+            expectedOutput: { pythonVer: '3.7', distro: 'pypy', distroVer: '7.3.5rc3-win64' },
+        },
+        {
+            input: 'pypy3.7-v7.3.5-win64',
+            expectedOutput: { pythonVer: '3.7', distro: 'pypy', distroVer: '7.3.5-win64' },
+        },
+        {
             input: 'pypy-5.7.1-beta-src',
             expectedOutput: { pythonVer: undefined, distro: 'pypy', distroVer: '5.7.1-beta-src' },
         },


### PR DESCRIPTION
I found this gap in our parsing while investigating a user issue on this. 