### PR TITLE
Remove start page-related commands and display logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
         "onCommand:python.switchToDailyChannel",
         "onCommand:python.switchToWeeklyChannel",
         "onCommand:python.clearWorkspaceInterpreter",
-        "onCommand:python.startPage.open",
         "onCommand:python.enableSourceMapSupport",
         "onCommand:python.launchTensorBoard",
         "onCommand:python.clearPersistentStorage",
@@ -323,11 +322,6 @@
                 "category": "Python Refactor",
                 "command": "python.sortImports",
                 "title": "%python.command.python.sortImports.title%"
-            },
-            {
-                "category": "Python",
-                "command": "python.startPage.open",
-                "title": "%python.command.python.startPage.open.title%"
             },
             {
                 "category": "Python",
@@ -1067,12 +1061,6 @@
                     "scope": "resource",
                     "type": "string"
                 },
-                "python.showStartPage": {
-                    "default": true,
-                    "description": "Show the Python Start Page when a new update is released.",
-                    "scope": "application",
-                    "type": "boolean"
-                },
                 "python.sortImports.args": {
                     "default": [],
                     "description": "Arguments passed in. Each argument is a separate item in the array.",
@@ -1796,11 +1784,6 @@
                     "command": "python.runTestNode",
                     "title": "Run",
                     "when": "config.noExists"
-                },
-                {
-                    "category": "Python",
-                    "command": "python.startPage.open",
-                    "title": "%python.command.python.startPage.open.title%"
                 },
                 {
                     "category": "Python",

--- a/src/client/common/startPage/startPage.ts
+++ b/src/client/common/startPage/startPage.ts
@@ -90,9 +90,7 @@ export class StartPage extends WebviewPanelHost<IStartPageMapping>
     public async activate(): Promise<void> {
         if (this.appEnvironment.uiKind === UIKind.Web) {
             // We're running in Codespaces browser-based editor, do not open start page.
-            return;
         }
-        this.activateBackground().ignoreErrors();
     }
 
     public dispose(): Promise<void> {
@@ -299,21 +297,6 @@ export class StartPage extends WebviewPanelHost<IStartPageMapping>
         // if savedVersion != version, there was an update
         await this.context.globalState.update(EXTENSION_VERSION_MEMENTO, version);
         return shouldShowStartPage;
-    }
-
-    private async activateBackground(): Promise<void> {
-        const settings = this.configuration.getSettings();
-
-        if (settings.showStartPage && this.appEnvironment.extensionChannel === 'stable') {
-            // extesionVersionChanged() reads CHANGELOG.md
-            // So we use separate if's to try and avoid reading a file every time
-            const firstTimeOrUpdate = await this.extensionVersionChanged();
-
-            if (firstTimeOrUpdate) {
-                this.firstTime = true;
-                this.open().ignoreErrors();
-            }
-        }
     }
 
     // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
For #16453 

This makes the existing start page inaccessible to prepare for #16709. The juicy code removal (+ news file) will be done in a separate PR 🧃 