### PR TITLE
Add link to docs page on how to install the Python extension to README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A [Visual Studio Code](https://code.visualstudio.com/) [extension](https://marke
 ## Quick start
 
 -   **Step 1.** [Install a supported version of Python on your system](https://code.visualstudio.com/docs/python/python-tutorial#_prerequisites) (note: that the system install of Python on macOS is not supported).
--   **Step 2.** Install the Python extension for Visual Studio Code (https://code.visualstudio.com/docs/editor/extension-gallery).
+-   **Step 2.** [Install the Python extension for Visual Studio Code](https://code.visualstudio.com/docs/editor/extension-gallery).
 -   **Step 3.** Open or create a Python file and start coding!
 
 ## Set up your environment

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A [Visual Studio Code](https://code.visualstudio.com/) [extension](https://marke
 ## Quick start
 
 -   **Step 1.** [Install a supported version of Python on your system](https://code.visualstudio.com/docs/python/python-tutorial#_prerequisites) (note: that the system install of Python on macOS is not supported).
--   **Step 2.** Install the Python extension for Visual Studio Code.
+-   **Step 2.** Install the Python extension for Visual Studio Code (https://code.visualstudio.com/docs/editor/extension-gallery).
 -   **Step 3.** Open or create a Python file and start coding!
 
 ## Set up your environment

--- a/news/2 Fixes/15199.md
+++ b/news/2 Fixes/15199.md
@@ -1,0 +1,1 @@
+Add link to docs page on how to install the Python extension to README.

--- a/news/2 Fixes/15199.md
+++ b/news/2 Fixes/15199.md
@@ -1,1 +1,1 @@
-Add link to docs page on how to install the Python extension to README.
+Add link to docs page on how to install the Python extension to README. (thanks [KamalSinghKhanna](https://github.com/KamalSinghKhanna))


### PR DESCRIPTION
fixes #15199 

I have added link to docs page on how to install the Python extension to README.