### PR TITLE
Changed "python.languageServer" to "Pylance" as per Issue #13007

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## 2021.7.28 (28 July 2021)
-
-### Enhancements
-1. Changed "python.languageServer" to "Pylance" (thanks [jasleen101010](https://github.com/jasleen101010))
-   ([#13007](https://github.com/microsoft/vscode-python/issues/13007))
-
-
 ## 2021.7.1 (21 July 2021)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2021.7.28 (28 July 2021)
+
+### Enhancements
+1. Changed "python.languageServer" to "Pylance" (thanks [jasleen101010](https://github.com/jasleen101010))
+   ([#13007](https://github.com/microsoft/vscode-python/issues/13007))
+
+
 ## 2021.7.1 (21 July 2021)
 
 ### Enhancements

--- a/news/.vscode/settings.json
+++ b/news/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "Pylance": "Microsoft",
+    "python.languageServer": "Pylance",
     "python.formatting.provider": "black",
     "editor.formatOnSave": true,
     "python.testing.pytestArgs": ["."],

--- a/news/.vscode/settings.json
+++ b/news/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "python.languageServer": "Microsoft",
+    "Pylance": "Microsoft",
     "python.formatting.provider": "black",
     "editor.formatOnSave": true,
     "python.testing.pytestArgs": ["."],

--- a/news/1 Enhancements/13007.md
+++ b/news/1 Enhancements/13007.md
@@ -1,0 +1,1 @@
+Changed "python.languageServer" to "Pylance" (thanks [jasleen101010](https://github.com/jasleen101010))


### PR DESCRIPTION
- Worked on Issue #13007 for OSD 2021.
- Located the settings.json file after forking and cloning.
- Replaced "python.languageServer" to "Pylance"