### PR TITLE
Fallback to path for environmentTypeComparer

### DIFF
--- a/news/2 Fixes/16893.md
+++ b/news/2 Fixes/16893.md
@@ -1,1 +1,2 @@
 Fix environment sorting for the `Python: Select Interpreter` command.
+(thanks [Marc Mueller](https://github.com/cdce8p))

--- a/news/2 Fixes/16893.md
+++ b/news/2 Fixes/16893.md
@@ -1,0 +1,1 @@
+Fix environment sorting for the `Python: Select Interpreter` command.

--- a/src/client/interpreter/configuration/environmentTypeComparer.ts
+++ b/src/client/interpreter/configuration/environmentTypeComparer.ts
@@ -168,7 +168,11 @@ function compareEnvironmentType(a: PythonEnvironment, b: PythonEnvironment, work
 export function getEnvTypeHeuristic(environment: PythonEnvironment, workspacePath: string): EnvTypeHeuristic {
     const { envType } = environment;
 
-    if (workspacePath.length > 0 && environment.envPath && isParentPath(environment.envPath, workspacePath)) {
+    if (
+        workspacePath.length > 0 &&
+        ((environment.envPath && isParentPath(environment.envPath, workspacePath)) ||
+            (environment.path && isParentPath(environment.path, workspacePath)))
+    ) {
         return EnvTypeHeuristic.Local;
     }
 

--- a/src/test/configuration/environmentTypeComparer.unit.test.ts
+++ b/src/test/configuration/environmentTypeComparer.unit.test.ts
@@ -266,6 +266,18 @@ suite('getEnvTypeHeuristic tests', () => {
 
             assert.strictEqual(envTypeHeuristic, EnvTypeHeuristic.Global);
         });
+
+        test('If envPath is not set, fallback to path', () => {
+            const environment = {
+                envType,
+                path: path.join(workspacePath, 'my-environment'),
+                version: { major: 3, minor: 10, patch: 2 },
+            } as PythonEnvironment;
+
+            const envTypeHeuristic = getEnvTypeHeuristic(environment, workspacePath);
+
+            assert.strictEqual(envTypeHeuristic, EnvTypeHeuristic.Local);
+        });
     });
 
     const globalInterpretersEnvTypes = [


### PR DESCRIPTION
I noticed that local environments weren't sorted correctly with `pythonSortEnvs`. Upon further investigation I found the issue was that `PythonEnvironment` only contained the `path` variable and not `envPath`. Thus the check failed to identify local environments correctly.

This PR would fix the issue. It is however primarily meant to help identify and narrow down the issue.

Steps to reproduce it:
1. Open a `folder` or `workspace` in VS Code
2. Create a virtual env with `python -m venv venv`
3. Run `Python: Select Interpreter` command

--
macOS Catalina (10.15.7)
VS Code: 1.59.0

--
**Current**
![Screen Shot 2021-08-08 at 00 28 23](https://user-images.githubusercontent.com/30130371/128615329-7f29cd51-5f3e-42f3-b5b3-a33eb53e2c34.png)

**With PR**
![Screen Shot 2021-08-08 at 00 27 18](https://user-images.githubusercontent.com/30130371/128615333-83d9d4c5-ce42-4e0d-aabf-b7cf1e0e1e80.png)

**Debug output**
![Screen Shot 2021-08-08 at 00 18 17](https://user-images.githubusercontent.com/30130371/128615340-9ca0cde5-d624-4fa6-b410-f2d06973d812.png)

--
Python extension log output
```
User belongs to experiment group 'pythonSortEnvs'
User belongs to experiment group 'pythonaa'
User belongs to experiment group 'pythonSendEntireLineToREPL'
User belongs to experiment group 'pythonNotDisplayLinterPrompt'
User belongs to experiment group 'pythonDiscoveryModuleWithoutWatcher'
User belongs to experiment group 'pythonTensorboardExperiment'
User belongs to experiment group 'PythonPyTorchProfiler'
Python interpreter path: ./venv-310/bin/python
> pyenv root
> conda --version
> python3.7 -c "import sys;print(sys.executable)"
> python3.6 -c "import sys;print(sys.executable)"
> python3 -c "import sys;print(sys.executable)"
> python2 -c "import sys;print(sys.executable)"
> python -c "import sys;print(sys.executable)"
> ~/Develop/test-files/venv-310/bin/python -c "import sys;print(sys.executable)"
> conda info --json
Starting Pylance language server.
> conda --version
```