### PR TITLE
Ensure JediLSP restart command is registered only once.

### DIFF
--- a/news/2 Fixes/16441.md
+++ b/news/2 Fixes/16441.md
@@ -1,0 +1,1 @@
+Ensure we dispose restart command registration before we create a new instance of Jedi LS.

--- a/src/client/activation/jedi/manager.ts
+++ b/src/client/activation/jedi/manager.ts
@@ -36,6 +36,8 @@ export class JediLanguageServerManager implements ILanguageServerManager {
 
     private disposables: IDisposable[] = [];
 
+    private static commandDispose: IDisposable;
+
     private connected = false;
 
     private lsVersion: string | undefined;
@@ -47,11 +49,12 @@ export class JediLanguageServerManager implements ILanguageServerManager {
         private readonly analysisOptions: ILanguageServerAnalysisOptions,
         @inject(ICommandManager) commandManager: ICommandManager,
     ) {
-        this.disposables.push(
-            commandManager.registerCommand(Commands.RestartLS, () => {
-                this.restartLanguageServer().ignoreErrors();
-            }),
-        );
+        if (JediLanguageServerManager.commandDispose) {
+            JediLanguageServerManager.commandDispose.dispose();
+        }
+        JediLanguageServerManager.commandDispose = commandManager.registerCommand(Commands.RestartLS, () => {
+            this.restartLanguageServer().ignoreErrors();
+        });
     }
 
     private static versionTelemetryProps(instance: JediLanguageServerManager) {
@@ -64,6 +67,7 @@ export class JediLanguageServerManager implements ILanguageServerManager {
         if (this.languageProxy) {
             this.languageProxy.dispose();
         }
+        JediLanguageServerManager.commandDispose.dispose();
         this.disposables.forEach((d) => d.dispose());
     }
 


### PR DESCRIPTION
Closes #16441
Closes https://github.com/microsoft/vscode-python-internalbacklog/issues/282

This is a temporary solution. The real fix here is to refactor how we do Language server client support in the extension.