### PR TITLE
Revert "Remove jupyter from the extension pack."

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -80,7 +80,7 @@ async function addExtensionPackDependencies() {
     // extension dependencies need not be installed during development
     const packageJsonContents = await fsExtra.readFile('package.json', 'utf-8');
     const packageJson = JSON.parse(packageJsonContents);
-    packageJson.extensionPack = ['ms-python.vscode-pylance'].concat(
+    packageJson.extensionPack = ['ms-toolsai.jupyter', 'ms-python.vscode-pylance'].concat(
         packageJson.extensionPack ? packageJson.extensionPack : [],
     );
     await fsExtra.writeFile('package.json', JSON.stringify(packageJson, null, 4), 'utf-8');

--- a/news/2 Fixes/17080.md
+++ b/news/2 Fixes/17080.md
@@ -1,1 +1,0 @@
-Removing Jupyter extension from the extension pack since it not web enabled.


### PR DESCRIPTION
Reverts microsoft/vscode-python#17080

We plan on removing Jupyter from the extension pack in october release. So reverting this for now.