### PR TITLE
fixed issue with left bracket in path to test file

### DIFF
--- a/news/2 Fixes/17461.md
+++ b/news/2 Fixes/17461.md
@@ -1,1 +1,2 @@
 Changed the way of searching left bracket [ in case of subsets of tests.
+(thanks [ilexei](https://github.com/ilexei))

--- a/news/2 Fixes/17461.md
+++ b/news/2 Fixes/17461.md
@@ -1,0 +1,1 @@
+Changed the way of searching left bracket [ in case of subsets of tests.


### PR DESCRIPTION
Hi!

I bumped into issue when pytest crashes on scanning my folders.
I had a structure like this
.
|-folder1-test_public.py
|-folder2-test_public.py
|-folder2[2]-test_public.py

And in case of folder folder2[2] the name of the test was determined wrong. 

I searched the similar issue but found nothing.

Hope this little fix help not only me.
