### PR TITLE
Remove deprecated setting usage in DS smoke test

### DIFF
--- a/src/test/smoke/datascience.smoke.test.ts
+++ b/src/test/smoke/datascience.smoke.test.ts
@@ -24,8 +24,6 @@ suite('Smoke Test: Datascience', () => {
         await verifyExtensionIsAvailable(JUPYTER_EXTENSION_ID);
         await initialize();
         await setAutoSaveDelayInWorkspaceRoot(1);
-        const jupyterConfig = vscode.workspace.getConfiguration('jupyter', null);
-        await jupyterConfig.update('alwaysTrustNotebooks', true, true);
 
         return undefined;
     });


### PR DESCRIPTION
Following up on https://github.com/microsoft/vscode-python/pull/16440#issuecomment-862645774

This isn't the only part of the smoke tests that needs updating. In the interest of not perturbing the release branch too much I'm just removing the minimum amount of code required to get CI green again.