### PR TITLE
Ensure we block getting active interpreter on auto-selection

### DIFF
--- a/news/2 Fixes/17370.md
+++ b/news/2 Fixes/17370.md
@@ -1,0 +1,1 @@
+Ensure we block getting active interpreter on auto-selection.

--- a/src/client/interpreter/display/index.ts
+++ b/src/client/interpreter/display/index.ts
@@ -3,17 +3,10 @@ import { Disposable, OutputChannel, StatusBarAlignment, StatusBarItem, Uri } fro
 import { IApplicationShell, IWorkspaceService } from '../../common/application/types';
 import { STANDARD_OUTPUT_CHANNEL } from '../../common/constants';
 import '../../common/extensions';
-import {
-    IDisposableRegistry,
-    IInterpreterPathProxyService,
-    IOutputChannel,
-    IPathUtils,
-    Resource,
-} from '../../common/types';
+import { IDisposableRegistry, IOutputChannel, IPathUtils, Resource } from '../../common/types';
 import { Interpreters } from '../../common/utils/localize';
 import { IServiceContainer } from '../../ioc/types';
 import { PythonEnvironment } from '../../pythonEnvironments/info';
-import { IInterpreterAutoSelectionService } from '../autoSelection/types';
 import {
     IInterpreterDisplay,
     IInterpreterHelper,
@@ -29,10 +22,8 @@ export class InterpreterDisplay implements IInterpreterDisplay {
     private readonly workspaceService: IWorkspaceService;
     private readonly pathUtils: IPathUtils;
     private readonly interpreterService: IInterpreterService;
-    private readonly interpreterPathExpHelper: IInterpreterPathProxyService;
     private currentlySelectedInterpreterPath?: string;
     private currentlySelectedWorkspaceFolder: Resource;
-    private readonly autoSelection: IInterpreterAutoSelectionService;
     private interpreterPath: string | undefined;
     private statusBarCanBeDisplayed?: boolean;
     private visibilityFilters: IInterpreterStatusbarVisibilityFilter[] = [];
@@ -43,14 +34,10 @@ export class InterpreterDisplay implements IInterpreterDisplay {
         this.workspaceService = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
         this.pathUtils = serviceContainer.get<IPathUtils>(IPathUtils);
         this.interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
-        this.autoSelection = serviceContainer.get<IInterpreterAutoSelectionService>(IInterpreterAutoSelectionService);
         this.python27SupportPrompt = serviceContainer.get<IPython27SupportPrompt>(IPython27SupportPrompt);
 
         const application = serviceContainer.get<IApplicationShell>(IApplicationShell);
         const disposableRegistry = serviceContainer.get<Disposable[]>(IDisposableRegistry);
-        this.interpreterPathExpHelper = serviceContainer.get<IInterpreterPathProxyService>(
-            IInterpreterPathProxyService,
-        );
 
         this.statusBar = application.createStatusBarItem(StatusBarAlignment.Left, 100);
         this.statusBar.command = 'python.setInterpreter';
@@ -86,10 +73,6 @@ export class InterpreterDisplay implements IInterpreterDisplay {
         }
     }
     private async updateDisplay(workspaceFolder?: Uri) {
-        const interpreterPath = this.interpreterPathExpHelper.get(workspaceFolder);
-        if (!interpreterPath || interpreterPath === 'python') {
-            await this.autoSelection.autoSelectInterpreter(workspaceFolder); // Block on this only if no interpreter selected.
-        }
         const interpreter = await this.interpreterService.getActiveInterpreter(workspaceFolder);
         this.currentlySelectedWorkspaceFolder = workspaceFolder;
         if (interpreter) {

--- a/src/test/common/installer.test.ts
+++ b/src/test/common/installer.test.ts
@@ -205,7 +205,10 @@ suite('Installer', () => {
         );
         ioc.serviceManager.addSingleton<IActiveResourceService>(IActiveResourceService, ActiveResourceService);
         ioc.serviceManager.addSingleton<IInterpreterPathService>(IInterpreterPathService, InterpreterPathService);
-        ioc.serviceManager.addSingleton<IInterpreterPathProxyService>(IInterpreterPathProxyService, InterpreterPathProxyService);
+        ioc.serviceManager.addSingleton<IInterpreterPathProxyService>(
+            IInterpreterPathProxyService,
+            InterpreterPathProxyService,
+        );
         ioc.serviceManager.addSingleton<IExtensions>(IExtensions, Extensions);
         ioc.serviceManager.addSingleton<IRandom>(IRandom, Random);
         ioc.serviceManager.addSingleton<ITerminalServiceFactory>(ITerminalServiceFactory, TerminalServiceFactory);

--- a/src/test/common/installer.test.ts
+++ b/src/test/common/installer.test.ts
@@ -103,6 +103,7 @@ import {
     IFileDownloader,
     IHttpClient,
     IInstaller,
+    IInterpreterPathProxyService,
     IInterpreterPathService,
     IPathUtils,
     IPersistentStateFactory,
@@ -122,6 +123,7 @@ import { MockModuleInstaller } from '../mocks/moduleInstaller';
 import { MockProcessService } from '../mocks/proc';
 import { UnitTestIocContainer } from '../testing/serviceRegistry';
 import { closeActiveWindows, initializeTest, IS_MULTI_ROOT_TEST } from '../initialize';
+import { InterpreterPathProxyService } from '../../client/common/interpreterPathProxyService';
 
 suite('Installer', () => {
     let ioc: UnitTestIocContainer;
@@ -203,6 +205,7 @@ suite('Installer', () => {
         );
         ioc.serviceManager.addSingleton<IActiveResourceService>(IActiveResourceService, ActiveResourceService);
         ioc.serviceManager.addSingleton<IInterpreterPathService>(IInterpreterPathService, InterpreterPathService);
+        ioc.serviceManager.addSingleton<IInterpreterPathProxyService>(IInterpreterPathProxyService, InterpreterPathProxyService);
         ioc.serviceManager.addSingleton<IExtensions>(IExtensions, Extensions);
         ioc.serviceManager.addSingleton<IRandom>(IRandom, Random);
         ioc.serviceManager.addSingleton<ITerminalServiceFactory>(ITerminalServiceFactory, TerminalServiceFactory);

--- a/src/test/common/moduleInstaller.test.ts
+++ b/src/test/common/moduleInstaller.test.ts
@@ -102,6 +102,7 @@ import {
     IFileDownloader,
     IHttpClient,
     IInstaller,
+    IInterpreterPathProxyService,
     IInterpreterPathService,
     IPathUtils,
     IPersistentStateFactory,
@@ -131,6 +132,7 @@ import { MockModuleInstaller } from '../mocks/moduleInstaller';
 import { MockProcessService } from '../mocks/proc';
 import { UnitTestIocContainer } from '../testing/serviceRegistry';
 import { closeActiveWindows, initializeTest } from '../initialize';
+import { InterpreterPathProxyService } from '../../client/common/interpreterPathProxyService';
 
 chaiUse(chaiAsPromised);
 
@@ -228,6 +230,10 @@ suite('Module Installer', () => {
 
             ioc.serviceManager.addSingleton<IActiveResourceService>(IActiveResourceService, ActiveResourceService);
             ioc.serviceManager.addSingleton<IInterpreterPathService>(IInterpreterPathService, InterpreterPathService);
+            ioc.serviceManager.addSingleton<IInterpreterPathProxyService>(
+                IInterpreterPathProxyService,
+                InterpreterPathProxyService,
+            );
             ioc.serviceManager.addSingleton<IExtensions>(IExtensions, Extensions);
             ioc.serviceManager.addSingleton<IRandom>(IRandom, Random);
             ioc.serviceManager.addSingleton<IApplicationShell>(IApplicationShell, ApplicationShell);

--- a/src/test/interpreters/display.unit.test.ts
+++ b/src/test/interpreters/display.unit.test.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import * as path from 'path';
 import { SemVer } from 'semver';
-import { anything, instance, mock, verify, when } from 'ts-mockito';
 import * as TypeMoq from 'typemoq';
 import {
     ConfigurationTarget,
@@ -15,17 +14,9 @@ import {
 import { IApplicationShell, IWorkspaceService } from '../../client/common/application/types';
 import { STANDARD_OUTPUT_CHANNEL } from '../../client/common/constants';
 import { IFileSystem } from '../../client/common/platform/types';
-import {
-    IInterpreterPathProxyService,
-    IDisposableRegistry,
-    IOutputChannel,
-    IPathUtils,
-    ReadWrite,
-} from '../../client/common/types';
+import { IDisposableRegistry, IOutputChannel, IPathUtils, ReadWrite } from '../../client/common/types';
 import { Interpreters } from '../../client/common/utils/localize';
 import { Architecture } from '../../client/common/utils/platform';
-import { InterpreterAutoSelectionService } from '../../client/interpreter/autoSelection';
-import { IInterpreterAutoSelectionService } from '../../client/interpreter/autoSelection/types';
 import {
     IInterpreterDisplay,
     IInterpreterHelper,
@@ -57,12 +48,10 @@ suite('Interpreters Display', () => {
     let fileSystem: TypeMoq.IMock<IFileSystem>;
     let disposableRegistry: Disposable[];
     let statusBar: TypeMoq.IMock<StatusBarItem>;
-    let interpreterPathProxyService: TypeMoq.IMock<IInterpreterPathProxyService>;
     let interpreterDisplay: IInterpreterDisplay;
     let interpreterHelper: TypeMoq.IMock<IInterpreterHelper>;
     let pathUtils: TypeMoq.IMock<IPathUtils>;
     let output: TypeMoq.IMock<IOutputChannel>;
-    let autoSelection: IInterpreterAutoSelectionService;
     let python27SupportPrompt: TypeMoq.IMock<IPython27SupportPrompt>;
 
     setup(() => {
@@ -74,11 +63,9 @@ suite('Interpreters Display', () => {
         interpreterHelper = TypeMoq.Mock.ofType<IInterpreterHelper>();
         disposableRegistry = [];
         statusBar = TypeMoq.Mock.ofType<StatusBarItem>();
-        interpreterPathProxyService = TypeMoq.Mock.ofType<IInterpreterPathProxyService>();
         pathUtils = TypeMoq.Mock.ofType<IPathUtils>();
         output = TypeMoq.Mock.ofType<IOutputChannel>();
         python27SupportPrompt = TypeMoq.Mock.ofType<IPython27SupportPrompt>();
-        autoSelection = mock(InterpreterAutoSelectionService);
 
         serviceContainer
             .setup((c) => c.get(TypeMoq.It.isValue(IOutputChannel), STANDARD_OUTPUT_CHANNEL))
@@ -95,15 +82,9 @@ suite('Interpreters Display', () => {
         serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(IFileSystem))).returns(() => fileSystem.object);
         serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(IDisposableRegistry))).returns(() => disposableRegistry);
         serviceContainer
-            .setup((c) => c.get(TypeMoq.It.isValue(IInterpreterPathProxyService)))
-            .returns(() => interpreterPathProxyService.object);
-        serviceContainer
             .setup((c) => c.get(TypeMoq.It.isValue(IInterpreterHelper)))
             .returns(() => interpreterHelper.object);
         serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(IPathUtils))).returns(() => pathUtils.object);
-        serviceContainer
-            .setup((c) => c.get(TypeMoq.It.isValue(IInterpreterAutoSelectionService)))
-            .returns(() => instance(autoSelection));
         serviceContainer
             .setup((c) => c.get(TypeMoq.It.isValue(IPython27SupportPrompt)))
             .returns(() => python27SupportPrompt.object);
@@ -148,7 +129,6 @@ suite('Interpreters Display', () => {
             path: path.join('user', 'development', 'env', 'bin', 'python'),
         };
         setupWorkspaceFolder(resource, workspaceFolder);
-        when(autoSelection.autoSelectInterpreter(anything())).thenResolve();
         interpreterService
             .setup((i) => i.getInterpreters(TypeMoq.It.isValue(workspaceFolder)))
             .returns(() => Promise.resolve([]));
@@ -158,7 +138,6 @@ suite('Interpreters Display', () => {
 
         await interpreterDisplay.refresh(resource);
 
-        verify(autoSelection.autoSelectInterpreter(anything())).once();
         statusBar.verify((s) => (s.text = TypeMoq.It.isValue(activeInterpreter.displayName)!), TypeMoq.Times.once());
         statusBar.verify((s) => (s.tooltip = TypeMoq.It.isValue(activeInterpreter.path)!), TypeMoq.Times.atLeastOnce());
     });
@@ -175,7 +154,6 @@ suite('Interpreters Display', () => {
             .setup((p) => p.getDisplayName(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => activeInterpreter.path);
         setupWorkspaceFolder(resource, workspaceFolder);
-        when(autoSelection.autoSelectInterpreter(anything())).thenResolve();
         interpreterService
             .setup((i) => i.getInterpreters(TypeMoq.It.isValue(workspaceFolder)))
             .returns(() => Promise.resolve([]));
@@ -223,7 +201,6 @@ suite('Interpreters Display', () => {
         interpreterService
             .setup((i) => i.getActiveInterpreter(TypeMoq.It.isValue(workspaceFolder)))
             .returns(() => Promise.resolve(undefined));
-        interpreterPathProxyService.setup((c) => c.get(TypeMoq.It.isAny())).returns(() => pythonPath);
         fileSystem.setup((f) => f.fileExists(TypeMoq.It.isValue(pythonPath))).returns(() => Promise.resolve(false));
         interpreterHelper
             .setup((v) => v.getInterpreterInformation(TypeMoq.It.isValue(pythonPath)))
@@ -278,7 +255,6 @@ suite('Interpreters Display', () => {
                 path: path.join('user', 'development', 'env', 'bin', 'python'),
             };
             setupWorkspaceFolder(resource, workspaceFolder);
-            when(autoSelection.autoSelectInterpreter(anything())).thenResolve();
             interpreterService
                 .setup((i) => i.getInterpreters(TypeMoq.It.isValue(workspaceFolder)))
                 .returns(() => Promise.resolve([]));

--- a/src/test/refactor/rename.test.ts
+++ b/src/test/refactor/rename.test.ts
@@ -6,7 +6,7 @@
 import { expect } from 'chai';
 import { EOL } from 'os';
 import * as path from 'path';
-import { instance, mock } from 'ts-mockito';
+import { anything, instance, mock, when } from 'ts-mockito';
 import * as typeMoq from 'typemoq';
 import {
     Range,
@@ -29,8 +29,14 @@ import {
     IPythonExecutionFactory,
     IPythonExecutionService,
 } from '../../client/common/process/types';
-import { IConfigurationService, IExperimentService, IPythonSettings } from '../../client/common/types';
+import {
+    IConfigurationService,
+    IExperimentService,
+    IInterpreterPathProxyService,
+    IPythonSettings,
+} from '../../client/common/types';
 import { IEnvironmentActivationService } from '../../client/interpreter/activation/types';
+import { IInterpreterAutoSelectionService } from '../../client/interpreter/autoSelection/types';
 import { IComponentAdapter, ICondaService, IInterpreterService } from '../../client/interpreter/contracts';
 import { IServiceContainer } from '../../client/ioc/types';
 import { RefactorProxy } from '../../client/refactor/proxy';
@@ -96,6 +102,10 @@ suite('Refactor Rename', () => {
             .setup((e) => e.inExperiment(DiscoveryVariants.discoverWithFileWatching))
             .returns(() => Promise.resolve(false));
 
+        const autoSelection = mock<IInterpreterAutoSelectionService>();
+        const interpreterPathExpHelper = mock<IInterpreterPathProxyService>();
+        when(interpreterPathExpHelper.get(anything())).thenReturn('selected interpreter path');
+
         serviceContainer
             .setup((s) => s.get(typeMoq.It.isValue(IPythonExecutionFactory), typeMoq.It.isAny()))
             .returns(
@@ -111,6 +121,8 @@ suite('Refactor Rename', () => {
                         undefined as any,
                         instance(pyenvs),
                         experimentService.object,
+                        instance(autoSelection),
+                        instance(interpreterPathExpHelper),
                     ),
             );
         const processLogger = typeMoq.Mock.ofType<IProcessLogger>();


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/17303

Now that extension activation is no longer blocked on auto-selection, we need to explicitly block on auto-selection on the APIs which needs it. One such API is `getActiveInterpreter` which jupyter extension relies on.