### PR TITLE
Fix interpreter fetching for untitled files

### DIFF
--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -302,8 +302,13 @@ class ComponentAdapter implements IComponentAdapter {
         if (resource !== undefined) {
             wsFolder = vscode.workspace.getWorkspaceFolder(resource);
         }
-        // Untitled files or files outside of the workspace should still use the workspace as the query location
-        if (!wsFolder && vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+        // Untitled files should still use the workspace as the query location
+        if (
+            !wsFolder &&
+            vscode.workspace.workspaceFolders &&
+            vscode.workspace.workspaceFolders.length > 0 &&
+            (!resource || resource.scheme === 'untitled')
+        ) {
             [wsFolder] = vscode.workspace.workspaceFolders;
         }
 

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -301,7 +301,9 @@ class ComponentAdapter implements IComponentAdapter {
         let wsFolder: vscode.WorkspaceFolder | undefined;
         if (resource !== undefined) {
             wsFolder = vscode.workspace.getWorkspaceFolder(resource);
-        } else if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+        }
+        // Untitled files or files outside of the workspace should still use the workspace as the query location
+        if (!wsFolder && vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
             [wsFolder] = vscode.workspace.workspaceFolders;
         }
 


### PR DESCRIPTION
After @karrtikr's last change I could no longer repro this bug here:
https://github.com/microsoft/vscode-python/issues/17492

However our tests were still reproing the problem for about half of the tests. 

Turns out they were using untitled files. Untitled files weren't using the workspace root.