### PR TITLE
Fix casing of text in 'unittest' patterns quickpick.

### DIFF
--- a/news/2 Fixes/17093.md
+++ b/news/2 Fixes/17093.md
@@ -1,0 +1,2 @@
+Fix casing of text in `unittest` patterns quickpick.
+(thanks [Anupama Nadig](https://github.com/anu-ka))

--- a/src/client/testing/common/testConfigurationManager.ts
+++ b/src/client/testing/common/testConfigurationManager.ts
@@ -88,11 +88,11 @@ export abstract class TestConfigurationManager implements ITestConfigurationMana
             placeHolder: 'Select the pattern to identify test files',
         };
         const items: QuickPickItem[] = [
-            { label: '*test.py', description: "Python Files ending with 'test'" },
-            { label: '*_test.py', description: "Python Files ending with '_test'" },
-            { label: 'test*.py', description: "Python Files beginning with 'test'" },
-            { label: 'test_*.py', description: "Python Files beginning with 'test_'" },
-            { label: '*test*.py', description: "Python Files containing the word 'test'" },
+            { label: '*test.py', description: "Python files ending with 'test'" },
+            { label: '*_test.py', description: "Python files ending with '_test'" },
+            { label: 'test*.py', description: "Python files beginning with 'test'" },
+            { label: 'test_*.py', description: "Python files beginning with 'test_'" },
+            { label: '*test*.py', description: "Python files containing the word 'test'" },
         ];
 
         return this.showQuickPick(items, options);


### PR DESCRIPTION
#17093 