### PR TITLE
Do not resolve inside iterEnvs in low-level locators

### DIFF
--- a/src/client/common/utils/async.ts
+++ b/src/client/common/utils/async.ts
@@ -99,7 +99,7 @@ export function createDeferredFromPromise<T>(promise: Promise<T>): Deferred<T> {
 
 // iterators
 
-interface IAsyncIterator<T> extends AsyncIterator<T, void>, Partial<AsyncIterable<T>> {}
+interface IAsyncIterator<T> extends AsyncIterator<T, void> {}
 
 export interface IAsyncIterableIterator<T> extends IAsyncIterator<T>, AsyncIterable<T> {}
 

--- a/src/client/pythonEnvironments/base/info/index.ts
+++ b/src/client/pythonEnvironments/base/info/index.ts
@@ -28,6 +28,14 @@ export enum PythonEnvKind {
     OtherVirtual = 'virt-other',
 }
 
+export const virtualEnvKinds = [
+    PythonEnvKind.Poetry,
+    PythonEnvKind.Pipenv,
+    PythonEnvKind.Venv,
+    PythonEnvKind.VirtualEnvWrapper,
+    PythonEnvKind.Conda,
+    PythonEnvKind.VirtualEnv,
+];
 /**
  * Information about a file.
  */

--- a/src/client/pythonEnvironments/base/locator.ts
+++ b/src/client/pythonEnvironments/base/locator.ts
@@ -11,7 +11,7 @@ import { BasicPythonEnvsChangedEvent, IPythonEnvsWatcher, PythonEnvsChangedEvent
 /**
  * A single update to a previously provided Python env object.
  */
-export type PythonEnvUpdatedEvent = {
+export type PythonEnvUpdatedEvent<I = PythonEnvInfo> = {
     /**
      * The iteration index of The env info that was previously provided.
      */
@@ -19,12 +19,12 @@ export type PythonEnvUpdatedEvent = {
     /**
      * The env info that was previously provided.
      */
-    old?: PythonEnvInfo;
+    old?: I;
     /**
      * The env info that replaces the old info.
      * Update is sent as `undefined` if we find out that the environment is no longer valid.
      */
-    update: PythonEnvInfo | undefined;
+    update: I | undefined;
 };
 
 /**
@@ -58,7 +58,7 @@ export interface IPythonEnvsIterator<I = PythonEnvInfo> extends IAsyncIterableIt
      * If this property is not provided then it means the iterator does
      * not support updates.
      */
-    onUpdated?: Event<PythonEnvUpdatedEvent | null>;
+    onUpdated?: Event<PythonEnvUpdatedEvent<I> | null>;
 }
 
 /**

--- a/src/client/pythonEnvironments/base/locator.ts
+++ b/src/client/pythonEnvironments/base/locator.ts
@@ -114,7 +114,7 @@ export type PythonLocatorQuery = BasicPythonLocatorQuery & {
 
 type QueryForEvent<E> = E extends PythonEnvsChangedEvent ? PythonLocatorQuery : BasicPythonLocatorQuery;
 
-export type BasicEnvInfo = { kind: PythonEnvKind; executable: string };
+export type BasicEnvInfo = { kind: PythonEnvKind; executablePath: string };
 
 /**
  * A single Python environment locator.

--- a/src/client/pythonEnvironments/base/locator.ts
+++ b/src/client/pythonEnvironments/base/locator.ts
@@ -49,7 +49,7 @@ export type PythonEnvUpdatedEvent = {
  * Callers can usually ignore the update event entirely and rely on
  * the locator to provide sufficiently complete information.
  */
-export interface IPythonEnvsIterator extends IAsyncIterableIterator<PythonEnvInfo> {
+export interface IPythonEnvsIterator<I = PythonEnvInfo> extends IAsyncIterableIterator<I> {
     /**
      * Provides possible updates for already-iterated envs.
      *
@@ -114,6 +114,8 @@ export type PythonLocatorQuery = BasicPythonLocatorQuery & {
 
 type QueryForEvent<E> = E extends PythonEnvsChangedEvent ? PythonLocatorQuery : BasicPythonLocatorQuery;
 
+export type BasicEnvInfo = { kind: PythonEnvKind; executable: string };
+
 /**
  * A single Python environment locator.
  *
@@ -128,7 +130,7 @@ type QueryForEvent<E> = E extends PythonEnvsChangedEvent ? PythonLocatorQuery : 
  * events emitted via `onChanged` do not need to provide information
  * for the specific environments that changed.
  */
-export interface ILocator<E extends BasicPythonEnvsChangedEvent = PythonEnvsChangedEvent>
+export interface ILocator<I = PythonEnvInfo, E extends BasicPythonEnvsChangedEvent = PythonEnvsChangedEvent>
     extends IPythonEnvsWatcher<E> {
     /**
      * Iterate over the enviroments known tos this locator.
@@ -146,7 +148,7 @@ export interface ILocator<E extends BasicPythonEnvsChangedEvent = PythonEnvsChan
      * @param query - if provided, the locator will limit results to match
      * @returns - the fast async iterator of Python envs, which may have incomplete info
      */
-    iterEnvs(query?: QueryForEvent<E>): IPythonEnvsIterator;
+    iterEnvs(query?: QueryForEvent<E>): IPythonEnvsIterator<I>;
 }
 
 interface IResolver {
@@ -159,7 +161,7 @@ interface IResolver {
     resolveEnv(env: string): Promise<PythonEnvInfo | undefined>;
 }
 
-export interface IResolvingLocator extends IResolver, ILocator {}
+export interface IResolvingLocator<I = PythonEnvInfo> extends IResolver, ILocator<I> {}
 
 interface IEmitter<E extends PythonEnvsChangedEvent> {
     fire(e: E): void;
@@ -177,7 +179,8 @@ interface IEmitter<E extends PythonEnvsChangedEvent> {
  * should be used.  Only in low-level cases should you consider using
  * `BasicPythonEnvsChangedEvent`.
  */
-abstract class LocatorBase<E extends BasicPythonEnvsChangedEvent = PythonEnvsChangedEvent> implements ILocator<E> {
+abstract class LocatorBase<I = PythonEnvInfo, E extends BasicPythonEnvsChangedEvent = PythonEnvsChangedEvent>
+    implements ILocator<I, E> {
     public readonly onChanged: Event<E>;
 
     protected readonly emitter: IEmitter<E>;
@@ -188,7 +191,7 @@ abstract class LocatorBase<E extends BasicPythonEnvsChangedEvent = PythonEnvsCha
     }
 
     // eslint-disable-next-line class-methods-use-this
-    public abstract iterEnvs(query?: QueryForEvent<E>): IPythonEnvsIterator;
+    public abstract iterEnvs(query?: QueryForEvent<E>): IPythonEnvsIterator<I>;
 }
 
 /**
@@ -203,7 +206,7 @@ abstract class LocatorBase<E extends BasicPythonEnvsChangedEvent = PythonEnvsCha
  * Only in low-level cases should you consider subclassing `LocatorBase`
  * using `BasicPythonEnvsChangedEvent.
  */
-export abstract class Locator extends LocatorBase {
+export abstract class Locator<I = PythonEnvInfo> extends LocatorBase<I> {
     constructor() {
         super(new PythonEnvsWatcher());
     }

--- a/src/client/pythonEnvironments/base/locatorUtils.ts
+++ b/src/client/pythonEnvironments/base/locatorUtils.ts
@@ -74,14 +74,14 @@ function getSearchLocationFilters(query: PythonLocatorQuery): ((u: Uri) => boole
  *
  * This includes applying any received updates.
  */
-export async function getEnvs(iterator: IPythonEnvsIterator): Promise<PythonEnvInfo[]> {
-    const envs: (PythonEnvInfo | undefined)[] = [];
+export async function getEnvs<I = PythonEnvInfo>(iterator: IPythonEnvsIterator<I>): Promise<I[]> {
+    const envs: (I | undefined)[] = [];
 
     const updatesDone = createDeferred<void>();
     if (iterator.onUpdated === undefined) {
         updatesDone.resolve();
     } else {
-        const listener = iterator.onUpdated((event: PythonEnvUpdatedEvent | null) => {
+        const listener = iterator.onUpdated((event: PythonEnvUpdatedEvent<I> | null) => {
             if (event === null) {
                 updatesDone.resolve();
                 listener.dispose();

--- a/src/client/pythonEnvironments/base/locators.ts
+++ b/src/client/pythonEnvironments/base/locators.ts
@@ -3,14 +3,15 @@
 
 import { chain } from '../../common/utils/async';
 import { Disposables } from '../../common/utils/resourceLifecycle';
+import { PythonEnvInfo } from './info';
 import { ILocator, IPythonEnvsIterator, PythonEnvUpdatedEvent, PythonLocatorQuery } from './locator';
 import { PythonEnvsWatchers } from './watchers';
 
 /**
  * Combine the `onUpdated` event of the given iterators into a single event.
  */
-export function combineIterators(iterators: IPythonEnvsIterator[]): IPythonEnvsIterator {
-    const result: IPythonEnvsIterator = chain(iterators);
+export function combineIterators<I>(iterators: IPythonEnvsIterator<I>[]): IPythonEnvsIterator<I> {
+    const result: IPythonEnvsIterator<I> = chain(iterators);
     const events = iterators.map((it) => it.onUpdated).filter((v) => v);
     if (!events || events.length === 0) {
         // There are no sub-events, so we leave `onUpdated` undefined.
@@ -18,11 +19,11 @@ export function combineIterators(iterators: IPythonEnvsIterator[]): IPythonEnvsI
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    result.onUpdated = (handleEvent: (e: PythonEnvUpdatedEvent | null) => any) => {
+    result.onUpdated = (handleEvent: (e: PythonEnvUpdatedEvent<I> | null) => any) => {
         const disposables = new Disposables();
         let numActive = events.length;
         events.forEach((event) => {
-            const disposable = event!((e: PythonEnvUpdatedEvent | null) => {
+            const disposable = event!((e: PythonEnvUpdatedEvent<I> | null) => {
                 // NOSONAR
                 if (e === null) {
                     numActive -= 1;
@@ -46,15 +47,15 @@ export function combineIterators(iterators: IPythonEnvsIterator[]): IPythonEnvsI
  *
  * Events and iterator results are combined.
  */
-export class Locators extends PythonEnvsWatchers implements ILocator {
+export class Locators<I = PythonEnvInfo> extends PythonEnvsWatchers implements ILocator<I> {
     constructor(
         // The locators will be watched as well as iterated.
-        private readonly locators: ReadonlyArray<ILocator>,
+        private readonly locators: ReadonlyArray<ILocator<I>>,
     ) {
         super(locators);
     }
 
-    public iterEnvs(query?: PythonLocatorQuery): IPythonEnvsIterator {
+    public iterEnvs(query?: PythonLocatorQuery): IPythonEnvsIterator<I> {
         const iterators = this.locators.map((loc) => loc.iterEnvs(query));
         return combineIterators(iterators);
     }

--- a/src/client/pythonEnvironments/base/locators/common/resourceBasedLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/common/resourceBasedLocator.ts
@@ -3,6 +3,7 @@
 
 import { createDeferred, Deferred } from '../../../../common/utils/async';
 import { Disposables, IDisposable } from '../../../../common/utils/resourceLifecycle';
+import { PythonEnvInfo } from '../../info';
 import { IPythonEnvsIterator, Locator, PythonLocatorQuery } from '../../locator';
 
 /**
@@ -17,7 +18,7 @@ import { IPythonEnvsIterator, Locator, PythonLocatorQuery } from '../../locator'
  *
  * Otherwise it will leak (and we have no leak detection).
  */
-export abstract class LazyResourceBasedLocator extends Locator implements IDisposable {
+export abstract class LazyResourceBasedLocator<I = PythonEnvInfo> extends Locator<I> implements IDisposable {
     protected readonly disposables = new Disposables();
 
     // This will be set only once we have to create necessary resources
@@ -30,7 +31,7 @@ export abstract class LazyResourceBasedLocator extends Locator implements IDispo
         await this.disposables.dispose();
     }
 
-    public async *iterEnvs(query?: PythonLocatorQuery): IPythonEnvsIterator {
+    public async *iterEnvs(query?: PythonLocatorQuery): IPythonEnvsIterator<I> {
         await this.ensureResourcesReady();
         yield* this.doIterEnvs(query);
         // There is not need to wait for the watchers to get started.
@@ -40,7 +41,7 @@ export abstract class LazyResourceBasedLocator extends Locator implements IDispo
     /**
      * The subclass implementation of iterEnvs().
      */
-    protected abstract doIterEnvs(query?: PythonLocatorQuery): IPythonEnvsIterator;
+    protected abstract doIterEnvs(query?: PythonLocatorQuery): IPythonEnvsIterator<I>;
 
     /**
      * This is where subclasses get their resources ready.

--- a/src/client/pythonEnvironments/base/locators/common/wrappingLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/common/wrappingLocator.ts
@@ -8,26 +8,26 @@ import { IPythonEnvsIterator, IResolvingLocator, PythonLocatorQuery } from '../.
 import { PythonEnvsChangedEvent, PythonEnvsWatcher } from '../../watcher';
 import { LazyResourceBasedLocator } from './resourceBasedLocator';
 
-export type GetLocatorFunc = () => Promise<IResolvingLocator & Partial<IDisposable>>;
+export type GetLocatorFunc<I = PythonEnvInfo> = () => Promise<IResolvingLocator<I> & Partial<IDisposable>>;
 
 /**
  * A locator that wraps another.
  *
  * This facilitates isolating the wrapped locator.
  */
-export class LazyWrappingLocator extends LazyResourceBasedLocator {
+export class LazyWrappingLocator<I = PythonEnvInfo> extends LazyResourceBasedLocator<I> {
     public readonly onChanged: Event<PythonEnvsChangedEvent>;
 
     private readonly watcher = new PythonEnvsWatcher();
 
-    private wrapped?: IResolvingLocator;
+    private wrapped?: IResolvingLocator<I>;
 
-    constructor(private readonly getLocator: GetLocatorFunc) {
+    constructor(private readonly getLocator: GetLocatorFunc<I>) {
         super();
         this.onChanged = this.watcher.onChanged;
     }
 
-    protected async *doIterEnvs(query?: PythonLocatorQuery): IPythonEnvsIterator {
+    protected async *doIterEnvs(query?: PythonLocatorQuery): IPythonEnvsIterator<I> {
         yield* this.wrapped!.iterEnvs(query);
     }
 

--- a/src/client/pythonEnvironments/base/locators/common/wrappingLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/common/wrappingLocator.ts
@@ -32,6 +32,7 @@ export class LazyWrappingLocator<I = PythonEnvInfo> extends LazyResourceBasedLoc
     }
 
     public async resolveEnv(env: string): Promise<PythonEnvInfo | undefined> {
+        await this.ensureResourcesReady();
         return this.wrapped!.resolveEnv(env);
     }
 

--- a/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
@@ -17,7 +17,7 @@ import {
     PythonLocatorQuery,
 } from '../../locator';
 import { PythonEnvsChangedEvent } from '../../watcher';
-import { resolveEnvUsingKind } from './resolverUtils';
+import { resolveBasicEnv } from './resolverUtils';
 
 /**
  * Calls environment info service which runs `interpreterInfo.py` script on environments received
@@ -35,7 +35,7 @@ export class PythonEnvsResolver implements IResolvingLocator {
 
     public async resolveEnv(executablePath: string): Promise<PythonEnvInfo | undefined> {
         const kind = await identifyEnvironment(executablePath);
-        const environment = await resolveEnvUsingKind({ kind, executablePath });
+        const environment = await resolveBasicEnv({ kind, executablePath });
         const info = await this.environmentInfoService.getEnvironmentInfo(environment.executable.filename);
         if (!info) {
             return undefined;
@@ -72,7 +72,7 @@ export class PythonEnvsResolver implements IResolvingLocator {
                         'Unsupported behavior: `undefined` environment updates are not supported from downstream locators in resolver',
                     );
                 } else if (seen[event.index] !== undefined) {
-                    seen[event.index] = await resolveEnvUsingKind(event.update);
+                    seen[event.index] = await resolveBasicEnv(event.update);
                     this.resolveInBackground(event.index, state, didUpdate, seen).ignoreErrors();
                 } else {
                     // This implies a problem in a downstream locator
@@ -85,7 +85,7 @@ export class PythonEnvsResolver implements IResolvingLocator {
 
         let result = await iterator.next();
         while (!result.done) {
-            const currEnv = await resolveEnvUsingKind(result.value);
+            const currEnv = await resolveBasicEnv(result.value);
             seen.push(currEnv);
             yield currEnv;
             this.resolveInBackground(seen.indexOf(currEnv), state, didUpdate, seen).ignoreErrors();

--- a/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
@@ -4,10 +4,12 @@
 import { cloneDeep } from 'lodash';
 import { Event, EventEmitter } from 'vscode';
 import { traceVerbose } from '../../../../common/logger';
+import { identifyEnvironment } from '../../../common/environmentIdentifier';
 import { IEnvironmentInfoService } from '../../../info/environmentInfoService';
 import { PythonEnvInfo } from '../../info';
 import { InterpreterInformation } from '../../info/interpreter';
 import {
+    BasicEnvInfo,
     ILocator,
     IPythonEnvsIterator,
     IResolvingLocator,
@@ -15,7 +17,7 @@ import {
     PythonLocatorQuery,
 } from '../../locator';
 import { PythonEnvsChangedEvent } from '../../watcher';
-import { resolveEnv } from './resolverUtils';
+import { resolveEnvFromKind } from './resolverUtils';
 
 /**
  * Calls environment info service which runs `interpreterInfo.py` script on environments received
@@ -27,12 +29,13 @@ export class PythonEnvsResolver implements IResolvingLocator {
     }
 
     constructor(
-        private readonly parentLocator: ILocator,
+        private readonly parentLocator: ILocator<BasicEnvInfo>,
         private readonly environmentInfoService: IEnvironmentInfoService,
     ) {}
 
     public async resolveEnv(executablePath: string): Promise<PythonEnvInfo | undefined> {
-        const environment = await resolveEnv(executablePath);
+        const kind = await identifyEnvironment(executablePath);
+        const environment = await resolveEnvFromKind({ kind, executablePath });
         const info = await this.environmentInfoService.getEnvironmentInfo(environment.executable.filename);
         if (!info) {
             return undefined;
@@ -49,7 +52,7 @@ export class PythonEnvsResolver implements IResolvingLocator {
     }
 
     private async *iterEnvsIterator(
-        iterator: IPythonEnvsIterator,
+        iterator: IPythonEnvsIterator<BasicEnvInfo>,
         didUpdate: EventEmitter<PythonEnvUpdatedEvent | null>,
     ): IPythonEnvsIterator {
         const state = {
@@ -59,7 +62,7 @@ export class PythonEnvsResolver implements IResolvingLocator {
         const seen: PythonEnvInfo[] = [];
 
         if (iterator.onUpdated !== undefined) {
-            const listener = iterator.onUpdated((event) => {
+            const listener = iterator.onUpdated(async (event) => {
                 if (event === null) {
                     state.done = true;
                     checkIfFinishedAndNotify(state, didUpdate);
@@ -69,7 +72,7 @@ export class PythonEnvsResolver implements IResolvingLocator {
                         'Unsupported behavior: `undefined` environment updates are not supported from downstream locators in resolver',
                     );
                 } else if (seen[event.index] !== undefined) {
-                    seen[event.index] = event.update;
+                    seen[event.index] = await resolveEnvFromKind(event.update);
                     this.resolveInBackground(event.index, state, didUpdate, seen).ignoreErrors();
                 } else {
                     // This implies a problem in a downstream locator
@@ -80,7 +83,7 @@ export class PythonEnvsResolver implements IResolvingLocator {
 
         let result = await iterator.next();
         while (!result.done) {
-            const currEnv = result.value;
+            const currEnv = await resolveEnvFromKind(result.value);
             seen.push(currEnv);
             yield currEnv;
             this.resolveInBackground(seen.indexOf(currEnv), state, didUpdate, seen).ignoreErrors();

--- a/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
@@ -35,7 +35,9 @@ export class PythonEnvsResolver implements IResolvingLocator {
 
     public async resolveEnv(executablePath: string): Promise<PythonEnvInfo | undefined> {
         const kind = await identifyEnvironment(executablePath);
+        console.time('Time taken');
         const environment = await resolveEnvFromKind({ kind, executablePath });
+        console.timeEnd('Time taken');
         const info = await this.environmentInfoService.getEnvironmentInfo(environment.executable.filename);
         if (!info) {
             return undefined;

--- a/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
@@ -63,9 +63,9 @@ export class PythonEnvsResolver implements IResolvingLocator {
 
         if (iterator.onUpdated !== undefined) {
             const listener = iterator.onUpdated(async (event) => {
+                state.pending += 1;
                 if (event === null) {
                     state.done = true;
-                    checkIfFinishedAndNotify(state, didUpdate);
                     listener.dispose();
                 } else if (event.update === undefined) {
                     throw new Error(
@@ -78,6 +78,8 @@ export class PythonEnvsResolver implements IResolvingLocator {
                     // This implies a problem in a downstream locator
                     traceVerbose(`Expected already iterated env, got ${event.old} (#${event.index})`);
                 }
+                state.pending -= 1;
+                checkIfFinishedAndNotify(state, didUpdate);
             });
         }
 

--- a/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
@@ -17,7 +17,7 @@ import {
     PythonLocatorQuery,
 } from '../../locator';
 import { PythonEnvsChangedEvent } from '../../watcher';
-import { resolveEnvFromKind } from './resolverUtils';
+import { resolveEnvUsingKind } from './resolverUtils';
 
 /**
  * Calls environment info service which runs `interpreterInfo.py` script on environments received
@@ -35,7 +35,7 @@ export class PythonEnvsResolver implements IResolvingLocator {
 
     public async resolveEnv(executablePath: string): Promise<PythonEnvInfo | undefined> {
         const kind = await identifyEnvironment(executablePath);
-        const environment = await resolveEnvFromKind({ kind, executablePath });
+        const environment = await resolveEnvUsingKind({ kind, executablePath });
         const info = await this.environmentInfoService.getEnvironmentInfo(environment.executable.filename);
         if (!info) {
             return undefined;
@@ -72,7 +72,7 @@ export class PythonEnvsResolver implements IResolvingLocator {
                         'Unsupported behavior: `undefined` environment updates are not supported from downstream locators in resolver',
                     );
                 } else if (seen[event.index] !== undefined) {
-                    seen[event.index] = await resolveEnvFromKind(event.update);
+                    seen[event.index] = await resolveEnvUsingKind(event.update);
                     this.resolveInBackground(event.index, state, didUpdate, seen).ignoreErrors();
                 } else {
                     // This implies a problem in a downstream locator
@@ -85,7 +85,7 @@ export class PythonEnvsResolver implements IResolvingLocator {
 
         let result = await iterator.next();
         while (!result.done) {
-            const currEnv = await resolveEnvFromKind(result.value);
+            const currEnv = await resolveEnvUsingKind(result.value);
             seen.push(currEnv);
             yield currEnv;
             this.resolveInBackground(seen.indexOf(currEnv), state, didUpdate, seen).ignoreErrors();

--- a/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/environmentsResolver.ts
@@ -35,9 +35,7 @@ export class PythonEnvsResolver implements IResolvingLocator {
 
     public async resolveEnv(executablePath: string): Promise<PythonEnvInfo | undefined> {
         const kind = await identifyEnvironment(executablePath);
-        console.time('Time taken');
         const environment = await resolveEnvFromKind({ kind, executablePath });
-        console.timeEnd('Time taken');
         const info = await this.environmentInfoService.getEnvironmentInfo(environment.executable.filename);
         if (!info) {
             return undefined;

--- a/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
@@ -19,6 +19,7 @@ import { parsePyenvVersion } from '../../../discovery/locators/services/pyenvLoc
 import { Architecture, getOSType, OSType } from '../../../../common/utils/platform';
 import { getPythonVersionFromPath as parsePythonVersionFromPath, parseVersion } from '../../info/pythonVersion';
 import { getRegistryInterpreters } from '../../../common/windowsUtils';
+import { BasicEnvInfo } from '../../locator';
 
 function getResolvers(): Map<PythonEnvKind, (executablePath: string) => Promise<PythonEnvInfo>> {
     const resolvers = new Map<PythonEnvKind, (_: string) => Promise<PythonEnvInfo>>();
@@ -39,6 +40,10 @@ function getResolvers(): Map<PythonEnvKind, (executablePath: string) => Promise<
  */
 export async function resolveEnv(executablePath: string): Promise<PythonEnvInfo> {
     const kind = await identifyEnvironment(executablePath);
+    return resolveEnvFromKind({ kind, executablePath });
+}
+
+export async function resolveEnvFromKind({ kind, executablePath }: BasicEnvInfo): Promise<PythonEnvInfo> {
     const resolvers = getResolvers();
     const resolverForKind = resolvers.get(kind)!;
     const resolvedEnv = await resolverForKind(executablePath);

--- a/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
@@ -74,7 +74,9 @@ function getSearchLocation(env: PythonEnvInfo): Uri | undefined {
 }
 
 async function updateEnvUsingRegistry(env: PythonEnvInfo): Promise<void> {
+    console.time('Time takenz');
     const interpreters = await getRegistryInterpreters();
+    console.timeEnd('Time takenz');
     const data = interpreters.find((i) => i.interpreterPath.toUpperCase() === env.executable.filename.toUpperCase());
     if (data) {
         const versionStr = data.versionStr ?? data.sysVersionStr ?? data.interpreterPath;

--- a/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
@@ -12,7 +12,6 @@ import {
     getInterpreterPathFromDir,
     getPythonVersionFromPath,
 } from '../../../common/commonUtils';
-import { identifyEnvironment } from '../../../common/environmentIdentifier';
 import { getFileInfo, getWorkspaceFolders, isParentPath } from '../../../common/externalDependencies';
 import { AnacondaCompanyName, Conda } from '../../../discovery/locators/services/conda';
 import { parsePyenvVersion } from '../../../discovery/locators/services/pyenvLocator';
@@ -34,16 +33,11 @@ function getResolvers(): Map<PythonEnvKind, (executablePath: string) => Promise<
 }
 
 /**
- * Find as much info about the given Python environment as possible without running the
- * Python executable and returns it. Notice `undefined` is never returned, so environment
+ * Find as much info about the given Python executable as possible using env kind without running the
+ * executable and returns it. Notice `undefined` is never returned, so environment
  * returned could still be invalid.
  */
-export async function resolveEnv(executablePath: string): Promise<PythonEnvInfo> {
-    const kind = await identifyEnvironment(executablePath);
-    return resolveEnvFromKind({ kind, executablePath });
-}
-
-export async function resolveEnvFromKind({ kind, executablePath }: BasicEnvInfo): Promise<PythonEnvInfo> {
+export async function resolveEnvUsingKind({ kind, executablePath }: BasicEnvInfo): Promise<PythonEnvInfo> {
     const resolvers = getResolvers();
     const resolverForKind = resolvers.get(kind)!;
     const resolvedEnv = await resolverForKind(executablePath);

--- a/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
@@ -92,9 +92,15 @@ async function updateEnvUsingRegistry(env: PythonEnvInfo): Promise<void> {
 }
 
 async function resolveGloballyInstalledEnv(executablePath: string, kind: PythonEnvKind): Promise<PythonEnvInfo> {
+    let version;
+    try {
+        version = parseVersion(path.basename(executablePath));
+    } catch {
+        version = UNKNOWN_PYTHON_VERSION;
+    }
     const envInfo = buildEnvInfo({
         kind,
-        version: await getPythonVersionFromPath(executablePath),
+        version,
         executable: executablePath,
     });
     const fileData = await getFileInfo(executablePath);

--- a/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
@@ -91,7 +91,6 @@ async function updateEnvUsingRegistry(env: PythonEnvInfo): Promise<void> {
         env.distro.defaultDisplayName = data.companyDisplayName;
         env.arch = data.bitnessStr === '32bit' ? Architecture.x86 : Architecture.x64;
         env.distro.org = data.distroOrgName ?? env.distro.org;
-        env.distro.defaultDisplayName = data.companyDisplayName;
         env.source = uniq(env.source.concat(PythonEnvSource.WindowsRegistry));
     }
 }

--- a/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
@@ -41,7 +41,7 @@ function getResolvers(): Map<PythonEnvKind, (executablePath: string) => Promise<
  * executable and returns it. Notice `undefined` is never returned, so environment
  * returned could still be invalid.
  */
-export async function resolveEnvUsingKind({ kind, executablePath }: BasicEnvInfo): Promise<PythonEnvInfo> {
+export async function resolveBasicEnv({ kind, executablePath }: BasicEnvInfo): Promise<PythonEnvInfo> {
     const resolvers = getResolvers();
     const resolverForKind = resolvers.get(kind)!;
     const resolvedEnv = await resolverForKind(executablePath);

--- a/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
@@ -74,9 +74,7 @@ function getSearchLocation(env: PythonEnvInfo): Uri | undefined {
 }
 
 async function updateEnvUsingRegistry(env: PythonEnvInfo): Promise<void> {
-    console.time('Time takenz');
     const interpreters = await getRegistryInterpreters();
-    console.timeEnd('Time takenz');
     const data = interpreters.find((i) => i.interpreterPath.toUpperCase() === env.executable.filename.toUpperCase());
     if (data) {
         const versionStr = data.versionStr ?? data.sysVersionStr ?? data.interpreterPath;

--- a/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
@@ -43,9 +43,7 @@ export async function resolveEnv(executablePath: string): Promise<PythonEnvInfo>
     const resolverForKind = resolvers.get(kind)!;
     const resolvedEnv = await resolverForKind(executablePath);
     resolvedEnv.searchLocation = getSearchLocation(resolvedEnv);
-    console.log('Try to resolve');
     if (getOSType() === OSType.Windows) {
-        console.log('Try to resolve2');
         // We can update env further using information we can get from the Windows registry.
         await updateEnvUsingRegistry(resolvedEnv);
     }
@@ -72,10 +70,7 @@ function getSearchLocation(env: PythonEnvInfo): Uri | undefined {
 
 async function updateEnvUsingRegistry(env: PythonEnvInfo): Promise<void> {
     const interpreters = await getRegistryInterpreters();
-    console.log('Executable to possibly update', env.executable.filename);
-    console.log('Interpreters from register are:', JSON.stringify(interpreters.map((i) => i.interpreterPath)));
     const data = interpreters.find((i) => i.interpreterPath.toUpperCase() === env.executable.filename.toUpperCase());
-    console.log('Data', JSON.stringify(data));
     if (data) {
         const versionStr = data.versionStr ?? data.sysVersionStr ?? data.interpreterPath;
         let version;
@@ -91,7 +86,6 @@ async function updateEnvUsingRegistry(env: PythonEnvInfo): Promise<void> {
         env.distro.org = data.distroOrgName ?? env.distro.org;
         env.distro.defaultDisplayName = data.companyDisplayName;
         env.source = uniq(env.source.concat(PythonEnvSource.WindowsRegistry));
-        console.log('final env', JSON.stringify(env));
     }
 }
 

--- a/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
@@ -43,7 +43,9 @@ export async function resolveEnv(executablePath: string): Promise<PythonEnvInfo>
     const resolverForKind = resolvers.get(kind)!;
     const resolvedEnv = await resolverForKind(executablePath);
     resolvedEnv.searchLocation = getSearchLocation(resolvedEnv);
+    console.log('Try to resolve');
     if (getOSType() === OSType.Windows) {
+        console.log('Try to resolve2');
         // We can update env further using information we can get from the Windows registry.
         await updateEnvUsingRegistry(resolvedEnv);
     }
@@ -70,7 +72,10 @@ function getSearchLocation(env: PythonEnvInfo): Uri | undefined {
 
 async function updateEnvUsingRegistry(env: PythonEnvInfo): Promise<void> {
     const interpreters = await getRegistryInterpreters();
+    console.log('Executable to possibly update', env.executable.filename);
+    console.log('Interpreters from register are:', JSON.stringify(interpreters.map((i) => i.interpreterPath)));
     const data = interpreters.find((i) => i.interpreterPath.toUpperCase() === env.executable.filename.toUpperCase());
+    console.log('Data', JSON.stringify(data));
     if (data) {
         const versionStr = data.versionStr ?? data.sysVersionStr ?? data.interpreterPath;
         let version;
@@ -86,6 +91,7 @@ async function updateEnvUsingRegistry(env: PythonEnvInfo): Promise<void> {
         env.distro.org = data.distroOrgName ?? env.distro.org;
         env.distro.defaultDisplayName = data.companyDisplayName;
         env.source = uniq(env.source.concat(PythonEnvSource.WindowsRegistry));
+        console.log('final env', JSON.stringify(env));
     }
 }
 

--- a/src/client/pythonEnvironments/base/locators/lowLevel/filesLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/lowLevel/filesLocator.ts
@@ -4,20 +4,14 @@
 // tslint:disable-next-line:no-single-line-block-comment
 /* eslint-disable max-classes-per-file */
 
-import { Event, EventEmitter } from 'vscode';
-import { traceError } from '../../../../common/logger';
-import { DirEntry } from '../../../../common/utils/filesystem';
+import { Event } from 'vscode';
 import { iterPythonExecutablesInDir } from '../../../common/commonUtils';
-import { resolvePath } from '../../../common/externalDependencies';
-import { PythonEnvInfo, PythonEnvKind } from '../../info';
-import { getFastEnvInfo } from '../../info/env';
-import { ILocator, IPythonEnvsIterator, PythonEnvUpdatedEvent, PythonLocatorQuery } from '../../locator';
-import { iterAndUpdateEnvs } from '../../locatorUtils';
+import { PythonEnvKind } from '../../info';
+import { buildEnvInfo } from '../../info/env';
+import { ILocator, IPythonEnvsIterator, PythonLocatorQuery } from '../../locator';
 import { PythonEnvsChangedEvent, PythonEnvsWatcher } from '../../watcher';
 
-type Executable = string | DirEntry;
-
-type GetExecutablesFunc = () => Promise<Executable[]> | AsyncIterableIterator<Executable>;
+type GetExecutablesFunc = () => AsyncIterableIterator<string>;
 
 /**
  * A naive locator the wraps a function that finds Python executables.
@@ -27,49 +21,23 @@ class FoundFilesLocator implements ILocator {
 
     protected readonly watcher = new PythonEnvsWatcher();
 
-    constructor(
-        private readonly defaultKind: PythonEnvKind,
-        // This is used only in iterEnvs().
-        private readonly getExecutables: GetExecutablesFunc,
-    ) {
+    constructor(private readonly kind: PythonEnvKind, private readonly getExecutables: GetExecutablesFunc) {
         this.onChanged = this.watcher.onChanged;
     }
 
     public iterEnvs(_query?: PythonLocatorQuery): IPythonEnvsIterator {
-        const executablesPromise = this.getExecutables();
-        const emitter = new EventEmitter<PythonEnvUpdatedEvent | null>();
-        async function* generator(defaultKind: PythonEnvKind): IPythonEnvsIterator {
-            const executables = await executablesPromise;
-            yield* iterAndUpdateEnvs(
-                iterMinimalEnvsFromExecutables(executables, defaultKind),
-                (evt: PythonEnvUpdatedEvent | null) => emitter.fire(evt),
-            );
+        const executables = this.getExecutables();
+        async function* generator(kind: PythonEnvKind): IPythonEnvsIterator {
+            for await (const executable of executables) {
+                yield buildEnvInfo({ executable, kind });
+            }
         }
-        const iterator = generator(this.defaultKind);
-        iterator.onUpdated = emitter.event;
+        const iterator = generator(this.kind);
         return iterator;
     }
 }
 
-/**
- * Build minimal env info corresponding to each executable filename.
- */
-async function* iterMinimalEnvsFromExecutables(
-    executables: Executable[] | AsyncIterableIterator<Executable>,
-    defaultKind: PythonEnvKind,
-): AsyncIterableIterator<PythonEnvInfo> {
-    for await (const executable of executables) {
-        const filename = typeof executable === 'string' ? executable : executable.filename;
-        const normFile = resolvePath(filename);
-        try {
-            yield getFastEnvInfo(defaultKind, normFile);
-        } catch (ex) {
-            traceError(`Failed to process environment: ${normFile}`, ex);
-        }
-    }
-}
-
-type GetDirExecutablesFunc = (dir: string) => AsyncIterableIterator<Executable>;
+type GetDirExecutablesFunc = (dir: string) => AsyncIterableIterator<string>;
 
 /**
  * A locator for executables in a single directory.
@@ -89,8 +57,8 @@ export class DirFilesLocator extends FoundFilesLocator {
 // a subclass of FSWatchingLocator that wraps a DirFilesLocator
 // instance.
 
-async function* getExecutablesDefault(dirname: string): AsyncIterableIterator<DirEntry> {
+async function* getExecutablesDefault(dirname: string): AsyncIterableIterator<string> {
     for await (const entry of iterPythonExecutablesInDir(dirname)) {
-        yield entry;
+        yield entry.filename;
     }
 }

--- a/src/client/pythonEnvironments/base/locators/lowLevel/filesLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/lowLevel/filesLocator.ts
@@ -7,8 +7,7 @@
 import { Event } from 'vscode';
 import { iterPythonExecutablesInDir } from '../../../common/commonUtils';
 import { PythonEnvKind } from '../../info';
-import { buildEnvInfo } from '../../info/env';
-import { ILocator, IPythonEnvsIterator, PythonLocatorQuery } from '../../locator';
+import { BasicEnvInfo, ILocator, IPythonEnvsIterator, PythonLocatorQuery } from '../../locator';
 import { PythonEnvsChangedEvent, PythonEnvsWatcher } from '../../watcher';
 
 type GetExecutablesFunc = () => AsyncIterableIterator<string>;
@@ -16,7 +15,7 @@ type GetExecutablesFunc = () => AsyncIterableIterator<string>;
 /**
  * A naive locator the wraps a function that finds Python executables.
  */
-class FoundFilesLocator implements ILocator {
+class FoundFilesLocator implements ILocator<BasicEnvInfo> {
     public readonly onChanged: Event<PythonEnvsChangedEvent>;
 
     protected readonly watcher = new PythonEnvsWatcher();
@@ -25,11 +24,11 @@ class FoundFilesLocator implements ILocator {
         this.onChanged = this.watcher.onChanged;
     }
 
-    public iterEnvs(_query?: PythonLocatorQuery): IPythonEnvsIterator {
+    public iterEnvs(_query?: PythonLocatorQuery): IPythonEnvsIterator<BasicEnvInfo> {
         const executables = this.getExecutables();
-        async function* generator(kind: PythonEnvKind): IPythonEnvsIterator {
-            for await (const executable of executables) {
-                yield buildEnvInfo({ executable, kind });
+        async function* generator(kind: PythonEnvKind): IPythonEnvsIterator<BasicEnvInfo> {
+            for await (const executablePath of executables) {
+                yield { executablePath, kind };
             }
         }
         const iterator = generator(this.kind);

--- a/src/client/pythonEnvironments/base/locators/lowLevel/fsWatchingLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/lowLevel/fsWatchingLocator.ts
@@ -15,7 +15,7 @@ import {
     resolvePythonExeGlobs,
     watchLocationForPythonBinaries,
 } from '../../../common/pythonBinariesWatcher';
-import { PythonEnvKind } from '../../info';
+import { PythonEnvInfo, PythonEnvKind } from '../../info';
 import { LazyResourceBasedLocator } from '../common/resourceBasedLocator';
 
 export enum FSWatcherKind {
@@ -53,7 +53,7 @@ function checkDirWatchable(dirname: string): DirUnwatchableReason {
  *
  * Subclasses can call `this.emitter.fire()` * to emit events.
  */
-export abstract class FSWatchingLocator extends LazyResourceBasedLocator {
+export abstract class FSWatchingLocator<I = PythonEnvInfo> extends LazyResourceBasedLocator<I> {
     constructor(
         /**
          * Location(s) to watch for python binaries.

--- a/src/client/pythonEnvironments/base/locators/lowLevel/windowsKnownPathsLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/lowLevel/windowsKnownPathsLocator.ts
@@ -4,14 +4,13 @@
 // tslint:disable-next-line:no-single-line-block-comment
 /* eslint-disable max-classes-per-file */
 
-import { uniq } from 'lodash';
 import { Event } from 'vscode';
 import { getSearchPathEntries } from '../../../../common/utils/exec';
 import { Disposables, IDisposable } from '../../../../common/utils/resourceLifecycle';
 import { iterPythonExecutablesInDir, looksLikeBasicGlobalPython } from '../../../common/commonUtils';
 import { isPyenvShimDir } from '../../../discovery/locators/services/pyenvLocator';
 import { isWindowsStoreDir } from '../../../discovery/locators/services/windowsStoreLocator';
-import { PythonEnvKind, PythonEnvSource } from '../../info';
+import { PythonEnvKind } from '../../info';
 import { ILocator, IPythonEnvsIterator, PythonLocatorQuery } from '../../locator';
 import { Locators } from '../../locators';
 import { getEnvs } from '../../locatorUtils';
@@ -90,11 +89,7 @@ function getDirFilesLocator(
     // rather than in each low-level locator.  In the meantime we
     // take a naive approach.
     async function* iterEnvs(query: PythonLocatorQuery): IPythonEnvsIterator {
-        const envs = await getEnvs(locator.iterEnvs(query));
-        for (const env of envs) {
-            env.source = env.source ? uniq([...env.source, PythonEnvSource.PathEnvVar]) : [PythonEnvSource.PathEnvVar];
-            yield env;
-        }
+        yield* await getEnvs(locator.iterEnvs(query));
     }
     return {
         iterEnvs,

--- a/src/client/pythonEnvironments/base/locators/lowLevel/windowsKnownPathsLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/lowLevel/windowsKnownPathsLocator.ts
@@ -11,7 +11,7 @@ import { iterPythonExecutablesInDir, looksLikeBasicGlobalPython } from '../../..
 import { isPyenvShimDir } from '../../../discovery/locators/services/pyenvLocator';
 import { isWindowsStoreDir } from '../../../discovery/locators/services/windowsStoreLocator';
 import { PythonEnvKind } from '../../info';
-import { ILocator, IPythonEnvsIterator, PythonLocatorQuery } from '../../locator';
+import { BasicEnvInfo, ILocator, IPythonEnvsIterator, PythonLocatorQuery } from '../../locator';
 import { Locators } from '../../locators';
 import { getEnvs } from '../../locatorUtils';
 import { PythonEnvsChangedEvent } from '../../watcher';
@@ -23,15 +23,15 @@ import { DirFilesLocator } from './filesLocator';
  * Note that we assume $PATH won't change, so we don't need to watch
  * it for changes.
  */
-export class WindowsPathEnvVarLocator implements ILocator, IDisposable {
+export class WindowsPathEnvVarLocator implements ILocator<BasicEnvInfo>, IDisposable {
     public readonly onChanged: Event<PythonEnvsChangedEvent>;
 
-    private readonly locators: Locators;
+    private readonly locators: Locators<BasicEnvInfo>;
 
     private readonly disposables = new Disposables();
 
     constructor() {
-        const dirLocators: (ILocator & IDisposable)[] = getSearchPathEntries()
+        const dirLocators: (ILocator<BasicEnvInfo> & IDisposable)[] = getSearchPathEntries()
             .filter(
                 (dirname) =>
                     // Filter out following directories:
@@ -56,7 +56,7 @@ export class WindowsPathEnvVarLocator implements ILocator, IDisposable {
         await this.disposables.dispose();
     }
 
-    public iterEnvs(query?: PythonLocatorQuery): IPythonEnvsIterator {
+    public iterEnvs(query?: PythonLocatorQuery): IPythonEnvsIterator<BasicEnvInfo> {
         // Note that we do no filtering here, including to check if files
         // are valid executables.  That is left to callers (e.g. composite
         // locators).
@@ -76,7 +76,7 @@ function getDirFilesLocator(
     // These are passed through to DirFilesLocator.
     dirname: string,
     kind: PythonEnvKind,
-): ILocator & IDisposable {
+): ILocator<BasicEnvInfo> & IDisposable {
     // For now we do not bother using a locator that watches for changes
     // in the directory.  If we did then we would use
     // `DirFilesWatchingLocator`, but only if not \\windows\system32 and
@@ -88,7 +88,7 @@ function getDirFilesLocator(
     // sophisticated.  Also, this should be done in ReducingLocator
     // rather than in each low-level locator.  In the meantime we
     // take a naive approach.
-    async function* iterEnvs(query: PythonLocatorQuery): IPythonEnvsIterator {
+    async function* iterEnvs(query: PythonLocatorQuery): IPythonEnvsIterator<BasicEnvInfo> {
         yield* await getEnvs(locator.iterEnvs(query));
     }
     return {

--- a/src/client/pythonEnvironments/base/locators/lowLevel/workspaceVirtualEnvLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/lowLevel/workspaceVirtualEnvLocator.ts
@@ -2,22 +2,16 @@
 // Licensed under the MIT License.
 
 import * as path from 'path';
-import { Uri } from 'vscode';
-import { traceError, traceVerbose } from '../../../../common/logger';
+import { traceVerbose } from '../../../../common/logger';
 import { chain, iterable } from '../../../../common/utils/async';
-import {
-    findInterpretersInDir,
-    getEnvironmentDirFromPath,
-    getPythonVersionFromPath,
-    looksLikeBasicVirtualPython,
-} from '../../../common/commonUtils';
-import { getFileInfo, pathExists } from '../../../common/externalDependencies';
+import { findInterpretersInDir, looksLikeBasicVirtualPython } from '../../../common/commonUtils';
+import { pathExists } from '../../../common/externalDependencies';
 import { isPipenvEnvironment } from '../../../discovery/locators/services/pipEnvHelper';
 import {
     isVenvEnvironment,
     isVirtualenvEnvironment,
 } from '../../../discovery/locators/services/virtualEnvironmentIdentifier';
-import { PythonEnvInfo, PythonEnvKind, PythonEnvSource } from '../../info';
+import { PythonEnvKind } from '../../info';
 import { buildEnvInfo } from '../../info/env';
 import { IPythonEnvsIterator } from '../../locator';
 import { FSWatchingLocator } from './fsWatchingLocator';
@@ -57,38 +51,6 @@ async function getVirtualEnvKind(interpreterPath: string): Promise<PythonEnvKind
 
     return PythonEnvKind.Unknown;
 }
-
-async function buildSimpleVirtualEnvInfo(
-    executablePath: string,
-    kind: PythonEnvKind,
-    source?: PythonEnvSource[],
-): Promise<PythonEnvInfo> {
-    const envInfo = buildEnvInfo({
-        kind,
-        version: await getPythonVersionFromPath(executablePath),
-        executable: executablePath,
-        source: source ?? [PythonEnvSource.Other],
-    });
-    const location = getEnvironmentDirFromPath(executablePath);
-    envInfo.location = location;
-    envInfo.name = path.basename(location);
-    // Search location particularly for virtual environments is intended as the
-    // directory in which the environment was found in. For eg. the default search location
-    // for an env containing 'bin' or 'Scripts' directory is:
-    //
-    // searchLocation <--- Default search location directory
-    // |__ env
-    //    |__ bin or Scripts
-    //        |__ python  <--- executable
-    envInfo.searchLocation = Uri.file(path.dirname(location));
-
-    // TODO: Call a general display name provider here to build display name.
-    const fileData = await getFileInfo(executablePath);
-    envInfo.executable.ctime = fileData.ctime;
-    envInfo.executable.mtime = fileData.mtime;
-    return envInfo;
-}
-
 /**
  * Finds and resolves virtual environments created in workspace roots.
  */
@@ -121,18 +83,8 @@ export class WorkspaceVirtualEnvironmentLocator extends FSWatchingLocator {
                             // check multiple times. Those checks are file system heavy and
                             // we can use the kind to determine this anyway.
                             const kind = await getVirtualEnvKind(filename);
-
-                            if (kind === PythonEnvKind.Unknown) {
-                                // We don't know the environment type so skip this one.
-                                traceVerbose(`Workspace Virtual Environment: [skipped] ${filename}`);
-                            } else {
-                                try {
-                                    yield buildSimpleVirtualEnvInfo(filename, kind);
-                                    traceVerbose(`Workspace Virtual Environment: [added] ${filename}`);
-                                } catch (ex) {
-                                    traceError(`Failed to process environment: ${filename}`, ex);
-                                }
-                            }
+                            yield buildEnvInfo({ kind, executable: filename });
+                            traceVerbose(`Workspace Virtual Environment: [added] ${filename}`);
                         } else {
                             traceVerbose(`Workspace Virtual Environment: [skipped] ${filename}`);
                         }

--- a/src/client/pythonEnvironments/base/locators/lowLevel/workspaceVirtualEnvLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/lowLevel/workspaceVirtualEnvLocator.ts
@@ -12,8 +12,7 @@ import {
     isVirtualenvEnvironment,
 } from '../../../discovery/locators/services/virtualEnvironmentIdentifier';
 import { PythonEnvKind } from '../../info';
-import { buildEnvInfo } from '../../info/env';
-import { IPythonEnvsIterator } from '../../locator';
+import { BasicEnvInfo, IPythonEnvsIterator } from '../../locator';
 import { FSWatchingLocator } from './fsWatchingLocator';
 import '../../../../common/extensions';
 import { asyncFilter } from '../../../../common/utils/arrayUtils';
@@ -54,7 +53,7 @@ async function getVirtualEnvKind(interpreterPath: string): Promise<PythonEnvKind
 /**
  * Finds and resolves virtual environments created in workspace roots.
  */
-export class WorkspaceVirtualEnvironmentLocator extends FSWatchingLocator {
+export class WorkspaceVirtualEnvironmentLocator extends FSWatchingLocator<BasicEnvInfo> {
     public constructor(private readonly root: string) {
         super(() => getWorkspaceVirtualEnvDirs(this.root), getVirtualEnvKind, {
             // Note detecting kind of virtual env depends on the file structure around the
@@ -63,7 +62,7 @@ export class WorkspaceVirtualEnvironmentLocator extends FSWatchingLocator {
         });
     }
 
-    protected doIterEnvs(): IPythonEnvsIterator {
+    protected doIterEnvs(): IPythonEnvsIterator<BasicEnvInfo> {
         async function* iterator(root: string) {
             const envRootDirs = await getWorkspaceVirtualEnvDirs(root);
             const envGenerators = envRootDirs.map((envRootDir) => {
@@ -83,7 +82,7 @@ export class WorkspaceVirtualEnvironmentLocator extends FSWatchingLocator {
                             // check multiple times. Those checks are file system heavy and
                             // we can use the kind to determine this anyway.
                             const kind = await getVirtualEnvKind(filename);
-                            yield buildEnvInfo({ kind, executable: filename });
+                            yield { kind, executablePath: filename };
                             traceVerbose(`Workspace Virtual Environment: [added] ${filename}`);
                         } else {
                             traceVerbose(`Workspace Virtual Environment: [skipped] ${filename}`);

--- a/src/client/pythonEnvironments/common/commonUtils.ts
+++ b/src/client/pythonEnvironments/common/commonUtils.ts
@@ -220,12 +220,10 @@ async function getPythonVersionFromNearByFiles(interpreterPath: string): Promise
  * @param interpreterPath Absolute path to the interpreter.
  * @param hint Any string that might contain version info.
  */
-export async function getPythonVersionFromPath(
-    interpreterPath: string | undefined,
-    hint?: string,
-): Promise<PythonVersion> {
+export async function getPythonVersionFromPath(interpreterPath: string, hint?: string): Promise<PythonVersion> {
     let versionA;
     try {
+        hint = hint ?? path.basename(interpreterPath);
         versionA = hint ? parseVersion(hint) : UNKNOWN_PYTHON_VERSION;
     } catch (ex) {
         versionA = UNKNOWN_PYTHON_VERSION;

--- a/src/client/pythonEnvironments/common/windowsUtils.ts
+++ b/src/client/pythonEnvironments/common/windowsUtils.ts
@@ -110,11 +110,21 @@ export async function getInterpreterDataFromRegistry(
     return (allData.filter((data) => data !== undefined) || []) as IRegistryInterpreterData[];
 }
 
-let registryInterpreters: IRegistryInterpreterData[] | undefined;
+let registryInterpretersCache: IRegistryInterpreterData[] | undefined;
 
-export async function getRegistryInterpreters(ignoreCache = false): Promise<IRegistryInterpreterData[]> {
-    if (!isTestExecution() && !ignoreCache && registryInterpreters !== undefined) {
-        return registryInterpreters;
+/**
+ * Returns windows registry interpreters from memory, returns undefined if memory is empty.
+ * getRegistryInterpreters() must be called prior to this to populate memory.
+ */
+export function getRegistryInterpretersSync(): IRegistryInterpreterData[] | undefined {
+    return !isTestExecution() ? registryInterpretersCache : undefined;
+}
+
+let registryInterpretersPromise: Promise<IRegistryInterpreterData[]> | undefined;
+
+export async function getRegistryInterpreters(): Promise<IRegistryInterpreterData[]> {
+    if (!isTestExecution() && registryInterpretersPromise !== undefined) {
+        return registryInterpretersPromise;
     }
 
     let registryData: IRegistryInterpreterData[] = [];
@@ -134,6 +144,6 @@ export async function getRegistryInterpreters(ignoreCache = false): Promise<IReg
             }
         }
     }
-    registryInterpreters = uniqBy(registryData, (r: IRegistryInterpreterData) => r.interpreterPath);
-    return registryInterpreters;
+    registryInterpretersCache = uniqBy(registryData, (r: IRegistryInterpreterData) => r.interpreterPath);
+    return registryInterpretersCache;
 }

--- a/src/client/pythonEnvironments/discovery/locators/services/condaLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaLocator.ts
@@ -2,19 +2,18 @@
 // Licensed under the MIT License.
 import '../../../../common/extensions';
 import { PythonEnvKind } from '../../../base/info';
-import { buildEnvInfo } from '../../../base/info/env';
-import { IPythonEnvsIterator, Locator } from '../../../base/locator';
+import { BasicEnvInfo, IPythonEnvsIterator, Locator } from '../../../base/locator';
 import { getInterpreterPathFromDir } from '../../../common/commonUtils';
 import { Conda } from './conda';
 import { traceError, traceVerbose } from '../../../../common/logger';
 
-export class CondaEnvironmentLocator extends Locator {
+export class CondaEnvironmentLocator extends Locator<BasicEnvInfo> {
     public constructor() {
         super();
     }
 
     // eslint-disable-next-line class-methods-use-this
-    public async *iterEnvs(): IPythonEnvsIterator {
+    public async *iterEnvs(): IPythonEnvsIterator<BasicEnvInfo> {
         const conda = await Conda.getConda();
         if (conda === undefined) {
             traceVerbose(`Couldn't locate the conda binary.`);
@@ -24,13 +23,13 @@ export class CondaEnvironmentLocator extends Locator {
 
         const envs = await conda.getEnvList();
         for (const { prefix } of envs) {
-            const executable = await getInterpreterPathFromDir(prefix);
-            if (executable !== undefined) {
-                traceVerbose(`Found conda environment: ${executable}`);
+            const executablePath = await getInterpreterPathFromDir(prefix);
+            if (executablePath !== undefined) {
+                traceVerbose(`Found conda environment: ${executablePath}`);
                 try {
-                    yield buildEnvInfo({ kind: PythonEnvKind.Conda, executable });
+                    yield { kind: PythonEnvKind.Conda, executablePath };
                 } catch (ex) {
-                    traceError(`Failed to process environment: ${executable}`, ex);
+                    traceError(`Failed to process environment: ${executablePath}`, ex);
                 }
             }
         }

--- a/src/client/pythonEnvironments/discovery/locators/services/condaLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaLocator.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import '../../../../common/extensions';
-import { PythonEnvKind, PythonEnvSource } from '../../../base/info';
+import { PythonEnvKind } from '../../../base/info';
 import { buildEnvInfo } from '../../../base/info/env';
 import { IPythonEnvsIterator, Locator } from '../../../base/locator';
-import { getInterpreterPathFromDir, getPythonVersionFromPath } from '../../../common/commonUtils';
-import { AnacondaCompanyName, Conda } from './conda';
+import { getInterpreterPathFromDir } from '../../../common/commonUtils';
+import { Conda } from './conda';
 import { traceError, traceVerbose } from '../../../../common/logger';
 
 export class CondaEnvironmentLocator extends Locator {
@@ -23,23 +23,12 @@ export class CondaEnvironmentLocator extends Locator {
         traceVerbose(`Searching for conda environments using ${conda.command}`);
 
         const envs = await conda.getEnvList();
-        for (const { name, prefix } of envs) {
+        for (const { prefix } of envs) {
             const executable = await getInterpreterPathFromDir(prefix);
             if (executable !== undefined) {
-                const info = buildEnvInfo({
-                    executable,
-                    kind: PythonEnvKind.Conda,
-                    org: AnacondaCompanyName,
-                    location: prefix,
-                    source: [PythonEnvSource.Conda],
-                    version: await getPythonVersionFromPath(executable),
-                });
-                if (name) {
-                    info.name = name;
-                }
                 traceVerbose(`Found conda environment: ${executable}`);
                 try {
-                    yield info;
+                    yield buildEnvInfo({ kind: PythonEnvKind.Conda, executable });
                 } catch (ex) {
                     traceError(`Failed to process environment: ${executable}`, ex);
                 }

--- a/src/client/pythonEnvironments/discovery/locators/services/customVirtualEnvLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/customVirtualEnvLocator.ts
@@ -7,8 +7,7 @@ import { traceError, traceVerbose } from '../../../../common/logger';
 import { chain, iterable } from '../../../../common/utils/async';
 import { getUserHomeDir } from '../../../../common/utils/platform';
 import { PythonEnvKind } from '../../../base/info';
-import { buildEnvInfo } from '../../../base/info/env';
-import { IPythonEnvsIterator } from '../../../base/locator';
+import { BasicEnvInfo, IPythonEnvsIterator } from '../../../base/locator';
 import { FSWatchingLocator } from '../../../base/locators/lowLevel/fsWatchingLocator';
 import { findInterpretersInDir, looksLikeBasicVirtualPython } from '../../../common/commonUtils';
 import {
@@ -79,7 +78,7 @@ async function getVirtualEnvKind(interpreterPath: string): Promise<PythonEnvKind
 /**
  * Finds and resolves custom virtual environments that users have provided.
  */
-export class CustomVirtualEnvironmentLocator extends FSWatchingLocator {
+export class CustomVirtualEnvironmentLocator extends FSWatchingLocator<BasicEnvInfo> {
     constructor() {
         super(getCustomVirtualEnvDirs, getVirtualEnvKind, {
             // Note detecting kind of virtual env depends on the file structure around the
@@ -96,7 +95,7 @@ export class CustomVirtualEnvironmentLocator extends FSWatchingLocator {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    protected doIterEnvs(): IPythonEnvsIterator {
+    protected doIterEnvs(): IPythonEnvsIterator<BasicEnvInfo> {
         async function* iterator() {
             const envRootDirs = await getCustomVirtualEnvDirs();
             const envGenerators = envRootDirs.map((envRootDir) => {
@@ -117,7 +116,7 @@ export class CustomVirtualEnvironmentLocator extends FSWatchingLocator {
                                 // check multiple times. Those checks are file system heavy and
                                 // we can use the kind to determine this anyway.
                                 const kind = await getVirtualEnvKind(filename);
-                                yield buildEnvInfo({ kind, executable: filename });
+                                yield { kind, executablePath: filename };
                                 traceVerbose(`Custom Virtual Environment: [added] ${filename}`);
                             } catch (ex) {
                                 traceError(`Failed to process environment: ${filename}`, ex);

--- a/src/client/pythonEnvironments/discovery/locators/services/globalVirtualEnvronmentLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/globalVirtualEnvronmentLocator.ts
@@ -7,8 +7,7 @@ import { traceError, traceVerbose } from '../../../../common/logger';
 import { chain, iterable } from '../../../../common/utils/async';
 import { getEnvironmentVariable, getOSType, getUserHomeDir, OSType } from '../../../../common/utils/platform';
 import { PythonEnvKind } from '../../../base/info';
-import { buildEnvInfo } from '../../../base/info/env';
-import { IPythonEnvsIterator } from '../../../base/locator';
+import { BasicEnvInfo, IPythonEnvsIterator } from '../../../base/locator';
 import { FSWatchingLocator } from '../../../base/locators/lowLevel/fsWatchingLocator';
 import { findInterpretersInDir, looksLikeBasicVirtualPython } from '../../../common/commonUtils';
 import { pathExists, untildify } from '../../../common/externalDependencies';
@@ -83,7 +82,7 @@ async function getVirtualEnvKind(interpreterPath: string): Promise<PythonEnvKind
 /**
  * Finds and resolves virtual environments created in known global locations.
  */
-export class GlobalVirtualEnvironmentLocator extends FSWatchingLocator {
+export class GlobalVirtualEnvironmentLocator extends FSWatchingLocator<BasicEnvInfo> {
     constructor(private readonly searchDepth?: number) {
         super(getGlobalVirtualEnvDirs, getVirtualEnvKind, {
             // Note detecting kind of virtual env depends on the file structure around the
@@ -94,7 +93,7 @@ export class GlobalVirtualEnvironmentLocator extends FSWatchingLocator {
         });
     }
 
-    protected doIterEnvs(): IPythonEnvsIterator {
+    protected doIterEnvs(): IPythonEnvsIterator<BasicEnvInfo> {
         // Number of levels of sub-directories to recurse when looking for
         // interpreters
         const searchDepth = this.searchDepth ?? DEFAULT_SEARCH_DEPTH;
@@ -119,7 +118,7 @@ export class GlobalVirtualEnvironmentLocator extends FSWatchingLocator {
                             // we can use the kind to determine this anyway.
                             const kind = await getVirtualEnvKind(filename);
                             try {
-                                yield buildEnvInfo({ kind, executable: filename });
+                                yield { kind, executablePath: filename };
                                 traceVerbose(`Global Virtual Environment: [added] ${filename}`);
                             } catch (ex) {
                                 traceError(`Failed to process environment: ${filename}`, ex);

--- a/src/client/pythonEnvironments/discovery/locators/services/posixKnownPathsLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/posixKnownPathsLocator.ts
@@ -1,23 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as path from 'path';
-import { traceError, traceVerbose } from '../../../../common/logger';
-import { Architecture } from '../../../../common/utils/platform';
-import { PythonEnvInfo, PythonEnvKind, PythonEnvSource, PythonReleaseLevel, PythonVersion } from '../../../base/info';
-import { buildEnvInfo } from '../../../base/info/env';
-import { parseVersion } from '../../../base/info/pythonVersion';
-import { IPythonEnvsIterator, Locator } from '../../../base/locator';
-import { getFileInfo } from '../../../common/externalDependencies';
+import { traceError } from '../../../../common/logger';
+import { PythonEnvKind } from '../../../base/info';
+import { BasicEnvInfo, IPythonEnvsIterator, Locator } from '../../../base/locator';
 import { commonPosixBinPaths, getPythonBinFromPosixPaths } from '../../../common/posixUtils';
 import { isPyenvShimDir } from './pyenvLocator';
 
-export class PosixKnownPathsLocator extends Locator {
+export class PosixKnownPathsLocator extends Locator<BasicEnvInfo> {
     private kind: PythonEnvKind = PythonEnvKind.OtherGlobal;
 
-    public iterEnvs(): IPythonEnvsIterator {
-        const buildPathEnvInfo = (bin: string) => this.buildPathEnvInfo(bin);
-        const iterator = async function* () {
+    public iterEnvs(): IPythonEnvsIterator<BasicEnvInfo> {
+        const iterator = async function* (kind: PythonEnvKind) {
             // Filter out pyenv shims. They are not actual python binaries, they are used to launch
             // the binaries specified in .python-version file in the cwd. We should not be reporting
             // those binaries as environments.
@@ -25,39 +19,12 @@ export class PosixKnownPathsLocator extends Locator {
             const pythonBinaries = await getPythonBinFromPosixPaths(knownDirs);
             for (const bin of pythonBinaries) {
                 try {
-                    const env = await buildPathEnvInfo(bin);
-                    yield env;
+                    yield { executablePath: bin, kind };
                 } catch (ex) {
                     traceError(`Failed to process environment: ${bin}`, ex);
                 }
             }
         };
-        return iterator();
-    }
-
-    private async buildPathEnvInfo(bin: string): Promise<PythonEnvInfo> {
-        let version: PythonVersion;
-        try {
-            version = parseVersion(path.basename(bin));
-        } catch (ex) {
-            traceVerbose(`Failed to parse version from path: ${bin}`, ex);
-            version = {
-                major: -1,
-                minor: -1,
-                micro: -1,
-                release: { level: PythonReleaseLevel.Final, serial: -1 },
-                sysVersion: undefined,
-            };
-        }
-        return buildEnvInfo({
-            name: '',
-            location: '',
-            kind: this.kind,
-            executable: bin,
-            fileInfo: await getFileInfo(bin),
-            version,
-            arch: Architecture.Unknown,
-            source: [PythonEnvSource.PathEnvVar],
-        });
+        return iterator(this.kind);
     }
 }

--- a/src/client/pythonEnvironments/discovery/locators/services/pyenvLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/pyenvLocator.ts
@@ -4,12 +4,12 @@
 import * as path from 'path';
 import { traceError } from '../../../../common/logger';
 import { getEnvironmentVariable, getOSType, getUserHomeDir, OSType } from '../../../../common/utils/platform';
-import { PythonEnvInfo, PythonEnvKind, PythonEnvSource } from '../../../base/info';
+import { PythonEnvInfo, PythonEnvKind } from '../../../base/info';
 import { buildEnvInfo } from '../../../base/info/env';
 import { IPythonEnvsIterator } from '../../../base/locator';
 import { FSWatchingLocator } from '../../../base/locators/lowLevel/fsWatchingLocator';
-import { getInterpreterPathFromDir, getPythonVersionFromPath } from '../../../common/commonUtils';
-import { arePathsSame, getFileInfo, getSubDirs, pathExists } from '../../../common/externalDependencies';
+import { getInterpreterPathFromDir } from '../../../common/commonUtils';
+import { arePathsSame, getSubDirs, pathExists } from '../../../common/externalDependencies';
 
 function getPyenvDir(): string {
     // Check if the pyenv environment variables exist: PYENV on Windows, PYENV_ROOT on Unix.
@@ -254,8 +254,7 @@ export function parsePyenvVersion(str: string): Promise<IPyenvVersionStrings | u
  * Gets all the pyenv environments.
  *
  * Remarks: This function looks at the <pyenv dir>/versions directory and gets
- * all the environments (global or virtual) in that directory. It also makes the
- * best effort at identifying the versions and distribution information.
+ * all the environments (global or virtual) in that directory.
  */
 async function* getPyenvEnvironments(): AsyncIterableIterator<PythonEnvInfo> {
     const pyenvVersionDir = getPyenvVersionsDir();
@@ -267,46 +266,9 @@ async function* getPyenvEnvironments(): AsyncIterableIterator<PythonEnvInfo> {
 
         if (interpreterPath) {
             try {
-                // The sub-directory name sometimes can contain distro and python versions.
-                // here we attempt to extract the texts out of the name.
-                const versionStrings = await parsePyenvVersion(envDirName);
-
-                // Here we look for near by files, or config files to see if we can get python version info
-                // without running python itself.
-                const pythonVersion = await getPythonVersionFromPath(interpreterPath, versionStrings?.pythonVer);
-
-                // Pyenv environments can fall in to these three categories:
-                // 1. Global Installs : These are environments that are created when you install
-                //    a supported python distribution using `pyenv install <distro>` command.
-                //    These behave similar to globally installed version of python or distribution.
-                //
-                // 2. Virtual Envs    : These are environments that are created when you use
-                //    `pyenv virtualenv <distro> <env-name>`. These are similar to environments
-                //    created using `python -m venv <env-name>`.
-                //
-                // 3. Conda Envs      : These are environments that are created when you use
-                //    `pyenv virtualenv <miniconda|anaconda> <env-name>`. These are similar to
-                //    environments created using `conda create -n <env-name>.
-                //
-                // All these environments are fully handled by `pyenv` and should be activated using
-                // `pyenv local|global <env-name>` or `pyenv shell <env-name>`
-                //
-                // For the display name we are going to treat these as `pyenv` environments.
-                const display = `${envDirName}:pyenv`;
-
-                const org = versionStrings && versionStrings.distro ? versionStrings.distro : '';
-
-                const fileInfo = await getFileInfo(interpreterPath);
-
                 const envInfo = buildEnvInfo({
                     kind: PythonEnvKind.Pyenv,
                     executable: interpreterPath,
-                    location: subDirPath,
-                    version: pythonVersion,
-                    source: [PythonEnvSource.Pyenv],
-                    display,
-                    org,
-                    fileInfo,
                 });
                 envInfo.name = envDirName;
                 yield envInfo;

--- a/src/client/pythonEnvironments/discovery/locators/services/windowsRegistryLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/windowsRegistryLocator.ts
@@ -10,7 +10,7 @@ export class WindowsRegistryLocator extends Locator<BasicEnvInfo> {
     // eslint-disable-next-line class-methods-use-this
     public iterEnvs(): IPythonEnvsIterator<BasicEnvInfo> {
         const iterator = async function* () {
-            const interpreters = await getRegistryInterpreters(true);
+            const interpreters = await getRegistryInterpreters();
             for (const interpreter of interpreters) {
                 try {
                     const env: BasicEnvInfo = {

--- a/src/client/pythonEnvironments/discovery/locators/services/windowsRegistryLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/windowsRegistryLocator.ts
@@ -3,21 +3,20 @@
 
 import { traceError } from '../../../../common/logger';
 import { PythonEnvKind } from '../../../base/info';
-import { buildEnvInfo } from '../../../base/info/env';
-import { IPythonEnvsIterator, Locator } from '../../../base/locator';
+import { BasicEnvInfo, IPythonEnvsIterator, Locator } from '../../../base/locator';
 import { getRegistryInterpreters } from '../../../common/windowsUtils';
 
-export class WindowsRegistryLocator extends Locator {
+export class WindowsRegistryLocator extends Locator<BasicEnvInfo> {
     // eslint-disable-next-line class-methods-use-this
-    public iterEnvs(): IPythonEnvsIterator {
+    public iterEnvs(): IPythonEnvsIterator<BasicEnvInfo> {
         const iterator = async function* () {
             const interpreters = await getRegistryInterpreters(true);
             for (const interpreter of interpreters) {
                 try {
-                    const env = buildEnvInfo({
+                    const env: BasicEnvInfo = {
                         kind: PythonEnvKind.OtherGlobal,
-                        executable: interpreter.interpreterPath,
-                    });
+                        executablePath: interpreter.interpreterPath,
+                    };
                     yield env;
                 } catch (ex) {
                     traceError(`Failed to process environment: ${interpreter}`, ex);

--- a/src/client/pythonEnvironments/discovery/locators/services/windowsRegistryLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/windowsRegistryLocator.ts
@@ -1,39 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { traceError, traceVerbose } from '../../../../common/logger';
-import { Architecture } from '../../../../common/utils/platform';
-import {
-    PythonEnvInfo,
-    PythonEnvKind,
-    PythonEnvSource,
-    PythonVersion,
-    UNKNOWN_PYTHON_VERSION,
-} from '../../../base/info';
+import { traceError } from '../../../../common/logger';
+import { PythonEnvKind } from '../../../base/info';
 import { buildEnvInfo } from '../../../base/info/env';
-import { parseVersion } from '../../../base/info/pythonVersion';
 import { IPythonEnvsIterator, Locator } from '../../../base/locator';
-import { getFileInfo } from '../../../common/externalDependencies';
-import { getRegistryInterpreters, IRegistryInterpreterData } from '../../../common/windowsUtils';
-
-function getArchitecture(data: IRegistryInterpreterData) {
-    let arch = Architecture.Unknown;
-    if (data.bitnessStr) {
-        arch = data.bitnessStr === '32bit' ? Architecture.x86 : Architecture.x64;
-    }
-    return arch;
-}
+import { getRegistryInterpreters } from '../../../common/windowsUtils';
 
 export class WindowsRegistryLocator extends Locator {
-    private kind: PythonEnvKind = PythonEnvKind.OtherGlobal;
-
+    // eslint-disable-next-line class-methods-use-this
     public iterEnvs(): IPythonEnvsIterator {
-        const buildRegistryEnvInfo = (data: IRegistryInterpreterData) => this.buildRegistryEnvInfo(data);
         const iterator = async function* () {
             const interpreters = await getRegistryInterpreters(true);
             for (const interpreter of interpreters) {
                 try {
-                    const env = await buildRegistryEnvInfo(interpreter);
+                    const env = buildEnvInfo({
+                        kind: PythonEnvKind.OtherGlobal,
+                        executable: interpreter.interpreterPath,
+                    });
                     yield env;
                 } catch (ex) {
                     traceError(`Failed to process environment: ${interpreter}`, ex);
@@ -41,28 +25,5 @@ export class WindowsRegistryLocator extends Locator {
             }
         };
         return iterator();
-    }
-
-    private async buildRegistryEnvInfo(data: IRegistryInterpreterData): Promise<PythonEnvInfo> {
-        const versionStr = data.versionStr ?? data.sysVersionStr ?? data.interpreterPath;
-        let version: PythonVersion = UNKNOWN_PYTHON_VERSION;
-
-        try {
-            version = parseVersion(versionStr);
-        } catch (ex) {
-            traceVerbose(`Failed to parse version: ${versionStr}`, ex);
-        }
-
-        const env = buildEnvInfo({
-            kind: this.kind,
-            executable: data.interpreterPath,
-            fileInfo: await getFileInfo(data.interpreterPath),
-            version,
-            arch: getArchitecture(data),
-            org: data.distroOrgName,
-            source: [PythonEnvSource.WindowsRegistry],
-        });
-        env.distro.defaultDisplayName = data.companyDisplayName;
-        return env;
     }
 }

--- a/src/client/pythonEnvironments/discovery/locators/services/windowsStoreLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/windowsStoreLocator.ts
@@ -7,8 +7,7 @@ import * as path from 'path';
 import { traceWarning } from '../../../../common/logger';
 import { getEnvironmentVariable } from '../../../../common/utils/platform';
 import { PythonEnvKind } from '../../../base/info';
-import { buildEnvInfo } from '../../../base/info/env';
-import { IPythonEnvsIterator } from '../../../base/locator';
+import { IPythonEnvsIterator, BasicEnvInfo } from '../../../base/locator';
 import { FSWatchingLocator } from '../../../base/locators/lowLevel/fsWatchingLocator';
 import { pathExists } from '../../../common/externalDependencies';
 import { PythonEnvStructure } from '../../../common/pythonBinariesWatcher';
@@ -194,7 +193,7 @@ export async function getWindowsStorePythonExes(): Promise<string[]> {
     return [];
 }
 
-export class WindowsStoreLocator extends FSWatchingLocator {
+export class WindowsStoreLocator extends FSWatchingLocator<BasicEnvInfo> {
     private readonly kind: PythonEnvKind = PythonEnvKind.WindowsStore;
 
     constructor() {
@@ -211,15 +210,13 @@ export class WindowsStoreLocator extends FSWatchingLocator {
         });
     }
 
-    protected doIterEnvs(): IPythonEnvsIterator {
+    protected doIterEnvs(): IPythonEnvsIterator<BasicEnvInfo> {
         const iterator = async function* (kind: PythonEnvKind) {
             const exes = await getWindowsStorePythonExes();
-            yield* exes.map(async (executable: string) =>
-                buildEnvInfo({
-                    kind,
-                    executable,
-                }),
-            );
+            yield* exes.map(async (executable: string) => ({
+                kind,
+                executable,
+            }));
         };
         return iterator(this.kind);
     }

--- a/src/client/pythonEnvironments/discovery/locators/services/windowsStoreLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/windowsStoreLocator.ts
@@ -5,13 +5,12 @@ import * as fsapi from 'fs-extra';
 import * as minimatch from 'minimatch';
 import * as path from 'path';
 import { traceWarning } from '../../../../common/logger';
-import { Architecture, getEnvironmentVariable } from '../../../../common/utils/platform';
-import { PythonEnvKind, PythonEnvSource } from '../../../base/info';
+import { getEnvironmentVariable } from '../../../../common/utils/platform';
+import { PythonEnvKind } from '../../../base/info';
 import { buildEnvInfo } from '../../../base/info/env';
-import { getPythonVersionFromPath } from '../../../base/info/pythonVersion';
 import { IPythonEnvsIterator } from '../../../base/locator';
 import { FSWatchingLocator } from '../../../base/locators/lowLevel/fsWatchingLocator';
-import { getFileInfo, pathExists } from '../../../common/externalDependencies';
+import { pathExists } from '../../../common/externalDependencies';
 import { PythonEnvStructure } from '../../../common/pythonBinariesWatcher';
 
 /**
@@ -219,11 +218,6 @@ export class WindowsStoreLocator extends FSWatchingLocator {
                 buildEnvInfo({
                     kind,
                     executable,
-                    version: getPythonVersionFromPath(executable),
-                    org: 'Microsoft',
-                    arch: Architecture.x64,
-                    fileInfo: await getFileInfo(executable),
-                    source: [PythonEnvSource.PathEnvVar],
                 }),
             );
         };

--- a/src/client/pythonEnvironments/discovery/locators/services/windowsStoreLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/windowsStoreLocator.ts
@@ -213,9 +213,9 @@ export class WindowsStoreLocator extends FSWatchingLocator<BasicEnvInfo> {
     protected doIterEnvs(): IPythonEnvsIterator<BasicEnvInfo> {
         const iterator = async function* (kind: PythonEnvKind) {
             const exes = await getWindowsStorePythonExes();
-            yield* exes.map(async (executable: string) => ({
+            yield* exes.map(async (executablePath: string) => ({
                 kind,
-                executable,
+                executablePath,
             }));
         };
         return iterator(this.kind);

--- a/src/client/pythonEnvironments/index.ts
+++ b/src/client/pythonEnvironments/index.ts
@@ -9,7 +9,7 @@ import { ActivationResult, ExtensionState } from '../components';
 import { PythonEnvironments } from './api';
 import { getPersistentCache } from './base/envsCache';
 import { PythonEnvInfo } from './base/info';
-import { ILocator, IResolvingLocator } from './base/locator';
+import { BasicEnvInfo, ILocator, IResolvingLocator } from './base/locator';
 import { CachingLocator } from './base/locators/composite/cachingLocator';
 import { PythonEnvsReducer } from './base/locators/composite/environmentsReducer';
 import { PythonEnvsResolver } from './base/locators/composite/environmentsResolver';
@@ -110,7 +110,7 @@ async function createLocators(
 }
 
 function createNonWorkspaceLocators(ext: ExtensionState): ILocator[] {
-    const locators: (ILocator & Partial<IDisposable>)[] = [];
+    const locators: (ILocator<BasicEnvInfo> & Partial<IDisposable>)[] = [];
     locators.push(
         // OS-independent locators go here.
         new PyenvLocator(),

--- a/src/client/pythonEnvironments/index.ts
+++ b/src/client/pythonEnvironments/index.ts
@@ -83,7 +83,7 @@ async function createLocators(
     // This is shared.
 ): Promise<IResolvingLocator> {
     // Create the low-level locators.
-    let locators: ILocator = new ExtensionLocators(
+    let locators: ILocator<BasicEnvInfo> = new ExtensionLocators<BasicEnvInfo>(
         // Here we pull the locators together.
         createNonWorkspaceLocators(ext),
         createWorkspaceLocator(ext),
@@ -109,7 +109,7 @@ async function createLocators(
     return caching;
 }
 
-function createNonWorkspaceLocators(ext: ExtensionState): ILocator[] {
+function createNonWorkspaceLocators(ext: ExtensionState): ILocator<BasicEnvInfo>[] {
     const locators: (ILocator<BasicEnvInfo> & Partial<IDisposable>)[] = [];
     locators.push(
         // OS-independent locators go here.
@@ -156,8 +156,8 @@ function watchRoots(args: WatchRootsArgs): IDisposable {
     });
 }
 
-function createWorkspaceLocator(ext: ExtensionState): WorkspaceLocators {
-    const locators = new WorkspaceLocators(watchRoots, [
+function createWorkspaceLocator(ext: ExtensionState): WorkspaceLocators<BasicEnvInfo> {
+    const locators = new WorkspaceLocators<BasicEnvInfo>(watchRoots, [
         (root: vscode.Uri) => [new WorkspaceVirtualEnvironmentLocator(root.fsPath), new PoetryLocator(root.fsPath)],
         // Add an ILocator factory func here for each kind of workspace-rooted locator.
     ]);

--- a/src/test/pythonEnvironments/base/common.ts
+++ b/src/test/pythonEnvironments/base/common.ts
@@ -4,7 +4,6 @@
 import { expect } from 'chai';
 import * as path from 'path';
 import { Event } from 'vscode';
-import { traceVerbose } from '../../../client/common/logger';
 import { createDeferred, flattenIterator, iterable, mapToIterator } from '../../../client/common/utils/async';
 import { getArchitecture } from '../../../client/common/utils/platform';
 import { getVersionString } from '../../../client/common/utils/version';

--- a/src/test/pythonEnvironments/base/common.ts
+++ b/src/test/pythonEnvironments/base/common.ts
@@ -153,7 +153,7 @@ export class SimpleLocator extends Locator {
     }
 }
 
-export async function getEnvs(iterator: IPythonEnvsIterator): Promise<PythonEnvInfo[]> {
+export async function getEnvs<I = PythonEnvInfo>(iterator: IPythonEnvsIterator<I>): Promise<I[]> {
     return flattenIterator(iterator);
 }
 

--- a/src/test/pythonEnvironments/base/locators/composite/environmentsReducer.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/composite/environmentsReducer.unit.test.ts
@@ -1,25 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { assert, expect } from 'chai';
-import { isEqual } from 'lodash';
+import { assert } from 'chai';
 import * as path from 'path';
 import { EventEmitter } from 'vscode';
 import { PythonEnvKind } from '../../../../../client/pythonEnvironments/base/info';
-import { PythonEnvUpdatedEvent } from '../../../../../client/pythonEnvironments/base/locator';
 import { PythonEnvsReducer } from '../../../../../client/pythonEnvironments/base/locators/composite/environmentsReducer';
 import { PythonEnvsChangedEvent } from '../../../../../client/pythonEnvironments/base/watcher';
-import { sleep } from '../../../../core';
-import { createNamedEnv, getEnvs, SimpleLocator } from '../../common';
+import { assertBasicEnvsEqual } from '../../../discovery/locators/envTestUtils';
+import { createBasicEnv, getEnvs, getEnvsWithUpdates, SimpleLocator } from '../../common';
+import { PythonEnvUpdatedEvent, BasicEnvInfo } from '../../../../../client/pythonEnvironments/base/locator';
 
 suite('Python envs locator - Environments Reducer', () => {
     suite('iterEnvs()', () => {
         test('Iterator only yields unique environments', async () => {
-            const env1 = createNamedEnv('env1', '3.5', PythonEnvKind.Venv, path.join('path', 'to', 'exec1'));
-            const env2 = createNamedEnv('env2', '3.8', PythonEnvKind.Conda, path.join('path', 'to', 'exec2'));
-            const env3 = createNamedEnv('env3', '2.7', PythonEnvKind.System, path.join('path', 'to', 'exec3'));
-            const env4 = createNamedEnv('env4', '3.8.1', PythonEnvKind.Unknown, path.join('path', 'to', 'exec2')); // Same as env2
-            const env5 = createNamedEnv('env5', '3.5.12b1', PythonEnvKind.Venv, path.join('path', 'to', 'exec1')); // Same as env1
+            const env1 = createBasicEnv(PythonEnvKind.Venv, path.join('path', 'to', 'exec1'));
+            const env2 = createBasicEnv(PythonEnvKind.Conda, path.join('path', 'to', 'exec2'));
+            const env3 = createBasicEnv(PythonEnvKind.System, path.join('path', 'to', 'exec3'));
+            const env4 = createBasicEnv(PythonEnvKind.Unknown, path.join('path', 'to', 'exec2')); // Same as env2
+            const env5 = createBasicEnv(PythonEnvKind.Venv, path.join('path', 'to', 'exec1')); // Same as env1
             const environmentsToBeIterated = [env1, env2, env3, env4, env5]; // Contains 3 unique environments
             const parentLocator = new SimpleLocator(environmentsToBeIterated);
             const reducer = new PythonEnvsReducer(parentLocator);
@@ -28,178 +27,49 @@ suite('Python envs locator - Environments Reducer', () => {
             const envs = await getEnvs(iterator);
 
             const expected = [env1, env2, env3];
-            assert.deepEqual(envs, expected);
+            assertBasicEnvsEqual(envs, expected);
         });
 
-        test('Single updates for multiple environments are sent correctly followed by the null event', async () => {
-            // Arrange
-            const env1 = createNamedEnv('env15', '3.5.12b1', PythonEnvKind.Unknown, path.join('path', 'to', 'exec1'));
-            const env2 = createNamedEnv(
-                'env24',
-                '3.8',
-                PythonEnvKind.Unknown,
-                {
-                    filename: path.join('path', 'to', 'folder', 'python3.8'),
-                    ctime: 15,
-                    mtime: -1,
-                    sysPrefix: '',
-                },
-                {
-                    org: 'OrgName',
-                    defaultDisplayName: 'Default name',
-                },
-            );
-            const env3 = createNamedEnv('env3', '2.7', PythonEnvKind.System, path.join('path', 'to', 'exec3'));
-            const env4 = createNamedEnv(
-                '',
-                '3.8.1',
-                PythonEnvKind.Conda,
-                {
-                    filename: path.join('path', 'to', 'folder', 'python'),
-                    ctime: -1,
-                    mtime: 15,
-                    sysPrefix: 'sysPrefix',
-                },
-                {
-                    org: 'Some other orgName',
-                    binDir: 'path/to/binDir',
-                    version: {
-                        raw: 'Raw version',
-                        major: 3,
-                        minor: -1,
-                        micro: 2,
-                    },
-                },
-            ); // Same as env2
-            const env5 = createNamedEnv('env15', '3.5', PythonEnvKind.Venv, path.join('path', 'to', 'exec1')); // Same as env1;
-            const environmentsToBeIterated = [env1, env2, env3, env4, env5]; // Contains 3 unique environments
+        test('Updates are applied correctly', async () => {
+            const env1 = createBasicEnv(PythonEnvKind.Venv, path.join('path', 'to', 'exec1'));
+            const env2 = createBasicEnv(PythonEnvKind.System, path.join('path', 'to', 'exec2'));
+            const env3 = createBasicEnv(PythonEnvKind.Conda, path.join('path', 'to', 'exec2')); // Same as env2
+            const env4 = createBasicEnv(PythonEnvKind.Unknown, path.join('path', 'to', 'exec2')); // Same as env2
+            const env5 = createBasicEnv(PythonEnvKind.Poetry, path.join('path', 'to', 'exec1')); // Same as env1
+            const env6 = createBasicEnv(PythonEnvKind.VirtualEnv, path.join('path', 'to', 'exec1')); // Same as env1
+            const environmentsToBeIterated = [env1, env2, env3, env4, env5, env6]; // Contains 3 unique environments
             const parentLocator = new SimpleLocator(environmentsToBeIterated);
-            const onUpdatedEvents: (PythonEnvUpdatedEvent | null)[] = [];
             const reducer = new PythonEnvsReducer(parentLocator);
 
-            const iterator = reducer.iterEnvs(); // Act
+            const iterator = reducer.iterEnvs();
+            const envs = await getEnvsWithUpdates(iterator);
 
-            // Assert
-            let { onUpdated } = iterator;
-            expect(onUpdated).to.not.equal(undefined, '');
-
-            // Arrange
-            onUpdated = onUpdated!;
-            onUpdated((e) => {
-                onUpdatedEvents.push(e);
-            });
-
-            // Act
-            await getEnvs(iterator);
-            await sleep(1); // Resolve pending calls in the background
-
-            // Assert
-            // Note merged env is constructed picking the better fields from the two envs.
-            // For eg. the merge for env2 & env4 should be,
-            const env24 = createNamedEnv(
-                // Pick name from env2
-                'env24',
-                // Choose version from env4
-                '3.8.1',
-                // Choose type from env4
-                PythonEnvKind.Conda,
-                {
-                    // Choose file info from env2
-                    filename: path.join('path', 'to', 'folder', 'python3.8'),
-                    ctime: 15,
-                    mtime: -1,
-                    // Choose sysPrefix from env4
-                    sysPrefix: 'sysPrefix',
-                },
-                // Choose distro info from env2
-                {
-                    org: 'OrgName',
-                    defaultDisplayName: 'Default name',
-                },
-            );
-            const env15 = createNamedEnv('env15', '3.5.12b1', PythonEnvKind.Venv, path.join('path', 'to', 'exec1'));
-            const expectedUpdates = [
-                { index: 1, old: env2, update: env24 },
-                { index: 0, old: env1, update: env15 },
-                null,
-            ];
-            assert.deepEqual(expectedUpdates, onUpdatedEvents);
+            const expected = [env5, env3];
+            assertBasicEnvsEqual(envs, expected);
         });
 
-        test('Multiple updates for the same environment are sent correctly followed by the null event', async () => {
+        test('Updates to environments from the incoming iterator replaces the previous info', async () => {
             // Arrange
-            const env1 = createNamedEnv('env123', '3.8', PythonEnvKind.Unknown, path.join('path', 'to', 'exec'));
-            const env2 = createNamedEnv('env123', '3.8.1', PythonEnvKind.System, path.join('path', 'to', 'exec'));
-            const env3 = createNamedEnv('env123', '3.8', PythonEnvKind.Conda, path.join('path', 'to', 'exec'));
-            const environmentsToBeIterated = [env1, env2, env3]; // All refer to the same environment
-            const parentLocator = new SimpleLocator(environmentsToBeIterated);
-            const onUpdatedEvents: (PythonEnvUpdatedEvent | null)[] = [];
+            const env = createBasicEnv(PythonEnvKind.Poetry, path.join('path', 'to', 'exec1'));
+            const updatedEnv = createBasicEnv(PythonEnvKind.Venv, path.join('path', 'to', 'exec1'));
+            const envsReturnedByParentLocator = [env];
+            const didUpdate = new EventEmitter<PythonEnvUpdatedEvent<BasicEnvInfo> | null>();
+            const parentLocator = new SimpleLocator<BasicEnvInfo>(envsReturnedByParentLocator, {
+                onUpdated: didUpdate.event,
+            });
             const reducer = new PythonEnvsReducer(parentLocator);
 
-            const iterator = reducer.iterEnvs(); // Act
-
-            // Assert
-            let { onUpdated } = iterator;
-            expect(onUpdated).to.not.equal(undefined, '');
-
-            // Arrange
-            onUpdated = onUpdated!;
-            onUpdated((e) => {
-                onUpdatedEvents.push(e);
-            });
-
             // Act
-            await getEnvs(iterator);
-            await sleep(1); // Resolve pending calls in the background
+            const iterator = reducer.iterEnvs();
+
+            const iteratorUpdateCallback = () => {
+                didUpdate.fire({ index: 0, old: env, update: updatedEnv });
+                didUpdate.fire(null); // It is essential for the incoming iterator to fire "null" event signifying it's done
+            };
+            const envs = await getEnvsWithUpdates(iterator, iteratorUpdateCallback);
 
             // Assert
-            const env12 = createNamedEnv('env123', '3.8.1', PythonEnvKind.System, path.join('path', 'to', 'exec'));
-            const env123 = createNamedEnv('env123', '3.8.1', PythonEnvKind.Conda, path.join('path', 'to', 'exec'));
-            const expectedUpdates: (PythonEnvUpdatedEvent | null)[] = [];
-            if (isEqual(env12, env123)) {
-                expectedUpdates.push({ index: 0, old: env1, update: env12 }, null);
-            } else {
-                expectedUpdates.push(
-                    { index: 0, old: env1, update: env12 },
-                    { index: 0, old: env12, update: env123 },
-                    null,
-                );
-            }
-            assert.deepEqual(onUpdatedEvents, expectedUpdates);
-        });
-
-        test('Updates to environments from the incoming iterator are passed on correctly followed by the null event', async () => {
-            // Arrange
-            const env1 = createNamedEnv('env12', '3.8.1', PythonEnvKind.Unknown, path.join('path', 'to', 'exec'));
-            const env2 = createNamedEnv('env12', '3.8', PythonEnvKind.System, path.join('path', 'to', 'exec'));
-            const environmentsToBeIterated = [env1];
-            const didUpdate = new EventEmitter<PythonEnvUpdatedEvent | null>();
-            const parentLocator = new SimpleLocator(environmentsToBeIterated, { onUpdated: didUpdate.event });
-            const onUpdatedEvents: (PythonEnvUpdatedEvent | null)[] = [];
-            const reducer = new PythonEnvsReducer(parentLocator);
-
-            const iterator = reducer.iterEnvs(); // Act
-
-            // Assert
-            let { onUpdated } = iterator;
-            expect(onUpdated).to.not.equal(undefined, '');
-
-            // Arrange
-            onUpdated = onUpdated!;
-            onUpdated((e) => {
-                onUpdatedEvents.push(e);
-            });
-
-            // Act
-            await getEnvs(iterator);
-            didUpdate.fire({ index: 0, old: env1, update: env2 });
-            didUpdate.fire(null); // It is essential for the incoming iterator to fire "null" event signifying it's done
-            await sleep(1);
-
-            // Assert
-            const env12 = createNamedEnv('env12', '3.8.1', PythonEnvKind.System, path.join('path', 'to', 'exec'));
-            const expectedUpdates = [{ index: 0, old: env1, update: env12 }, null];
-            assert.deepEqual(expectedUpdates, onUpdatedEvents);
+            assertBasicEnvsEqual(envs, [updatedEnv]);
             didUpdate.dispose();
         });
     });

--- a/src/test/pythonEnvironments/base/locators/composite/environmentsResolver.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/composite/environmentsResolver.unit.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { assert, expect } from 'chai';
+import { assert } from 'chai';
 import { cloneDeep } from 'lodash';
 import * as path from 'path';
 import * as sinon from 'sinon';
@@ -17,24 +17,28 @@ import {
     PythonVersion,
     UNKNOWN_PYTHON_VERSION,
 } from '../../../../../client/pythonEnvironments/base/info';
-import { parseVersion } from '../../../../../client/pythonEnvironments/base/info/pythonVersion';
-import { PythonEnvUpdatedEvent } from '../../../../../client/pythonEnvironments/base/locator';
-import { PythonEnvsResolver } from '../../../../../client/pythonEnvironments/base/locators/composite/environmentsResolver';
 import { getEnvs as getEnvsWithUpdates } from '../../../../../client/pythonEnvironments/base/locatorUtils';
+import { parseVersion } from '../../../../../client/pythonEnvironments/base/info/pythonVersion';
+import { BasicEnvInfo, PythonEnvUpdatedEvent } from '../../../../../client/pythonEnvironments/base/locator';
+import { PythonEnvsResolver } from '../../../../../client/pythonEnvironments/base/locators/composite/environmentsResolver';
 import { PythonEnvsChangedEvent } from '../../../../../client/pythonEnvironments/base/watcher';
-import * as ExternalDep from '../../../../../client/pythonEnvironments/common/externalDependencies';
+import * as externalDependencies from '../../../../../client/pythonEnvironments/common/externalDependencies';
 import {
     getEnvironmentInfoService,
     IEnvironmentInfoService,
 } from '../../../../../client/pythonEnvironments/info/environmentInfoService';
-import { sleep } from '../../../../core';
 import { TEST_LAYOUT_ROOT } from '../../../common/commonTestConstants';
-import { assertEnvEqual } from '../../../discovery/locators/envTestUtils';
-import { createNamedEnv, getEnvs, SimpleLocator } from '../../common';
+import { assertEnvEqual, assertEnvsEqual } from '../../../discovery/locators/envTestUtils';
+import { getEnvs, SimpleLocator } from '../../common';
+
+export function createBasicEnv(kind: PythonEnvKind, executablePath: string): BasicEnvInfo {
+    return { executablePath, kind };
+}
 
 suite('Python envs locator - Environments Resolver', () => {
     let envInfoService: IEnvironmentInfoService;
     let disposables: IDisposableRegistry;
+    const testVirtualHomeDir = path.join(TEST_LAYOUT_ROOT, 'virtualhome');
 
     setup(() => {
         disposables = [];
@@ -59,11 +63,38 @@ suite('Python envs locator - Environments Resolver', () => {
         updatedEnv.arch = Architecture.x64;
         return updatedEnv;
     }
+
+    function createExpectedResolvedEnvInfo(
+        interpreterPath: string,
+        kind: PythonEnvKind,
+        version: PythonVersion = UNKNOWN_PYTHON_VERSION,
+        name = '',
+        location = '',
+    ): PythonEnvInfo {
+        return {
+            name,
+            location,
+            kind,
+            executable: {
+                filename: interpreterPath,
+                sysPrefix: '',
+                ctime: -1,
+                mtime: -1,
+            },
+            display: undefined,
+            version,
+            arch: Architecture.Unknown,
+            distro: { org: '' },
+            searchLocation: Uri.file(path.dirname(location)),
+            source: [],
+        };
+    }
     suite('iterEnvs()', () => {
         let stubShellExec: sinon.SinonStub;
         setup(() => {
+            sinon.stub(platformApis, 'getOSType').callsFake(() => platformApis.OSType.Windows);
             stubShellExec = ImportMock.mockFunction(
-                ExternalDep,
+                externalDependencies,
                 'shellExecute',
                 new Promise<ExecutionResult<string>>((resolve) => {
                     resolve({
@@ -72,59 +103,56 @@ suite('Python envs locator - Environments Resolver', () => {
                     });
                 }),
             );
+            sinon.stub(externalDependencies, 'getWorkspaceFolders').returns([testVirtualHomeDir]);
         });
 
         teardown(() => {
-            stubShellExec.restore();
+            sinon.restore();
         });
 
-        test('Iterator yields environments as-is', async () => {
-            const env1 = createNamedEnv('env1', '3.5.12b1', PythonEnvKind.Venv, path.join('path', 'to', 'exec1'));
-            const env2 = createNamedEnv('env2', '3.8.1', PythonEnvKind.Conda, path.join('path', 'to', 'exec2'));
-            const env3 = createNamedEnv('env3', '2.7', PythonEnvKind.System, path.join('path', 'to', 'exec3'));
-            const env4 = createNamedEnv('env4', '3.9.0rc2', PythonEnvKind.Unknown, path.join('path', 'to', 'exec2'));
-            const environmentsToBeIterated = [env1, env2, env3, env4];
-            const parentLocator = new SimpleLocator(environmentsToBeIterated);
+        test('Iterator yields environments after resolving basic envs received from parent iterator', async () => {
+            const env1 = createBasicEnv(
+                PythonEnvKind.Venv,
+                path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe'),
+            );
+            const resolvedEnvReturnedByBasicResolver = createExpectedResolvedEnvInfo(
+                path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe'),
+                PythonEnvKind.Venv,
+                undefined,
+                'win1',
+                path.join(testVirtualHomeDir, '.venvs', 'win1'),
+            );
+            const envsReturnedByParentLocator = [env1];
+            const parentLocator = new SimpleLocator<BasicEnvInfo>(envsReturnedByParentLocator);
             const resolver = new PythonEnvsResolver(parentLocator, envInfoService);
 
             const iterator = resolver.iterEnvs();
             const envs = await getEnvs(iterator);
 
-            assert.deepEqual(envs, environmentsToBeIterated);
+            assertEnvsEqual(envs, [resolvedEnvReturnedByBasicResolver]);
         });
 
         test('Updates for environments are sent correctly followed by the null event', async () => {
             // Arrange
-            const env1 = createNamedEnv('env1', '3.5.12b1', PythonEnvKind.Unknown, path.join('path', 'to', 'exec1'));
-            const env2 = createNamedEnv('env2', '3.8.1', PythonEnvKind.Unknown, path.join('path', 'to', 'exec2'));
-            const environmentsToBeIterated = [env1, env2];
-            const parentLocator = new SimpleLocator(environmentsToBeIterated);
-            const onUpdatedEvents: (PythonEnvUpdatedEvent | null)[] = [];
+            const env1 = createBasicEnv(
+                PythonEnvKind.Venv,
+                path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe'),
+            );
+            const resolvedEnvReturnedByBasicResolver = createExpectedResolvedEnvInfo(
+                path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe'),
+                PythonEnvKind.Venv,
+                undefined,
+                'win1',
+                path.join(testVirtualHomeDir, '.venvs', 'win1'),
+            );
+            const envsReturnedByParentLocator = [env1];
+            const parentLocator = new SimpleLocator<BasicEnvInfo>(envsReturnedByParentLocator);
             const resolver = new PythonEnvsResolver(parentLocator, envInfoService);
 
-            const iterator = resolver.iterEnvs(); // Act
+            const iterator = resolver.iterEnvs();
+            const envs = await getEnvsWithUpdates(iterator);
 
-            // Assert
-            let { onUpdated } = iterator;
-            expect(onUpdated).to.not.equal(undefined, '');
-
-            // Arrange
-            onUpdated = onUpdated!;
-            onUpdated((e) => {
-                onUpdatedEvents.push(e);
-            });
-
-            // Act
-            await getEnvs(iterator);
-            await sleep(1); // Resolve pending calls in the background
-
-            // Assert
-            const expectedUpdates = [
-                { index: 0, old: env1, update: createExpectedEnvInfo(env1) },
-                { index: 1, old: env2, update: createExpectedEnvInfo(env2) },
-                null,
-            ];
-            assert.deepEqual(onUpdatedEvents, expectedUpdates);
+            assertEnvsEqual(envs, [createExpectedEnvInfo(resolvedEnvReturnedByBasicResolver)]);
         });
 
         test('If fetching interpreter info fails, it is not reported in the final list of envs', async () => {
@@ -137,10 +165,13 @@ suite('Python envs locator - Environments Resolver', () => {
                     });
                 }),
             );
-            const env1 = createNamedEnv('env1', '3.5.12b1', PythonEnvKind.Unknown, path.join('path', 'to', 'exec1'));
-            const env2 = createNamedEnv('env2', '3.8.1', PythonEnvKind.Unknown, path.join('path', 'to', 'exec2'));
-            const environmentsToBeIterated = [env1, env2];
-            const parentLocator = new SimpleLocator(environmentsToBeIterated);
+            // Arrange
+            const env1 = createBasicEnv(
+                PythonEnvKind.Venv,
+                path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe'),
+            );
+            const envsReturnedByParentLocator = [env1];
+            const parentLocator = new SimpleLocator<BasicEnvInfo>(envsReturnedByParentLocator);
             const resolver = new PythonEnvsResolver(parentLocator, envInfoService);
 
             // Act
@@ -148,47 +179,43 @@ suite('Python envs locator - Environments Resolver', () => {
             const envs = await getEnvsWithUpdates(iterator);
 
             // Assert
-            assert.deepEqual(envs, []);
+            assertEnvsEqual(envs, []);
         });
 
-        test('Updates to environments from the incoming iterator are sent correctly followed by the null event', async () => {
+        test('Updates to environments from the incoming iterator are applied properly', async () => {
             // Arrange
-            const env = createNamedEnv('env1', '3.8', PythonEnvKind.Unknown, path.join('path', 'to', 'exec'));
-            const updatedEnv = createNamedEnv('env1', '3.8.1', PythonEnvKind.System, path.join('path', 'to', 'exec'));
-            const environmentsToBeIterated = [env];
-            const didUpdate = new EventEmitter<PythonEnvUpdatedEvent | null>();
-            const parentLocator = new SimpleLocator(environmentsToBeIterated, { onUpdated: didUpdate.event });
-            const onUpdatedEvents: (PythonEnvUpdatedEvent | null)[] = [];
+            const env = createBasicEnv(
+                PythonEnvKind.Venv,
+                path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe'),
+            );
+            const updatedEnv = createBasicEnv(
+                PythonEnvKind.Poetry,
+                path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe'),
+            );
+            const resolvedUpdatedEnvReturnedByBasicResolver = createExpectedResolvedEnvInfo(
+                path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe'),
+                PythonEnvKind.Poetry,
+                undefined,
+                'win1',
+                path.join(testVirtualHomeDir, '.venvs', 'win1'),
+            );
+            const envsReturnedByParentLocator = [env];
+            const didUpdate = new EventEmitter<PythonEnvUpdatedEvent<BasicEnvInfo> | null>();
+            const parentLocator = new SimpleLocator<BasicEnvInfo>(envsReturnedByParentLocator, {
+                onUpdated: didUpdate.event,
+            });
             const resolver = new PythonEnvsResolver(parentLocator, envInfoService);
 
-            const iterator = resolver.iterEnvs(); // Act
-
-            // Assert
-            let { onUpdated } = iterator;
-            expect(onUpdated).to.not.equal(undefined, '');
-
-            // Arrange
-            onUpdated = onUpdated!;
-            onUpdated((e) => {
-                onUpdatedEvents.push(e);
-            });
-
             // Act
+            const iterator = resolver.iterEnvs();
             await getEnvs(iterator);
-            await sleep(1);
             didUpdate.fire({ index: 0, old: env, update: updatedEnv });
             didUpdate.fire(null); // It is essential for the incoming iterator to fire "null" event signifying it's done
-            await sleep(1);
+
+            const envs = await getEnvsWithUpdates(iterator);
 
             // Assert
-            // The updates can be anything, even the number of updates, but they should lead to the same final state
-            const { length } = onUpdatedEvents;
-            assert.deepEqual(
-                onUpdatedEvents[length - 2]?.update,
-                createExpectedEnvInfo(updatedEnv),
-                'The final update to environment is incorrect',
-            );
-            assert.equal(onUpdatedEvents[length - 1], null, 'Last update should be null');
+            assertEnvsEqual(envs, [createExpectedEnvInfo(resolvedUpdatedEnvReturnedByBasicResolver)]);
             didUpdate.dispose();
         });
     });
@@ -211,36 +238,10 @@ suite('Python envs locator - Environments Resolver', () => {
 
     suite('resolveEnv()', () => {
         let stubShellExec: sinon.SinonStub;
-        const testVirtualHomeDir = path.join(TEST_LAYOUT_ROOT, 'virtualhome');
-        function createExpectedResolvedEnvInfo(
-            interpreterPath: string,
-            kind: PythonEnvKind,
-            version: PythonVersion = UNKNOWN_PYTHON_VERSION,
-            name = '',
-            location = '',
-        ): PythonEnvInfo {
-            return {
-                name,
-                location,
-                kind,
-                executable: {
-                    filename: interpreterPath,
-                    sysPrefix: '',
-                    ctime: -1,
-                    mtime: -1,
-                },
-                display: undefined,
-                version,
-                arch: Architecture.Unknown,
-                distro: { org: '' },
-                searchLocation: Uri.file(path.dirname(location)),
-                source: [],
-            };
-        }
         setup(() => {
             sinon.stub(platformApis, 'getOSType').callsFake(() => platformApis.OSType.Windows);
             stubShellExec = ImportMock.mockFunction(
-                ExternalDep,
+                externalDependencies,
                 'shellExecute',
                 new Promise<ExecutionResult<string>>((resolve) => {
                     resolve({
@@ -249,7 +250,7 @@ suite('Python envs locator - Environments Resolver', () => {
                     });
                 }),
             );
-            sinon.stub(ExternalDep, 'getWorkspaceFolders').returns([testVirtualHomeDir]);
+            sinon.stub(externalDependencies, 'getWorkspaceFolders').returns([testVirtualHomeDir]);
         });
 
         teardown(() => {

--- a/src/test/pythonEnvironments/base/locators/composite/resolverUtils.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/composite/resolverUtils.unit.test.ts
@@ -32,6 +32,8 @@ suite('Resolver Utils', () => {
         const testPyenvVersionsDir = path.join(testPyenvRoot, 'versions');
         setup(() => {
             sinon.stub(externalDependencies, 'getWorkspaceFolders').returns([]);
+            sinon.stub(winreg, 'readRegistryValues').resolves([]);
+            sinon.stub(winreg, 'readRegistryKeys').resolves([]);
             sinon.stub(platformApis, 'getEnvironmentVariable').withArgs('PYENV_ROOT').returns(testPyenvRoot);
         });
 
@@ -70,6 +72,8 @@ suite('Resolver Utils', () => {
 
         setup(() => {
             sinon.stub(externalDependencies, 'getWorkspaceFolders').returns([]);
+            sinon.stub(winreg, 'readRegistryValues').resolves([]);
+            sinon.stub(winreg, 'readRegistryKeys').resolves([]);
             sinon.stub(platformApis, 'getEnvironmentVariable').withArgs('LOCALAPPDATA').returns(testLocalAppData);
         });
 
@@ -196,6 +200,8 @@ suite('Resolver Utils', () => {
 
         setup(() => {
             sinon.stub(externalDependencies, 'getWorkspaceFolders').returns([]);
+            sinon.stub(winreg, 'readRegistryValues').resolves([]);
+            sinon.stub(winreg, 'readRegistryKeys').resolves([]);
         });
 
         teardown(() => {
@@ -252,6 +258,8 @@ suite('Resolver Utils', () => {
         const testVirtualHomeDir = path.join(TEST_LAYOUT_ROOT, 'virtualhome');
         setup(() => {
             sinon.stub(externalDependencies, 'getWorkspaceFolders').returns([testVirtualHomeDir]);
+            sinon.stub(winreg, 'readRegistryValues').resolves([]);
+            sinon.stub(winreg, 'readRegistryKeys').resolves([]);
         });
 
         teardown(() => {

--- a/src/test/pythonEnvironments/base/locators/composite/resolverUtils.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/composite/resolverUtils.unit.test.ts
@@ -328,6 +328,7 @@ suite('Resolver Utils', () => {
         const testLocation3 = path.join(testPosixKnownPathsRoot, 'location3');
         setup(() => {
             sinon.stub(externalDependencies, 'getWorkspaceFolders').returns([]);
+            sinon.stub(platformApis, 'getOSType').callsFake(() => platformApis.OSType.Linux);
         });
 
         teardown(() => {
@@ -560,7 +561,6 @@ suite('Resolver Utils', () => {
                 version: parseVersion('3.8.5'), // Registry provides more complete version info.
                 arch: Architecture.x86, // Provided by registry
                 org: 'PythonCodingPack', // Provided by registry
-                name: 'python38',
                 source: [PythonEnvSource.WindowsRegistry],
             });
             expected.distro.defaultDisplayName = 'Python 3.8 (32-bit)';

--- a/src/test/pythonEnvironments/base/locators/composite/resolverUtils.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/composite/resolverUtils.unit.test.ts
@@ -24,7 +24,7 @@ import {
     AnacondaCompanyName,
     CondaInfo,
 } from '../../../../../client/pythonEnvironments/discovery/locators/services/conda';
-import { resolveEnvUsingKind } from '../../../../../client/pythonEnvironments/base/locators/composite/resolverUtils';
+import { resolveBasicEnv } from '../../../../../client/pythonEnvironments/base/locators/composite/resolverUtils';
 
 suite('Resolver Utils', () => {
     suite('Pyenv', () => {
@@ -61,7 +61,7 @@ suite('Resolver Utils', () => {
             const executablePath = path.join(testPyenvVersionsDir, '3.9.0', 'bin', 'python');
             const expected = getExpectedPyenvInfo();
 
-            const actual = await resolveEnvUsingKind({ executablePath, kind: PythonEnvKind.Pyenv });
+            const actual = await resolveBasicEnv({ executablePath, kind: PythonEnvKind.Pyenv });
             assertEnvEqual(actual, expected);
         });
     });
@@ -121,7 +121,7 @@ suite('Resolver Utils', () => {
                 ...createExpectedInterpreterInfo(python38path),
             };
 
-            const actual = await resolveEnvUsingKind({
+            const actual = await resolveBasicEnv({
                 executablePath: python38path,
                 kind: PythonEnvKind.WindowsStore,
             });
@@ -142,7 +142,7 @@ suite('Resolver Utils', () => {
                 ...createExpectedInterpreterInfo(python38path),
             };
 
-            const actual = await resolveEnvUsingKind({
+            const actual = await resolveBasicEnv({
                 executablePath: python38path,
                 kind: PythonEnvKind.WindowsStore,
             });
@@ -222,7 +222,7 @@ suite('Resolver Utils', () => {
                 }
                 throw new Error(`${command} is missing or is not executable`);
             });
-            const actual = await resolveEnvUsingKind({
+            const actual = await resolveBasicEnv({
                 executablePath: path.join(TEST_LAYOUT_ROOT, 'conda1', 'python.exe'),
                 kind: PythonEnvKind.Conda,
             });
@@ -237,7 +237,7 @@ suite('Resolver Utils', () => {
                 }
                 throw new Error(`${command} is missing or is not executable`);
             });
-            const actual = await resolveEnvUsingKind({
+            const actual = await resolveBasicEnv({
                 executablePath: path.join(TEST_LAYOUT_ROOT, 'conda2', 'bin', 'python'),
                 kind: PythonEnvKind.Conda,
             });
@@ -252,7 +252,7 @@ suite('Resolver Utils', () => {
             sinon.stub(externalDependencies, 'exec').callsFake(async (command: string) => {
                 throw new Error(`${command} is missing or is not executable`);
             });
-            const actual = await resolveEnvUsingKind({
+            const actual = await resolveBasicEnv({
                 executablePath: path.join(TEST_LAYOUT_ROOT, 'conda1', 'python.exe'),
                 kind: PythonEnvKind.Conda,
             });
@@ -315,7 +315,7 @@ suite('Resolver Utils', () => {
                 'win1',
                 path.join(testVirtualHomeDir, '.venvs', 'win1'),
             );
-            const actual = await resolveEnvUsingKind({
+            const actual = await resolveBasicEnv({
                 executablePath: path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe'),
                 kind: PythonEnvKind.Venv,
             });
@@ -532,7 +532,7 @@ suite('Resolver Utils', () => {
 
         test('If data provided by registry is more informative than kind resolvers, use it to update environment (64bit)', async () => {
             const interpreterPath = path.join(regTestRoot, 'py39', 'python.exe');
-            const actual = await resolveEnvUsingKind({
+            const actual = await resolveBasicEnv({
                 executablePath: interpreterPath,
                 kind: PythonEnvKind.Unknown,
             });
@@ -550,7 +550,7 @@ suite('Resolver Utils', () => {
 
         test('If data provided by registry is more informative than kind resolvers, use it to update environment (32bit)', async () => {
             const interpreterPath = path.join(regTestRoot, 'python38', 'python.exe');
-            const actual = await resolveEnvUsingKind({
+            const actual = await resolveBasicEnv({
                 executablePath: interpreterPath,
                 kind: PythonEnvKind.Unknown,
             });
@@ -572,7 +572,7 @@ suite('Resolver Utils', () => {
                 throw new Error(`${command} is missing or is not executable`);
             });
             const interpreterPath = path.join(regTestRoot, 'conda3', 'python.exe');
-            const actual = await resolveEnvUsingKind({
+            const actual = await resolveBasicEnv({
                 executablePath: interpreterPath,
                 kind: PythonEnvKind.Conda,
             });

--- a/src/test/pythonEnvironments/base/locators/lowLevel/windowsKnownPathsLocator.functional.test.ts
+++ b/src/test/pythonEnvironments/base/locators/lowLevel/windowsKnownPathsLocator.functional.test.ts
@@ -3,26 +3,15 @@
 
 import { assert } from 'chai';
 import * as path from 'path';
-import { Architecture, getOSType, OSType } from '../../../../../client/common/utils/platform';
-import { PythonEnvInfo, PythonEnvKind, PythonEnvSource } from '../../../../../client/pythonEnvironments/base/info';
-import { PythonLocatorQuery } from '../../../../../client/pythonEnvironments/base/locator';
+import { getOSType, OSType } from '../../../../../client/common/utils/platform';
+import { PythonEnvKind } from '../../../../../client/pythonEnvironments/base/info';
+import { BasicEnvInfo, PythonLocatorQuery } from '../../../../../client/pythonEnvironments/base/locator';
 import { WindowsPathEnvVarLocator } from '../../../../../client/pythonEnvironments/base/locators/lowLevel/windowsKnownPathsLocator';
 import { ensureFSTree } from '../../../../utils/fs';
-import { createNamedEnv, getEnvs, sortedEnvs } from '../../common';
+import { assertBasicEnvsEqual } from '../../../discovery/locators/envTestUtils';
+import { createBasicEnv, getEnvs } from '../../common';
 
 const IS_WINDOWS = getOSType() === OSType.Windows;
-
-function getEnv(
-    // These will all be provided.
-    name: string,
-    version: string,
-    executable: string,
-): PythonEnvInfo {
-    const env = createNamedEnv(name, version, PythonEnvKind.System, executable);
-    env.arch = Architecture.Unknown;
-    env.source = [PythonEnvSource.PathEnvVar];
-    return env;
-}
 
 suite('Python envs locator - WindowsPathEnvVarLocator', async () => {
     let cleanUps: (() => void)[];
@@ -123,7 +112,7 @@ suite('Python envs locator - WindowsPathEnvVarLocator', async () => {
 
     suite('iterEnvs()', () => {
         test('no executables found', async () => {
-            const expected: PythonEnvInfo[] = [];
+            const expected: BasicEnvInfo[] = [];
             const locator = getActiveLocator(ROOT3, ROOT4, DOES_NOT_EXIST, ROOT5);
             const query: PythonLocatorQuery | undefined = undefined;
 
@@ -134,7 +123,7 @@ suite('Python envs locator - WindowsPathEnvVarLocator', async () => {
         });
 
         test('no executables match', async () => {
-            const expected: PythonEnvInfo[] = [];
+            const expected: BasicEnvInfo[] = [];
             const locator = getActiveLocator(ROOT6, DOES_NOT_EXIST);
             const query: PythonLocatorQuery | undefined = undefined;
 
@@ -145,8 +134,8 @@ suite('Python envs locator - WindowsPathEnvVarLocator', async () => {
         });
 
         test('some executables match', async () => {
-            const expected: PythonEnvInfo[] = [
-                getEnv('', '', path.join(ROOT1, 'python.exe')),
+            const expected: BasicEnvInfo[] = [
+                createBasicEnv(PythonEnvKind.System, path.join(ROOT1, 'python.exe')),
 
                 // We will expect the following once we switch
                 // to a better filter than isStandardPythonBinary().
@@ -166,7 +155,7 @@ suite('Python envs locator - WindowsPathEnvVarLocator', async () => {
             const iterator = locator.iterEnvs(query);
             const envs = await getEnvs(iterator);
 
-            assert.deepEqual(sortedEnvs(envs), sortedEnvs(expected));
+            assertBasicEnvsEqual(envs, expected);
         });
     });
 });

--- a/src/test/pythonEnvironments/base/locators/lowLevel/workspaceVirtualEnvLocator.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/lowLevel/workspaceVirtualEnvLocator.unit.test.ts
@@ -1,62 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as assert from 'assert';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import { Uri } from 'vscode';
 import * as fsWatcher from '../../../../../client/common/platform/fileSystemWatcher';
 import * as platformUtils from '../../../../../client/common/utils/platform';
-import {
-    PythonEnvInfo,
-    PythonEnvKind,
-    PythonEnvSource,
-    PythonReleaseLevel,
-    PythonVersion,
-    UNKNOWN_PYTHON_VERSION,
-} from '../../../../../client/pythonEnvironments/base/info';
+import { PythonEnvKind } from '../../../../../client/pythonEnvironments/base/info';
 import { WorkspaceVirtualEnvironmentLocator } from '../../../../../client/pythonEnvironments/base/locators/lowLevel/workspaceVirtualEnvLocator';
 import { getEnvs } from '../../../../../client/pythonEnvironments/base/locatorUtils';
 import { TEST_LAYOUT_ROOT } from '../../../common/commonTestConstants';
-import { assertEnvsEqual } from '../../../discovery/locators/envTestUtils';
+import { assertBasicEnvsEqual } from '../../../discovery/locators/envTestUtils';
+import { createBasicEnv } from '../../common';
 
 suite('WorkspaceVirtualEnvironment Locator', () => {
     const testWorkspaceFolder = path.join(TEST_LAYOUT_ROOT, 'workspace', 'folder1');
     let getOSTypeStub: sinon.SinonStub;
     let watchLocationForPatternStub: sinon.SinonStub;
     let locator: WorkspaceVirtualEnvironmentLocator;
-
-    function createExpectedEnvInfo(
-        interpreterPath: string,
-        kind: PythonEnvKind,
-        version: PythonVersion = UNKNOWN_PYTHON_VERSION,
-        name = '',
-        location = path.join(testWorkspaceFolder, name),
-    ): PythonEnvInfo {
-        return {
-            name,
-            location,
-            kind,
-            executable: {
-                filename: interpreterPath,
-                sysPrefix: '',
-                ctime: -1,
-                mtime: -1,
-            },
-            display: undefined,
-            version,
-            arch: platformUtils.Architecture.Unknown,
-            distro: { org: '' },
-            searchLocation: Uri.file(path.dirname(location)),
-            source: [PythonEnvSource.Other],
-        };
-    }
-
-    function comparePaths(actual: PythonEnvInfo[], expected: PythonEnvInfo[]) {
-        const actualPaths = actual.map((a) => a.executable.filename);
-        const expectedPaths = expected.map((a) => a.executable.filename);
-        assert.deepStrictEqual(actualPaths, expectedPaths);
-    }
 
     setup(() => {
         getOSTypeStub = sinon.stub(platformUtils, 'getOSType');
@@ -71,72 +31,40 @@ suite('WorkspaceVirtualEnvironment Locator', () => {
     });
     teardown(async () => {
         await locator.dispose();
-        getOSTypeStub.restore();
-        watchLocationForPatternStub.restore();
+        sinon.restore();
     });
 
     test('iterEnvs(): Windows', async () => {
         getOSTypeStub.returns(platformUtils.OSType.Windows);
         const expectedEnvs = [
-            createExpectedEnvInfo(
-                path.join(testWorkspaceFolder, 'win1', 'python.exe'),
+            createBasicEnv(PythonEnvKind.Venv, path.join(testWorkspaceFolder, 'win1', 'python.exe')),
+            createBasicEnv(
                 PythonEnvKind.Venv,
-                {
-                    major: 3,
-                    minor: 9,
-                    micro: 0,
-                    release: { level: PythonReleaseLevel.Alpha, serial: 1 },
-                    sysVersion: undefined,
-                },
-                'win1',
-            ),
-            createExpectedEnvInfo(
                 path.join(testWorkspaceFolder, '.direnv', 'win2', 'Scripts', 'python.exe'),
-                PythonEnvKind.Venv,
-                { major: 3, minor: 6, micro: 1 },
-                'win2',
-                path.join(testWorkspaceFolder, '.direnv', 'win2'),
             ),
-            createExpectedEnvInfo(
-                path.join(testWorkspaceFolder, '.venv', 'Scripts', 'python.exe'),
-                PythonEnvKind.Pipenv,
-                {
-                    major: 3,
-                    minor: 8,
-                    micro: 2,
-                    release: { level: PythonReleaseLevel.Final, serial: 0 },
-                    sysVersion: undefined,
-                },
-                '.venv',
-            ),
-        ].sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
+            createBasicEnv(PythonEnvKind.Pipenv, path.join(testWorkspaceFolder, '.venv', 'Scripts', 'python.exe')),
+        ];
 
         const iterator = locator.iterEnvs();
-        const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-            a.executable.filename.localeCompare(b.executable.filename),
-        );
+        const actualEnvs = await getEnvs(iterator);
 
-        comparePaths(actualEnvs, expectedEnvs);
-        assertEnvsEqual(actualEnvs, expectedEnvs);
+        assertBasicEnvsEqual(actualEnvs, expectedEnvs);
     });
 
     test('iterEnvs(): Non-Windows', async () => {
+        getOSTypeStub.returns(platformUtils.OSType.Linux);
         const expectedEnvs = [
-            createExpectedEnvInfo(
-                path.join(testWorkspaceFolder, '.direnv', 'posix1virtualenv', 'bin', 'python'),
+            createBasicEnv(
                 PythonEnvKind.VirtualEnv,
-                { major: 3, minor: 8, micro: -1 },
-                'posix1virtualenv',
-                path.join(testWorkspaceFolder, '.direnv', 'posix1virtualenv'),
+                path.join(testWorkspaceFolder, '.direnv', 'posix1virtualenv', 'bin', 'python'),
             ),
-        ].sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
+            createBasicEnv(PythonEnvKind.Unknown, path.join(testWorkspaceFolder, 'posix2conda', 'python')),
+            createBasicEnv(PythonEnvKind.Unknown, path.join(testWorkspaceFolder, 'posix3custom', 'bin', 'python')),
+        ];
 
         const iterator = locator.iterEnvs();
-        const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-            a.executable.filename.localeCompare(b.executable.filename),
-        );
+        const actualEnvs = await getEnvs(iterator);
 
-        comparePaths(actualEnvs, expectedEnvs);
-        assertEnvsEqual(actualEnvs, expectedEnvs);
+        assertBasicEnvsEqual(actualEnvs, expectedEnvs);
     });
 });

--- a/src/test/pythonEnvironments/discovery/locators/condaHelper.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaHelper.unit.test.ts
@@ -6,12 +6,11 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 import * as util from 'util';
 import * as platform from '../../../../client/common/utils/platform';
-import { PythonEnvKind, PythonEnvSource } from '../../../../client/pythonEnvironments/base/info';
+import { PythonEnvKind } from '../../../../client/pythonEnvironments/base/info';
 import { getEnvs } from '../../../../client/pythonEnvironments/base/locatorUtils';
 import * as externalDependencies from '../../../../client/pythonEnvironments/common/externalDependencies';
 import * as windowsUtils from '../../../../client/pythonEnvironments/common/windowsUtils';
 import {
-    AnacondaCompanyName,
     AnacondaDisplayName,
     Conda,
     CondaInfo,

--- a/src/test/pythonEnvironments/discovery/locators/condaHelper.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaHelper.unit.test.ts
@@ -21,6 +21,8 @@ import {
     parseCondaEnvFileContents,
 } from '../../../../client/pythonEnvironments/discovery/locators/services/condaHelper';
 import { CondaEnvironmentLocator } from '../../../../client/pythonEnvironments/discovery/locators/services/condaLocator';
+import { createBasicEnv } from '../../base/common';
+import { assertBasicEnvsEqual } from './envTestUtils';
 
 suite('Interpreters display name from Conda Environments', () => {
     test('Must return default display name for invalid Conda Info', () => {
@@ -628,43 +630,20 @@ suite('Conda and its environments are located correctly', () => {
 
         test('Must iterate conda environments correctly', async () => {
             const locator = new CondaEnvironmentLocator();
-            const envs = await getEnvs(await locator.iterEnvs());
+            const envs = await getEnvs(locator.iterEnvs());
 
-            function condaEnv(name: string, prefix: string) {
-                return {
-                    name,
-                    kind: PythonEnvKind.Conda,
-                    arch: platform.Architecture.Unknown,
-                    display: undefined,
-                    searchLocation: undefined,
-                    distro: { org: AnacondaCompanyName },
-                    version: {
-                        major: -1,
-                        minor: -1,
-                        micro: -1,
-                        release: { level: 'final', serial: -1 },
-                        sysVersion: undefined,
-                    },
-                    location: prefix,
-                    executable: {
-                        filename: path.join(prefix, 'bin', 'python'),
-                        ctime: -1,
-                        mtime: -1,
-                        sysPrefix: '',
-                    },
-                    source: [PythonEnvSource.Conda],
-                };
-            }
-
-            expect(envs).to.have.deep.members([
-                condaEnv('base', '/home/user/miniconda3'),
-                condaEnv('env1', '/home/user/miniconda3/envs/env1'),
-                // no env2, because there's no bin/python* under it
-                condaEnv('', '/home/user/miniconda3/envs/dir/env3'),
-                condaEnv('env4', '/home/user/.conda/envs/env4'),
-                // no env5, because there's no bin/python* under it
-                condaEnv('', '/env6'),
-            ]);
+            assertBasicEnvsEqual(
+                envs,
+                [
+                    path.join('/home/user/miniconda3', 'bin', 'python'),
+                    path.join('/home/user/miniconda3/envs/env1', 'bin', 'python'),
+                    // no env2, because there's no bin/python* under it
+                    path.join('/home/user/miniconda3/envs/dir/env3', 'bin', 'python'),
+                    path.join('/home/user/.conda/envs/env4', 'bin', 'python'),
+                    // no env5, because there's no bin/python* under it
+                    path.join('/env6', 'bin', 'python'),
+                ].map((executablePath) => createBasicEnv(PythonEnvKind.Conda, executablePath)),
+            );
         });
     });
 });

--- a/src/test/pythonEnvironments/discovery/locators/customVirtualEnvLocator.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/customVirtualEnvLocator.unit.test.ts
@@ -6,14 +6,7 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 import * as fsWatcher from '../../../../client/common/platform/fileSystemWatcher';
 import * as platformUtils from '../../../../client/common/utils/platform';
-import {
-    PythonEnvInfo,
-    PythonEnvKind,
-    PythonEnvSource,
-    PythonReleaseLevel,
-    PythonVersion,
-    UNKNOWN_PYTHON_VERSION,
-} from '../../../../client/pythonEnvironments/base/info';
+import { PythonEnvKind } from '../../../../client/pythonEnvironments/base/info';
 import { getEnvs } from '../../../../client/pythonEnvironments/base/locatorUtils';
 import { PythonEnvsChangedEvent } from '../../../../client/pythonEnvironments/base/watcher';
 import * as externalDependencies from '../../../../client/pythonEnvironments/common/externalDependencies';
@@ -22,8 +15,9 @@ import {
     VENVFOLDERS_SETTING_KEY,
     VENVPATH_SETTING_KEY,
 } from '../../../../client/pythonEnvironments/discovery/locators/services/customVirtualEnvLocator';
+import { createBasicEnv } from '../../base/common';
 import { TEST_LAYOUT_ROOT } from '../../common/commonTestConstants';
-import { assertEnvsEqual } from './envTestUtils';
+import { assertBasicEnvsEqual } from './envTestUtils';
 
 suite('CustomVirtualEnvironment Locator', () => {
     const testVirtualHomeDir = path.join(TEST_LAYOUT_ROOT, 'virtualhome');
@@ -36,38 +30,6 @@ suite('CustomVirtualEnvironment Locator', () => {
     let getPythonSettingStub: sinon.SinonStub;
     let onDidChangePythonSettingStub: sinon.SinonStub;
     let untildify: sinon.SinonStub;
-
-    function createExpectedEnvInfo(
-        interpreterPath: string,
-        kind: PythonEnvKind,
-        version: PythonVersion = UNKNOWN_PYTHON_VERSION,
-        name = '',
-        location = '',
-    ): PythonEnvInfo {
-        return {
-            name,
-            location,
-            kind,
-            executable: {
-                filename: interpreterPath,
-                sysPrefix: '',
-                ctime: -1,
-                mtime: -1,
-            },
-            display: undefined,
-            version,
-            arch: platformUtils.Architecture.Unknown,
-            distro: { org: '' },
-            searchLocation: undefined,
-            source: [PythonEnvSource.Other],
-        };
-    }
-
-    function comparePaths(actual: PythonEnvInfo[], expected: PythonEnvInfo[]) {
-        const actualPaths = actual.map((a) => a.executable.filename);
-        const expectedPaths = expected.map((a) => a.executable.filename);
-        assert.deepStrictEqual(actualPaths, expectedPaths);
-    }
 
     setup(async () => {
         untildify = sinon.stub(externalDependencies, 'untildify');
@@ -117,77 +79,38 @@ suite('CustomVirtualEnvironment Locator', () => {
         getPythonSettingStub.withArgs('venvFolders').returns(['.venvs', '.virtualenvs', 'Envs']);
         getOSTypeStub.returns(platformUtils.OSType.Windows);
         const expectedEnvs = [
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe'),
-                PythonEnvKind.Venv,
-                undefined,
-                'win1',
-                path.join(testVirtualHomeDir, '.venvs', 'win1'),
-            ),
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.venvs', 'win2', 'bin', 'python.exe'),
-                PythonEnvKind.Venv,
-                {
-                    major: 3,
-                    minor: 9,
-                    micro: 0,
-                    release: { level: PythonReleaseLevel.Alpha, serial: 1 },
-                    sysVersion: undefined,
-                },
-                'win2',
-                path.join(testVirtualHomeDir, '.venvs', 'win2'),
-            ),
-            createExpectedEnvInfo(
+            createBasicEnv(PythonEnvKind.Venv, path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe')),
+            createBasicEnv(PythonEnvKind.Venv, path.join(testVirtualHomeDir, '.venvs', 'win2', 'bin', 'python.exe')),
+            createBasicEnv(
+                PythonEnvKind.VirtualEnv,
                 path.join(testVirtualHomeDir, '.virtualenvs', 'win1', 'python.exe'),
-                PythonEnvKind.VirtualEnv,
-                undefined,
-                'win1',
-                path.join(testVirtualHomeDir, '.virtualenvs', 'win1'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnv,
                 path.join(testVirtualHomeDir, '.virtualenvs', 'win2', 'bin', 'python.exe'),
-                PythonEnvKind.VirtualEnv,
-                undefined,
-                'win2',
-                path.join(testVirtualHomeDir, '.virtualenvs', 'win2'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, 'Envs', 'wrapper_win1', 'python.exe'),
-                PythonEnvKind.VirtualEnvWrapper,
-                undefined,
-                'wrapper_win1',
-                path.join(testVirtualHomeDir, 'Envs', 'wrapper_win1'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, 'Envs', 'wrapper_win2', 'bin', 'python.exe'),
-                PythonEnvKind.VirtualEnvWrapper,
-                undefined,
-                'wrapper_win2',
-                path.join(testVirtualHomeDir, 'Envs', 'wrapper_win2'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnv,
                 path.join(testVirtualHomeDir, 'customfolder', 'win1', 'python.exe'),
-                PythonEnvKind.VirtualEnv,
-                undefined,
-                'win1',
-                path.join(testVirtualHomeDir, 'customfolder', 'win1'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnv,
                 path.join(testVirtualHomeDir, 'customfolder', 'win2', 'bin', 'python.exe'),
-                PythonEnvKind.VirtualEnv,
-                undefined,
-                'win2',
-                path.join(testVirtualHomeDir, 'customfolder', 'win2'),
             ),
-        ].sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
+        ];
 
         const iterator = locator.iterEnvs();
-        const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-            a.executable.filename.localeCompare(b.executable.filename),
-        );
+        const actualEnvs = await getEnvs(iterator);
 
-        comparePaths(actualEnvs, expectedEnvs);
-        assertEnvsEqual(actualEnvs, expectedEnvs);
+        assertBasicEnvsEqual(actualEnvs, expectedEnvs);
     });
 
     test('iterEnvs(): Non-Windows with both settings set', async () => {
@@ -198,63 +121,27 @@ suite('CustomVirtualEnvironment Locator', () => {
             .withArgs('venvFolders')
             .returns(['.venvs', '.virtualenvs', 'envs', path.join('.local', 'share', 'virtualenvs')]);
         const expectedEnvs = [
-            createExpectedEnvInfo(
-                path.join(testWorkspaceFolder, 'posix2conda', 'python'),
-                PythonEnvKind.Unknown,
-                { major: 3, minor: 8, micro: 5 },
-                'posix2conda',
-                path.join(testWorkspaceFolder, 'posix2conda'),
-            ),
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.venvs', 'posix1', 'python'),
-                PythonEnvKind.Venv,
-                undefined,
-                'posix1',
-                path.join(testVirtualHomeDir, '.venvs', 'posix1'),
-            ),
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.venvs', 'posix2', 'bin', 'python'),
-                PythonEnvKind.Venv,
-                undefined,
-                'posix2',
-                path.join(testVirtualHomeDir, '.venvs', 'posix2'),
-            ),
-            createExpectedEnvInfo(
+            createBasicEnv(PythonEnvKind.Unknown, path.join(testWorkspaceFolder, 'posix2conda', 'python')),
+            createBasicEnv(PythonEnvKind.Venv, path.join(testVirtualHomeDir, '.venvs', 'posix1', 'python')),
+            createBasicEnv(PythonEnvKind.Venv, path.join(testVirtualHomeDir, '.venvs', 'posix2', 'bin', 'python')),
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, '.virtualenvs', 'posix1', 'python'),
-                PythonEnvKind.VirtualEnvWrapper,
-                { major: 3, minor: 8, micro: -1 },
-                'posix1',
-                path.join(testVirtualHomeDir, '.virtualenvs', 'posix1'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, '.virtualenvs', 'posix2', 'bin', 'python'),
-                PythonEnvKind.VirtualEnvWrapper,
-                undefined,
-                'posix2',
-                path.join(testVirtualHomeDir, '.virtualenvs', 'posix2'),
             ),
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.local', 'share', 'virtualenvs', 'project2-vnNIWe9P', 'bin', 'python'),
+            createBasicEnv(
                 PythonEnvKind.Pipenv,
-                {
-                    major: 3,
-                    minor: 8,
-                    micro: 2,
-                    release: { level: PythonReleaseLevel.Final, serial: 0 },
-                    sysVersion: undefined,
-                },
-                'project2-vnNIWe9P',
-                path.join(testVirtualHomeDir, '.local', 'share', 'virtualenvs', 'project2-vnNIWe9P'),
+                path.join(testVirtualHomeDir, '.local', 'share', 'virtualenvs', 'project2-vnNIWe9P', 'bin', 'python'),
             ),
-        ].sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
+        ];
 
         const iterator = locator.iterEnvs();
-        const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-            a.executable.filename.localeCompare(b.executable.filename),
-        );
+        const actualEnvs = await getEnvs(iterator);
 
-        comparePaths(actualEnvs, expectedEnvs);
-        assertEnvsEqual(actualEnvs, expectedEnvs);
+        assertBasicEnvsEqual(actualEnvs, expectedEnvs);
     });
 
     test('iterEnvs(): No User home dir set', async () => {
@@ -264,92 +151,50 @@ suite('CustomVirtualEnvironment Locator', () => {
         getPythonSettingStub.withArgs('venvFolders').returns(['.venvs', '.virtualenvs', 'Envs']);
         getOSTypeStub.returns(platformUtils.OSType.Windows);
         const expectedEnvs = [
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnv,
                 path.join(testVirtualHomeDir, 'customfolder', 'win1', 'python.exe'),
-                PythonEnvKind.VirtualEnv,
-                undefined,
-                'win1',
-                path.join(testVirtualHomeDir, 'customfolder', 'win1'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnv,
                 path.join(testVirtualHomeDir, 'customfolder', 'win2', 'bin', 'python.exe'),
-                PythonEnvKind.VirtualEnv,
-                undefined,
-                'win2',
-                path.join(testVirtualHomeDir, 'customfolder', 'win2'),
             ),
-        ].sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
+        ];
 
         const iterator = locator.iterEnvs();
-        const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-            a.executable.filename.localeCompare(b.executable.filename),
-        );
+        const actualEnvs = await getEnvs(iterator);
 
-        comparePaths(actualEnvs, expectedEnvs);
-        assertEnvsEqual(actualEnvs, expectedEnvs);
+        assertBasicEnvsEqual(actualEnvs, expectedEnvs);
     });
 
     test('iterEnvs(): with only venvFolders set', async () => {
         getPythonSettingStub.withArgs('venvFolders').returns(['.venvs', '.virtualenvs', 'Envs']);
         getOSTypeStub.returns(platformUtils.OSType.Windows);
         const expectedEnvs = [
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe'),
-                PythonEnvKind.Venv,
-                undefined,
-                'win1',
-                path.join(testVirtualHomeDir, '.venvs', 'win1'),
-            ),
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.venvs', 'win2', 'bin', 'python.exe'),
-                PythonEnvKind.Venv,
-                {
-                    major: 3,
-                    minor: 9,
-                    micro: 0,
-                    release: { level: PythonReleaseLevel.Alpha, serial: 1 },
-                    sysVersion: undefined,
-                },
-                'win2',
-                path.join(testVirtualHomeDir, '.venvs', 'win2'),
-            ),
-            createExpectedEnvInfo(
+            createBasicEnv(PythonEnvKind.Venv, path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe')),
+            createBasicEnv(PythonEnvKind.Venv, path.join(testVirtualHomeDir, '.venvs', 'win2', 'bin', 'python.exe')),
+            createBasicEnv(
+                PythonEnvKind.VirtualEnv,
                 path.join(testVirtualHomeDir, '.virtualenvs', 'win1', 'python.exe'),
-                PythonEnvKind.VirtualEnv,
-                undefined,
-                'win1',
-                path.join(testVirtualHomeDir, '.virtualenvs', 'win1'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnv,
                 path.join(testVirtualHomeDir, '.virtualenvs', 'win2', 'bin', 'python.exe'),
-                PythonEnvKind.VirtualEnv,
-                undefined,
-                'win2',
-                path.join(testVirtualHomeDir, '.virtualenvs', 'win2'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, 'Envs', 'wrapper_win1', 'python.exe'),
-                PythonEnvKind.VirtualEnvWrapper,
-                undefined,
-                'wrapper_win1',
-                path.join(testVirtualHomeDir, 'Envs', 'wrapper_win1'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, 'Envs', 'wrapper_win2', 'bin', 'python.exe'),
-                PythonEnvKind.VirtualEnvWrapper,
-                undefined,
-                'wrapper_win2',
-                path.join(testVirtualHomeDir, 'Envs', 'wrapper_win2'),
             ),
-        ].sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
+        ];
 
         const iterator = locator.iterEnvs();
-        const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-            a.executable.filename.localeCompare(b.executable.filename),
-        );
+        const actualEnvs = await getEnvs(iterator);
 
-        comparePaths(actualEnvs, expectedEnvs);
-        assertEnvsEqual(actualEnvs, expectedEnvs);
+        assertBasicEnvsEqual(actualEnvs, expectedEnvs);
     });
 
     test('iterEnvs(): with only venvPath set', async () => {
@@ -357,22 +202,13 @@ suite('CustomVirtualEnvironment Locator', () => {
 
         getPythonSettingStub.withArgs('venvPath').returns(path.join(testWorkspaceFolder, 'posix2conda'));
         const expectedEnvs = [
-            createExpectedEnvInfo(
-                path.join(testWorkspaceFolder, 'posix2conda', 'python'),
-                PythonEnvKind.Unknown,
-                { major: 3, minor: 8, micro: 5 },
-                'posix2conda',
-                path.join(testWorkspaceFolder, 'posix2conda'),
-            ),
-        ].sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
+            createBasicEnv(PythonEnvKind.Unknown, path.join(testWorkspaceFolder, 'posix2conda', 'python')),
+        ];
 
         const iterator = locator.iterEnvs();
-        const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-            a.executable.filename.localeCompare(b.executable.filename),
-        );
+        const actualEnvs = await getEnvs(iterator);
 
-        comparePaths(actualEnvs, expectedEnvs);
-        assertEnvsEqual(actualEnvs, expectedEnvs);
+        assertBasicEnvsEqual(actualEnvs, expectedEnvs);
     });
 
     test('onChanged fires if venvPath setting changes', async () => {

--- a/src/test/pythonEnvironments/discovery/locators/envTestUtils.ts
+++ b/src/test/pythonEnvironments/discovery/locators/envTestUtils.ts
@@ -7,6 +7,7 @@ import { zip } from 'lodash';
 import { promisify } from 'util';
 import { PythonEnvInfo, PythonVersion, UNKNOWN_PYTHON_VERSION } from '../../../../client/pythonEnvironments/base/info';
 import { getEmptyVersion } from '../../../../client/pythonEnvironments/base/info/pythonVersion';
+import { BasicEnvInfo } from '../../../../client/pythonEnvironments/base/locator';
 
 const execAsync = promisify(exec);
 export async function run(argv: string[], options?: { cwd?: string; env?: NodeJS.ProcessEnv }): Promise<void> {
@@ -69,5 +70,15 @@ export function assertEnvsEqual(
     zip(actualEnvs, expectedEnvs).forEach((value) => {
         const [actual, expected] = value;
         assertEnvEqual(actual, expected);
+    });
+}
+
+export function assertBasicEnvsEqual(actualEnvs: BasicEnvInfo[], expectedEnvs: BasicEnvInfo[]): void {
+    actualEnvs = actualEnvs.sort((a, b) => a.executable.localeCompare(b.executable));
+    expectedEnvs = expectedEnvs.sort((a, b) => a.executable.localeCompare(b.executable));
+    assert.deepStrictEqual(actualEnvs.length, expectedEnvs.length, 'Number of envs');
+    zip(actualEnvs, expectedEnvs).forEach((value) => {
+        const [actual, expected] = value;
+        assert.deepStrictEqual(actual, expected);
     });
 }

--- a/src/test/pythonEnvironments/discovery/locators/envTestUtils.ts
+++ b/src/test/pythonEnvironments/discovery/locators/envTestUtils.ts
@@ -74,8 +74,8 @@ export function assertEnvsEqual(
 }
 
 export function assertBasicEnvsEqual(actualEnvs: BasicEnvInfo[], expectedEnvs: BasicEnvInfo[]): void {
-    actualEnvs = actualEnvs.sort((a, b) => a.executable.localeCompare(b.executable));
-    expectedEnvs = expectedEnvs.sort((a, b) => a.executable.localeCompare(b.executable));
+    actualEnvs = actualEnvs.sort((a, b) => a.executablePath.localeCompare(b.executablePath));
+    expectedEnvs = expectedEnvs.sort((a, b) => a.executablePath.localeCompare(b.executablePath));
     assert.deepStrictEqual(actualEnvs.length, expectedEnvs.length, 'Number of envs');
     zip(actualEnvs, expectedEnvs).forEach((value) => {
         const [actual, expected] = value;

--- a/src/test/pythonEnvironments/discovery/locators/globalVirtualEnvironmentLocator.functional.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/globalVirtualEnvironmentLocator.functional.test.ts
@@ -1,24 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as assert from 'assert';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import * as fsWatcher from '../../../../client/common/platform/fileSystemWatcher';
 import * as platformUtils from '../../../../client/common/utils/platform';
-import {
-    PythonEnvInfo,
-    PythonEnvKind,
-    PythonEnvSource,
-    PythonReleaseLevel,
-    PythonVersion,
-    UNKNOWN_PYTHON_VERSION,
-} from '../../../../client/pythonEnvironments/base/info';
+import { PythonEnvKind } from '../../../../client/pythonEnvironments/base/info';
 import { getEnvs } from '../../../../client/pythonEnvironments/base/locatorUtils';
 import * as externalDependencies from '../../../../client/pythonEnvironments/common/externalDependencies';
 import { GlobalVirtualEnvironmentLocator } from '../../../../client/pythonEnvironments/discovery/locators/services/globalVirtualEnvronmentLocator';
+import { createBasicEnv } from '../../base/common';
 import { TEST_LAYOUT_ROOT } from '../../common/commonTestConstants';
-import { assertEnvsEqual } from './envTestUtils';
+import { assertBasicEnvsEqual } from './envTestUtils';
 
 suite('GlobalVirtualEnvironment Locator', () => {
     const testVirtualHomeDir = path.join(TEST_LAYOUT_ROOT, 'virtualhome');
@@ -29,38 +22,6 @@ suite('GlobalVirtualEnvironment Locator', () => {
     let readFileStub: sinon.SinonStub;
     let locator: GlobalVirtualEnvironmentLocator;
     let watchLocationForPatternStub: sinon.SinonStub;
-
-    function createExpectedEnvInfo(
-        interpreterPath: string,
-        kind: PythonEnvKind,
-        version: PythonVersion = UNKNOWN_PYTHON_VERSION,
-        name = '',
-        location = '',
-    ): PythonEnvInfo {
-        return {
-            name,
-            location,
-            kind,
-            executable: {
-                filename: interpreterPath,
-                sysPrefix: '',
-                ctime: -1,
-                mtime: -1,
-            },
-            display: undefined,
-            version,
-            arch: platformUtils.Architecture.Unknown,
-            distro: { org: '' },
-            searchLocation: undefined,
-            source: [PythonEnvSource.Other],
-        };
-    }
-
-    function comparePaths(actual: PythonEnvInfo[], expected: PythonEnvInfo[]) {
-        const actualPaths = actual.map((a) => a.executable.filename);
-        const expectedPaths = expected.map((a) => a.executable.filename);
-        assert.deepStrictEqual(actualPaths, expectedPaths);
-    }
 
     setup(async () => {
         getEnvVariableStub = sinon.stub(platformUtils, 'getEnvironmentVariable');
@@ -103,360 +64,183 @@ suite('GlobalVirtualEnvironment Locator', () => {
     test('iterEnvs(): Windows', async () => {
         getOSTypeStub.returns(platformUtils.OSType.Windows);
         const expectedEnvs = [
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe'),
-                PythonEnvKind.Venv,
-                undefined,
-                'win1',
-                path.join(testVirtualHomeDir, '.venvs', 'win1'),
-            ),
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.venvs', 'win2', 'bin', 'python.exe'),
-                PythonEnvKind.Venv,
-                {
-                    major: 3,
-                    minor: 9,
-                    micro: 0,
-                    release: { level: PythonReleaseLevel.Alpha, serial: 1 },
-                    sysVersion: undefined,
-                },
-                'win2',
-                path.join(testVirtualHomeDir, '.venvs', 'win2'),
-            ),
-            createExpectedEnvInfo(
+            createBasicEnv(PythonEnvKind.Venv, path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe')),
+            createBasicEnv(PythonEnvKind.Venv, path.join(testVirtualHomeDir, '.venvs', 'win2', 'bin', 'python.exe')),
+            createBasicEnv(
+                PythonEnvKind.VirtualEnv,
                 path.join(testVirtualHomeDir, '.virtualenvs', 'win1', 'python.exe'),
-                PythonEnvKind.VirtualEnv,
-                undefined,
-                'win1',
-                path.join(testVirtualHomeDir, '.virtualenvs', 'win1'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnv,
                 path.join(testVirtualHomeDir, '.virtualenvs', 'win2', 'bin', 'python.exe'),
-                PythonEnvKind.VirtualEnv,
-                undefined,
-                'win2',
-                path.join(testVirtualHomeDir, '.virtualenvs', 'win2'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnv,
                 path.join(testVirtualHomeDir, 'Envs', 'wrapper_win1', 'python.exe'),
-                PythonEnvKind.VirtualEnv,
-                undefined,
-                'wrapper_win1',
-                path.join(testVirtualHomeDir, 'Envs', 'wrapper_win1'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnv,
                 path.join(testVirtualHomeDir, 'Envs', 'wrapper_win2', 'bin', 'python.exe'),
-                PythonEnvKind.VirtualEnv,
-                undefined,
-                'wrapper_win2',
-                path.join(testVirtualHomeDir, 'Envs', 'wrapper_win2'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, 'workonhome', 'win1', 'python.exe'),
-                PythonEnvKind.VirtualEnvWrapper,
-                undefined,
-                'win1',
-                path.join(testVirtualHomeDir, 'workonhome', 'win1'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, 'workonhome', 'win2', 'bin', 'python.exe'),
-                PythonEnvKind.VirtualEnvWrapper,
-                undefined,
-                'win2',
-                path.join(testVirtualHomeDir, 'workonhome', 'win2'),
             ),
-        ].sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
+        ];
 
         locator = new GlobalVirtualEnvironmentLocator();
         const iterator = locator.iterEnvs();
-        const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-            a.executable.filename.localeCompare(b.executable.filename),
-        );
+        const actualEnvs = await getEnvs(iterator);
 
-        comparePaths(actualEnvs, expectedEnvs);
-        assertEnvsEqual(actualEnvs, expectedEnvs);
+        assertBasicEnvsEqual(actualEnvs, expectedEnvs);
     });
 
     test('iterEnvs(): Windows (WORKON_HOME NOT set)', async () => {
         getOSTypeStub.returns(platformUtils.OSType.Windows);
         getEnvVariableStub.withArgs('WORKON_HOME').returns(undefined);
         const expectedEnvs = [
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe'),
-                PythonEnvKind.Venv,
-                undefined,
-                'win1',
-                path.join(testVirtualHomeDir, '.venvs', 'win1'),
-            ),
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.venvs', 'win2', 'bin', 'python.exe'),
-                PythonEnvKind.Venv,
-                {
-                    major: 3,
-                    minor: 9,
-                    micro: 0,
-                    release: { level: PythonReleaseLevel.Alpha, serial: 1 },
-                    sysVersion: undefined,
-                },
-                'win2',
-                path.join(testVirtualHomeDir, '.venvs', 'win2'),
-            ),
-            createExpectedEnvInfo(
+            createBasicEnv(PythonEnvKind.Venv, path.join(testVirtualHomeDir, '.venvs', 'win1', 'python.exe')),
+            createBasicEnv(PythonEnvKind.Venv, path.join(testVirtualHomeDir, '.venvs', 'win2', 'bin', 'python.exe')),
+            createBasicEnv(
+                PythonEnvKind.VirtualEnv,
                 path.join(testVirtualHomeDir, '.virtualenvs', 'win1', 'python.exe'),
-                PythonEnvKind.VirtualEnv,
-                undefined,
-                'win1',
-                path.join(testVirtualHomeDir, '.virtualenvs', 'win1'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnv,
                 path.join(testVirtualHomeDir, '.virtualenvs', 'win2', 'bin', 'python.exe'),
-                PythonEnvKind.VirtualEnv,
-                undefined,
-                'win2',
-                path.join(testVirtualHomeDir, '.virtualenvs', 'win2'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, 'Envs', 'wrapper_win1', 'python.exe'),
-                PythonEnvKind.VirtualEnvWrapper,
-                undefined,
-                'wrapper_win1',
-                path.join(testVirtualHomeDir, 'Envs', 'wrapper_win1'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, 'Envs', 'wrapper_win2', 'bin', 'python.exe'),
-                PythonEnvKind.VirtualEnvWrapper,
-                undefined,
-                'wrapper_win2',
-                path.join(testVirtualHomeDir, 'Envs', 'wrapper_win2'),
             ),
-        ].sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
+        ];
 
         locator = new GlobalVirtualEnvironmentLocator();
         const iterator = locator.iterEnvs();
-        const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-            a.executable.filename.localeCompare(b.executable.filename),
-        );
+        const actualEnvs = await getEnvs(iterator);
 
-        comparePaths(actualEnvs, expectedEnvs);
-        assertEnvsEqual(actualEnvs, expectedEnvs);
+        assertBasicEnvsEqual(actualEnvs, expectedEnvs);
     });
 
     test('iterEnvs(): Non-Windows', async () => {
         const expectedEnvs = [
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.venvs', 'posix1', 'python'),
-                PythonEnvKind.Venv,
-                undefined,
-                'posix1',
-                path.join(testVirtualHomeDir, '.venvs', 'posix1'),
-            ),
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.venvs', 'posix2', 'bin', 'python'),
-                PythonEnvKind.Venv,
-                undefined,
-                'posix2',
-                path.join(testVirtualHomeDir, '.venvs', 'posix2'),
-            ),
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.virtualenvs', 'posix1', 'python'),
+            createBasicEnv(PythonEnvKind.Venv, path.join(testVirtualHomeDir, '.venvs', 'posix1', 'python')),
+            createBasicEnv(PythonEnvKind.Venv, path.join(testVirtualHomeDir, '.venvs', 'posix2', 'bin', 'python')),
+            createBasicEnv(PythonEnvKind.VirtualEnv, path.join(testVirtualHomeDir, '.virtualenvs', 'posix1', 'python')),
+            createBasicEnv(
                 PythonEnvKind.VirtualEnv,
-                { major: 3, minor: 8, micro: -1 },
-                'posix1',
-                path.join(testVirtualHomeDir, '.virtualenvs', 'posix1'),
-            ),
-            createExpectedEnvInfo(
                 path.join(testVirtualHomeDir, '.virtualenvs', 'posix2', 'bin', 'python'),
-                PythonEnvKind.VirtualEnv,
-                undefined,
-                'posix2',
-                path.join(testVirtualHomeDir, '.virtualenvs', 'posix2'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, 'workonhome', 'posix1', 'python'),
-                PythonEnvKind.VirtualEnvWrapper,
-                { major: 3, minor: 5, micro: -1 },
-                'posix1',
-                path.join(testVirtualHomeDir, 'workonhome', 'posix1'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, 'workonhome', 'posix2', 'bin', 'python'),
-                PythonEnvKind.VirtualEnvWrapper,
-                undefined,
-                'posix2',
-                path.join(testVirtualHomeDir, 'workonhome', 'posix2'),
             ),
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.local', 'share', 'virtualenvs', 'project2-vnNIWe9P', 'bin', 'python'),
+            createBasicEnv(
                 PythonEnvKind.Pipenv,
-                {
-                    major: 3,
-                    minor: 8,
-                    micro: 2,
-                    release: { level: PythonReleaseLevel.Final, serial: 0 },
-                    sysVersion: undefined,
-                },
-                'project2-vnNIWe9P',
-                path.join(testVirtualHomeDir, '.local', 'share', 'virtualenvs', 'project2-vnNIWe9P'),
+                path.join(testVirtualHomeDir, '.local', 'share', 'virtualenvs', 'project2-vnNIWe9P', 'bin', 'python'),
             ),
-        ].sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
+        ];
 
         locator = new GlobalVirtualEnvironmentLocator();
         const iterator = locator.iterEnvs();
-        const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-            a.executable.filename.localeCompare(b.executable.filename),
-        );
+        const actualEnvs = await getEnvs(iterator);
 
-        comparePaths(actualEnvs, expectedEnvs);
-        assertEnvsEqual(actualEnvs, expectedEnvs);
+        assertBasicEnvsEqual(actualEnvs, expectedEnvs);
     });
 
     test('iterEnvs(): with depth set', async () => {
         const expectedEnvs = [
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.venvs', 'posix1', 'python'),
-                PythonEnvKind.Venv,
-                undefined,
-                'posix1',
-                path.join(testVirtualHomeDir, '.venvs', 'posix1'),
-            ),
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.virtualenvs', 'posix1', 'python'),
-                PythonEnvKind.VirtualEnv,
-                { major: 3, minor: 8, micro: -1 },
-                'posix1',
-                path.join(testVirtualHomeDir, '.virtualenvs', 'posix1'),
-            ),
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, 'workonhome', 'posix1', 'python'),
+            createBasicEnv(PythonEnvKind.Venv, path.join(testVirtualHomeDir, '.venvs', 'posix1', 'python')),
+            createBasicEnv(PythonEnvKind.VirtualEnv, path.join(testVirtualHomeDir, '.virtualenvs', 'posix1', 'python')),
+            createBasicEnv(
                 PythonEnvKind.VirtualEnvWrapper,
-                { major: 3, minor: 5, micro: -1 },
-                'posix1',
-                path.join(testVirtualHomeDir, 'workonhome', 'posix1'),
+                path.join(testVirtualHomeDir, 'workonhome', 'posix1', 'python'),
             ),
-        ].sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
+        ];
 
         locator = new GlobalVirtualEnvironmentLocator(1);
         const iterator = locator.iterEnvs();
-        const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-            a.executable.filename.localeCompare(b.executable.filename),
-        );
+        const actualEnvs = await getEnvs(iterator);
 
-        comparePaths(actualEnvs, expectedEnvs);
-        assertEnvsEqual(actualEnvs, expectedEnvs);
+        assertBasicEnvsEqual(actualEnvs, expectedEnvs);
     });
 
     test('iterEnvs(): Non-Windows (WORKON_HOME not set)', async () => {
         getEnvVariableStub.withArgs('WORKON_HOME').returns(undefined);
         const expectedEnvs = [
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.venvs', 'posix1', 'python'),
-                PythonEnvKind.Venv,
-                undefined,
-                'posix1',
-                path.join(testVirtualHomeDir, '.venvs', 'posix1'),
-            ),
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.venvs', 'posix2', 'bin', 'python'),
-                PythonEnvKind.Venv,
-                undefined,
-                'posix2',
-                path.join(testVirtualHomeDir, '.venvs', 'posix2'),
-            ),
-            createExpectedEnvInfo(
+            createBasicEnv(PythonEnvKind.Venv, path.join(testVirtualHomeDir, '.venvs', 'posix1', 'python')),
+            createBasicEnv(PythonEnvKind.Venv, path.join(testVirtualHomeDir, '.venvs', 'posix2', 'bin', 'python')),
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, '.virtualenvs', 'posix1', 'python'),
-                PythonEnvKind.VirtualEnvWrapper,
-                { major: 3, minor: 8, micro: -1 },
-                'posix1',
-                path.join(testVirtualHomeDir, '.virtualenvs', 'posix1'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, '.virtualenvs', 'posix2', 'bin', 'python'),
-                PythonEnvKind.VirtualEnvWrapper,
-                undefined,
-                'posix2',
-                path.join(testVirtualHomeDir, '.virtualenvs', 'posix2'),
             ),
-            createExpectedEnvInfo(
-                path.join(testVirtualHomeDir, '.local', 'share', 'virtualenvs', 'project2-vnNIWe9P', 'bin', 'python'),
+            createBasicEnv(
                 PythonEnvKind.Pipenv,
-                {
-                    major: 3,
-                    minor: 8,
-                    micro: 2,
-                    release: { level: PythonReleaseLevel.Final, serial: 0 },
-                    sysVersion: undefined,
-                },
-                'project2-vnNIWe9P',
-                path.join(testVirtualHomeDir, '.local', 'share', 'virtualenvs', 'project2-vnNIWe9P'),
+                path.join(testVirtualHomeDir, '.local', 'share', 'virtualenvs', 'project2-vnNIWe9P', 'bin', 'python'),
             ),
-        ].sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
+        ];
 
         locator = new GlobalVirtualEnvironmentLocator();
         const iterator = locator.iterEnvs();
-        const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-            a.executable.filename.localeCompare(b.executable.filename),
-        );
+        const actualEnvs = await getEnvs(iterator);
 
-        comparePaths(actualEnvs, expectedEnvs);
-        assertEnvsEqual(actualEnvs, expectedEnvs);
+        assertBasicEnvsEqual(actualEnvs, expectedEnvs);
     });
 
     test('iterEnvs(): No User home dir set', async () => {
         getUserHomeDirStub.returns(undefined);
         const expectedEnvs = [
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, 'workonhome', 'posix1', 'python'),
-                PythonEnvKind.VirtualEnvWrapper,
-                { major: 3, minor: 5, micro: -1 },
-                'posix1',
-                path.join(testVirtualHomeDir, 'workonhome', 'posix1'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, 'workonhome', 'posix2', 'bin', 'python'),
-                PythonEnvKind.VirtualEnvWrapper,
-                undefined,
-                'posix2',
-                path.join(testVirtualHomeDir, 'workonhome', 'posix2'),
             ),
-        ].sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
+        ];
 
         locator = new GlobalVirtualEnvironmentLocator();
         const iterator = locator.iterEnvs();
-        const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-            a.executable.filename.localeCompare(b.executable.filename),
-        );
+        const actualEnvs = await getEnvs(iterator);
 
-        comparePaths(actualEnvs, expectedEnvs);
-        assertEnvsEqual(actualEnvs, expectedEnvs);
+        assertBasicEnvsEqual(actualEnvs, expectedEnvs);
     });
 
     test('iterEnvs(): No default virtual environment dirs ', async () => {
         // We can simulate that by pointing the user home dir to some random directory
         getUserHomeDirStub.returns(path.join('some', 'random', 'directory'));
         const expectedEnvs = [
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, 'workonhome', 'posix1', 'python'),
-                PythonEnvKind.VirtualEnvWrapper,
-                { major: 3, minor: 5, micro: -1 },
-                'posix1',
-                path.join(testVirtualHomeDir, 'workonhome', 'posix1'),
             ),
-            createExpectedEnvInfo(
+            createBasicEnv(
+                PythonEnvKind.VirtualEnvWrapper,
                 path.join(testVirtualHomeDir, 'workonhome', 'posix2', 'bin', 'python'),
-                PythonEnvKind.VirtualEnvWrapper,
-                undefined,
-                'posix2',
-                path.join(testVirtualHomeDir, 'workonhome', 'posix2'),
             ),
-        ].sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
+        ];
 
         locator = new GlobalVirtualEnvironmentLocator(2);
         const iterator = locator.iterEnvs();
-        const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-            a.executable.filename.localeCompare(b.executable.filename),
-        );
+        const actualEnvs = await getEnvs(iterator);
 
-        comparePaths(actualEnvs, expectedEnvs);
-        assertEnvsEqual(actualEnvs, expectedEnvs);
+        assertBasicEnvsEqual(actualEnvs, expectedEnvs);
     });
 });

--- a/src/test/pythonEnvironments/discovery/locators/poetryLocator.testvirtualenvs.ts
+++ b/src/test/pythonEnvironments/discovery/locators/poetryLocator.testvirtualenvs.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 import { ExecutionResult, ShellOptions } from '../../../../client/common/process/types';
 import { PythonEnvKind } from '../../../../client/pythonEnvironments/base/info';
-import { ILocator } from '../../../../client/pythonEnvironments/base/locator';
+import { BasicEnvInfo, ILocator } from '../../../../client/pythonEnvironments/base/locator';
 import { getEnvs } from '../../../../client/pythonEnvironments/base/locatorUtils';
 import * as externalDependencies from '../../../../client/pythonEnvironments/common/externalDependencies';
 import { PoetryLocator } from '../../../../client/pythonEnvironments/discovery/locators/services/poetryLocator';
@@ -44,7 +44,7 @@ suite('Poetry Watcher', async () => {
 });
 
 suite('Poetry Locator', async () => {
-    let locator: ILocator;
+    let locator: ILocator<BasicEnvInfo>;
     suiteSetup(async function () {
         if (process.env.CI_PYTHON_VERSION && process.env.CI_PYTHON_VERSION.startsWith('2.')) {
             // Poetry is soon to be deprecated for Python2.7, and tests do not pass
@@ -57,7 +57,7 @@ suite('Poetry Locator', async () => {
     test('Discovers existing poetry environments', async () => {
         const items = await getEnvs(locator.iterEnvs());
         const isLocated = items.some(
-            (item) => item.kind === PythonEnvKind.Poetry && item.name.startsWith('poetry-tutorial-project'),
+            (item) => item.kind === PythonEnvKind.Poetry && item.executablePath.includes('poetry-tutorial-project'),
         );
         expect(isLocated).to.equal(true);
     });

--- a/src/test/pythonEnvironments/discovery/locators/poetryLocator.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/poetryLocator.unit.test.ts
@@ -3,23 +3,16 @@
 
 import * as path from 'path';
 import * as sinon from 'sinon';
-import { Uri } from 'vscode';
-import {
-    PythonEnvInfo,
-    PythonEnvKind,
-    PythonEnvSource,
-    PythonReleaseLevel,
-    PythonVersion,
-    UNKNOWN_PYTHON_VERSION,
-} from '../../../../client/pythonEnvironments/base/info';
+import { PythonEnvKind } from '../../../../client/pythonEnvironments/base/info';
 import * as externalDependencies from '../../../../client/pythonEnvironments/common/externalDependencies';
 import * as platformUtils from '../../../../client/common/utils/platform';
 import { getEnvs } from '../../../../client/pythonEnvironments/base/locatorUtils';
 import { PoetryLocator } from '../../../../client/pythonEnvironments/discovery/locators/services/poetryLocator';
 import { TEST_LAYOUT_ROOT } from '../../common/commonTestConstants';
-import { assertEnvsEqual } from './envTestUtils';
+import { assertBasicEnvsEqual } from './envTestUtils';
 import { ExecutionResult, ShellOptions } from '../../../../client/common/process/types';
 import { Poetry } from '../../../../client/pythonEnvironments/discovery/locators/services/poetry';
+import { createBasicEnv } from '../../base/common';
 
 suite('Poetry Locator', () => {
     let shellExecute: sinon.SinonStub;
@@ -31,33 +24,6 @@ suite('Poetry Locator', () => {
     suiteTeardown(() => {
         Poetry._poetryPromise = new Map();
     });
-
-    function createExpectedEnvInfo(
-        interpreterPath: string,
-        kind: PythonEnvKind,
-        version: PythonVersion = UNKNOWN_PYTHON_VERSION,
-        name = '',
-        location = path.join(testPoetryDir, name),
-        searchLocation: Uri | undefined = undefined,
-    ): PythonEnvInfo {
-        return {
-            name,
-            location,
-            kind,
-            executable: {
-                filename: interpreterPath,
-                sysPrefix: '',
-                ctime: -1,
-                mtime: -1,
-            },
-            display: undefined,
-            version,
-            arch: platformUtils.Architecture.Unknown,
-            distro: { org: '' },
-            searchLocation,
-            source: [PythonEnvSource.Other],
-        };
-    }
 
     suiteSetup(() => {
         getPythonSetting = sinon.stub(externalDependencies, 'getPythonSetting');
@@ -90,46 +56,21 @@ suite('Poetry Locator', () => {
         test('iterEnvs()', async () => {
             // Act
             const iterator = locator.iterEnvs();
-            const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-                a.executable.filename.localeCompare(b.executable.filename),
-            );
+            const actualEnvs = await getEnvs(iterator);
 
             // Assert
             const expectedEnvs = [
-                createExpectedEnvInfo(
+                createBasicEnv(
+                    PythonEnvKind.Poetry,
                     path.join(testPoetryDir, 'poetry-tutorial-project-6hnqYwvD-py3.8', 'Scripts', 'python.exe'),
-                    PythonEnvKind.Poetry,
-                    {
-                        major: 3,
-                        minor: 9,
-                        micro: 0,
-                        release: { level: PythonReleaseLevel.Alpha, serial: 1 },
-                        sysVersion: undefined,
-                    },
-                    'poetry-tutorial-project-6hnqYwvD-py3.8',
                 ),
-                createExpectedEnvInfo(
+                createBasicEnv(
+                    PythonEnvKind.Poetry,
                     path.join(testPoetryDir, 'globalwinproject-9hvDnqYw-py3.11', 'Scripts', 'python.exe'),
-                    PythonEnvKind.Poetry,
-                    { major: 3, minor: 6, micro: 1 },
-                    'globalwinproject-9hvDnqYw-py3.11',
                 ),
-                createExpectedEnvInfo(
-                    path.join(project1, '.venv', 'Scripts', 'python.exe'),
-                    PythonEnvKind.Poetry,
-                    {
-                        major: 3,
-                        minor: 8,
-                        micro: 2,
-                        release: { level: PythonReleaseLevel.Final, serial: 0 },
-                        sysVersion: undefined,
-                    },
-                    '.venv',
-                    path.join(project1, '.venv'),
-                    Uri.file(project1),
-                ),
-            ].sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
-            assertEnvsEqual(actualEnvs, expectedEnvs);
+                createBasicEnv(PythonEnvKind.Poetry, path.join(project1, '.venv', 'Scripts', 'python.exe')),
+            ];
+            assertBasicEnvsEqual(actualEnvs, expectedEnvs);
         });
     });
 
@@ -154,34 +95,21 @@ suite('Poetry Locator', () => {
         test('iterEnvs()', async () => {
             // Act
             const iterator = locator.iterEnvs();
-            const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-                a.executable.filename.localeCompare(b.executable.filename),
-            );
+            const actualEnvs = await getEnvs(iterator);
 
             // Assert
             const expectedEnvs = [
-                createExpectedEnvInfo(
+                createBasicEnv(
+                    PythonEnvKind.Poetry,
                     path.join(testPoetryDir, 'posix1project-9hvDnqYw-py3.4', 'python'),
-                    PythonEnvKind.Poetry,
-                    undefined,
-                    'posix1project-9hvDnqYw-py3.4',
                 ),
-                createExpectedEnvInfo(
+                createBasicEnv(
+                    PythonEnvKind.Poetry,
                     path.join(testPoetryDir, 'posix2project-6hnqYwvD-py3.7', 'bin', 'python'),
-                    PythonEnvKind.Poetry,
-                    undefined,
-                    'posix2project-6hnqYwvD-py3.7',
                 ),
-                createExpectedEnvInfo(
-                    path.join(project2, '.venv', 'bin', 'python'),
-                    PythonEnvKind.Poetry,
-                    { major: 3, minor: 6, micro: 1 },
-                    '.venv',
-                    path.join(project2, '.venv'),
-                    Uri.file(project2),
-                ),
-            ].sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
-            assertEnvsEqual(actualEnvs, expectedEnvs);
+                createBasicEnv(PythonEnvKind.Poetry, path.join(project2, '.venv', 'bin', 'python')),
+            ];
+            assertBasicEnvsEqual(actualEnvs, expectedEnvs);
         });
     });
 });

--- a/src/test/pythonEnvironments/discovery/locators/pyenvLocator.functional.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/pyenvLocator.functional.test.ts
@@ -5,12 +5,12 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 import * as fsWatcher from '../../../../client/common/platform/fileSystemWatcher';
 import * as platformUtils from '../../../../client/common/utils/platform';
-import { PythonEnvInfo, PythonEnvKind, PythonEnvSource } from '../../../../client/pythonEnvironments/base/info';
-import { buildEnvInfo } from '../../../../client/pythonEnvironments/base/info/env';
+import { PythonEnvKind } from '../../../../client/pythonEnvironments/base/info';
 import { getEnvs } from '../../../../client/pythonEnvironments/base/locatorUtils';
 import { PyenvLocator } from '../../../../client/pythonEnvironments/discovery/locators/services/pyenvLocator';
+import { createBasicEnv } from '../../base/common';
 import { TEST_LAYOUT_ROOT } from '../../common/commonTestConstants';
-import { assertEnvsEqual } from './envTestUtils';
+import { assertBasicEnvsEqual } from './envTestUtils';
 
 suite('Pyenv Locator Tests', () => {
     let getEnvVariableStub: sinon.SinonStub;
@@ -39,101 +39,19 @@ suite('Pyenv Locator Tests', () => {
     });
 
     teardown(() => {
-        getEnvVariableStub.restore();
-        getOsTypeStub.restore();
-        watchLocationForPatternStub.restore();
+        sinon.restore();
     });
-
-    function getExpectedPyenvInfo(name: string): PythonEnvInfo | undefined {
-        if (name === '3.9.0') {
-            const envInfo = buildEnvInfo({
-                kind: PythonEnvKind.Pyenv,
-                executable: path.join(testPyenvVersionsDir, '3.9.0', 'bin', 'python'),
-                version: {
-                    major: 3,
-                    minor: 9,
-                    micro: 0,
-                },
-                source: [PythonEnvSource.Pyenv],
-            });
-            envInfo.display = '3.9.0:pyenv';
-            envInfo.location = path.join(testPyenvVersionsDir, '3.9.0');
-            envInfo.name = '3.9.0';
-            return envInfo;
-        }
-
-        if (name === 'conda1') {
-            const envInfo = buildEnvInfo({
-                kind: PythonEnvKind.Pyenv,
-                executable: path.join(testPyenvVersionsDir, 'conda1', 'bin', 'python'),
-                version: {
-                    major: 3,
-                    minor: 8,
-                    micro: 5,
-                },
-                source: [PythonEnvSource.Pyenv],
-            });
-            envInfo.display = 'conda1:pyenv';
-            envInfo.location = path.join(testPyenvVersionsDir, 'conda1');
-            envInfo.name = 'conda1';
-            return envInfo;
-        }
-
-        if (name === 'miniconda') {
-            const envInfo = buildEnvInfo({
-                kind: PythonEnvKind.Pyenv,
-                executable: path.join(testPyenvVersionsDir, 'miniconda3-4.7.12', 'bin', 'python'),
-                version: {
-                    major: 3,
-                    minor: 7,
-                    micro: -1,
-                },
-                source: [PythonEnvSource.Pyenv],
-            });
-            envInfo.display = 'miniconda3-4.7.12:pyenv';
-            envInfo.location = path.join(testPyenvVersionsDir, 'miniconda3-4.7.12');
-            envInfo.name = 'miniconda3-4.7.12';
-            envInfo.distro.org = 'miniconda3';
-            return envInfo;
-        }
-
-        if (name === 'venv1') {
-            const envInfo = buildEnvInfo({
-                kind: PythonEnvKind.Pyenv,
-                executable: path.join(testPyenvVersionsDir, 'venv1', 'bin', 'python'),
-                version: {
-                    major: 3,
-                    minor: 9,
-                    micro: 0,
-                },
-                source: [PythonEnvSource.Pyenv],
-            });
-            envInfo.display = 'venv1:pyenv';
-            envInfo.location = path.join(testPyenvVersionsDir, 'venv1');
-            envInfo.name = 'venv1';
-            return envInfo;
-        }
-        return undefined;
-    }
 
     test('iterEnvs()', async () => {
         const expectedEnvs = [
-            getExpectedPyenvInfo('3.9.0'),
-            getExpectedPyenvInfo('conda1'),
-            getExpectedPyenvInfo('miniconda'),
-            getExpectedPyenvInfo('venv1'),
-        ]
-            .filter((e) => e !== undefined)
-            .sort((a, b) => {
-                if (a && b) {
-                    return a.executable.filename.localeCompare(b.executable.filename);
-                }
-                return 0;
-            });
+            createBasicEnv(PythonEnvKind.Pyenv, path.join(testPyenvVersionsDir, '3.9.0', 'bin', 'python')),
+            createBasicEnv(PythonEnvKind.Pyenv, path.join(testPyenvVersionsDir, 'conda1', 'bin', 'python')),
 
-        const actualEnvs = (await getEnvs(locator.iterEnvs()))
-            // We sort for a stable comparison.
-            .sort((a, b) => a.executable.filename.localeCompare(b.executable.filename));
-        assertEnvsEqual(actualEnvs, expectedEnvs);
+            createBasicEnv(PythonEnvKind.Pyenv, path.join(testPyenvVersionsDir, 'miniconda3-4.7.12', 'bin', 'python')),
+            createBasicEnv(PythonEnvKind.Pyenv, path.join(testPyenvVersionsDir, 'venv1', 'bin', 'python')),
+        ];
+
+        const actualEnvs = await getEnvs(locator.iterEnvs());
+        assertBasicEnvsEqual(actualEnvs, expectedEnvs);
     });
 });

--- a/src/test/pythonEnvironments/discovery/locators/watcherTestUtils.ts
+++ b/src/test/pythonEnvironments/discovery/locators/watcherTestUtils.ts
@@ -12,7 +12,7 @@ import { createDeferred, Deferred, sleep } from '../../../../client/common/utils
 import { getOSType, OSType } from '../../../../client/common/utils/platform';
 import { IDisposable } from '../../../../client/common/utils/resourceLifecycle';
 import { PythonEnvKind } from '../../../../client/pythonEnvironments/base/info';
-import { ILocator } from '../../../../client/pythonEnvironments/base/locator';
+import { BasicEnvInfo, ILocator } from '../../../../client/pythonEnvironments/base/locator';
 import { getEnvs } from '../../../../client/pythonEnvironments/base/locatorUtils';
 import { PythonEnvsChangedEvent } from '../../../../client/pythonEnvironments/base/watcher';
 import { getInterpreterPathFromDir } from '../../../../client/pythonEnvironments/common/commonUtils';
@@ -97,10 +97,10 @@ class Venvs {
     }
 }
 
-type locatorFactoryFuncType1 = () => Promise<ILocator & IDisposable>;
+type locatorFactoryFuncType1 = () => Promise<ILocator<BasicEnvInfo> & IDisposable>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type locatorFactoryFuncType2 = (_: any) => Promise<ILocator & IDisposable>;
+type locatorFactoryFuncType2 = (_: any) => Promise<ILocator<BasicEnvInfo> & IDisposable>;
 
 export type locatorFactoryFuncType = locatorFactoryFuncType1 & locatorFactoryFuncType2;
 
@@ -137,7 +137,7 @@ export function testLocatorWatcher(
         doNotVerifyIfLocated?: boolean;
     },
 ): void {
-    let locator: ILocator & IDisposable;
+    let locator: ILocator<BasicEnvInfo> & IDisposable;
     let inExperimentStub: sinon.SinonStub;
     const venvs = new Venvs(root);
 
@@ -151,7 +151,7 @@ export function testLocatorWatcher(
 
     async function isLocated(executable: string): Promise<boolean> {
         const items = await getEnvs(locator.iterEnvs());
-        return items.some((item) => externalDeps.arePathsSame(item.executable.filename, executable));
+        return items.some((item) => externalDeps.arePathsSame(item.executablePath, executable));
     }
 
     suiteSetup(() => venvs.cleanUp());

--- a/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.test.ts
@@ -95,7 +95,7 @@ suite('Windows Store Locator', async () => {
 
     async function isLocated(executable: string): Promise<boolean> {
         const items = await getEnvs(locator.iterEnvs());
-        return items.some((item) => externalDeps.arePathsSame(item.executable, executable));
+        return items.some((item) => externalDeps.arePathsSame(item.executablePath, executable));
     }
 
     suiteSetup(async () => {

--- a/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.test.ts
@@ -95,7 +95,7 @@ suite('Windows Store Locator', async () => {
 
     async function isLocated(executable: string): Promise<boolean> {
         const items = await getEnvs(locator.iterEnvs());
-        return items.some((item) => externalDeps.arePathsSame(item.executable.filename, executable));
+        return items.some((item) => externalDeps.arePathsSame(item.executable, executable));
     }
 
     suiteSetup(async () => {

--- a/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.unit.test.ts
@@ -7,15 +7,8 @@ import * as sinon from 'sinon';
 import * as fsWatcher from '../../../../client/common/platform/fileSystemWatcher';
 import { ExecutionResult } from '../../../../client/common/process/types';
 import * as platformApis from '../../../../client/common/utils/platform';
-import {
-    PythonEnvInfo,
-    PythonEnvKind,
-    PythonEnvSource,
-    PythonVersion,
-    UNKNOWN_PYTHON_VERSION,
-} from '../../../../client/pythonEnvironments/base/info';
-import { InterpreterInformation } from '../../../../client/pythonEnvironments/base/info/interpreter';
-import { parseVersion } from '../../../../client/pythonEnvironments/base/info/pythonVersion';
+import { PythonEnvKind } from '../../../../client/pythonEnvironments/base/info';
+import { BasicEnvInfo } from '../../../../client/pythonEnvironments/base/locator';
 import * as externalDep from '../../../../client/pythonEnvironments/common/externalDependencies';
 import {
     getWindowsStorePythonExes,
@@ -24,7 +17,7 @@ import {
 } from '../../../../client/pythonEnvironments/discovery/locators/services/windowsStoreLocator';
 import { getEnvs } from '../../base/common';
 import { TEST_LAYOUT_ROOT } from '../../common/commonTestConstants';
-import { assertEnvsEqual } from './envTestUtils';
+import { assertBasicEnvsEqual } from './envTestUtils';
 
 suite('Windows Store', () => {
     suite('Utils', () => {
@@ -96,30 +89,10 @@ suite('Windows Store', () => {
         pathToData.set(path.join(testStoreAppRoot, 'python3.8.exe'), python383data);
         pathToData.set(path.join(testStoreAppRoot, 'python3.7.exe'), python379data);
 
-        function createExpectedInterpreterInfo(
-            executable: string,
-            sysVersion?: string,
-            sysPrefix?: string,
-            versionStr?: string,
-        ): InterpreterInformation {
-            let version: PythonVersion;
-            try {
-                version = parseVersion(versionStr ?? path.basename(executable));
-                if (sysVersion) {
-                    version.sysVersion = sysVersion;
-                }
-            } catch (e) {
-                version = UNKNOWN_PYTHON_VERSION;
-            }
+        function createExpectedInfo(executable: string): BasicEnvInfo {
             return {
-                version,
-                arch: platformApis.Architecture.x64,
-                executable: {
-                    filename: executable,
-                    sysPrefix: sysPrefix ?? '',
-                    ctime: -1,
-                    mtime: -1,
-                },
+                executable,
+                kind: PythonEnvKind.WindowsStore,
             };
         }
 
@@ -150,37 +123,19 @@ suite('Windows Store', () => {
 
         teardown(async () => {
             await locator.dispose();
-            stubShellExec.restore();
-            getEnvVar.restore();
-            watchLocationForPatternStub.restore();
+            sinon.restore();
         });
 
         test('iterEnvs()', async () => {
-            const expectedEnvs = [...pathToData.keys()]
-                .sort((a: string, b: string) => a.localeCompare(b))
-                .map((k): PythonEnvInfo | undefined => {
-                    const data = pathToData.get(k);
-                    if (data) {
-                        return {
-                            display: undefined,
-                            searchLocation: undefined,
-                            name: '',
-                            location: '',
-                            kind: PythonEnvKind.WindowsStore,
-                            distro: { org: 'Microsoft' },
-                            source: [PythonEnvSource.PathEnvVar],
-                            ...createExpectedInterpreterInfo(k),
-                        };
-                    }
-                    return undefined;
-                });
+            const expectedEnvs = [
+                createExpectedInfo(path.join(testStoreAppRoot, 'python3.7.exe')),
+                createExpectedInfo(path.join(testStoreAppRoot, 'python3.8.exe')),
+            ];
 
             const iterator = locator.iterEnvs();
-            const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
-                a.executable.filename.localeCompare(b.executable.filename),
-            );
+            const actualEnvs = (await getEnvs(iterator)).sort((a, b) => a.executable.localeCompare(b.executable));
 
-            assertEnvsEqual(actualEnvs, expectedEnvs);
+            assertBasicEnvsEqual(actualEnvs, expectedEnvs);
         });
     });
 });

--- a/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.unit.test.ts
@@ -91,7 +91,7 @@ suite('Windows Store', () => {
 
         function createExpectedInfo(executable: string): BasicEnvInfo {
             return {
-                executable,
+                executablePath: executable,
                 kind: PythonEnvKind.WindowsStore,
             };
         }
@@ -133,7 +133,9 @@ suite('Windows Store', () => {
             ];
 
             const iterator = locator.iterEnvs();
-            const actualEnvs = (await getEnvs(iterator)).sort((a, b) => a.executable.localeCompare(b.executable));
+            const actualEnvs = (await getEnvs(iterator)).sort((a, b) =>
+                a.executablePath.localeCompare(b.executablePath),
+            );
 
             assertBasicEnvsEqual(actualEnvs, expectedEnvs);
         });


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python-internalbacklog/issues/310

Just focus on the lines added and it won't seem much 😉 All changes are very similar.

This changes the low-level locators to return `BasicEnvInfo` instead of `PythonEnvInfo`, which just contains two fields: `kind` and `executablePath`.

Key changes:
- Change `ILocator` interface to support return generic types, so low-level locators return `BasicEnvInfo`, meanwhile the API, resolver etc. can still return `PythonEnvInfo`.
- This rippled through code and had to change certain base classes to adopt the new return type as well.
- Plucked resolving from path locator to created resolver to resolve globally installed environments.
- The rest is deleted code.