### PR TITLE
Ensure `conda info --json` times out after 50 seconds

### DIFF
--- a/news/2 Fixes/17576.md
+++ b/news/2 Fixes/17576.md
@@ -1,0 +1,1 @@
+Add timeout of 60 seconds when discovery runs `conda info --json` command.

--- a/news/2 Fixes/17576.md
+++ b/news/2 Fixes/17576.md
@@ -1,1 +1,1 @@
-Add timeout of 60 seconds when discovery runs `conda info --json` command.
+Add timeout when discovery runs `conda info --json` command.

--- a/src/client/pythonEnvironments/common/environmentManagers/conda.ts
+++ b/src/client/pythonEnvironments/common/environmentManagers/conda.ts
@@ -354,7 +354,7 @@ export class Conda {
     // eslint-disable-next-line class-methods-use-this
     private async getInfoCached(command: string): Promise<CondaInfo> {
         const disposables = new Set<IDisposable>();
-        const result = await exec(command, ['info', '--json'], {}, disposables);
+        const result = await exec(command, ['info', '--json'], { timeout: 60000 }, disposables);
         traceVerbose(`conda info --json: ${result.stdout}`);
 
         // Ensure the process we started is cleaned up.

--- a/src/client/pythonEnvironments/common/environmentManagers/conda.ts
+++ b/src/client/pythonEnvironments/common/environmentManagers/conda.ts
@@ -354,7 +354,7 @@ export class Conda {
     // eslint-disable-next-line class-methods-use-this
     private async getInfoCached(command: string): Promise<CondaInfo> {
         const disposables = new Set<IDisposable>();
-        const result = await exec(command, ['info', '--json'], { timeout: 60000 }, disposables);
+        const result = await exec(command, ['info', '--json'], { timeout: 50000 }, disposables);
         traceVerbose(`conda info --json: ${result.stdout}`);
 
         // Ensure the process we started is cleaned up.


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/17569

Time taken for entire discovery to finish:

![image](https://user-images.githubusercontent.com/13199757/135539473-f3420a21-023e-45aa-89e1-b8a2dde74f61.png)

Based on this 50 seconds should be enough time to wait for conda command to return.
