### PR TITLE
Correctly set `shellIdentificationSource`.

### DIFF
--- a/news/2 Fixes/16517.md
+++ b/news/2 Fixes/16517.md
@@ -1,0 +1,1 @@
+Ensure `shellIdentificationSource` is set correctly. (thanks [intrigus-lgtm](https://github.com/intrigus-lgtm))

--- a/src/client/common/terminal/shellDetectors/settingsShellDetector.ts
+++ b/src/client/common/terminal/shellDetectors/settingsShellDetector.ts
@@ -59,8 +59,9 @@ export class SettingsShellDetector extends BaseShellDetector {
 
         if (shell !== TerminalShellType.other) {
             telemetryProperties.shellIdentificationSource = 'environment';
+        } else {
+            telemetryProperties.shellIdentificationSource = 'settings';
         }
-        telemetryProperties.shellIdentificationSource = 'settings';
         traceVerbose(`Shell path from user settings '${shellPath}'`);
         return shell;
     }


### PR DESCRIPTION
Add an `else` to correctly set `shellIdentificationSource`.
Without an `else`, Line 63 would *always* overwrite 
what has been set previously in Line 61.

Closes #16517