### PR TITLE
Make getInterpreters() API faster for subsequent calls

### DIFF
--- a/src/client/common/experiments/helpers.ts
+++ b/src/client/common/experiments/helpers.ts
@@ -13,3 +13,10 @@ export async function inDiscoveryExperiment(experimentService: IExperimentServic
     ]);
     return results.includes(true);
 }
+
+export function inDiscoveryExperimentSync(experimentService: IExperimentService): boolean {
+    return (
+        experimentService.inExperimentSync(DiscoveryVariants.discoverWithFileWatching) ||
+        experimentService.inExperimentSync(DiscoveryVariants.discoveryWithoutFileWatching)
+    );
+}

--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -33,7 +33,7 @@ import {
 } from './contracts';
 import { IVirtualEnvironmentManager } from './virtualEnvs/types';
 import { getInterpreterHash } from '../pythonEnvironments/discovery/locators/services/hashProvider';
-import { inDiscoveryExperiment } from '../common/experiments/helpers';
+import { inDiscoveryExperiment, inDiscoveryExperimentSync } from '../common/experiments/helpers';
 import { StopWatch } from '../common/utils/stopWatch';
 import { PythonVersion } from '../pythonEnvironments/info/pythonVersion';
 
@@ -139,7 +139,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
     public async getInterpreters(resource?: Uri, options?: GetInterpreterOptions): Promise<PythonEnvironment[]> {
         let environments: PythonEnvironment[] = [];
         const stopWatch = new StopWatch();
-        if (await inDiscoveryExperiment(this.experimentService)) {
+        if (inDiscoveryExperimentSync(this.experimentService)) {
             environments = await this.pyenvs.getInterpreters(resource, options);
         } else {
             const locator = this.serviceContainer.get<IInterpreterLocatorService>(


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/16671

On an average, earlier it took around 0.9 to 1 seconds everytime, now it takes around 0.1 seconds. Although do note that the first call still takes around 1 second, but not the subsequent calls.