### PR TITLE
Fix go to definition in Python notebooks (#16385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2021.5.3 (10 June 2021)
+
+### Fixes
+
+1. Fix go to definition in Python notebooks.
+   ([#16385](https://github.com/microsoft/vscode-python/issues/16385))
+
 ## 2021.5.2 (14 May 2021)
 
 ### Fixes

--- a/src/client/common/application/notebook.ts
+++ b/src/client/common/application/notebook.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import { DocumentSelector, Event, EventEmitter } from 'vscode';
+import { DocumentSelector, Event, EventEmitter, workspace } from 'vscode';
 import type { notebook, NotebookConcatTextDocument, NotebookDocument } from 'vscode-proposed';
 import { UseProposedApi } from '../constants';
 import { IApplicationEnvironment, IVSCodeNotebook } from './types';
@@ -10,21 +10,22 @@ import { IApplicationEnvironment, IVSCodeNotebook } from './types';
 @injectable()
 export class VSCodeNotebook implements IVSCodeNotebook {
     public get onDidOpenNotebookDocument(): Event<NotebookDocument> {
-        return this.canUseNotebookApi
-            ? this.notebook.onDidOpenNotebookDocument
-            : new EventEmitter<NotebookDocument>().event;
+        const onDidOpenNotebookDocument =
+            this.notebook.onDidOpenNotebookDocument ?? (workspace as any).onDidOpenNotebookDocument;
+        return this.canUseNotebookApi ? onDidOpenNotebookDocument : new EventEmitter<NotebookDocument>().event;
     }
     public get onDidCloseNotebookDocument(): Event<NotebookDocument> {
-        return this.canUseNotebookApi
-            ? this.notebook.onDidCloseNotebookDocument
-            : new EventEmitter<NotebookDocument>().event;
+        const onDidCloseNotebookDocument =
+            this.notebook.onDidCloseNotebookDocument ?? (workspace as any).onDidCloseNotebookDocument;
+        return this.canUseNotebookApi ? onDidCloseNotebookDocument : new EventEmitter<NotebookDocument>().event;
     }
     public get notebookDocuments(): ReadonlyArray<NotebookDocument> {
-        return this.canUseNotebookApi ? this.notebook.notebookDocuments : [];
+        const notebookDocuments = this.notebook.notebookDocuments ?? (workspace as any).notebookDocuments;
+        return this.canUseNotebookApi ? notebookDocuments : [];
     }
     private get notebook() {
         if (!this._notebook) {
-            this._notebook = require('vscode').notebook;
+            this._notebook = require('vscode').notebook ?? require('vscode').notebooks;
         }
         return this._notebook!;
     }

--- a/src/test/initialize.ts
+++ b/src/test/initialize.ts
@@ -69,7 +69,7 @@ export async function closeActiveNotebooks(): Promise<void> {
     }
     // We could have untitled notebooks, close them by reverting changes.
 
-    while ((vscode as any).notebook.activeNotebookEditor || vscode.window.activeTextEditor) {
+    while ((vscode as any).window.activeNotebookEditor || vscode.window.activeTextEditor) {
         await vscode.commands.executeCommand('workbench.action.revertAndCloseActiveEditor');
     }
     // Work around VS Code issues (sometimes notebooks do not get closed).
@@ -102,10 +102,10 @@ async function closeWindowsInteral() {
 
 function isANotebookOpen() {
     if (
-        Array.isArray((vscode as any).notebook.visibleNotebookEditors) &&
-        (vscode as any).notebook.visibleNotebookEditors.length
+        Array.isArray((vscode as any).window.visibleNotebookEditors) &&
+        (vscode as any).window.visibleNotebookEditors.length
     ) {
         return true;
     }
-    return !!(vscode as any).notebook.activeNotebookEditor;
+    return !!(vscode as any).window.activeNotebookEditor;
 }

--- a/src/test/insiders/languageServer.insiders.test.ts
+++ b/src/test/insiders/languageServer.insiders.test.ts
@@ -101,15 +101,7 @@ suite('Insiders Test: Language Server', () => {
                 expect(activeEditor).not.to.be.equal(undefined, 'Active editor not found in notebook');
                 await activeEditor!.edit((edit) => {
                     edit.replaceCells(0, 0, [
-                        new vscode.NotebookCellData(
-                            vscode.NotebookCellKind.Code,
-                            PYTHON_LANGUAGE,
-                            'x = 4',
-                            [],
-                            new vscode.NotebookCellMetadata().with({
-                                hasExecutionOrder: false,
-                            }),
-                        ),
+                        new vscode.NotebookCellData(vscode.NotebookCellKind.Code, PYTHON_LANGUAGE, 'x = 4', []),
                     ]);
                 });
 
@@ -124,15 +116,7 @@ suite('Insiders Test: Language Server', () => {
                 await activeEditor!.edit((edit) => {
                     edit.replaceCells(0, 1, []);
                     edit.replaceCells(1, 0, [
-                        new vscode.NotebookCellData(
-                            vscode.NotebookCellKind.Code,
-                            PYTHON_LANGUAGE,
-                            'x = 4',
-                            [],
-                            new vscode.NotebookCellMetadata().with({
-                                hasExecutionOrder: false,
-                            }),
-                        ),
+                        new vscode.NotebookCellData(vscode.NotebookCellKind.Code, PYTHON_LANGUAGE, 'x = 4', []),
                     ]);
                 });
 

--- a/src/test/insiders/languageServer.insiders.test.ts
+++ b/src/test/insiders/languageServer.insiders.test.ts
@@ -101,7 +101,7 @@ suite('Insiders Test: Language Server', () => {
                 expect(activeEditor).not.to.be.equal(undefined, 'Active editor not found in notebook');
                 await activeEditor!.edit((edit) => {
                     edit.replaceCells(0, 0, [
-                        new vscode.NotebookCellData(vscode.NotebookCellKind.Code, PYTHON_LANGUAGE, 'x = 4', []),
+                        new vscode.NotebookCellData(vscode.NotebookCellKind.Code, PYTHON_LANGUAGE, 'x = 4'),
                     ]);
                 });
 
@@ -116,7 +116,7 @@ suite('Insiders Test: Language Server', () => {
                 await activeEditor!.edit((edit) => {
                     edit.replaceCells(0, 1, []);
                     edit.replaceCells(1, 0, [
-                        new vscode.NotebookCellData(vscode.NotebookCellKind.Code, PYTHON_LANGUAGE, 'x = 4', []),
+                        new vscode.NotebookCellData(vscode.NotebookCellKind.Code, PYTHON_LANGUAGE, 'x = 4'),
                     ]);
                 });
 

--- a/src/test/smoke/datascience.smoke.test.ts
+++ b/src/test/smoke/datascience.smoke.test.ts
@@ -24,9 +24,6 @@ suite('Smoke Test: Datascience', () => {
         await verifyExtensionIsAvailable(JUPYTER_EXTENSION_ID);
         await initialize();
         await setAutoSaveDelayInWorkspaceRoot(1);
-        const jupyterConfig = vscode.workspace.getConfiguration('jupyter', null);
-        await jupyterConfig.update('alwaysTrustNotebooks', true, true);
-
         return undefined;
     });
     setup(initializeTest);


### PR DESCRIPTION
Point fix for language server support in the Python extension in VS Code Stable 1.57.0. This fix was submitted to main but needed to be included in a hotfix release.