### PR TITLE
Detect shells ending in .exe (for Windows/Cygwin)

### DIFF
--- a/news/2 Fixes/17426.md
+++ b/news/2 Fixes/17426.md
@@ -1,0 +1,2 @@
+Improve pattern matching for shell detection on Windows.
+(thanks [Erik Demaine](https://github.com/edemaine/))

--- a/src/client/common/terminal/shellDetector.ts
+++ b/src/client/common/terminal/shellDetector.ts
@@ -29,10 +29,10 @@ export class ShellDetector {
     /**
      * Logic is as follows:
      * 1. Try to identify the type of the shell based on the name of the terminal.
-     * 2. Try to identify the type of the shell based on the usettigs in VSC.
+     * 2. Try to identify the type of the shell based on the settings in VSC.
      * 3. Try to identify the type of the shell based on the user environment (OS).
      * 4. If all else fail, use defaults hardcoded (cmd for windows, bash for linux & mac).
-     * More information here See solution here https://github.com/microsoft/vscode/issues/74233#issuecomment-497527337
+     * More information here: https://github.com/microsoft/vscode/issues/74233#issuecomment-497527337
      *
      * @param {Terminal} [terminal]
      * @returns {TerminalShellType}

--- a/src/client/common/terminal/shellDetectors/baseShellDetector.ts
+++ b/src/client/common/terminal/shellDetectors/baseShellDetector.ts
@@ -19,14 +19,14 @@ When identifying the shell use the following algorithm:
 
 // Types of shells can be found here:
 // 1. https://wiki.ubuntu.com/ChangingShells
-const IS_GITBASH = /(gitbash.exe$)/i;
-const IS_BASH = /(bash.exe$|bash$)/i;
-const IS_WSL = /(wsl.exe$)/i;
+const IS_GITBASH = /(gitbash$)/i;
+const IS_BASH = /(bash$)/i;
+const IS_WSL = /(wsl$)/i;
 const IS_ZSH = /(zsh$)/i;
 const IS_KSH = /(ksh$)/i;
-const IS_COMMAND = /(cmd.exe$|cmd$)/i;
-const IS_POWERSHELL = /(powershell.exe$|powershell$)/i;
-const IS_POWERSHELL_CORE = /(pwsh.exe$|pwsh$)/i;
+const IS_COMMAND = /(cmd$)/i;
+const IS_POWERSHELL = /(powershell$)/i;
+const IS_POWERSHELL_CORE = /(pwsh$)/i;
 const IS_FISH = /(fish$)/i;
 const IS_CSHELL = /(csh$)/i;
 const IS_TCSHELL = /(tcsh$)/i;
@@ -54,17 +54,21 @@ export abstract class BaseShellDetector implements IShellDetector {
         terminal?: Terminal,
     ): TerminalShellType | undefined;
     public identifyShellFromShellPath(shellPath: string): TerminalShellType {
+        // Remove .exe extension so shells can be more consistently detected
+        // on Windows (including Cygwin).
+        const basePath = shellPath.replace(/\.exe$/, '');
+
         const shell = Array.from(detectableShells.keys()).reduce((matchedShell, shellToDetect) => {
             if (matchedShell === TerminalShellType.other) {
                 const pat = detectableShells.get(shellToDetect);
-                if (pat && pat.test(shellPath)) {
+                if (pat && pat.test(basePath)) {
                     return shellToDetect;
                 }
             }
             return matchedShell;
         }, TerminalShellType.other);
 
-        traceVerbose(`Shell path '${shellPath}'`);
+        traceVerbose(`Shell path '${shellPath}', base path '${basePath}'`);
         traceVerbose(`Shell path identified as shell '${shell}'`);
         return shell;
     }

--- a/src/test/common/terminals/shellDetectors/shellDetectors.unit.test.ts
+++ b/src/test/common/terminals/shellDetectors/shellDetectors.unit.test.ts
@@ -33,7 +33,11 @@ suite('Shell Detectors', () => {
     shellPathsAndIdentification.set('c:\\windows\\system32\\wsl.exe', TerminalShellType.wsl);
     shellPathsAndIdentification.set('c:\\windows\\system32\\gitbash.exe', TerminalShellType.gitbash);
     shellPathsAndIdentification.set('/usr/bin/bash', TerminalShellType.bash);
+    shellPathsAndIdentification.set('c:\\cygwin\\bin\\bash.exe', TerminalShellType.bash);
+    shellPathsAndIdentification.set('c:\\cygwin64\\bin\\bash.exe', TerminalShellType.bash);
     shellPathsAndIdentification.set('/usr/bin/zsh', TerminalShellType.zsh);
+    shellPathsAndIdentification.set('c:\\cygwin\\bin\\zsh.exe', TerminalShellType.zsh);
+    shellPathsAndIdentification.set('c:\\cygwin64\\bin\\zsh.exe', TerminalShellType.zsh);
     shellPathsAndIdentification.set('/usr/bin/ksh', TerminalShellType.ksh);
     shellPathsAndIdentification.set('c:\\windows\\system32\\powershell.exe', TerminalShellType.powershell);
     shellPathsAndIdentification.set('c:\\windows\\system32\\pwsh.exe', TerminalShellType.powershellCore);


### PR DESCRIPTION
Strip `.exe` extension before detecting shells, so all detections work in Windows / Cygwin.  Fixes #17426 (specifically subissue 1).

Side note: I feel like the regular expressions should start with `\b` or something to ensure the shell names aren't suffixes. Currently, `notzsh` would be detected as `zsh`. But I haven't changed that; as far as I know, no shell name is a prefix of another, so it's probably fine as is. Well... many shells are a prefix of `sh`, but that's not a recognized shell (should it be?).