### PR TITLE
Don't log error during settings migration without settings.json

### DIFF
--- a/news/2 Fixes/11354.md
+++ b/news/2 Fixes/11354.md
@@ -1,0 +1,1 @@
+Don't log error during settings migration if settings.json doesn't exist.

--- a/src/client/testing/common/updateTestSettings.ts
+++ b/src/client/testing/common/updateTestSettings.ts
@@ -87,6 +87,10 @@ export class UpdateTestSettingService implements IExtensionActivationService {
 
     public async doesFileNeedToBeFixed(filePath: string): Promise<boolean> {
         try {
+            if (!(await this.fs.fileExists(filePath))) {
+                return false;
+            }
+
             const contents = await this.fs.readFile(filePath);
             return (
                 contents.indexOf('python.jediEnabled') > 0 ||

--- a/src/test/application/diagnostics/checks/updateTestSettings.unit.test.ts
+++ b/src/test/application/diagnostics/checks/updateTestSettings.unit.test.ts
@@ -151,6 +151,7 @@ suite('Application Diagnostics - Check Test Settings', () => {
         },
     ].forEach((item) => {
         test(item.testTitle, async () => {
+            when(fs.fileExists(__filename)).thenResolve(true);
             when(fs.readFile(__filename)).thenResolve(item.contents);
 
             const needsToBeFixed = await diagnosticService.doesFileNeedToBeFixed(__filename);
@@ -160,6 +161,7 @@ suite('Application Diagnostics - Check Test Settings', () => {
         });
     });
     test("File should not be fixed if there's an error in reading the file", async () => {
+        when(fs.fileExists(__filename)).thenResolve(true);
         when(fs.readFile(__filename)).thenReject(new Error('Kaboom'));
 
         const needsToBeFixed = await diagnosticService.doesFileNeedToBeFixed(__filename);
@@ -172,6 +174,7 @@ suite('Application Diagnostics - Check Test Settings', () => {
         assert.ok(!needsToBeFixed);
     });
     test('Verify `python.jediEnabled` is found in user settings', async () => {
+        when(fs.fileExists(__filename)).thenResolve(true);
         when(fs.readFile(__filename)).thenResolve('"python.jediEnabled": false');
         const needsToBeFixed = await diagnosticService.doesFileNeedToBeFixed(__filename);
         assert.ok(needsToBeFixed);
@@ -207,6 +210,7 @@ suite('Application Diagnostics - Check Test Settings', () => {
         },
     ].forEach((item) => {
         test(item.testTitle, async () => {
+            when(fs.fileExists(__filename)).thenResolve(true);
             when(fs.readFile(__filename)).thenResolve(item.contents);
             when(fs.writeFile(__filename, anything())).thenResolve();
 
@@ -266,6 +270,7 @@ suite('Application Diagnostics - Check Test Settings', () => {
         },
     ].forEach((item) => {
         test(item.testTitle, async () => {
+            when(fs.fileExists(__filename)).thenResolve(true);
             when(fs.readFile(__filename)).thenResolve(item.contents);
 
             const actualContent = await diagnosticService.fixSettingInFile(__filename);

--- a/src/test/application/diagnostics/checks/updateTestSettings.unit.test.ts
+++ b/src/test/application/diagnostics/checks/updateTestSettings.unit.test.ts
@@ -167,6 +167,10 @@ suite('Application Diagnostics - Check Test Settings', () => {
         assert.ok(!needsToBeFixed);
         verify(fs.readFile(__filename)).once();
     });
+    test('File should not be fixed if file does not exist', async () => {
+        const needsToBeFixed = await diagnosticService.doesFileNeedToBeFixed(__filename + 'doesnotexist');
+        assert.ok(!needsToBeFixed);
+    });
     test('Verify `python.jediEnabled` is found in user settings', async () => {
         when(fs.readFile(__filename)).thenResolve('"python.jediEnabled": false');
         const needsToBeFixed = await diagnosticService.doesFileNeedToBeFixed(__filename);


### PR DESCRIPTION
Fixes #11354.

This has annoyed me one too many times. 🙂 