### PR TITLE
Add webpack build for browser entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ debugpy*.log
 pydevd*.log
 nodeLanguageServer/**
 nodeLanguageServer.*/**
+dist/**

--- a/build/webpack/webpack.extension.browser.config.js
+++ b/build/webpack/webpack.extension.browser.config.js
@@ -47,7 +47,7 @@ const nodeConfig = (_, { mode }) => ({
                 test: /\.ts$/,
                 loader: 'ts-loader',
                 options: {
-                    configFile: 'tsconfig.json',
+                    configFile: 'tsconfig.browser.json',
                 },
             },
             {

--- a/build/webpack/webpack.extension.browser.config.js
+++ b/build/webpack/webpack.extension.browser.config.js
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+const path = require('path');
+// eslint-disable-next-line camelcase
+const tsconfig_paths_webpack_plugin = require('tsconfig-paths-webpack-plugin');
+const constants = require('../constants');
+const common = require('./common');
+
+const configFileName = path.join(constants.ExtensionRootDir, 'tsconfig.browser.json');
+// Some modules will be pre-genearted and stored in out/.. dir and they'll be referenced via
+// NormalModuleReplacementPlugin. We need to ensure they do not get bundled into the output
+// (as they are large).
+const existingModulesInOutDir = common.getListOfExistingModulesInOutDir();
+const config = {
+    mode: 'production',
+    target: 'webworker',
+    entry: {
+        extension: './src/client/browser/extension.ts',
+    },
+    devtool: 'source-map',
+    node: {
+        __dirname: false,
+    },
+    module: {
+        rules: [
+            {
+                test: /\.ts$/,
+                use: [
+                    {
+                        loader: path.join(__dirname, 'loaders', 'externalizeDependencies.js'),
+                    },
+                ],
+            },
+            {
+                test: /\.ts$/,
+                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: 'ts-loader',
+                    },
+                ],
+            },
+        ],
+    },
+    externals: ['vscode', 'commonjs', ...existingModulesInOutDir],
+    plugins: [...common.getDefaultPlugins('extension')],
+    resolve: {
+        alias: {
+            // Pointing pdfkit to a dummy js file so webpack doesn't fall over.
+            // Since pdfkit has been externalized (it gets updated with the valid code by copying the pdfkit files
+            // into the right destination).
+            pdfkit: path.resolve(__dirname, 'pdfkit.js'),
+        },
+        extensions: ['.ts', '.js'],
+        plugins: [new tsconfig_paths_webpack_plugin.TsconfigPathsPlugin({ configFile: configFileName })],
+    },
+    output: {
+        filename: '[name].browser.js',
+        path: path.resolve(constants.ExtensionRootDir, 'out', 'client'),
+        libraryTarget: 'commonjs2',
+        devtoolModuleFilenameTemplate: '../../[resource-path]',
+    },
+};
+
+exports.default = config;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,7 +67,7 @@ gulp.task('webpack', async () => {
     // Build node_modules.
     await buildWebPackForDevOrProduction('./build/webpack/webpack.extension.dependencies.config.js', 'production');
     await buildWebPackForDevOrProduction('./build/webpack/webpack.extension.config.js', 'extension');
-    await buildWebPackForDevOrProduction('./build/webpack/webpack.browser.config.js', 'browser');
+    await buildWebPackForDevOrProduction('./build/webpack/webpack.extension.browser.config.js', 'browser');
 });
 
 gulp.task('addExtensionPackDependencies', async () => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,6 +67,7 @@ gulp.task('webpack', async () => {
     // Build node_modules.
     await buildWebPackForDevOrProduction('./build/webpack/webpack.extension.dependencies.config.js', 'production');
     await buildWebPackForDevOrProduction('./build/webpack/webpack.extension.config.js', 'extension');
+    await buildWebPackForDevOrProduction('./build/webpack/webpack.browser.config.js', 'browser');
 });
 
 gulp.task('addExtensionPackDependencies', async () => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -192,6 +192,8 @@ function getAllowedWarningsForWebPack(buildConfig) {
                 'WARNING in ./node_modules/diagnostic-channel-publishers/dist/src/azure-coretracing.pub.js',
                 'WARNING in ./node_modules/applicationinsights/out/AutoCollection/NativePerformance.js',
             ];
+        case 'browser':
+            return [];
         default:
             throw new Error('Unknown WebPack Configuration');
     }

--- a/news/1 Enhancements/16869.md
+++ b/news/1 Enhancements/16869.md
@@ -1,0 +1,1 @@
+Add a basic web extension bundle.

--- a/news/1 Enhancements/16870.md
+++ b/news/1 Enhancements/16870.md
@@ -1,0 +1,1 @@
+Add basic Pylance support to the web extension.

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "workspaceContains:app.py"
     ],
     "main": "./out/client/extension",
-    "browser": "./out/client/browser/extension",
+    "browser": "./dist/extension.browser.js",
     "contributes": {
         "walkthroughs": [
             {
@@ -198,7 +198,7 @@
                                 "light": "resources/walkthrough/open-folder-light.png",
                                 "dark": "resources/walkthrough/open-folder-dark.png",
                                 "hc": "resources/walkthrough/open-folder-hc.png"
-                               },
+                            },
                             "altText": "Open a folder"
                         },
                         "completionEvents": [
@@ -215,7 +215,7 @@
                                 "light": "resources/walkthrough/open-folder-light.png",
                                 "dark": "resources/walkthrough/open-folder-dark.png",
                                 "hc": "resources/walkthrough/open-folder-hc.png"
-                               },
+                            },
                             "altText": "Open a folder"
                         },
                         "completionEvents": [

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
         "workspaceContains:app.py"
     ],
     "main": "./out/client/extension",
+    "browser": "./out/client/browser/extension",
     "contributes": {
         "walkthroughs": [
             {

--- a/src/client/browser/extension.ts
+++ b/src/client/browser/extension.ts
@@ -51,7 +51,7 @@ async function runPylance(context: vscode.ExtensionContext): Promise<void> {
             },
         };
 
-        const languageClient = new LanguageClient('python', 'Pylance', clientOptions, worker);
+        const languageClient = new LanguageClient('python', 'Python Language Server', clientOptions, worker);
         const disposable = languageClient.start();
 
         context.subscriptions.push(disposable);

--- a/src/client/browser/extension.ts
+++ b/src/client/browser/extension.ts
@@ -1,0 +1,55 @@
+import * as vscode from 'vscode';
+import { LanguageClientOptions } from 'vscode-languageclient';
+import { LanguageClient } from 'vscode-languageclient/browser';
+import { ILSExtensionApi } from '../activation/node/languageServerFolderService';
+import { PYLANCE_EXTENSION_ID } from '../common/constants';
+
+interface BrowserConfig {
+    distUrl: string; // URL to Pylance's dist folder.
+}
+
+declare interface DedicatedWorkerGlobalScope {}
+
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    const pylanceExtension = vscode.extensions.getExtension<ILSExtensionApi>(PYLANCE_EXTENSION_ID);
+    const pylanceApi = await pylanceExtension?.activate();
+    if (!pylanceApi?.languageServerFolder) {
+        throw new Error('Could not find Pylance extension');
+    }
+
+    const { path: distUrl } = await pylanceApi.languageServerFolder();
+
+    try {
+        const worker = new Worker(`${distUrl}/browser.server.js`);
+
+        // Pass the configuration as the first message to the worker so it can
+        // have info like the URL of the dist folder early enough.
+        //
+        // This is the same method used by the TS worker:
+        // https://github.com/microsoft/vscode/blob/90aa979bb75a795fd8c33d38aee263ea655270d0/extensions/typescript-language-features/src/tsServer/serverProcess.browser.ts#L55
+        const config: BrowserConfig = {
+            distUrl,
+        };
+        worker.postMessage(config);
+
+        const clientOptions: LanguageClientOptions = {
+            // Register the server for python source files.
+            documentSelector: [
+                {
+                    language: 'python',
+                },
+            ],
+            synchronize: {
+                // Synchronize the setting section to the server.
+                configurationSection: ['python'],
+            },
+        };
+
+        const languageClient = new LanguageClient('python', 'Pylance', clientOptions, worker);
+        const disposable = languageClient.start();
+
+        context.subscriptions.push(disposable);
+    } catch (e) {
+        console.log(e);
+    }
+}

--- a/src/client/browser/extension.ts
+++ b/src/client/browser/extension.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 import * as vscode from 'vscode';
 import { LanguageClientOptions } from 'vscode-languageclient';
 import { LanguageClient } from 'vscode-languageclient/browser';
@@ -8,9 +11,12 @@ interface BrowserConfig {
     distUrl: string; // URL to Pylance's dist folder.
 }
 
-declare interface DedicatedWorkerGlobalScope {}
-
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    // Run in a promise and return early so that VS Code can go activate Pylance.
+    runPylance(context);
+}
+
+async function runPylance(context: vscode.ExtensionContext): Promise<void> {
     const pylanceExtension = vscode.extensions.getExtension<ILSExtensionApi>(PYLANCE_EXTENSION_ID);
     const pylanceApi = await pylanceExtension?.activate();
     if (!pylanceApi?.languageServerFolder) {
@@ -20,7 +26,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const { path: distUrl } = await pylanceApi.languageServerFolder();
 
     try {
-        const worker = new Worker(`${distUrl}/browser.server.js`);
+        const worker = new Worker(`${distUrl}/browser.server.bundle.js`);
 
         // Pass the configuration as the first message to the worker so it can
         // have info like the URL of the dist folder early enough.

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -1,6 +1,6 @@
 {
-        "extends": "./tsconfig.extension.json",
+        "extends": "./tsconfig.json",
         "include": [
-            "./src/browser"
+            "./src/client/browser"
         ]
 }

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -1,0 +1,6 @@
+{
+        "extends": "./tsconfig.extension.json",
+        "include": [
+            "./src/browser"
+        ]
+}

--- a/typings/webworker.fix.d.ts
+++ b/typings/webworker.fix.d.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Fake interfaces that are required for web workers to work around
+// tsconfig's DOM and WebWorker lib options being mutally exclusive.
+// https://github.com/microsoft/TypeScript/issues/20595
+
+interface DedicatedWorkerGlobalScope {}


### PR DESCRIPTION
Closes #16869
Closes #16870.

This is a minimal approach, reusing the current webpack, but building a separate browser all-in-one bundle. The bundle goes into a `dist` folder, as opposed to `out`; in the future, it's likely we can change this packaging to eliminate `out` and just have `dist` produced by webpack, just like in Pylance.