### PR TITLE
Update to new LSP middleware interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1036,9 +1036,9 @@
             }
         },
         "@vscode/jupyter-lsp-middleware": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.3.tgz",
-            "integrity": "sha512-y4WxQRhmvsihf24y0xtU9KdYuGu6ZMkpd/AB1WmZTyz1L03E3dAMhQ8f6Uk3flgQL+WmoleD5O9tComqz/Wp/w==",
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.5.tgz",
+            "integrity": "sha512-meBZPkGy87CTKUhKYqs2/V5BYJIuN8O+hCWtZN2fxu9JmBhbYmMkKNMsm90hxLme5yoeKy0OqyBCYsgezD5JjA==",
             "requires": {
                 "uuid": "^3.3.2",
                 "vscode-languageclient": "7.0.0"

--- a/package.json
+++ b/package.json
@@ -1976,7 +1976,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@vscode/jupyter-lsp-middleware": "0.2.3",
+        "@vscode/jupyter-lsp-middleware": "^0.2.5",
         "arch": "^2.1.0",
         "azure-storage": "^2.10.4",
         "chokidar": "^3.4.3",

--- a/src/client/activation/languageClientMiddleware.ts
+++ b/src/client/activation/languageClientMiddleware.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import NotebookMiddlewareAddon from '@vscode/jupyter-lsp-middleware';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { IJupyterExtensionDependencyManager, IVSCodeNotebook } from '../common/application/types';
 import { PYTHON_LANGUAGE } from '../common/constants';
@@ -13,6 +12,8 @@ import { sendTelemetryEvent } from '../telemetry';
 
 import { LanguageClientMiddlewareBase } from './languageClientMiddlewareBase';
 import { LanguageServerType } from './types';
+
+import { createMiddlewareAddon } from '@vscode/jupyter-lsp-middleware';
 
 export class LanguageClientMiddleware extends LanguageClientMiddlewareBase {
     public constructor(
@@ -37,7 +38,7 @@ export class LanguageClientMiddleware extends LanguageClientMiddlewareBase {
 
         // Enable notebook support if jupyter support is installed
         if (jupyterDependencyManager && jupyterDependencyManager.isJupyterExtensionInstalled) {
-            this.notebookAddon = new NotebookMiddlewareAddon(
+            this.notebookAddon = createMiddlewareAddon(
                 notebookApi,
                 getClient,
                 traceInfo,
@@ -52,7 +53,7 @@ export class LanguageClientMiddleware extends LanguageClientMiddlewareBase {
                     if (this.notebookAddon && !jupyterDependencyManager.isJupyterExtensionInstalled) {
                         this.notebookAddon = undefined;
                     } else if (!this.notebookAddon && jupyterDependencyManager.isJupyterExtensionInstalled) {
-                        this.notebookAddon = new NotebookMiddlewareAddon(
+                        this.notebookAddon = createMiddlewareAddon(
                             notebookApi,
                             getClient,
                             traceInfo,

--- a/src/client/activation/languageClientMiddlewareBase.ts
+++ b/src/client/activation/languageClientMiddlewareBase.ts
@@ -30,7 +30,7 @@ import {
     Middleware,
     ResponseError,
 } from 'vscode-languageclient';
-import type NotebookMiddlewareAddon from '@vscode/jupyter-lsp-middleware';
+import type { MiddlewareAddon } from '@vscode/jupyter-lsp-middleware';
 
 import { HiddenFilePrefix } from '../common/constants';
 import { IConfigurationService } from '../common/types';
@@ -111,7 +111,7 @@ export class LanguageClientMiddlewareBase implements Middleware {
         },
     };
 
-    protected notebookAddon: NotebookMiddlewareAddon | undefined;
+    protected notebookAddon: MiddlewareAddon | undefined;
 
     private connected = false; // Default to not forwarding to VS code.
 
@@ -343,7 +343,7 @@ export class LanguageClientMiddlewareBase implements Middleware {
         }
     }
 
-    private callNext(funcName: keyof NotebookMiddlewareAddon, args: IArguments) {
+    private callNext(funcName: keyof MiddlewareAddon, args: IArguments) {
         // This function uses the last argument to call the 'next' item. If we're allowing notebook
         // middleware, it calls into the notebook middleware first.
         if (this.notebookAddon) {


### PR DESCRIPTION
Prior to working on https://github.com/microsoft/vscode-jupyter/issues/6333 wanted to move to a more generic interface for creating the LSP middleware addon.

This will allow me to change what the function returns instead of tying to a specific class implementation.