### PR TITLE
Bump MPLS deprecation prompt frequency to weekly, update wording

### DIFF
--- a/news/1 Enhancements/17361.md
+++ b/news/1 Enhancements/17361.md
@@ -1,0 +1,1 @@
+Increase Microsoft Python Language Server deprecation prompt frequency and update wording.

--- a/package.nls.json
+++ b/package.nls.json
@@ -224,7 +224,7 @@
     "TensorBoard.launchNativeTensorBoardSessionCodeLens": "▶ Launch TensorBoard Session",
     "TensorBoard.enterRemoteUrl": "Enter remote URL",
     "TensorBoard.enterRemoteUrlDetail": "Enter a URL pointing to a remote directory containing your TensorBoard log files",
-    "MPLSDeprecation.bannerMessage": "The Microsoft Python Language Server is reaching end of life at the beginning of November. Read more about this in our [September release blog post](https://aka.ms/pvsc-september-2021). Please switch your language server to a supported value:",
+    "MPLSDeprecation.bannerMessage": "The Microsoft Python Language Server is reaching end of life at the beginning of November. If you do not select a new language server, you will have your setting automatically updated at deprecation. Read more about this in our [September release blog post](https://aka.ms/pvsc-september-2021). Please switch your language server to a supported value:",
     "MPLSDeprecation.switchToPylance": "Switch to Pylance (recommended)",
     "MPLSDeprecation.switchToJedi": "Switch to Jedi (open source)"
 }

--- a/src/client/activation/languageServer/deprecationPrompt.ts
+++ b/src/client/activation/languageServer/deprecationPrompt.ts
@@ -17,8 +17,9 @@ import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { IMPLSDeprecationPrompt, LanguageServerType } from '../types';
 
-const doNotShowPromptStateKey = 'MESSAGE_KEY_FOR_MPLS_DEPRECATION_PROMPT2';
-const frequency = 1000 * 60 * 60 * 24 * 7; // One week.
+// Exported for testing.
+export const mplsDeprecationPromptStateKey = 'MESSAGE_KEY_FOR_MPLS_DEPRECATION_PROMPT2';
+export const mplsDeprecationPromptFrequency = 1000 * 60 * 60 * 24 * 7; // One week.
 
 @injectable()
 export class MPLSDeprecationPrompt implements IMPLSDeprecationPrompt {
@@ -73,9 +74,17 @@ export class MPLSDeprecationPrompt implements IMPLSDeprecationPrompt {
     private getPersistentState(): IPersistentState<boolean> {
         const target = this.getConfigurationTarget();
         if (target === ConfigurationTarget.Global) {
-            return this.persistentState.createGlobalPersistentState<boolean>(doNotShowPromptStateKey, false, frequency);
+            return this.persistentState.createGlobalPersistentState<boolean>(
+                mplsDeprecationPromptStateKey,
+                false,
+                mplsDeprecationPromptFrequency,
+            );
         }
-        return this.persistentState.createWorkspacePersistentState<boolean>(doNotShowPromptStateKey, false, frequency);
+        return this.persistentState.createWorkspacePersistentState<boolean>(
+            mplsDeprecationPromptStateKey,
+            false,
+            mplsDeprecationPromptFrequency,
+        );
     }
 
     private getConfigurationTarget() {

--- a/src/client/activation/languageServer/deprecationPrompt.ts
+++ b/src/client/activation/languageServer/deprecationPrompt.ts
@@ -17,8 +17,8 @@ import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { IMPLSDeprecationPrompt, LanguageServerType } from '../types';
 
-const doNotShowPromptStateKey = 'MESSAGE_KEY_FOR_MPLS_DEPRECATION_PROMPT';
-const frequency = 1000 * 60 * 60 * 24 * 30; // One month.
+const doNotShowPromptStateKey = 'MESSAGE_KEY_FOR_MPLS_DEPRECATION_PROMPT2';
+const frequency = 1000 * 60 * 60 * 24 * 7; // One week.
 
 @injectable()
 export class MPLSDeprecationPrompt implements IMPLSDeprecationPrompt {

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -553,7 +553,7 @@ export namespace Python27Support {
 export namespace MPLSDeprecation {
     export const bannerMessage = localize(
         'MPLSDeprecation.bannerMessage',
-        'The Microsoft Python Language Server is reaching end of life at the beginning of November. Read more about this in our [September release blog post](https://aka.ms/pvsc-september-2021). Please switch your language server to a supported value:',
+        'The Microsoft Python Language Server is reaching end of life at the beginning of November. If you do not select a new language server, you will have your setting automatically updated at deprecation. Read more about this in our [September release blog post](https://aka.ms/pvsc-september-2021). Please switch your language server to a supported value:',
     );
     export const switchToPylance = localize('MPLSDeprecation.switchToPylance', 'Switch to Pylance (recommended)');
     export const switchToJedi = localize('MPLSDeprecation.switchToJedi', 'Switch to Jedi (open source)');

--- a/src/test/activation/languageServer/deprecationPrompt.unit.test.ts
+++ b/src/test/activation/languageServer/deprecationPrompt.unit.test.ts
@@ -7,7 +7,11 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { ConfigurationTarget, WorkspaceConfiguration } from 'vscode';
-import { MPLSDeprecationPrompt } from '../../../client/activation/languageServer/deprecationPrompt';
+import {
+    MPLSDeprecationPrompt,
+    mplsDeprecationPromptFrequency,
+    mplsDeprecationPromptStateKey,
+} from '../../../client/activation/languageServer/deprecationPrompt';
 import { LanguageServerType } from '../../../client/activation/types';
 import { IApplicationShell, IWorkspaceService } from '../../../client/common/application/types';
 import { PersistentState } from '../../../client/common/persistentState';
@@ -39,12 +43,20 @@ suite('MPLS deprecation prompt', () => {
         persistentStateFactory = mock();
         globalState = mock<PersistentState<boolean>>(PersistentState);
         workspaceState = mock<PersistentState<boolean>>(PersistentState);
-        when(persistentStateFactory.createGlobalPersistentState(anything(), anything(), anything())).thenReturn(
-            instance(globalState),
-        );
-        when(persistentStateFactory.createWorkspacePersistentState(anything(), anything(), anything())).thenReturn(
-            instance(workspaceState),
-        );
+        when(
+            persistentStateFactory.createGlobalPersistentState(
+                mplsDeprecationPromptStateKey,
+                false,
+                mplsDeprecationPromptFrequency,
+            ),
+        ).thenReturn(instance(globalState));
+        when(
+            persistentStateFactory.createWorkspacePersistentState(
+                mplsDeprecationPromptStateKey,
+                false,
+                mplsDeprecationPromptFrequency,
+            ),
+        ).thenReturn(instance(workspaceState));
 
         workspaceService = mock();
         workspaceConfiguration = mock();


### PR DESCRIPTION
In line with the deprecation spec, the October release of the Python extension should start to show this weekly instead of monthly, and the prompt wording has been strengthened.

Closes #17361.