### PR TITLE
Fix order of default unittest arguments

### DIFF
--- a/news/2 Fixes/16882.md
+++ b/news/2 Fixes/16882.md
@@ -1,0 +1,2 @@
+Fix the order of default unittest arguments.
+(thanks [Nikolay Kondratyev](https://github.com/kondratyev-nv/))

--- a/package.json
+++ b/package.json
@@ -1216,11 +1216,11 @@
                 },
                 "python.testing.unittestArgs": {
                     "default": [
-                        "*test*.py",
-                        "-p",
-                        "-s",
                         "-v",
-                        "."
+                        "-s",
+                        ".",
+                        "-p",
+                        "*test*.py"
                     ],
                     "description": "Arguments passed in. Each argument is a separate item in the array.",
                     "items": {


### PR DESCRIPTION
Broken with #16696

Test discovery is not working when using default unittest arguments.
```
Traceback (most recent call last):
  File "<string>", line 4, in <module>
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.9_3.9.1776.0_x64__qbz5n2kfra8p0\lib\unittest\loader.py", line 346, in discover
    raise ImportError('Start directory is not importable: %r' % start_dir)
ImportError: Start directory is not importable: '-v'
```

Related to https://github.com/kondratyev-nv/vscode-python-test-adapter/issues/262 and https://github.com/kondratyev-nv/vscode-python-test-adapter/issues/266#issuecomment-894029784.