### PR TITLE
Fix `Python extension loading...` issue for users who have disabled telemetry

### DIFF
--- a/news/2 Fixes/17447.md
+++ b/news/2 Fixes/17447.md
@@ -1,0 +1,1 @@
+Fix `Python extension loading...` issue for users who have disabled telemetry.

--- a/src/client/common/experiments/service.ts
+++ b/src/client/common/experiments/service.ts
@@ -12,6 +12,7 @@ import { IApplicationEnvironment, IWorkspaceService } from '../application/types
 import { PVSC_EXTENSION_ID, STANDARD_OUTPUT_CHANNEL } from '../constants';
 import { GLOBAL_MEMENTO, IExperimentService, IMemento, IOutputChannel } from '../types';
 import { Experiments } from '../utils/localize';
+import { DiscoveryVariants } from './groups';
 import { ExperimentationTelemetry } from './telemetry';
 
 const EXP_MEMENTO_KEY = 'VSCode.ABExp.FeatureData';
@@ -123,6 +124,11 @@ export class ExperimentService implements IExperimentService {
             // this to ensure the experiment service is ready and internal states are fully
             // synced with the experiment server.
             this.experimentationService.getTreatmentVariable(EXP_CONFIG_ID, experiment);
+            return true;
+        }
+
+        if (experiment === DiscoveryVariants.discoveryWithoutFileWatching) {
+            // Enable discovery experiment for all users.
             return true;
         }
 

--- a/src/test/common/experiments/service.unit.test.ts
+++ b/src/test/common/experiments/service.unit.test.ts
@@ -12,6 +12,7 @@ import { ApplicationEnvironment } from '../../../client/common/application/appli
 import { IApplicationEnvironment, IWorkspaceService } from '../../../client/common/application/types';
 import { WorkspaceService } from '../../../client/common/application/workspace';
 import { Channel } from '../../../client/common/constants';
+import { DiscoveryVariants } from '../../../client/common/experiments/groups';
 import { ExperimentService } from '../../../client/common/experiments/service';
 import { Experiments } from '../../../client/common/utils/localize';
 import * as Telemetry from '../../../client/telemetry';
@@ -157,14 +158,14 @@ suite('Experimentation service', () => {
 
     suite('In-experiment-sync check', () => {
         const experiment = 'Test Experiment - experiment';
-        let telemetryEvents: { eventName: string; properties: Record<string, unknown> }[] = [];
+        let telemetryEvents: { eventName: string; properties: unknown }[] = [];
         let getTreatmentVariable: sinon.SinonStub;
         let sendTelemetryEventStub: sinon.SinonStub;
 
         setup(() => {
             sendTelemetryEventStub = sinon
                 .stub(Telemetry, 'sendTelemetryEvent')
-                .callsFake((eventName: string, _, properties: Record<string, unknown>) => {
+                .callsFake((eventName: string, _, properties: unknown) => {
                     const telemetry = { eventName, properties };
                     telemetryEvents.push(telemetry);
                 });
@@ -180,6 +181,20 @@ suite('Experimentation service', () => {
         teardown(() => {
             telemetryEvents = [];
             sinon.restore();
+        });
+
+        test('Enable discovery experiment without file watching for all users', async () => {
+            configureSettings(true, [], []);
+
+            const experimentService = new ExperimentService(
+                instance(workspaceService),
+                instance(appEnvironment),
+                globalMemento,
+                outputChannel,
+            );
+            const result = experimentService.inExperimentSync(DiscoveryVariants.discoveryWithoutFileWatching);
+
+            assert.isTrue(result);
         });
 
         test('If the opt-in and opt-out arrays are empty, return the value from the experimentation framework for a given experiment', async () => {
@@ -401,13 +416,13 @@ suite('Experimentation service', () => {
     });
 
     suite('Opt-in/out telemetry', () => {
-        let telemetryEvents: { eventName: string; properties: Record<string, unknown> }[] = [];
+        let telemetryEvents: { eventName: string; properties: unknown }[] = [];
         let sendTelemetryEventStub: sinon.SinonStub;
 
         setup(() => {
             sendTelemetryEventStub = sinon
                 .stub(Telemetry, 'sendTelemetryEvent')
-                .callsFake((eventName: string, _, properties: Record<string, unknown>) => {
+                .callsFake((eventName: string, _, properties: unknown) => {
                     const telemetry = { eventName, properties };
                     telemetryEvents.push(telemetry);
                 });


### PR DESCRIPTION

* Enable discovery experiments for all users including those who have opted out of telemetry

* News entry

* Oops

* Ensure we still respect optInto/optOutFrom setting for discovery experiment