### PR TITLE
Ignore cache when querying for interpreters during auto-selection

### DIFF
--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -61,7 +61,6 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
             Promise.all(this.singleActivationServices.map((item) => item.activate())),
             this.activateWorkspace(this.activeResourceService.getActiveResource()),
         ]);
-        await this.autoSelection.autoSelectInterpreter(undefined);
     }
 
     @traceDecorators.error('Failed to activate a workspace')

--- a/src/client/interpreter/autoSelection/index.ts
+++ b/src/client/interpreter/autoSelection/index.ts
@@ -260,7 +260,7 @@ export class InterpreterAutoSelectionService implements IInterpreterAutoSelectio
      * As such, we can sort interpreters based on what it returns.
      */
     private async autoselectInterpreterWithLocators(resource: Resource): Promise<void> {
-        const interpreters = await this.interpreterService.getInterpreters(resource);
+        const interpreters = await this.interpreterService.getInterpreters(resource, { ignoreCache: true });
         const workspaceUri = this.interpreterHelper.getActiveWorkspaceUri(resource);
 
         // When auto-selecting an intepreter for a workspace, we either want to return a local one

--- a/src/test/activation/activationManager.unit.test.ts
+++ b/src/test/activation/activationManager.unit.test.ts
@@ -456,25 +456,16 @@ suite('Activation Manager', () => {
                 .setup((s) => s.activate())
                 .returns(() => Promise.resolve())
                 .verifiable(typemoq.Times.once());
-            autoSelection
-                .setup((a) => a.autoSelectInterpreter(undefined))
-                .returns(() => Promise.resolve())
-                .verifiable(typemoq.Times.once());
             when(activeResourceService.getActiveResource()).thenReturn(resource);
             await managerTest.activate();
             assert.ok(initialize.calledOnce);
             assert.ok(activateWorkspace.calledOnce);
             singleActivationService.verifyAll();
-            autoSelection.verifyAll();
         });
 
         test('Throws error if execution fails', async () => {
             singleActivationService
                 .setup((s) => s.activate())
-                .returns(() => Promise.resolve())
-                .verifiable(typemoq.Times.once());
-            autoSelection
-                .setup((a) => a.autoSelectInterpreter(undefined))
                 .returns(() => Promise.reject(new Error('Kaboom')))
                 .verifiable(typemoq.Times.once());
             when(activeResourceService.getActiveResource()).thenReturn(resource);


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/16727

Note: The check that we wanted to use to prevent auto-selection from running again (checking the workspace state using `getWorkspaceState` doesn't work. 

https://github.com/microsoft/vscode-python/blob/ae979b1769154c9dcc614f249575ffba76d7f278/src/client/common/configSettings.ts#L679-L689

`PythonSettings.update` makes the earliest auto-selection related call, and it turns out that the return value on line 679 will be the global interpreter:

https://github.com/microsoft/vscode-python/blob/ae979b1769154c9dcc614f249575ffba76d7f278/src/client/interpreter/autoSelection/index.ts#L146-L161

So `autoSelectedPythonInterpreter` will always be set. We can revisit that once we release though (https://github.com/microsoft/vscode-python/issues/16735).