### PR TITLE
Adds support for Pytest run using the new Test UI

### DIFF
--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -93,4 +93,5 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [Commands.Exec_In_Terminal_Icon]: [undefined, Uri];
     [Commands.Tests_Configure]: [undefined, undefined | CommandSource, undefined | Uri];
     [Commands.LaunchTensorBoard]: [TensorBoardEntrypoint, TensorBoardEntrypointTrigger];
+    ['testing.refreshTests']: [];
 }

--- a/src/client/testing/common/types.ts
+++ b/src/client/testing/common/types.ts
@@ -534,14 +534,6 @@ export interface IArgumentsHelper {
     ): string[];
 }
 
-export const ITestResultDisplay = Symbol('ITestResultDisplay');
-export interface ITestResultDisplay extends Disposable {
-    enabled: boolean;
-    readonly onDidChange: Event<void>;
-    displayProgressStatus(testRunResult: Promise<Tests>, debug?: boolean): void;
-    displayDiscoverStatus(testDiscovery: Promise<Tests>, quietMode?: boolean): Promise<Tests>;
-}
-
 export const ITestDisplay = Symbol('ITestDisplay');
 export interface ITestDisplay {
     displayStopTestUI(workspace: Uri, message: string): void;

--- a/src/client/testing/configuration/index.ts
+++ b/src/client/testing/configuration/index.ts
@@ -2,7 +2,7 @@
 
 import { inject, injectable } from 'inversify';
 import { Uri } from 'vscode';
-import { IApplicationShell, IWorkspaceService } from '../../common/application/types';
+import { IApplicationShell, ICommandManager, IWorkspaceService } from '../../common/application/types';
 import { traceError } from '../../common/logger';
 import { IConfigurationService, Product } from '../../common/types';
 import { IServiceContainer } from '../../ioc/types';
@@ -29,10 +29,13 @@ export class UnitTestConfigurationService implements ITestConfigurationService {
 
     private readonly workspaceService: IWorkspaceService;
 
+    private readonly commandManager: ICommandManager;
+
     constructor(@inject(IServiceContainer) private serviceContainer: IServiceContainer) {
         this.configurationService = serviceContainer.get<IConfigurationService>(IConfigurationService);
         this.appShell = serviceContainer.get<IApplicationShell>(IApplicationShell);
         this.workspaceService = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
+        this.commandManager = serviceContainer.get<ICommandManager>(ICommandManager);
     }
 
     public async displayTestFrameworkError(wkspace: Uri): Promise<void> {
@@ -151,6 +154,7 @@ export class UnitTestConfigurationService implements ITestConfigurationService {
                 traceError('Python Extension: applying unit test config updates', exc);
                 telemetryProps.failed = true;
             }
+            await this.commandManager.executeCommand('testing.refreshTests');
         } finally {
             sendTelemetryEvent(EventName.UNITTEST_CONFIGURING, undefined, telemetryProps);
         }

--- a/src/client/testing/configuration/index.ts
+++ b/src/client/testing/configuration/index.ts
@@ -38,13 +38,13 @@ export class UnitTestConfigurationService implements ITestConfigurationService {
         this.commandManager = serviceContainer.get<ICommandManager>(ICommandManager);
     }
 
-    public async displayTestFrameworkError(wkspace: Uri): Promise<void> {
-        const settings = this.configurationService.getSettings(wkspace);
+    public async displayTestFrameworkError(workspace: Uri): Promise<void> {
+        const settings = this.configurationService.getSettings(workspace);
         let enabledCount = settings.testing.pytestEnabled ? 1 : 0;
         enabledCount += settings.testing.unittestEnabled ? 1 : 0;
         if (enabledCount > 1) {
             return this._promptToEnableAndConfigureTestFramework(
-                wkspace,
+                workspace,
                 'Enable only one of the test frameworks (unittest or pytest).',
                 true,
             );
@@ -57,7 +57,7 @@ export class UnitTestConfigurationService implements ITestConfigurationService {
         if (item !== option) {
             throw NONE_SELECTED;
         }
-        return this._promptToEnableAndConfigureTestFramework(wkspace);
+        return this._promptToEnableAndConfigureTestFramework(workspace);
     }
 
     public async selectTestRunner(placeHolderMessage: string): Promise<UnitTestProduct | undefined> {

--- a/src/client/testing/main.ts
+++ b/src/client/testing/main.ts
@@ -32,7 +32,6 @@ import {
     ITestDisplay,
     TestFile,
     TestFunction,
-    ITestResultDisplay,
     ITestsHelper,
     TestStatus,
     TestsToRun,
@@ -63,7 +62,6 @@ export class UnitTestManagementService implements ITestManagementService, IExten
     private workspaceTestManagerService?: IWorkspaceTestManagerService;
     private documentManager: IDocumentManager;
     private workspaceService: IWorkspaceService;
-    private testResultDisplay?: ITestResultDisplay;
     private autoDiscoverTimer?: NodeJS.Timer | number;
     private configChangedTimer?: NodeJS.Timer | number;
     private testManagers = new Set<ITestManager>();
@@ -167,18 +165,11 @@ export class UnitTestManagementService implements ITestManagementService, IExten
             .get<IConfigurationService>(IConfigurationService)
             .getSettings(workspaceUri);
         if (!settings.testing.pytestEnabled && !settings.testing.unittestEnabled) {
-            if (this.testResultDisplay) {
-                this.testResultDisplay.enabled = false;
-            }
-
             // TODO: Why are we disposing, what happens when tests are enabled.
             if (this.workspaceTestManagerService) {
                 this.workspaceTestManagerService.dispose();
             }
             return;
-        }
-        if (this.testResultDisplay) {
-            this.testResultDisplay.enabled = true;
         }
         this.autoDiscoverTests(workspaceUri).catch((ex) =>
             traceError('Failed to auto discover tests upon activation', ex),
@@ -239,9 +230,6 @@ export class UnitTestManagementService implements ITestManagementService, IExten
             return;
         }
 
-        if (!this.testResultDisplay) {
-            this.testResultDisplay = this.serviceContainer.get<ITestResultDisplay>(ITestResultDisplay);
-        }
         const discoveryPromise = testManager.discoverTests(
             cmdSource,
             ignoreCache,
@@ -249,9 +237,6 @@ export class UnitTestManagementService implements ITestManagementService, IExten
             userInitiated,
             clearTestStatus,
         );
-        this.testResultDisplay
-            .displayDiscoverStatus(discoveryPromise, quietMode)
-            .catch((ex) => traceError('Python Extension: displayDiscoverStatus', ex));
         await discoveryPromise;
     }
     public async stopTests(resource: Uri) {
@@ -321,10 +306,6 @@ export class UnitTestManagementService implements ITestManagementService, IExten
             return;
         }
 
-        if (!this.testResultDisplay) {
-            this.testResultDisplay = this.serviceContainer.get<ITestResultDisplay>(ITestResultDisplay);
-        }
-
         const promise = testManager.runTest(cmdSource, testsToRun, runFailedTests, debug).catch((reason) => {
             if (reason !== CANCELLATION_REASON) {
                 this.outputChannel.appendLine(`Error: ${reason}`);
@@ -332,7 +313,6 @@ export class UnitTestManagementService implements ITestManagementService, IExten
             return Promise.reject(reason);
         });
 
-        this.testResultDisplay.displayProgressStatus(promise, debug);
         await promise;
     }
 

--- a/src/client/testing/main.ts
+++ b/src/client/testing/main.ts
@@ -20,7 +20,7 @@ import { IInterpreterService } from '../interpreter/contracts';
 import { IServiceContainer } from '../ioc/types';
 import { EventName } from '../telemetry/constants';
 import { captureTelemetry, sendTelemetryEvent } from '../telemetry/index';
-import { CANCELLATION_REASON } from './common/constants';
+import { CANCELLATION_REASON, PYTEST_PROVIDER } from './common/constants';
 import { selectTestWorkspace } from './common/testUtils';
 import { TestSettingsPropertyNames } from './configuration/types';
 import {
@@ -43,6 +43,7 @@ import { ITestingService } from './types';
 import { PythonTestController } from './testController/controller';
 import { IExtensionActivationService } from '../activation/types';
 import { CommandSource } from '../common/constants';
+import { ITestController } from './testController/common/types';
 
 @injectable()
 export class TestingService implements ITestingService {
@@ -108,7 +109,11 @@ export class UnitTestManagementService implements ITestManagementService, IExten
         );
 
         if (test && test.registerTestController) {
-            this.disposableRegistry.push(test.registerTestController(new PythonTestController()));
+            const controller = new PythonTestController(
+                this.serviceContainer.get<IConfigurationService>(IConfigurationService),
+                this.serviceContainer.get<ITestController>(ITestController, PYTEST_PROVIDER),
+            );
+            this.disposableRegistry.push(test.registerTestController(controller));
         }
     }
     public async getTestManager(

--- a/src/client/testing/serviceRegistry.ts
+++ b/src/client/testing/serviceRegistry.ts
@@ -60,6 +60,7 @@ import { TestManagerRunner as PytestManagerRunner } from './pytest/runner';
 import { ArgumentsService as PyTestArgumentsService } from './pytest/services/argsService';
 import { TestDiscoveryService as PytestTestDiscoveryService } from './pytest/services/discoveryService';
 import { TestMessageService } from './pytest/services/testMessageService';
+import { registerTestControllerTypes } from './testController/serviceRegistry';
 import { ITestingService, TestProvider } from './types';
 import { UnitTestHelper } from './unittest/helper';
 import { TestManager as UnitTestTestManager } from './unittest/main';
@@ -150,4 +151,6 @@ export function registerTypes(serviceManager: IServiceManager) {
             return new TestManagerService(workspaceFolder, testsHelper, serviceContainer);
         };
     });
+
+    registerTestControllerTypes(serviceManager);
 }

--- a/src/client/testing/testController/common/discoveryHelper.ts
+++ b/src/client/testing/testController/common/discoveryHelper.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { inject, injectable } from 'inversify';
 import {
     ExecutionFactoryCreateWithEnvironmentOptions,
     IPythonExecutionFactory,
@@ -10,8 +11,9 @@ import { RawDiscoveredTests } from '../../common/services/types';
 import { TestDiscoveryOptions } from '../../common/types';
 import { ITestDiscoveryHelper } from './types';
 
+@injectable()
 export class TestDiscoveryHelper implements ITestDiscoveryHelper {
-    constructor(private readonly pythonExecFactory: IPythonExecutionFactory) {}
+    constructor(@inject(IPythonExecutionFactory) private readonly pythonExecFactory: IPythonExecutionFactory) {}
 
     public async runTestDiscovery(options: TestDiscoveryOptions): Promise<RawDiscoveredTests[]> {
         const creationOptions: ExecutionFactoryCreateWithEnvironmentOptions = {

--- a/src/client/testing/testController/common/externalDependencies.ts
+++ b/src/client/testing/testController/common/externalDependencies.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as tmp from 'tmp';
+import { TemporaryFile } from '../../../common/platform/types';
+
+export function createTemporaryFile(ext = '.tmp'): Promise<TemporaryFile> {
+    return new Promise<TemporaryFile>((resolve, reject) => {
+        tmp.file({ postfix: ext }, (err, filename, _fd, cleanUp): void => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve({
+                    filePath: filename,
+                    dispose: cleanUp,
+                });
+            }
+        });
+    });
+}

--- a/src/client/testing/testController/common/resultsHelper.ts
+++ b/src/client/testing/testController/common/resultsHelper.ts
@@ -123,7 +123,7 @@ export async function updateResultFromJunitXml(
         const errors = getSafeInt(junitSuite.$.errors);
 
         runInstance.appendOutput(`Total number of tests passed: ${totalTests - failures - skipped - errors}${os.EOL}`);
-        runInstance.appendOutput(`Total number of tests failed : ${failures}${os.EOL}`);
+        runInstance.appendOutput(`Total number of tests failed: ${failures}${os.EOL}`);
         runInstance.appendOutput(`Total number of tests failed with errors: ${errors}${os.EOL}`);
         runInstance.appendOutput(`Total number of tests skipped: ${skipped}${os.EOL}`);
 

--- a/src/client/testing/testController/common/resultsHelper.ts
+++ b/src/client/testing/testController/common/resultsHelper.ts
@@ -80,9 +80,9 @@ function getJunitResults(parserResult: unknown): TestSuiteResult | undefined {
 }
 
 function getSafeInt(value: string, defaultValue = 0): number {
-    const num = parseInt(value, 10);
+    const num = Number.parseInt(value, 10);
     // eslint-disable-next-line no-restricted-globals
-    if (isNaN(num)) {
+    if (Number.isNaN(num)) {
         return defaultValue;
     }
     return num;
@@ -96,7 +96,7 @@ export async function updateResultFromJunitXml(
     const data = await fsapi.readFile(outputXmlFile);
     const parserResult = await parseXML(data.toString('utf8'));
     const junitSuite = getJunitResults(parserResult);
-    const testCaseNodes = await getTestCaseNodes(testNode);
+    const testCaseNodes = getTestCaseNodes(testNode);
 
     if (junitSuite && junitSuite.testcase.length > 0 && testCaseNodes.length > 0) {
         const totalTests = getSafeInt(junitSuite.$.tests);

--- a/src/client/testing/testController/common/resultsHelper.ts
+++ b/src/client/testing/testController/common/resultsHelper.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import * as fsapi from 'fs-extra';
+import * as os from 'os';
 import { TestItem, TestMessage, TestMessageSeverity, TestResultState, TestRun } from 'vscode';
 import { TestCase } from './testCase';
 import { TestCollection } from './testCollection';
@@ -121,20 +122,20 @@ export async function updateResultFromJunitXml(
         const skipped = getSafeInt(junitSuite.$.skips ? junitSuite.$.skips : junitSuite.$.skip);
         const errors = getSafeInt(junitSuite.$.errors);
 
-        runInstance.appendOutput(`total number of tests passed: ${totalTests - failures - skipped - errors}`);
-        runInstance.appendOutput(`Total number of tests failed : ${failures}`);
-        runInstance.appendOutput(`Total number of tests failed with errors: ${errors}`);
-        runInstance.appendOutput(`Total number of tests skipped: ${skipped}`);
+        runInstance.appendOutput(`Total number of tests passed: ${totalTests - failures - skipped - errors}${os.EOL}`);
+        runInstance.appendOutput(`Total number of tests failed : ${failures}${os.EOL}`);
+        runInstance.appendOutput(`Total number of tests failed with errors: ${errors}${os.EOL}`);
+        runInstance.appendOutput(`Total number of tests skipped: ${skipped}${os.EOL}`);
 
         testCaseNodes.forEach((node) => {
             const result = junitSuite.testcase.find((t) => {
-                const id = `${t.$.file.replace('\\', '/')}::${t.$.name}`;
+                const id = `${t.$.file.replace(/\\/g, '/')}::${t.$.name}`;
                 return id === node.data.raw.id || node.data.raw.id.endsWith(id);
             });
             if (result) {
                 if (result.error) {
                     const error = result.error[0];
-                    const text = `${node.data.raw.id} Failed with Error: [${error.$.type}]${error.$.message}\n${error._}`;
+                    const text = `${node.data.raw.id} Failed with Error: [${error.$.type}]${error.$.message}${os.EOL}${error._}${os.EOL}${os.EOL}`;
                     const message = new TestMessage(text);
                     message.severity = TestMessageSeverity.Error;
 
@@ -143,7 +144,7 @@ export async function updateResultFromJunitXml(
                     runInstance.appendMessage(node, message);
                 } else if (result.failure) {
                     const failure = result.failure[0];
-                    const text = `${node.data.raw.id} Failed: [${failure.$.type}]${failure.$.message}\n${failure._}`;
+                    const text = `${node.data.raw.id} Failed: [${failure.$.type}]${failure.$.message}${os.EOL}${failure._}${os.EOL}`;
                     const message = new TestMessage(text);
                     message.severity = TestMessageSeverity.Information;
 
@@ -152,16 +153,16 @@ export async function updateResultFromJunitXml(
                     runInstance.appendMessage(node, message);
                 } else if (result.skipped) {
                     const skip = result.skipped[0];
-                    const text = `${node.data.raw.id} Skipped: [${skip.$.type}]${skip.$.message}`;
+                    const text = `${node.data.raw.id} Skipped: [${skip.$.type}]${skip.$.message}${os.EOL}`;
                     runInstance.setState(node, TestResultState.Skipped);
                     runInstance.appendOutput(text);
                 } else {
-                    const text = `${node.data.raw.id} Passed`;
+                    const text = `${node.data.raw.id} Passed${os.EOL}`;
                     runInstance.setState(node, TestResultState.Passed);
                     runInstance.appendOutput(text);
                 }
             } else {
-                runInstance.appendOutput(`Test result not found for: ${node.data.raw.id}`);
+                runInstance.appendOutput(`Test result not found for: ${node.data.raw.id}${os.EOL}`);
                 runInstance.setState(node, TestResultState.Unset);
             }
         });

--- a/src/client/testing/testController/common/resultsHelper.ts
+++ b/src/client/testing/testController/common/resultsHelper.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import * as fsapi from 'fs-extra';
-import * as os from 'os';
 import { TestItem, TestMessage, TestMessageSeverity, TestResultState, TestRun } from 'vscode';
 import { TestCase } from './testCase';
 import { TestCollection } from './testCollection';
@@ -122,10 +121,10 @@ export async function updateResultFromJunitXml(
         const skipped = getSafeInt(junitSuite.$.skips ? junitSuite.$.skips : junitSuite.$.skip);
         const errors = getSafeInt(junitSuite.$.errors);
 
-        runInstance.appendOutput(`Total number of tests passed: ${totalTests - failures - skipped - errors}${os.EOL}`);
-        runInstance.appendOutput(`Total number of tests failed: ${failures}${os.EOL}`);
-        runInstance.appendOutput(`Total number of tests failed with errors: ${errors}${os.EOL}`);
-        runInstance.appendOutput(`Total number of tests skipped: ${skipped}${os.EOL}`);
+        runInstance.appendOutput(`Total number of tests passed: ${totalTests - failures - skipped - errors}\r\n`);
+        runInstance.appendOutput(`Total number of tests failed: ${failures}\r\n`);
+        runInstance.appendOutput(`Total number of tests failed with errors: ${errors}\r\n`);
+        runInstance.appendOutput(`Total number of tests skipped: ${skipped}\r\n`);
 
         testCaseNodes.forEach((node) => {
             const result = junitSuite.testcase.find((t) => {
@@ -135,7 +134,7 @@ export async function updateResultFromJunitXml(
             if (result) {
                 if (result.error) {
                     const error = result.error[0];
-                    const text = `${node.data.raw.id} Failed with Error: [${error.$.type}]${error.$.message}${os.EOL}${error._}${os.EOL}${os.EOL}`;
+                    const text = `${node.data.raw.id} Failed with Error: [${error.$.type}]${error.$.message}\r\n${error._}\r\n\r\n`;
                     const message = new TestMessage(text);
                     message.severity = TestMessageSeverity.Error;
 
@@ -144,7 +143,7 @@ export async function updateResultFromJunitXml(
                     runInstance.appendMessage(node, message);
                 } else if (result.failure) {
                     const failure = result.failure[0];
-                    const text = `${node.data.raw.id} Failed: [${failure.$.type}]${failure.$.message}${os.EOL}${failure._}${os.EOL}`;
+                    const text = `${node.data.raw.id} Failed: [${failure.$.type}]${failure.$.message}\r\n${failure._}\r\n`;
                     const message = new TestMessage(text);
                     message.severity = TestMessageSeverity.Information;
 
@@ -153,16 +152,16 @@ export async function updateResultFromJunitXml(
                     runInstance.appendMessage(node, message);
                 } else if (result.skipped) {
                     const skip = result.skipped[0];
-                    const text = `${node.data.raw.id} Skipped: [${skip.$.type}]${skip.$.message}${os.EOL}`;
+                    const text = `${node.data.raw.id} Skipped: [${skip.$.type}]${skip.$.message}\r\n`;
                     runInstance.setState(node, TestResultState.Skipped);
                     runInstance.appendOutput(text);
                 } else {
-                    const text = `${node.data.raw.id} Passed${os.EOL}`;
+                    const text = `${node.data.raw.id} Passed\r\n`;
                     runInstance.setState(node, TestResultState.Passed);
                     runInstance.appendOutput(text);
                 }
             } else {
-                runInstance.appendOutput(`Test result not found for: ${node.data.raw.id}${os.EOL}`);
+                runInstance.appendOutput(`Test result not found for: ${node.data.raw.id}\r\n`);
                 runInstance.setState(node, TestResultState.Unset);
             }
         });

--- a/src/client/testing/testController/common/resultsHelper.ts
+++ b/src/client/testing/testController/common/resultsHelper.ts
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as fsapi from 'fs-extra';
+import { TestItem, TestMessage, TestMessageSeverity, TestResultState, TestRun } from 'vscode';
+import { TestCase } from './testCase';
+import { TestCollection } from './testCollection';
+import { TestFile } from './testFile';
+import { TestFolder } from './testFolder';
+import { PythonTestData } from './types';
+
+type SupportedTestItemType = TestFolder | TestFile | TestCollection | TestCase;
+
+type TestSuiteResult = {
+    $: {
+        errors: string;
+        failures: string;
+        name: string;
+        skips: string;
+        skip: string;
+        tests: string;
+        time: string;
+    };
+    testcase: TestCaseResult[];
+};
+type TestCaseResult = {
+    $: {
+        classname: string;
+        file: string;
+        line: string;
+        name: string;
+        time: string;
+    };
+    failure: {
+        _: string;
+        $: { message: string; type: string };
+    }[];
+    error: {
+        _: string;
+        $: { message: string; type: string };
+    }[];
+    skipped: {
+        _: string;
+        $: { message: string; type: string };
+    }[];
+};
+
+async function parseXML(data: string): Promise<unknown> {
+    const xml2js = await import('xml2js');
+
+    return new Promise<unknown>((resolve, reject) => {
+        xml2js.parseString(data, (error: Error, result: unknown) => {
+            if (error) {
+                return reject(error);
+            }
+            return resolve(result);
+        });
+    });
+}
+
+function getJunitResults(parserResult: unknown): TestSuiteResult | undefined {
+    // This is the newer JUnit XML format (e.g. pytest 5.1 and later).
+    const fullResults = parserResult as { testsuites: { testsuite: TestSuiteResult[] } };
+    if (!fullResults.testsuites) {
+        return (parserResult as { testsuite: TestSuiteResult }).testsuite;
+    }
+
+    const junitSuites = fullResults.testsuites.testsuite;
+    if (!Array.isArray(junitSuites)) {
+        throw Error('bad JUnit XML data');
+    }
+    if (junitSuites.length === 0) {
+        return undefined;
+    }
+    if (junitSuites.length > 1) {
+        throw Error('got multiple XML results');
+    }
+    return junitSuites[0];
+}
+
+function getSafeInt(value: string, defaultValue = 0): number {
+    const num = parseInt(value, 10);
+    // eslint-disable-next-line no-restricted-globals
+    if (isNaN(num)) {
+        return defaultValue;
+    }
+    return num;
+}
+
+async function getTestCaseNodes(
+    testNode: TestItem<SupportedTestItemType>,
+    collection: TestItem<TestCase>[] = [],
+): Promise<TestItem<TestCase>[]> {
+    const nodes = Array.from(testNode.children.values());
+    for (const node of nodes) {
+        if (node instanceof TestCase) {
+            collection.push(node);
+        } else {
+            await getTestCaseNodes(node, collection);
+        }
+    }
+    return Promise.resolve(collection);
+}
+
+export async function updateResultFromJunitXml(
+    outputXmlFile: string,
+    testNode: TestItem<SupportedTestItemType>,
+    runInstance: TestRun<PythonTestData>,
+): Promise<void> {
+    const data = await fsapi.readFile(outputXmlFile);
+    const parserResult = await parseXML(data.toString('utf8'));
+    const junitSuite = getJunitResults(parserResult);
+    const testCaseNodes = await getTestCaseNodes(testNode);
+
+    if (junitSuite && junitSuite.testcase.length > 0 && testCaseNodes.length > 0) {
+        const totalTests = getSafeInt(junitSuite.$.tests);
+        const failures = getSafeInt(junitSuite.$.failures);
+        const skipped = getSafeInt(junitSuite.$.skips ? junitSuite.$.skips : junitSuite.$.skip);
+        const errors = getSafeInt(junitSuite.$.errors);
+
+        runInstance.appendOutput(`total number of tests passed: ${totalTests - failures - skipped - errors}`);
+        runInstance.appendOutput(`Total number of tests failed : ${failures}`);
+        runInstance.appendOutput(`Total number of tests failed with errors: ${errors}`);
+        runInstance.appendOutput(`Total number of tests skipped: ${skipped}`);
+
+        const testCaseResults = junitSuite.testcase.map((t) => {
+            const o = {
+                ...t,
+            };
+            o.$.classname = t.$.classname
+                .replace(/\(\)/g, '')
+                .replace(/\.\./g, '.')
+                .replace(/\.\./g, '.')
+                .replace(/\.+$/, '');
+            return o;
+        });
+        testCaseNodes.forEach((node) => {
+            const result = testCaseResults.find((t) => {
+                return `${t.$.classname}:${t.$.name}` === node.data.raw.id;
+            });
+            if (result) {
+                if (result.error) {
+                    const error = result.error[0];
+                    const text = `${node.data.raw.id} Failed with Error: [${error.$.type}]${error.$.message}\n${error._}`;
+                    const message = new TestMessage(text);
+                    message.severity = TestMessageSeverity.Error;
+
+                    runInstance.setState(node, TestResultState.Errored);
+                    runInstance.appendOutput(text);
+                    runInstance.appendMessage(node, message);
+                } else if (result.failure) {
+                    const failure = result.failure[0];
+                    const text = `${node.data.raw.id} Failed: [${failure.$.type}]${failure.$.message}\n${failure._}`;
+                    const message = new TestMessage(text);
+                    message.severity = TestMessageSeverity.Information;
+
+                    runInstance.setState(node, TestResultState.Failed);
+                    runInstance.appendOutput(text);
+                    runInstance.appendMessage(node, message);
+                } else if (result.skipped) {
+                    const skip = result.skipped[0];
+                    const text = `${node.data.raw.id} Skipped: [${skip.$.type}]${skip.$.message}`;
+                    runInstance.setState(node, TestResultState.Skipped);
+                    runInstance.appendOutput(text);
+                } else {
+                    const text = `${node.data.raw.id} Passed`;
+                    runInstance.setState(node, TestResultState.Passed);
+                    runInstance.appendOutput(text);
+                }
+            } else {
+                runInstance.appendOutput(`Test result not found for: ${node.data.raw.id}`);
+                runInstance.setState(node, TestResultState.Unset);
+            }
+        });
+    }
+}

--- a/src/client/testing/testController/common/testCase.ts
+++ b/src/client/testing/testController/common/testCase.ts
@@ -2,19 +2,31 @@
 // Licensed under the MIT License.
 
 import * as path from 'path';
-import { test, TestItem } from 'vscode';
+import { Position, Range, test, TestItem, Uri } from 'vscode';
 import { RawTest } from '../../common/services/types';
 
 export class TestCase {
     public static create(testRoot: string, rawData: RawTest): TestItem<TestCase> {
-        const fullPath = path.join(testRoot, rawData.id);
+        const fullId = path.join(testRoot, rawData.id);
+        const documentPath = path.join(testRoot, rawData.source.substr(0, rawData.source.indexOf(':')));
         const item = test.createTestItem<TestCase>({
-            id: fullPath,
+            id: fullId,
             label: rawData.name,
+            uri: Uri.file(documentPath),
         });
 
         item.debuggable = true;
         item.data = new TestCase(item, rawData);
+
+        try {
+            const sourceLine = rawData.source.substr(rawData.source.indexOf(':') + 1);
+            const line = parseInt(sourceLine, 10);
+            // Lines in raw data start at 1, vscode lines start at 0
+            item.range = new Range(new Position(line - 1, 0), new Position(line, 0));
+        } catch (ex) {
+            // ignore
+        }
+
         return item;
     }
 

--- a/src/client/testing/testController/common/testCase.ts
+++ b/src/client/testing/testController/common/testCase.ts
@@ -37,7 +37,7 @@ export class TestCase {
         // saves us from running symbol script or querying language server for this info.
         try {
             const sourceLine = rawData.source.substr(rawData.source.indexOf(':') + 1);
-            const line = parseInt(sourceLine, 10);
+            const line = Number.parseInt(sourceLine, 10);
             // Lines in raw data start at 1, vscode lines start at 0
             item.range = new Range(new Position(line - 1, 0), new Position(line, 0));
         } catch (ex) {

--- a/src/client/testing/testController/common/testCase.ts
+++ b/src/client/testing/testController/common/testCase.ts
@@ -5,19 +5,36 @@ import * as path from 'path';
 import { Position, Range, test, TestItem, Uri } from 'vscode';
 import { RawTest } from '../../common/services/types';
 
+/**
+ * This class represents the leaf node in the test view.
+ */
 export class TestCase {
     public static create(testRoot: string, rawData: RawTest): TestItem<TestCase> {
+        // fullId can look like test_something.py::SomeClass::someTest[x1]
         const fullId = path.join(testRoot, rawData.id);
+
+        // We need the actual document path so we can set the location for the tests. This will be
+        // used to provide test result status next to the tests.
         const documentPath = path.join(testRoot, rawData.source.substr(0, rawData.source.indexOf(':')));
+
         const item = test.createTestItem<TestCase>({
             id: fullId,
             label: rawData.name,
             uri: Uri.file(documentPath),
         });
 
-        item.debuggable = true;
-        item.data = new TestCase(item, rawData);
+        // This is the id that will be used to compare with the results from JUnit file.
+        const runId = rawData.id
+            .replace(/[\\\:\/]/g, '.')
+            .replace(/\:\:/g, '.')
+            .replace(/\.\./g, '.')
+            .replace(/\.py/g, '');
 
+        item.debuggable = true;
+        item.data = new TestCase(item, rawData, runId);
+
+        // We have to extract the line number from the source data. If it is available it
+        // saves us from running symbol script or querying language server for this info.
         try {
             const sourceLine = rawData.source.substr(rawData.source.indexOf(':') + 1);
             const line = parseInt(sourceLine, 10);
@@ -30,5 +47,9 @@ export class TestCase {
         return item;
     }
 
-    constructor(public readonly item: TestItem<TestCase>, public readonly raw: RawTest) {}
+    constructor(
+        public readonly item: TestItem<TestCase>,
+        public readonly raw: RawTest,
+        public readonly runId: string,
+    ) {}
 }

--- a/src/client/testing/testController/common/testFile.ts
+++ b/src/client/testing/testController/common/testFile.ts
@@ -18,6 +18,7 @@ export class TestFile {
 
         item.debuggable = true;
         item.data = new TestFile(item, rawData);
+        item.description = fullPath;
         return item;
     }
 

--- a/src/client/testing/testController/common/testFolder.ts
+++ b/src/client/testing/testController/common/testFolder.ts
@@ -15,6 +15,7 @@ export class TestFolder {
             uri: Uri.file(fullPath),
         });
 
+        item.description = fullPath;
         item.debuggable = true;
         item.data = new TestFolder(item, rawData);
         return item;

--- a/src/client/testing/testController/common/testItemUtilities.ts
+++ b/src/client/testing/testController/common/testItemUtilities.ts
@@ -91,10 +91,10 @@ export function getUri(node: TestItem<PythonTestData>): Uri | undefined {
     return node.uri;
 }
 
-export async function getTestCaseNodes(
+export function getTestCaseNodes(
     testNode: TestItem<PythonTestData>,
     collection: TestItem<TestCase>[] = [],
-): Promise<TestItem<TestCase>[]> {
+): TestItem<TestCase>[] {
     if (testNode.data instanceof TestCase) {
         collection.push(testNode as TestItem<TestCase>);
     }
@@ -103,8 +103,8 @@ export async function getTestCaseNodes(
         if (node.data instanceof TestCase) {
             collection.push(node);
         } else {
-            await getTestCaseNodes(node, collection);
+            getTestCaseNodes(node, collection);
         }
     }
-    return Promise.resolve(collection);
+    return collection;
 }

--- a/src/client/testing/testController/common/testItemUtilities.ts
+++ b/src/client/testing/testController/common/testItemUtilities.ts
@@ -90,3 +90,21 @@ export function getUri(node: TestItem<PythonTestData>): Uri | undefined {
     }
     return node.uri;
 }
+
+export async function getTestCaseNodes(
+    testNode: TestItem<PythonTestData>,
+    collection: TestItem<TestCase>[] = [],
+): Promise<TestItem<TestCase>[]> {
+    if (testNode.data instanceof TestCase) {
+        collection.push(testNode as TestItem<TestCase>);
+    }
+    const nodes = Array.from(testNode.children.values());
+    for (const node of nodes) {
+        if (node.data instanceof TestCase) {
+            collection.push(node);
+        } else {
+            await getTestCaseNodes(node, collection);
+        }
+    }
+    return Promise.resolve(collection);
+}

--- a/src/client/testing/testController/common/testItemUtilities.ts
+++ b/src/client/testing/testController/common/testItemUtilities.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { TestItem } from 'vscode';
+import { TestItem, Uri } from 'vscode';
 import { traceVerbose } from '../../../common/logger';
 import {
     RawDiscoveredTests,
@@ -14,6 +14,7 @@ import { TestCase } from './testCase';
 import { TestCollection } from './testCollection';
 import { TestFile } from './testFile';
 import { TestFolder } from './testFolder';
+import { PythonTestData } from './types';
 import { WorkspaceTestRoot } from './workspaceTestRoot';
 
 export function updateTestRoot(
@@ -81,4 +82,11 @@ export function updateTestRoot(
     });
 
     return root;
+}
+
+export function getUri(node: TestItem<PythonTestData>): Uri | undefined {
+    if (!node.uri && node.parent) {
+        return getUri(node.parent);
+    }
+    return node.uri;
 }

--- a/src/client/testing/testController/common/types.ts
+++ b/src/client/testing/testController/common/types.ts
@@ -12,6 +12,7 @@ import { WorkspaceTestRoot } from './workspaceTestRoot';
 
 export type PythonTestData = WorkspaceTestRoot | TestFolder | TestFile | TestCollection | TestCase;
 
+export const ITestDiscovery = Symbol('ITestDiscovery');
 export interface ITestDiscovery {
     /**
      * Runs test discovery for the entire workspace.
@@ -20,6 +21,7 @@ export interface ITestDiscovery {
     discoverWorkspaceTests(options: TestDiscoveryOptions): Promise<TestItem<PythonTestData> | undefined>;
 }
 
+export const ITestDiscoveryHelper = Symbol('ITestDiscoveryHelper');
 export interface ITestDiscoveryHelper {
     runTestDiscovery(options: TestDiscoveryOptions): Promise<RawDiscoveredTests[]>;
 }

--- a/src/client/testing/testController/common/types.ts
+++ b/src/client/testing/testController/common/types.ts
@@ -10,7 +10,8 @@ import { TestFile } from './testFile';
 import { TestFolder } from './testFolder';
 import { WorkspaceTestRoot } from './workspaceTestRoot';
 
-export type PythonTestData = WorkspaceTestRoot | TestFolder | TestFile | TestCollection | TestCase;
+export type PythonRunnableTestData = TestFolder | TestFile | TestCollection | TestCase;
+export type PythonTestData = WorkspaceTestRoot | PythonRunnableTestData;
 
 export const ITestDiscovery = Symbol('ITestDiscovery');
 export interface ITestDiscovery {

--- a/src/client/testing/testController/common/types.ts
+++ b/src/client/testing/testController/common/types.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { TestItem } from 'vscode';
+import { CancellationToken, TestItem, TestRunRequest, TextDocument, Uri, WorkspaceFolder } from 'vscode';
 import { RawDiscoveredTests } from '../../common/services/types';
 import { TestDiscoveryOptions } from '../../common/types';
 import { TestCase } from './testCase';
@@ -25,3 +25,28 @@ export const ITestDiscoveryHelper = Symbol('ITestDiscoveryHelper');
 export interface ITestDiscoveryHelper {
     runTestDiscovery(options: TestDiscoveryOptions): Promise<RawDiscoveredTests[]>;
 }
+
+export const ITestController = Symbol('ITestController');
+export interface ITestController {
+    createWorkspaceTests(
+        workspace: WorkspaceFolder,
+        token: CancellationToken,
+    ): Promise<TestItem<PythonTestData> | undefined>;
+    createOrUpdateDocumentTests(
+        document: TextDocument,
+        token: CancellationToken,
+    ): Promise<TestItem<PythonTestData> | undefined>;
+    runTests(options: TestRunRequest<PythonTestData>, token: CancellationToken): Promise<void>;
+}
+
+export const ITestsRunner = Symbol('ITestsRunner');
+export interface ITestsRunner {
+    runTests(request: TestRunRequest<PythonTestData>, options: TestRunOptions): Promise<void>;
+}
+
+export type TestRunOptions = {
+    workspaceFolder: Uri;
+    cwd: string;
+    args: string[];
+    token: CancellationToken;
+};

--- a/src/client/testing/testController/common/types.ts
+++ b/src/client/testing/testController/common/types.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { CancellationToken, TestItem, TestRunRequest, TextDocument, Uri, WorkspaceFolder } from 'vscode';
+import { CancellationToken, TestItem, TestRunRequest, Uri, WorkspaceFolder } from 'vscode';
 import { RawDiscoveredTests } from '../../common/services/types';
 import { TestDiscoveryOptions } from '../../common/types';
 import { TestCase } from './testCase';
@@ -31,10 +31,6 @@ export const ITestController = Symbol('ITestController');
 export interface ITestController {
     createWorkspaceTests(
         workspace: WorkspaceFolder,
-        token: CancellationToken,
-    ): Promise<TestItem<PythonTestData> | undefined>;
-    createOrUpdateDocumentTests(
-        document: TextDocument,
         token: CancellationToken,
     ): Promise<TestItem<PythonTestData> | undefined>;
     runTests(options: TestRunRequest<PythonTestData>, token: CancellationToken): Promise<void>;

--- a/src/client/testing/testController/common/workspaceTestRoot.ts
+++ b/src/client/testing/testController/common/workspaceTestRoot.ts
@@ -7,6 +7,7 @@ export class WorkspaceTestRoot {
     public static create(options: vscode.TestItemOptions): vscode.TestItem<WorkspaceTestRoot> {
         const item = vscode.test.createTestItem<WorkspaceTestRoot>(options);
         item.data = new WorkspaceTestRoot(item);
+        item.description = item.uri?.fsPath;
         return item;
     }
 

--- a/src/client/testing/testController/pytest/arguments.ts
+++ b/src/client/testing/testController/pytest/arguments.ts
@@ -147,6 +147,10 @@ export function getTestFolders(args: string[]): string[] {
     return positionalArgs.filter((arg) => !arg.toUpperCase().endsWith('.PY'));
 }
 
+export function removePositionalFoldersAndFiles(args: string[]): string[] {
+    return pytestFilterArguments(args, TestFilter.removeTests);
+}
+
 function pytestFilterArguments(args: string[], argumentToRemoveOrFilter: string[] | TestFilter): string[] {
     const optionsWithoutArgsToRemove: string[] = [];
     const optionsWithArgsToRemove: string[] = [];

--- a/src/client/testing/testController/pytest/discovery.ts
+++ b/src/client/testing/testController/pytest/discovery.ts
@@ -58,17 +58,27 @@ export class PytestDiscoveryService implements ITestDiscovery {
         }
 
         // This is the root object for all `pytest`
-        const testRoot = WorkspaceTestRoot.create({
-            id: 'pytest',
-            uri: options.workspaceFolder,
-            label: 'Pytest Tests',
-        });
+        let testRoot: TestItem<WorkspaceTestRoot>;
 
         if (rawTestData.length === 1) {
+            testRoot = WorkspaceTestRoot.create({
+                id: rawTestData[0].root,
+                uri: options.workspaceFolder,
+                label: path.basename(rawTestData[0].root),
+            });
             if (rawTestData[0].tests.length > 0) {
                 updateTestRoot(testRoot, rawTestData[0]);
+                return testRoot;
             }
         } else if (rawTestData.length > 1) {
+            testRoot = WorkspaceTestRoot.create({
+                id: options.workspaceFolder.fsPath,
+                uri: options.workspaceFolder,
+                label: path.basename(options.workspaceFolder.fsPath),
+            });
+            testRoot.description =
+                'This node is the root for all tests discovered with pytest, and may contain tests from multiple roots.';
+
             rawTestData.forEach((data) => {
                 if (data.tests.length > 0) {
                     const subRootItem = WorkspaceTestRoot.create({
@@ -80,7 +90,9 @@ export class PytestDiscoveryService implements ITestDiscovery {
                     updateTestRoot(subRootItem, data);
                 }
             });
+            return testRoot;
         }
-        return testRoot.children.size > 0 ? testRoot : undefined;
+
+        return undefined;
     }
 }

--- a/src/client/testing/testController/pytest/discovery.ts
+++ b/src/client/testing/testController/pytest/discovery.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { inject, injectable } from 'inversify';
 import { flatten } from 'lodash';
 import * as path from 'path';
 import { TestItem, Uri } from 'vscode';
@@ -11,8 +12,9 @@ import { ITestDiscovery, ITestDiscoveryHelper, PythonTestData } from '../common/
 import { WorkspaceTestRoot } from '../common/workspaceTestRoot';
 import { getTestFolders, preparePytestArgumentsForDiscovery } from './arguments';
 
+@injectable()
 export class PytestDiscoveryService implements ITestDiscovery {
-    constructor(private readonly discoveryHelper: ITestDiscoveryHelper) {}
+    constructor(@inject(ITestDiscoveryHelper) private readonly discoveryHelper: ITestDiscoveryHelper) {}
 
     public async discoverWorkspaceTests(options: TestDiscoveryOptions): Promise<TestItem<PythonTestData> | undefined> {
         // Get individual test directories selected by the user.

--- a/src/client/testing/testController/pytest/pytestController.ts
+++ b/src/client/testing/testController/pytest/pytestController.ts
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { inject, injectable, named } from 'inversify';
+import { WorkspaceFolder, CancellationToken, TestItem, TextDocument, TestRunRequest, Uri } from 'vscode';
+import { IWorkspaceService } from '../../../common/application/types';
+import { IConfigurationService } from '../../../common/types';
+import { PYTEST_PROVIDER } from '../../common/constants';
+import { getUri } from '../common/testItemUtilities';
+import { ITestController, ITestDiscovery, ITestsRunner, PythonTestData } from '../common/types';
+
+@injectable()
+export class PytestController implements ITestController {
+    constructor(
+        @inject(ITestDiscovery) @named(PYTEST_PROVIDER) private readonly discovery: ITestDiscovery,
+        @inject(ITestsRunner) @named(PYTEST_PROVIDER) private readonly runner: ITestsRunner,
+        @inject(IConfigurationService) private readonly configService: IConfigurationService,
+        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
+    ) {}
+
+    public createWorkspaceTests(
+        workspace: WorkspaceFolder,
+        token: CancellationToken,
+    ): Promise<TestItem<PythonTestData> | undefined> {
+        const settings = this.configService.getSettings(workspace.uri);
+        const options = {
+            workspaceFolder: workspace.uri,
+            cwd: settings.testing.cwd ?? workspace.uri.fsPath,
+            args: settings.testing.pytestArgs,
+            token,
+            ignoreCache: true,
+        };
+        return this.discovery.discoverWorkspaceTests(options);
+    }
+
+    public createOrUpdateDocumentTests(
+        document: TextDocument,
+        token: CancellationToken,
+    ): Promise<TestItem<PythonTestData> | undefined> {
+        const settings = this.configService.getSettings(document.uri);
+        const workspaceFolder = this.workspaceService.getWorkspaceFolder(document.uri);
+        const cwd = workspaceFolder?.uri.fsPath ?? process.cwd();
+        const options = {
+            workspaceFolder: document.uri,
+            cwd: settings.testing.cwd ?? cwd,
+            args: settings.testing.pytestArgs,
+            token,
+            ignoreCache: true,
+        };
+        return this.discovery.discoverWorkspaceTests(options);
+    }
+
+    public runTests(options: TestRunRequest<PythonTestData>, token: CancellationToken): Promise<void> {
+        const workspaceFolder = this.workspaceService.getWorkspaceFolder(getUri(options.tests[0]));
+        const settings = this.configService.getSettings(workspaceFolder?.uri);
+        const cwd = workspaceFolder?.uri.fsPath ?? process.cwd();
+        return this.runner.runTests(options, {
+            workspaceFolder: workspaceFolder?.uri ?? Uri.file(cwd),
+            cwd: settings.testing.cwd ?? cwd,
+            token,
+            args: settings.testing.pytestArgs,
+        });
+    }
+}

--- a/src/client/testing/testController/pytest/pytestController.ts
+++ b/src/client/testing/testController/pytest/pytestController.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { inject, injectable, named } from 'inversify';
-import { WorkspaceFolder, CancellationToken, TestItem, TextDocument, TestRunRequest, Uri } from 'vscode';
+import { WorkspaceFolder, CancellationToken, TestItem, TestRunRequest, Uri } from 'vscode';
 import { IWorkspaceService } from '../../../common/application/types';
 import { IConfigurationService } from '../../../common/types';
 import { PYTEST_PROVIDER } from '../../common/constants';
@@ -26,23 +26,6 @@ export class PytestController implements ITestController {
         const options = {
             workspaceFolder: workspace.uri,
             cwd: settings.testing.cwd ?? workspace.uri.fsPath,
-            args: settings.testing.pytestArgs,
-            token,
-            ignoreCache: true,
-        };
-        return this.discovery.discoverWorkspaceTests(options);
-    }
-
-    public createOrUpdateDocumentTests(
-        document: TextDocument,
-        token: CancellationToken,
-    ): Promise<TestItem<PythonTestData> | undefined> {
-        const settings = this.configService.getSettings(document.uri);
-        const workspaceFolder = this.workspaceService.getWorkspaceFolder(document.uri);
-        const cwd = workspaceFolder?.uri.fsPath ?? process.cwd();
-        const options = {
-            workspaceFolder: document.uri,
-            cwd: settings.testing.cwd ?? cwd,
             args: settings.testing.pytestArgs,
             token,
             ignoreCache: true,

--- a/src/client/testing/testController/pytest/runner.ts
+++ b/src/client/testing/testController/pytest/runner.ts
@@ -1,11 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { inject, injectable } from 'inversify';
+import { inject, injectable, named } from 'inversify';
 import { CancellationToken, Disposable, test, TestItem, TestResultState, TestRun, TestRunRequest, Uri } from 'vscode';
-import { IDisposableRegistry } from '../../../common/types';
+import { IOutputChannel } from '../../../common/types';
+import { PYTEST_PROVIDER } from '../../common/constants';
+import { ITestDebugLauncher, ITestRunner, LaunchOptions, Options } from '../../common/types';
+import { TEST_OUTPUT_CHANNEL } from '../../constants';
 import { filterArguments, getOptionValues } from '../common/argumentsHelper';
 import { createTemporaryFile } from '../common/externalDependencies';
+import { updateResultFromJunitXml } from '../common/resultsHelper';
 import { TestCase } from '../common/testCase';
 import { TestCollection } from '../common/testCollection';
 import { TestFile } from '../common/testFile';
@@ -26,7 +30,7 @@ type PytestRunInstanceOptions = TestRunOptions & {
 };
 
 type PytestRunTestFunction = (
-    tests: string[],
+    testNode: TestItem<TestFolder | TestFile | TestCollection | TestCase>,
     runInstance: TestRun<TestFolder>,
     options: PytestRunInstanceOptions,
 ) => Promise<void>;
@@ -58,16 +62,16 @@ export async function processTestNode(
             await Promise.all(testSubNodes.map((subNode) => processTestNode(subNode, runInstance, options, runTest)));
         }
         if (testNode.data instanceof TestFolder) {
-            return runTest([(testNode as TestItem<TestFolder>).data.raw.id], runInstance, options);
+            return runTest(testNode as TestItem<TestFolder>, runInstance, options);
         }
         if (testNode.data instanceof TestFile) {
-            return runTest([(testNode as TestItem<TestFile>).data.raw.id], runInstance, options);
+            return runTest(testNode as TestItem<TestFile>, runInstance, options);
         }
         if (testNode.data instanceof TestCollection) {
-            return runTest([(testNode as TestItem<TestCollection>).data.raw.id], runInstance, options);
+            return runTest(testNode as TestItem<TestCollection>, runInstance, options);
         }
         if (testNode.data instanceof TestCase) {
-            return runTest([(testNode as TestItem<TestCase>).data.raw.id], runInstance, options);
+            return runTest(testNode as TestItem<TestCase>, runInstance, options);
         }
     } else {
         runInstance.appendOutput(`Excluded: ${testNode.label}`);
@@ -75,13 +79,17 @@ export async function processTestNode(
     return Promise.resolve();
 }
 
-export interface ITestRunner {
+export interface ITestsRunner {
     runTests(request: TestRunRequest<PythonTestData>, options: TestRunOptions): Promise<void>;
 }
 
 @injectable()
-export class PytestRunner implements ITestRunner {
-    constructor(@inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry) {}
+export class PytestRunner implements ITestsRunner {
+    constructor(
+        @inject(ITestRunner) private readonly runner: ITestRunner,
+        @inject(ITestDebugLauncher) private readonly debugLauncher: ITestDebugLauncher,
+        @inject(IOutputChannel) @named(TEST_OUTPUT_CHANNEL) private readonly outputChannel: IOutputChannel,
+    ) {}
 
     public async runTests(request: TestRunRequest<PythonTestData>, options: TestRunOptions): Promise<void> {
         const runOptions: PytestRunInstanceOptions = {
@@ -98,20 +106,51 @@ export class PytestRunner implements ITestRunner {
     }
 
     private async runTest(
-        testRunIds: string[],
+        testNode: TestItem<TestFolder | TestFile | TestCollection | TestCase>,
         runInstance: TestRun<PythonTestData>,
         options: PytestRunInstanceOptions,
     ): Promise<void> {
-        const junitFilePath = await getPytestJunitXmlTempFile(options.args, this.disposables);
+        const disposables: Disposable[] = [];
+        const junitFilePath = await getPytestJunitXmlTempFile(options.args, disposables);
 
-        // Remove the '--junitxml' or '--junit-xml' if it exists, and add it with our path.
-        const testArgs = filterArguments(options.args, [JunitXmlArg, JunitXmlArgOld]);
-        testArgs.splice(0, 0, `${JunitXmlArg}=${junitFilePath}`);
+        try {
+            // Remove the '--junitxml' or '--junit-xml' if it exists, and add it with our path.
+            const testArgs = filterArguments(options.args, [JunitXmlArg, JunitXmlArgOld]);
+            testArgs.splice(0, 0, `${JunitXmlArg}=${junitFilePath}`);
 
-        testArgs.splice(0, 0, '--rootdir', options.workspaceFolder.fsPath);
-        testArgs.splice(0, 0, '--override-ini', 'junit_family=xunit1');
+            testArgs.splice(0, 0, '--rootdir', options.workspaceFolder.fsPath);
+            testArgs.splice(0, 0, '--override-ini', 'junit_family=xunit1');
 
-        // Positional arguments control the tests to be run.
-        testArgs.push(...testRunIds);
+            // Positional arguments control the tests to be run.
+            testArgs.push(testNode.data.raw.id);
+
+            if (options.debug) {
+                const debuggerArgs = [options.cwd, 'pytest'].concat(testArgs);
+                const launchOptions: LaunchOptions = {
+                    cwd: options.cwd,
+                    args: debuggerArgs,
+                    token: options.token,
+                    outChannel: this.outputChannel,
+                    testProvider: PYTEST_PROVIDER,
+                };
+                await this.debugLauncher.launchDebugger(launchOptions);
+            } else {
+                const runOptions: Options = {
+                    args: testArgs,
+                    cwd: options.cwd,
+                    outChannel: this.outputChannel,
+                    token: options.token,
+                    workspaceFolder: options.workspaceFolder,
+                };
+                await this.runner.run(PYTEST_PROVIDER, runOptions);
+            }
+
+            await updateResultFromJunitXml(junitFilePath, testNode, runInstance);
+        } catch (ex) {
+            return Promise.reject(ex);
+        } finally {
+            disposables.forEach((d) => d.dispose());
+        }
+        return Promise.resolve();
     }
 }

--- a/src/client/testing/testController/pytest/runner.ts
+++ b/src/client/testing/testController/pytest/runner.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as os from 'os';
 import { inject, injectable, named } from 'inversify';
 import { Disposable, test, TestItem, TestResultState, TestRun, TestRunRequest } from 'vscode';
 import { IOutputChannel } from '../../../common/types';
@@ -67,7 +66,7 @@ export async function processTestNode(
             return runTest(testNode as TestItem<TestCase>, runInstance, options);
         }
     } else {
-        runInstance.appendOutput(`Excluded: ${testNode.label}${os.EOL}`);
+        runInstance.appendOutput(`Excluded: ${testNode.label}\r\n`);
     }
     return Promise.resolve();
 }
@@ -94,9 +93,9 @@ export class PytestRunner implements ITestsRunner {
                 ),
             );
         } catch (ex) {
-            runInstance.appendOutput(`Error while running tests:${os.EOL}${ex}${os.EOL}${os.EOL}`);
+            runInstance.appendOutput(`Error while running tests:\r\n${ex}\r\n\r\n`);
         } finally {
-            runInstance.appendOutput(`Finished running tests!${os.EOL}`);
+            runInstance.appendOutput(`Finished running tests!\r\n`);
             runInstance.end();
         }
     }
@@ -106,7 +105,7 @@ export class PytestRunner implements ITestsRunner {
         runInstance: TestRun<PythonTestData>,
         options: PytestRunInstanceOptions,
     ): Promise<void> {
-        runInstance.appendOutput(`Running tests: ${testNode.label}${os.EOL}`);
+        runInstance.appendOutput(`Running tests: ${testNode.label}\r\n`);
         runInstance.setState(testNode, TestResultState.Running);
 
         const disposables: Disposable[] = [];
@@ -144,16 +143,16 @@ export class PytestRunner implements ITestsRunner {
                     token: options.token,
                     workspaceFolder: options.workspaceFolder,
                 };
-                runInstance.appendOutput(`Running test with arguments: ${runOptions.args.join(' ')}${os.EOL}`);
-                runInstance.appendOutput(`Current working directory: ${runOptions.cwd}${os.EOL}`);
-                runInstance.appendOutput(`Workspace directory: ${runOptions.workspaceFolder.fsPath}${os.EOL}`);
+                runInstance.appendOutput(`Running test with arguments: ${runOptions.args.join(' ')}\r\n`);
+                runInstance.appendOutput(`Current working directory: ${runOptions.cwd}\r\n`);
+                runInstance.appendOutput(`Workspace directory: ${runOptions.workspaceFolder.fsPath}\r\n`);
                 await this.runner.run(PYTEST_PROVIDER, runOptions);
             }
 
-            runInstance.appendOutput(`Run completed, parsing output${os.EOL}`);
+            runInstance.appendOutput(`Run completed, parsing output\r\n`);
             await updateResultFromJunitXml(junitFilePath, testNode, runInstance);
         } catch (ex) {
-            runInstance.appendOutput(`Error while running tests: ${testNode.label}${os.EOL}${ex}${os.EOL}${os.EOL}`);
+            runInstance.appendOutput(`Error while running tests: ${testNode.label}\r\n${ex}\r\n\r\n`);
             return Promise.reject(ex);
         } finally {
             disposables.forEach((d) => d.dispose());

--- a/src/client/testing/testController/pytest/runner.ts
+++ b/src/client/testing/testController/pytest/runner.ts
@@ -110,7 +110,7 @@ export class PytestRunner implements ITestsRunner {
 
         // VS Code API requires that we set the run state on the leaf nodes. The state of the
         // parent nodes are computed based on the state of child nodes.
-        const testCaseNodes = await getTestCaseNodes(testNode);
+        const testCaseNodes = getTestCaseNodes(testNode);
         testCaseNodes.forEach((node) => runInstance.setState(node, TestResultState.Running));
 
         // For pytest we currently use JUnit XML to get the results. We create a temporary file here

--- a/src/client/testing/testController/pytest/runner.ts
+++ b/src/client/testing/testController/pytest/runner.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { inject, injectable } from 'inversify';
+import { CancellationToken, Disposable, test, TestItem, TestResultState, TestRun, TestRunRequest, Uri } from 'vscode';
+import { IDisposableRegistry } from '../../../common/types';
+import { filterArguments, getOptionValues } from '../common/argumentsHelper';
+import { createTemporaryFile } from '../common/externalDependencies';
+import { TestCase } from '../common/testCase';
+import { TestCollection } from '../common/testCollection';
+import { TestFile } from '../common/testFile';
+import { TestFolder } from '../common/testFolder';
+import { PythonTestData } from '../common/types';
+import { WorkspaceTestRoot } from '../common/workspaceTestRoot';
+
+export type TestRunOptions = {
+    workspaceFolder: Uri;
+    cwd: string;
+    args: string[];
+    token: CancellationToken;
+};
+
+type PytestRunInstanceOptions = TestRunOptions & {
+    exclude?: TestItem<PythonTestData>[];
+    debug: boolean;
+};
+
+type PytestRunTestFunction = (
+    tests: string[],
+    runInstance: TestRun<TestFolder>,
+    options: PytestRunInstanceOptions,
+) => Promise<void>;
+
+const JunitXmlArgOld = '--junitxml';
+const JunitXmlArg = '--junit-xml';
+
+async function getPytestJunitXmlTempFile(args: string[], disposables: Disposable[]): Promise<string> {
+    const argValues = getOptionValues(args, JunitXmlArg);
+    if (argValues.length === 1) {
+        return argValues[0];
+    }
+    const tempFile = await createTemporaryFile('.xml');
+    disposables.push(tempFile);
+    return tempFile.filePath;
+}
+
+export async function processTestNode(
+    testNode: TestItem<PythonTestData>,
+    runInstance: TestRun<PythonTestData>,
+    options: PytestRunInstanceOptions,
+    runTest: PytestRunTestFunction,
+): Promise<void> {
+    if (!options.exclude?.includes(testNode)) {
+        runInstance.appendOutput(`Running tests: ${testNode.label}`);
+        runInstance.setState(testNode, TestResultState.Running);
+        if (testNode.data instanceof WorkspaceTestRoot) {
+            const testSubNodes = Array.from(testNode.children.values());
+            await Promise.all(testSubNodes.map((subNode) => processTestNode(subNode, runInstance, options, runTest)));
+        }
+        if (testNode.data instanceof TestFolder) {
+            return runTest([(testNode as TestItem<TestFolder>).data.raw.id], runInstance, options);
+        }
+        if (testNode.data instanceof TestFile) {
+            return runTest([(testNode as TestItem<TestFile>).data.raw.id], runInstance, options);
+        }
+        if (testNode.data instanceof TestCollection) {
+            return runTest([(testNode as TestItem<TestCollection>).data.raw.id], runInstance, options);
+        }
+        if (testNode.data instanceof TestCase) {
+            return runTest([(testNode as TestItem<TestCase>).data.raw.id], runInstance, options);
+        }
+    } else {
+        runInstance.appendOutput(`Excluded: ${testNode.label}`);
+    }
+    return Promise.resolve();
+}
+
+export interface ITestRunner {
+    runTests(request: TestRunRequest<PythonTestData>, options: TestRunOptions): Promise<void>;
+}
+
+@injectable()
+export class PytestRunner implements ITestRunner {
+    constructor(@inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry) {}
+
+    public async runTests(request: TestRunRequest<PythonTestData>, options: TestRunOptions): Promise<void> {
+        const runOptions: PytestRunInstanceOptions = {
+            ...options,
+            exclude: request.exclude,
+            debug: request.debug,
+        };
+        const runInstance = test.createTestRun(request);
+        await Promise.all(
+            request.tests.map((testNode) =>
+                processTestNode(testNode, runInstance, runOptions, this.runTest.bind(this)),
+            ),
+        );
+    }
+
+    private async runTest(
+        testRunIds: string[],
+        runInstance: TestRun<PythonTestData>,
+        options: PytestRunInstanceOptions,
+    ): Promise<void> {
+        const junitFilePath = await getPytestJunitXmlTempFile(options.args, this.disposables);
+
+        // Remove the '--junitxml' or '--junit-xml' if it exists, and add it with our path.
+        const testArgs = filterArguments(options.args, [JunitXmlArg, JunitXmlArgOld]);
+        testArgs.splice(0, 0, `${JunitXmlArg}=${junitFilePath}`);
+
+        testArgs.splice(0, 0, '--rootdir', options.workspaceFolder.fsPath);
+        testArgs.splice(0, 0, '--override-ini', 'junit_family=xunit1');
+
+        // Positional arguments control the tests to be run.
+        testArgs.push(...testRunIds);
+    }
+}

--- a/src/client/testing/testController/serviceRegistry.ts
+++ b/src/client/testing/testController/serviceRegistry.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { IServiceManager } from '../../ioc/types';
+import { PYTEST_PROVIDER } from '../common/constants';
+import { TestDiscoveryHelper } from './common/discoveryHelper';
+import { ITestController, ITestDiscovery, ITestDiscoveryHelper, ITestsRunner } from './common/types';
+import { PytestDiscoveryService } from './pytest/discovery';
+import { PytestController } from './pytest/pytestController';
+import { PytestRunner } from './pytest/runner';
+
+export function registerTestControllerTypes(serviceManager: IServiceManager): void {
+    serviceManager.addSingleton<ITestController>(ITestController, PytestController, PYTEST_PROVIDER);
+    serviceManager.addSingleton<ITestDiscovery>(ITestDiscovery, PytestDiscoveryService, PYTEST_PROVIDER);
+    serviceManager.addSingleton<ITestsRunner>(ITestsRunner, PytestRunner, PYTEST_PROVIDER);
+    serviceManager.addSingleton<ITestDiscoveryHelper>(ITestDiscoveryHelper, TestDiscoveryHelper);
+}


### PR DESCRIPTION
I have not added tests in this PR. This is intentional, I want to address the `unittest` scenario to ensure the API is stable before adding tests.