### PR TITLE
Add simple web build

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,6 +38,20 @@
             "preLaunchTask": "Compile"
         },
         {
+            "name": "Run Web Extension",
+			"type": "pwa-extensionHost",
+			"debugWebWorkerHost": true,
+			"request": "launch",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionDevelopmentKind=web"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/client-web/**/*.js"
+			],
+			"preLaunchTask": "npm: compile-web"
+        },
+        {
             "name": "Python: Current File",
             "type": "python",
             "request": "launch",

--- a/build/webpack/webpack.extension.web.config.js
+++ b/build/webpack/webpack.extension.web.config.js
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+const path = require('path');
+const constants = require('../constants');
+
+const root = path.join(__dirname, '..', '..');
+
+const config = {
+    mode: 'production',
+    target: 'web',
+    entry: {
+        extension: path.join(root, './src/client/extension.web.ts'),
+    },
+    module: {
+        rules: [
+            {
+                test: /\.ts$/,
+                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: 'ts-loader',
+                        options: {
+                            configFile: "tsconfig.extension.web.json"
+                        }
+                    },
+                ],
+            }
+        ]
+    },
+    resolve: {
+        extensions: ['.ts', '.js', '.json']
+    },
+    externals: ['vscode'],
+    output: {
+        filename: '[name].js',
+        path: path.resolve(constants.ExtensionRootDir, 'out', 'client-web'),
+        libraryTarget: 'commonjs2',
+        devtoolModuleFilenameTemplate: '../../[resource-path]',
+    },
+};
+
+exports.default = config;

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
         "workspaceContains:app.py"
     ],
     "main": "./out/client/extension",
+    "browser": "./out/client-web/extension",
     "contributes": {
             "breakpoints": [
                 {
@@ -2075,7 +2076,9 @@
         "addExtensionPackDependencies": "gulp addExtensionPackDependencies",
         "updateBuildNumber": "gulp updateBuildNumber",
         "verifyBundle": "gulp verifyBundle",
-        "webpack": "webpack"
+        "webpack": "webpack",
+        "compile-web": "webpack --config ./build/webpack/webpack.extension.web.config.js",
+        "watch-web": "webpack --watch --config ./build/webpack/webpack.extension.web.config.js"
     },
     "dependencies": {
         "arch": "^2.1.0",

--- a/src/client/extension.web.ts
+++ b/src/client/extension.web.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as vscode from 'vscode';
+import type { LanguageClientOptions } from 'vscode-languageclient';
+import { LanguageClient } from 'vscode-languageclient/browser';
+import { PYLANCE_EXTENSION_ID } from './common/constants';
+
+declare const Worker: {
+    new(stringUrl: string): any;
+};
+
+const pylancePath = 'dist/browser.server.js'
+
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    const pylanceExtension = vscode.extensions.getExtension(PYLANCE_EXTENSION_ID);
+    if (!pylanceExtension) {
+        throw new Error('Could not find Pylance extension');
+    }
+
+    await pylanceExtension.activate();
+
+    const serverMain = vscode.Uri.joinPath(pylanceExtension.extensionUri, pylancePath);
+    try {
+        const worker = new Worker(serverMain.toString());
+
+        const clientOptions: LanguageClientOptions = {
+            // Register the server for python source files.
+            documentSelector: [
+                {
+                    scheme: 'file',
+                    language: 'python',
+                },
+            ],
+            synchronize: {
+                // Synchronize the setting section to the server.
+                configurationSection: ['python', 'pyright'],
+            },
+            // TODO: replace cancellation strategy with SharedArrayBuffer (shared worker memory)
+            // connectionOptions: { cancellationStrategy: cancellationStrategy },
+        };
+
+        const languageClient = new LanguageClient('python', 'Pylance', clientOptions, worker);
+        const disposable = languageClient.start();
+
+        context.subscriptions.push(disposable);
+
+        languageClient.onTelemetry((eventInfo) => {
+            console.log(`onTelemetry EventName: ${eventInfo.EventName}`);
+
+            for (const [prop, value] of Object.entries(eventInfo.Properties)) {
+                console.log(`               Property: ${prop} : ${value}`);
+            }
+
+            for (const [measure, value] of Object.entries(eventInfo.Measurements)) {
+                console.log(`               Measurement: ${measure} : ${value}`);
+            }
+        });
+    } catch (e) {
+        console.log(e);
+    }
+}

--- a/tsconfig.extension.web.json
+++ b/tsconfig.extension.web.json
@@ -1,0 +1,6 @@
+{
+    "extends": "./tsconfig.extension.json",
+    "files": [
+        "./src/client/extension.web.ts"
+    ]
+}


### PR DESCRIPTION
This adds a very simple web version of this extension. All it does it look for pylance and then launch it as a language server

This relies on the experimental web enabled builds of the pylance extension. It also also requires modifying the pylance extension to not launch its own language service client