### PR TITLE
Fix for `unittest` ModuleNotFoundError when discovering tests

### DIFF
--- a/news/2 Fixes/17363.md
+++ b/news/2 Fixes/17363.md
@@ -1,0 +1,1 @@
+Fix for `unittest` ModuleNotFoundError when discovering tests.

--- a/pythonFiles/testing_tools/unittest_discovery.py
+++ b/pythonFiles/testing_tools/unittest_discovery.py
@@ -5,7 +5,7 @@ import traceback
 
 start_dir = sys.argv[1]
 pattern = sys.argv[2]
-
+sys.path.insert(0,'')
 
 def get_sourceline(obj):
     try:

--- a/pythonFiles/testing_tools/unittest_discovery.py
+++ b/pythonFiles/testing_tools/unittest_discovery.py
@@ -1,11 +1,12 @@
 import unittest
 import inspect
+import os
 import sys
 import traceback
 
 start_dir = sys.argv[1]
 pattern = sys.argv[2]
-sys.path.insert(0,'')
+sys.path.insert(0, os.getcwd())
 
 def get_sourceline(obj):
     try:

--- a/pythonFiles/testing_tools/unittest_discovery.py
+++ b/pythonFiles/testing_tools/unittest_discovery.py
@@ -8,6 +8,7 @@ start_dir = sys.argv[1]
 pattern = sys.argv[2]
 sys.path.insert(0, os.getcwd())
 
+
 def get_sourceline(obj):
     try:
         s, n = inspect.getsourcelines(obj)


### PR DESCRIPTION
Closes #17363