### PR TITLE
Remove output from report issue command template

### DIFF
--- a/resources/report_issue_template.md
+++ b/resources/report_issue_template.md
@@ -40,7 +40,7 @@ You can attach such things **after** you create your issue on GitHub.
 <!-- Run the "Python: Show Output" command to see the requested output. --->
 
 ```
-{3}
+
 ```
 
 </p>
@@ -53,7 +53,7 @@ You can attach such things **after** you create your issue on GitHub.
 <p>
 
 ```
-{4}
+{3}
 ```
 
 </p>

--- a/src/client/common/application/commands/reportIssueCommand.ts
+++ b/src/client/common/application/commands/reportIssueCommand.ts
@@ -12,7 +12,6 @@ import { ICommandManager, IWorkspaceService } from '../types';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
 import { IInterpreterService, IInterpreterVersionService } from '../../../interpreter/contracts';
 import { identifyEnvironment } from '../../../pythonEnvironments/common/environmentIdentifier';
-import { getPythonOutputChannelContent } from '../../../logging';
 import { Commands } from '../../constants';
 import { IConfigurationService, IPythonSettings } from '../../types';
 
@@ -63,7 +62,6 @@ export class ReportIssueCommandHandler implements IExtensionSingleActivationServ
                 }
             }
         });
-        const pythonLogs = await getPythonOutputChannelContent();
         const template = await fs.readFile(this.templatePath, 'utf8');
         const interpreterPath = (await this.interpreterService.getActiveInterpreter())?.path || 'not-selected';
         const pythonVersion = await this.interpreterVersionService.getVersion(interpreterPath, '');
@@ -73,7 +71,7 @@ export class ReportIssueCommandHandler implements IExtensionSingleActivationServ
 
         this.commandManager.executeCommand('workbench.action.openIssueReporter', {
             extensionId: 'ms-python.python',
-            issueBody: template.format(pythonVersion, virtualEnv, languageServer, pythonLogs, userSettings),
+            issueBody: template.format(pythonVersion, virtualEnv, languageServer, userSettings),
         });
     }
 }

--- a/src/test/common/application/commands/issueTemplateVenv1.md
+++ b/src/test/common/application/commands/issueTemplateVenv1.md
@@ -40,7 +40,7 @@ You can attach such things **after** you create your issue on GitHub.
 <!-- Run the "Python: Show Output" command to see the requested output. --->
 
 ```
-Python Output
+
 ```
 
 </p>


### PR DESCRIPTION
- [x] Remove output logging from report issue command template.
- [x] Fix tests

For https://github.com/microsoft/vscode-python/issues/17330