### PR TITLE
Use quickpick detail instead of description for default interpreter path entry

### DIFF
--- a/news/2 Fixes/17124.md
+++ b/news/2 Fixes/17124.md
@@ -1,0 +1,1 @@
+Use quickpick details for the "Use Python from `python.defaultInterpreterPath` setting" entry.

--- a/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -76,7 +76,7 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand {
         if (defaultInterpreterPathValue && defaultInterpreterPathValue !== 'python') {
             defaultInterpreterPathSuggestion = {
                 label: `${Octicons.Gear} ${InterpreterQuickPickList.defaultInterpreterPath.label()}`,
-                description: this.pathUtils.getDisplayName(
+                detail: this.pathUtils.getDisplayName(
                     defaultInterpreterPathValue,
                     state.workspace ? state.workspace.fsPath : undefined,
                 ),

--- a/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
+++ b/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
@@ -100,7 +100,7 @@ suite('Set Interpreter Command', () => {
         const defaultInterpreterPath = 'defaultInterpreterPath';
         const defaultInterpreterPathSuggestion = {
             label: `${Octicons.Gear} ${InterpreterQuickPickList.defaultInterpreterPath.label()}`,
-            description: defaultInterpreterPath,
+            detail: defaultInterpreterPath,
             path: defaultInterpreterPath,
             alwaysShow: true,
         };


### PR DESCRIPTION
Closes #17124 

![image](https://user-images.githubusercontent.com/51720070/131406890-a7744523-240a-41e7-83d0-68bbaef3268f.png)
