### PR TITLE
Use the first workspace folder to query interpreters if no resource is passed in getInterpreters() API

### DIFF
--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -298,13 +298,17 @@ class ComponentAdapter implements IComponentAdapter {
         this.refreshing.fire();
 
         const query: PythonLocatorQuery = {};
+        let wsFolder: vscode.WorkspaceFolder | undefined;
         if (resource !== undefined) {
-            const wsFolder = vscode.workspace.getWorkspaceFolder(resource);
-            if (wsFolder !== undefined) {
-                query.searchLocations = {
-                    roots: [wsFolder.uri],
-                };
-            }
+            wsFolder = vscode.workspace.getWorkspaceFolder(resource);
+        } else if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+            [wsFolder] = vscode.workspace.workspaceFolders;
+        }
+
+        if (wsFolder !== undefined) {
+            query.searchLocations = {
+                roots: [wsFolder.uri],
+            };
         } else {
             query.searchLocations = {
                 roots: [],


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/17492