### PR TITLE
Recommend >= 0.2.0 of `torch-tb-profiler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
    ([#16102](https://github.com/Microsoft/vscode-python/issues/16102))
 1. Add an `enumDescriptions` key under the `python.languageServer` setting to describe all language server options.
    ([#16141](https://github.com/Microsoft/vscode-python/issues/16141))
+1. Ensure users upgrade to v0.2.0 of the torch-tb-profiler TensorBoard plugin to access jump-to-source functionality.
+   ([#16330](https://github.com/Microsoft/vscode-python/issues/16339))
 
 ### Fixes
 

--- a/news/1 Enhancements/16330.md
+++ b/news/1 Enhancements/16330.md
@@ -1,1 +1,0 @@
-Ensure users upgrade to v0.2.0 of the torch-tb-profiler TensorBoard plugin to access jump-to-source functionality.

--- a/news/1 Enhancements/16330.md
+++ b/news/1 Enhancements/16330.md
@@ -1,0 +1,1 @@
+Ensure users upgrade to v0.2.0 of the torch-tb-profiler TensorBoard plugin to access jump-to-source functionality.

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -177,11 +177,11 @@ export namespace TensorBoard {
     );
     export const installTensorBoardAndProfilerPluginPrompt = localize(
         'TensorBoard.installTensorBoardAndProfilerPluginPrompt',
-        'TensorBoard >= 2.4.1 and the PyTorch Profiler TensorBoard plugin are required. Would you like to install these packages?',
+        'TensorBoard >= 2.4.1 and the PyTorch Profiler TensorBoard plugin >= 0.2.0 are required. Would you like to install these packages?',
     );
     export const installProfilerPluginPrompt = localize(
         'TensorBoard.installProfilerPluginPrompt',
-        'We recommend installing the PyTorch Profiler TensorBoard plugin. Would you like to install the package?',
+        'We recommend installing version >= 0.2.0 of the PyTorch Profiler TensorBoard plugin. Would you like to install the package?',
     );
     export const upgradePrompt = localize(
         'TensorBoard.upgradePrompt',

--- a/src/client/tensorBoard/tensorBoardSession.ts
+++ b/src/client/tensorBoard/tensorBoardSession.ts
@@ -143,7 +143,7 @@ export class TensorBoardSession {
 
     private async promptToInstall(
         tensorBoardInstallStatus: ProductInstallStatus,
-        shouldInstallProfilerPlugin: boolean,
+        profilerPluginInstallStatus: ProductInstallStatus,
     ) {
         sendTelemetryEvent(EventName.TENSORBOARD_INSTALL_PROMPT_SHOWN);
         const yes = Common.bannerLabelYes();
@@ -151,10 +151,13 @@ export class TensorBoardSession {
         const isUpgrade = tensorBoardInstallStatus === ProductInstallStatus.NeedsUpgrade;
         let message;
 
-        if (tensorBoardInstallStatus === ProductInstallStatus.Installed && shouldInstallProfilerPlugin) {
+        if (
+            tensorBoardInstallStatus === ProductInstallStatus.Installed &&
+            profilerPluginInstallStatus !== ProductInstallStatus.Installed
+        ) {
             // PyTorch user already has TensorBoard, just ask if they want the profiler plugin
             message = TensorBoard.installProfilerPluginPrompt();
-        } else if (shouldInstallProfilerPlugin) {
+        } else if (profilerPluginInstallStatus !== ProductInstallStatus.Installed) {
             // PyTorch user doesn't have compatible TensorBoard or the profiler plugin
             message = TensorBoard.installTensorBoardAndProfilerPluginPrompt();
         } else if (isUpgrade) {
@@ -194,14 +197,14 @@ export class TensorBoardSession {
         // First see what dependencies we're missing
         let [tensorboardInstallStatus, profilerPluginInstallStatus] = await Promise.all([
             this.installer.isProductVersionCompatible(Product.tensorboard, '>= 2.4.1', interpreter),
-            this.installer.isInstalled(Product.torchProfilerImportName, interpreter),
+            this.installer.isProductVersionCompatible(Product.torchProfilerImportName, '>= 0.2.0', interpreter),
         ]);
         const isTorchUserAndInExperiment = ImportTracker.hasModuleImport('torch') && this.isInTorchProfilerExperiment;
         const needsTensorBoardInstall = tensorboardInstallStatus !== ProductInstallStatus.Installed;
-        const needsProfilerPluginInstall = isTorchUserAndInExperiment && profilerPluginInstallStatus !== true;
+        const needsProfilerPluginInstall = profilerPluginInstallStatus !== ProductInstallStatus.Installed;
         if (
             // PyTorch user, in profiler install experiment, TensorBoard and profiler plugin already installed
-            (isTorchUserAndInExperiment && !needsTensorBoardInstall && profilerPluginInstallStatus === true) ||
+            (isTorchUserAndInExperiment && !needsTensorBoardInstall && !needsProfilerPluginInstall) ||
             // Not PyTorch user or not in profiler install experiment, so no need for profiler plugin,
             // and TensorBoard is already installed
             (!isTorchUserAndInExperiment && tensorboardInstallStatus === ProductInstallStatus.Installed)
@@ -212,7 +215,7 @@ export class TensorBoardSession {
         // Ask the user if they want to install packages to start a TensorBoard session
         const selection = await this.promptToInstall(
             tensorboardInstallStatus,
-            isTorchUserAndInExperiment && !profilerPluginInstallStatus,
+            isTorchUserAndInExperiment ? profilerPluginInstallStatus : ProductInstallStatus.Installed,
         );
         if (selection !== Common.bannerLabelYes() && !needsTensorBoardInstall) {
             return true;
@@ -243,26 +246,35 @@ export class TensorBoardSession {
                 ),
             );
         }
-        if (needsProfilerPluginInstall) {
-            installPromises.push(this.installer.install(Product.torchProfilerInstallName, interpreter, installerToken));
+        if (isTorchUserAndInExperiment && needsProfilerPluginInstall) {
+            installPromises.push(
+                this.installer.install(
+                    Product.torchProfilerInstallName,
+                    interpreter,
+                    installerToken,
+                    profilerPluginInstallStatus === ProductInstallStatus.NeedsUpgrade
+                        ? ModuleInstallFlags.upgrade
+                        : undefined,
+                ),
+            );
         }
         await Promise.race([...installPromises, cancellationPromise]);
 
         // Check install status again after installing
         [tensorboardInstallStatus, profilerPluginInstallStatus] = await Promise.all([
             this.installer.isProductVersionCompatible(Product.tensorboard, '>= 2.4.1', interpreter),
-            this.installer.isInstalled(Product.torchProfilerImportName, interpreter),
+            this.installer.isProductVersionCompatible(Product.torchProfilerImportName, '>= 0.2.0', interpreter),
         ]);
         // Send telemetry regarding results of install
         sendTelemetryEvent(EventName.TENSORBOARD_PACKAGE_INSTALL_RESULT, undefined, {
             wasTensorBoardAttempted: needsTensorBoardInstall,
             wasProfilerPluginAttempted: needsProfilerPluginInstall,
             wasTensorBoardInstalled: tensorboardInstallStatus === ProductInstallStatus.Installed,
-            wasProfilerPluginInstalled: profilerPluginInstallStatus,
+            wasProfilerPluginInstalled: profilerPluginInstallStatus === ProductInstallStatus.Installed,
         });
         // Profiler plugin is not required to start TensorBoard. If it failed, note that it failed
         // in the log, but report success only based on TensorBoard package install status.
-        if (isTorchUserAndInExperiment && profilerPluginInstallStatus === false) {
+        if (isTorchUserAndInExperiment && profilerPluginInstallStatus !== ProductInstallStatus.Installed) {
             traceError(`Failed to install torch-tb-plugin. Profiler plugin will not appear in TensorBoard session.`);
         }
         return tensorboardInstallStatus === ProductInstallStatus.Installed;


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/16330

This is going directly into the release branch for now, because `torch-tb-profiler` is slated to release 0.2.0 (which contains jump to source support) June 15. We can't merge into main before that as it'll cause users in Insiders to get prompted to upgrade their `torch-tb-profiler` module install when the upgrade is not yet available on PyPI.

I tested this PR, and jump to source support, against their release candidate (`pip install torch-tb-profiler==0.2.0rc3`).

I'll port this change back to main when 0.2.0 is released.