### PR TITLE
Implement cases for pipenv and poetry module installers for the DataScienceInstaller

### DIFF
--- a/news/2 Fixes/16615.md
+++ b/news/2 Fixes/16615.md
@@ -1,0 +1,1 @@
+The Jupyter Notebook extension will install any missing dependencies using Poetry or Pipenv if those are the selected environments. (thanks [Anthony Shaw](https://github.com/tonybaloney))

--- a/src/client/common/installer/condaInstaller.ts
+++ b/src/client/common/installer/condaInstaller.ts
@@ -5,6 +5,7 @@
 import { inject, injectable } from 'inversify';
 import { ICondaService, ICondaLocatorService, IComponentAdapter } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
+import { ModuleInstallerType } from '../../pythonEnvironments/info';
 import { inDiscoveryExperiment } from '../experiments/helpers';
 import { ExecutionInfo, IConfigurationService, IExperimentService } from '../types';
 import { isResource } from '../utils/misc';
@@ -31,6 +32,10 @@ export class CondaInstaller extends ModuleInstaller {
 
     public get displayName(): string {
         return 'Conda';
+    }
+
+    public get type(): ModuleInstallerType {
+        return ModuleInstallerType.Conda;
     }
 
     public get priority(): number {

--- a/src/client/common/installer/moduleInstaller.ts
+++ b/src/client/common/installer/moduleInstaller.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import { CancellationToken, OutputChannel, ProgressLocation, ProgressOptions } from 'vscode';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
-import { EnvironmentType } from '../../pythonEnvironments/info';
+import { EnvironmentType, ModuleInstallerType } from '../../pythonEnvironments/info';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { IApplicationShell } from '../application/types';
@@ -26,6 +26,7 @@ export abstract class ModuleInstaller implements IModuleInstaller {
     public abstract get priority(): number;
     public abstract get name(): string;
     public abstract get displayName(): string;
+    public abstract get type(): ModuleInstallerType;
 
     constructor(protected serviceContainer: IServiceContainer) {}
 

--- a/src/client/common/installer/pipEnvInstaller.ts
+++ b/src/client/common/installer/pipEnvInstaller.ts
@@ -5,7 +5,7 @@ import { inject, injectable } from 'inversify';
 import { IInterpreterLocatorService, IInterpreterService, PIPENV_SERVICE } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { isPipenvEnvironmentRelatedToFolder } from '../../pythonEnvironments/discovery/locators/services/pipEnvHelper';
-import { EnvironmentType } from '../../pythonEnvironments/info';
+import { EnvironmentType, ModuleInstallerType } from '../../pythonEnvironments/info';
 import { IWorkspaceService } from '../application/types';
 import { inDiscoveryExperiment } from '../experiments/helpers';
 import { ExecutionInfo, IExperimentService } from '../types';
@@ -19,6 +19,10 @@ export const pipenvName = 'pipenv';
 export class PipEnvInstaller extends ModuleInstaller {
     public get name(): string {
         return 'pipenv';
+    }
+
+    public get type(): ModuleInstallerType {
+        return ModuleInstallerType.Pipenv;
     }
 
     public get displayName() {

--- a/src/client/common/installer/pipInstaller.ts
+++ b/src/client/common/installer/pipInstaller.ts
@@ -3,6 +3,7 @@
 
 import { inject, injectable } from 'inversify';
 import { IServiceContainer } from '../../ioc/types';
+import { ModuleInstallerType } from '../../pythonEnvironments/info';
 import { IWorkspaceService } from '../application/types';
 import { IPythonExecutionFactory } from '../process/types';
 import { ExecutionInfo } from '../types';
@@ -14,6 +15,10 @@ import { InterpreterUri, ModuleInstallFlags } from './types';
 export class PipInstaller extends ModuleInstaller {
     public get name(): string {
         return 'Pip';
+    }
+
+    public get type(): ModuleInstallerType {
+        return ModuleInstallerType.Pip;
     }
 
     public get displayName() {

--- a/src/client/common/installer/poetryInstaller.ts
+++ b/src/client/common/installer/poetryInstaller.ts
@@ -9,7 +9,7 @@ import { Uri } from 'vscode';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { isPoetryEnvironmentRelatedToFolder } from '../../pythonEnvironments/discovery/locators/services/poetry';
-import { EnvironmentType } from '../../pythonEnvironments/info';
+import { EnvironmentType, ModuleInstallerType } from '../../pythonEnvironments/info';
 import { IWorkspaceService } from '../application/types';
 import { inDiscoveryExperiment } from '../experiments/helpers';
 import { traceError } from '../logger';
@@ -28,6 +28,11 @@ export class PoetryInstaller extends ModuleInstaller {
     // eslint-disable-next-line class-methods-use-this
     public get name(): string {
         return 'poetry';
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    public get type(): ModuleInstallerType {
+        return ModuleInstallerType.Poetry;
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/src/client/common/installer/productInstaller.ts
+++ b/src/client/common/installer/productInstaller.ts
@@ -40,6 +40,8 @@ import {
     IProductService,
     ModuleInstallFlags,
 } from './types';
+import { pipenvName } from './pipEnvInstaller';
+import { poetryName } from './poetryInstaller';
 
 export { Product } from '../types';
 
@@ -482,8 +484,19 @@ class DataScienceInstaller extends BaseInstaller {
             installerModule = channels.find((v) => v.name === 'Pip');
             requiredInstaller = 'pip';
         } else {
-            installerModule = channels.find((v) => v.name === 'Pip');
-            requiredInstaller = 'pip';
+            switch (interpreter.envType) {
+                case EnvironmentType.Pipenv:
+                    installerModule = channels.find((v) => v.name === pipenvName);
+                    requiredInstaller = pipenvName;
+                    break;
+                case EnvironmentType.Poetry:
+                    installerModule = channels.find((v) => v.name === poetryName);
+                    requiredInstaller = poetryName;
+                    break;
+                default:
+                    installerModule = channels.find((v) => v.name === 'Pip');
+                    requiredInstaller = 'pip';
+            }
         }
 
         const version = `${interpreter.version?.major || ''}.${interpreter.version?.minor || ''}.${

--- a/src/client/common/installer/productInstaller.ts
+++ b/src/client/common/installer/productInstaller.ts
@@ -447,7 +447,7 @@ class RefactoringLibraryInstaller extends BaseInstaller {
     }
 }
 
-class DataScienceInstaller extends BaseInstaller {
+export class DataScienceInstaller extends BaseInstaller {
     // Override base installer to support a more DS-friendly streamlined installation.
     public async install(
         product: Product,

--- a/src/client/common/installer/types.ts
+++ b/src/client/common/installer/types.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { CancellationToken, Uri } from 'vscode';
-import { PythonEnvironment } from '../../pythonEnvironments/info';
+import { ModuleInstallerType, PythonEnvironment } from '../../pythonEnvironments/info';
 import { Product, ProductType, Resource } from '../types';
 
 export type InterpreterUri = Resource | PythonEnvironment;
@@ -12,6 +12,7 @@ export interface IModuleInstaller {
     readonly name: string;
     readonly displayName: string;
     readonly priority: number;
+    readonly type: ModuleInstallerType;
     /**
      * Installs a module
      * If a cancellation token is provided, then a cancellable progress message is dispalyed.

--- a/src/client/pythonEnvironments/info/index.ts
+++ b/src/client/pythonEnvironments/info/index.ts
@@ -24,6 +24,17 @@ export enum EnvironmentType {
 }
 
 /**
+ * The IModuleInstaller implementations.
+ */
+export enum ModuleInstallerType {
+    Unknown = 'Unknown',
+    Conda = 'Conda',
+    Pip = 'Pip',
+    Poetry = 'Poetry',
+    Pipenv = 'Pipenv',
+}
+
+/**
  * Details about a Python runtime.
  *
  * @prop path - the location of the executable file

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -54,7 +54,7 @@ import {
     IInterpreterService,
 } from '../../../client/interpreter/contracts';
 import { IServiceContainer } from '../../../client/ioc/types';
-import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
+import { EnvironmentType, ModuleInstallerType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
 
 /* Complex test to ensure we cover all combinations:
 We could have written separate tests for each installer, but we'd be replicate code.
@@ -81,6 +81,10 @@ suite('Module Installer', () => {
 
         public get displayName(): string {
             return '';
+        }
+
+        public get type(): ModuleInstallerType {
+            return ModuleInstallerType.Unknown;
         }
 
         public isSupported(): Promise<boolean> {

--- a/src/test/common/installer/productInstaller.unit.test.ts
+++ b/src/test/common/installer/productInstaller.unit.test.ts
@@ -15,7 +15,7 @@ import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnviro
 
 class AlwaysInstalledDataScienceInstaller extends DataScienceInstaller {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, class-methods-use-this
-    public async isInstalled(product: Product, resource?: InterpreterUri): Promise<boolean> {
+    public async isInstalled(_product: Product, _resource?: InterpreterUri): Promise<boolean> {
         return true;
     }
 }

--- a/src/test/common/installer/productInstaller.unit.test.ts
+++ b/src/test/common/installer/productInstaller.unit.test.ts
@@ -11,7 +11,7 @@ import { IInstallationChannelManager, IModuleInstaller, InterpreterUri } from '.
 import { InstallerResponse, IOutputChannel, Product } from '../../../client/common/types';
 import { Architecture } from '../../../client/common/utils/platform';
 import { IServiceContainer } from '../../../client/ioc/types';
-import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
+import { EnvironmentType, ModuleInstallerType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
 
 class AlwaysInstalledDataScienceInstaller extends DataScienceInstaller {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, class-methods-use-this
@@ -84,7 +84,7 @@ suite('DataScienceInstaller install', async () => {
             sysPrefix: '',
         };
         const testInstaller = TypeMoq.Mock.ofType<IModuleInstaller>();
-        testInstaller.setup((c) => c.name).returns(() => EnvironmentType.Conda);
+        testInstaller.setup((c) => c.type).returns(() => ModuleInstallerType.Conda);
         testInstaller
             .setup((c) =>
                 c.installModule(
@@ -115,7 +115,7 @@ suite('DataScienceInstaller install', async () => {
         };
         const testInstaller = TypeMoq.Mock.ofType<IModuleInstaller>();
 
-        testInstaller.setup((c) => c.name).returns(() => 'Pip');
+        testInstaller.setup((c) => c.type).returns(() => ModuleInstallerType.Pip);
         testInstaller
             .setup((c) =>
                 c.installModule(
@@ -146,7 +146,7 @@ suite('DataScienceInstaller install', async () => {
         };
         const testInstaller = TypeMoq.Mock.ofType<IModuleInstaller>();
 
-        testInstaller.setup((c) => c.name).returns(() => 'poetry');
+        testInstaller.setup((c) => c.type).returns(() => ModuleInstallerType.Poetry);
         testInstaller
             .setup((c) =>
                 c.installModule(
@@ -177,7 +177,7 @@ suite('DataScienceInstaller install', async () => {
         };
         const testInstaller = TypeMoq.Mock.ofType<IModuleInstaller>();
 
-        testInstaller.setup((c) => c.name).returns(() => 'pipenv');
+        testInstaller.setup((c) => c.type).returns(() => ModuleInstallerType.Pipenv);
         testInstaller
             .setup((c) =>
                 c.installModule(
@@ -209,7 +209,7 @@ suite('DataScienceInstaller install', async () => {
         };
         const testInstaller = TypeMoq.Mock.ofType<IModuleInstaller>();
 
-        testInstaller.setup((c) => c.name).returns(() => 'Pip');
+        testInstaller.setup((c) => c.type).returns(() => ModuleInstallerType.Pip);
         testInstaller
             .setup((c) =>
                 c.installModule(

--- a/src/test/common/installer/productInstaller.unit.test.ts
+++ b/src/test/common/installer/productInstaller.unit.test.ts
@@ -1,0 +1,199 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect } from 'chai';
+import * as TypeMoq from 'typemoq';
+import { IApplicationShell } from '../../../client/common/application/types';
+import { DataScienceInstaller } from '../../../client/common/installer/productInstaller';
+import { IInstallationChannelManager, IModuleInstaller, InterpreterUri } from '../../../client/common/installer/types';
+import { InstallerResponse, IOutputChannel, Product } from '../../../client/common/types';
+import { Architecture } from '../../../client/common/utils/platform';
+import { IServiceContainer } from '../../../client/ioc/types';
+import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
+
+class AlwaysInstalledDataScienceInstaller extends DataScienceInstaller {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, class-methods-use-this
+    public async isInstalled(product: Product, resource?: InterpreterUri): Promise<boolean> {
+        return true;
+    }
+}
+
+suite('DataScienceInstaller install', async () => {
+    let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+    let installationChannelManager: TypeMoq.IMock<IInstallationChannelManager>;
+    let dataScienceInstaller: DataScienceInstaller;
+    let outputChannel: TypeMoq.IMock<IOutputChannel>;
+    let appShell: TypeMoq.IMock<IApplicationShell>;
+
+    const interpreterPath = 'path/to/interpreter';
+
+    setup(() => {
+        serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        installationChannelManager = TypeMoq.Mock.ofType<IInstallationChannelManager>();
+        outputChannel = TypeMoq.Mock.ofType<IOutputChannel>();
+        appShell = TypeMoq.Mock.ofType<IApplicationShell>();
+        appShell.setup((a) => a.showErrorMessage(TypeMoq.It.isAnyString())).returns(() => Promise.resolve(undefined));
+        serviceContainer
+            .setup((c) => c.get(TypeMoq.It.isValue(IInstallationChannelManager)))
+            .returns(() => installationChannelManager.object);
+
+        serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(IApplicationShell))).returns(() => appShell.object);
+
+        dataScienceInstaller = new AlwaysInstalledDataScienceInstaller(serviceContainer.object, outputChannel.object);
+    });
+
+    teardown(() => {
+        // noop
+    });
+
+    test('Requires interpreter Uri', async () => {
+        let threwUp = false;
+        try {
+            await dataScienceInstaller.install(Product.ipykernel);
+        } catch (ex) {
+            threwUp = true;
+        }
+        expect(threwUp).to.equal(true, 'Should raise exception');
+    });
+
+    test('Will ignore with no installer modules', async () => {
+        const testEnvironment: PythonEnvironment = {
+            envType: EnvironmentType.VirtualEnv,
+            envName: 'test',
+            envPath: interpreterPath,
+            path: interpreterPath,
+            architecture: Architecture.x64,
+            sysPrefix: '',
+        };
+        installationChannelManager
+            .setup((c) => c.getInstallationChannels(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve([]));
+        const result = await dataScienceInstaller.install(Product.ipykernel, testEnvironment);
+        expect(result).to.equal(InstallerResponse.Ignore, 'Should be InstallerResponse.Ignore');
+    });
+
+    test('Will invoke conda for conda environments', async () => {
+        const testEnvironment: PythonEnvironment = {
+            envType: EnvironmentType.Conda,
+            envName: 'test',
+            envPath: interpreterPath,
+            path: interpreterPath,
+            architecture: Architecture.x64,
+            sysPrefix: '',
+        };
+        const testInstaller = TypeMoq.Mock.ofType<IModuleInstaller>();
+        testInstaller.setup((c) => c.name).returns(() => EnvironmentType.Conda);
+        testInstaller
+            .setup((c) =>
+                c.installModule(
+                    TypeMoq.It.isValue(Product.ipykernel),
+                    TypeMoq.It.isValue(testEnvironment),
+                    TypeMoq.It.isAny(),
+                    TypeMoq.It.isAny(),
+                ),
+            )
+            .returns(() => Promise.resolve());
+
+        installationChannelManager
+            .setup((c) => c.getInstallationChannels(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve([testInstaller.object]));
+
+        const result = await dataScienceInstaller.install(Product.ipykernel, testEnvironment);
+        expect(result).to.equal(InstallerResponse.Installed, 'Should be Installed');
+    });
+
+    test('Will invoke pip by default', async () => {
+        const testEnvironment: PythonEnvironment = {
+            envType: EnvironmentType.VirtualEnv,
+            envName: 'test',
+            envPath: interpreterPath,
+            path: interpreterPath,
+            architecture: Architecture.x64,
+            sysPrefix: '',
+        };
+        const testInstaller = TypeMoq.Mock.ofType<IModuleInstaller>();
+
+        testInstaller.setup((c) => c.name).returns(() => 'Pip');
+        testInstaller
+            .setup((c) =>
+                c.installModule(
+                    TypeMoq.It.isValue(Product.ipykernel),
+                    TypeMoq.It.isValue(testEnvironment),
+                    TypeMoq.It.isAny(),
+                    TypeMoq.It.isAny(),
+                ),
+            )
+            .returns(() => Promise.resolve());
+
+        installationChannelManager
+            .setup((c) => c.getInstallationChannels(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve([testInstaller.object]));
+
+        const result = await dataScienceInstaller.install(Product.ipykernel, testEnvironment);
+        expect(result).to.equal(InstallerResponse.Installed, 'Should be Installed');
+    });
+
+    test('Will invoke poetry', async () => {
+        const testEnvironment: PythonEnvironment = {
+            envType: EnvironmentType.Poetry,
+            envName: 'test',
+            envPath: interpreterPath,
+            path: interpreterPath,
+            architecture: Architecture.x64,
+            sysPrefix: '',
+        };
+        const testInstaller = TypeMoq.Mock.ofType<IModuleInstaller>();
+
+        testInstaller.setup((c) => c.name).returns(() => 'poetry');
+        testInstaller
+            .setup((c) =>
+                c.installModule(
+                    TypeMoq.It.isValue(Product.ipykernel),
+                    TypeMoq.It.isValue(testEnvironment),
+                    TypeMoq.It.isAny(),
+                    TypeMoq.It.isAny(),
+                ),
+            )
+            .returns(() => Promise.resolve());
+
+        installationChannelManager
+            .setup((c) => c.getInstallationChannels(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve([testInstaller.object]));
+
+        const result = await dataScienceInstaller.install(Product.ipykernel, testEnvironment);
+        expect(result).to.equal(InstallerResponse.Installed, 'Should be Installed');
+    });
+
+    test('Will invoke pipenv', async () => {
+        const testEnvironment: PythonEnvironment = {
+            envType: EnvironmentType.Pipenv,
+            envName: 'test',
+            envPath: interpreterPath,
+            path: interpreterPath,
+            architecture: Architecture.x64,
+            sysPrefix: '',
+        };
+        const testInstaller = TypeMoq.Mock.ofType<IModuleInstaller>();
+
+        testInstaller.setup((c) => c.name).returns(() => 'pipenv');
+        testInstaller
+            .setup((c) =>
+                c.installModule(
+                    TypeMoq.It.isValue(Product.ipykernel),
+                    TypeMoq.It.isValue(testEnvironment),
+                    TypeMoq.It.isAny(),
+                    TypeMoq.It.isAny(),
+                ),
+            )
+            .returns(() => Promise.resolve());
+
+        installationChannelManager
+            .setup((c) => c.getInstallationChannels(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve([testInstaller.object]));
+
+        const result = await dataScienceInstaller.install(Product.ipykernel, testEnvironment);
+        expect(result).to.equal(InstallerResponse.Installed, 'Should be Installed');
+    });
+});

--- a/src/test/mocks/moduleInstaller.ts
+++ b/src/test/mocks/moduleInstaller.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 import { Uri } from 'vscode';
 import { IModuleInstaller } from '../../client/common/installer/types';
 import { Product } from '../../client/common/types';
+import { ModuleInstallerType } from '../../client/pythonEnvironments/info';
 
 export class MockModuleInstaller extends EventEmitter implements IModuleInstaller {
     constructor(public readonly displayName: string, private supported: boolean) {
@@ -11,6 +12,11 @@ export class MockModuleInstaller extends EventEmitter implements IModuleInstalle
     // eslint-disable-next-line class-methods-use-this
     public get name(): string {
         return 'mock';
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    public get type(): ModuleInstallerType {
+        return ModuleInstallerType.Pip;
     }
 
     // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
Fixes #16615 

There are 4 module installers:

```
    serviceManager.addSingleton<IModuleInstaller>(IModuleInstaller, CondaInstaller);
    serviceManager.addSingleton<IModuleInstaller>(IModuleInstaller, PipInstaller);
    serviceManager.addSingleton<IModuleInstaller>(IModuleInstaller, PipEnvInstaller);
    serviceManager.addSingleton<IModuleInstaller>(IModuleInstaller, PoetryInstaller);
```

I noticed that the names of the Pipenv and poetry installers are constants, so I've imported those constant values instead of hardcoding the string (like it is with the `Pip` string)