### PR TITLE
If active interpreter type is detected as Unknown, make sure we log it as an error

### DIFF
--- a/src/client/startupTelemetry.ts
+++ b/src/client/startupTelemetry.ts
@@ -17,7 +17,7 @@ import { IStopWatch } from './common/utils/stopWatch';
 import { IInterpreterAutoSelectionService } from './interpreter/autoSelection/types';
 import { ICondaService, IInterpreterService } from './interpreter/contracts';
 import { IServiceContainer } from './ioc/types';
-import { PythonEnvironment } from './pythonEnvironments/info';
+import { EnvironmentType, PythonEnvironment } from './pythonEnvironments/info';
 import { sendTelemetryEvent } from './telemetry';
 import { EventName } from './telemetry/constants';
 import { EditorLoadTelemetry } from './telemetry/types';
@@ -124,6 +124,9 @@ async function getActivationTelemetryProps(serviceContainer: IServiceContainer):
         .catch<PythonEnvironment | undefined>(() => undefined);
     const pythonVersion = interpreter && interpreter.version ? interpreter.version.raw : undefined;
     const interpreterType = interpreter ? interpreter.envType : undefined;
+    if (interpreterType === EnvironmentType.Unknown) {
+        traceError('Active interpreter type is detected as Unknown', JSON.stringify(interpreter));
+    }
     const usingUserDefinedInterpreter = hasUserDefinedPythonPath(mainWorkspaceUri, serviceContainer);
     const usingGlobalInterpreter = isUsingGlobalInterpreterInWorkspace(settings.pythonPath, serviceContainer);
 


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/17359

This is so we can see it in the error reports we see on Github. cc @luabud 