### PR TITLE
Don't override user provided `--rootdir` in pytest args.

### DIFF
--- a/news/2 Fixes/8678.md
+++ b/news/2 Fixes/8678.md
@@ -1,0 +1,1 @@
+Don't override user provided `--rootdir` in pytest args.

--- a/src/client/testing/testController/pytest/arguments.ts
+++ b/src/client/testing/testController/pytest/arguments.ts
@@ -217,7 +217,6 @@ function pytestFilterArguments(args: string[], argumentToRemoveOrFilter: string[
                         '--verbosity',
                         '-r',
                         '--tb',
-                        '--rootdir',
                         '--show-capture',
                         '--durations',
                         '--junit-xml',
@@ -277,6 +276,10 @@ export function preparePytestArgumentsForDiscovery(options: TestDiscoveryOptions
     if (args.indexOf('-s') === -1) {
         args.splice(0, 0, '-s');
     }
-    args.splice(0, 0, '--rootdir', options.workspaceFolder.fsPath);
+
+    // Only add --rootdir if user has not already provided one
+    if (args.filter((a) => a.startsWith('--rootdir')).length === 0) {
+        args.splice(0, 0, '--rootdir', options.cwd);
+    }
     return args;
 }

--- a/src/client/testing/testController/pytest/runner.ts
+++ b/src/client/testing/testController/pytest/runner.ts
@@ -86,8 +86,11 @@ export class PytestRunner implements ITestsRunner {
             // Ensure that we use the xunit1 format.
             testArgs.splice(0, 0, '--override-ini', 'junit_family=xunit1');
 
-            // Make sure root dir is set so pytest can find the relative paths
-            testArgs.splice(0, 0, '--rootdir', options.workspaceFolder.fsPath);
+            // if user has provided `--rootdir` then use that, otherwise add `cwd`
+            if (testArgs.filter((a) => a.startsWith('--rootdir')).length === 0) {
+                // Make sure root dir is set so pytest can find the relative paths
+                testArgs.splice(0, 0, '--rootdir', options.workspaceFolder.fsPath);
+            }
 
             // Positional arguments control the tests to be run.
             const rawData = idToRawData.get(testNode.id);


### PR DESCRIPTION
For #8678

The sample repo provided for the bug works with this change:
![image](https://user-images.githubusercontent.com/3840081/134602929-6aa32149-4080-4fd6-bfba-531c00b7dc29.png)
