### PR TITLE
Fix test hang caused by loop in getting interpreter information

### DIFF
--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -59,8 +59,9 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
     }
 
     public async create(options: ExecutionFactoryCreationOptions): Promise<IPythonExecutionService> {
+        // Auto select should not happen if we're in the middle of parsing interpreters
         const interpreterPath = this.interpreterPathExpHelper.get(options.resource);
-        if (!interpreterPath || interpreterPath === 'python') {
+        if (!options.skipAutoSelect && (!interpreterPath || interpreterPath === 'python')) {
             await this.autoSelection.autoSelectInterpreter(options.resource); // Block on this only if no interpreter selected.
         }
         const pythonPath = options.pythonPath

--- a/src/client/common/process/types.ts
+++ b/src/client/common/process/types.ts
@@ -60,6 +60,7 @@ export const IPythonExecutionFactory = Symbol('IPythonExecutionFactory');
 export type ExecutionFactoryCreationOptions = {
     resource?: Uri;
     pythonPath?: string;
+    skipAutoSelect?: boolean;
 };
 export type ExecutionFactoryCreateWithEnvironmentOptions = {
     resource?: Uri;


### PR DESCRIPTION
During some of our tests the getInterpreterList was never returning. It looks to me like an deadlock where getInterpreterList ends up calling down to helper.getInterpreterInfo which then calls autoSelectInterpreter which then calls getInterpreterList.

This change fixes the hang in the test code.