### PR TITLE
Issue #17037: Update text for "entire workspace" when selecting or clearing interpreters 

### DIFF
--- a/news/2 Fixes/10737.md
+++ b/news/2 Fixes/10737.md
@@ -1,0 +1,2 @@
+Change text to "Select at workspace level" instead of "Entire workspace" when selecting or clearing interpreters in a multiroot folder scenario.
+(Thanks [Quynh Do](https://github.com/quynhd07))

--- a/package.nls.json
+++ b/package.nls.json
@@ -47,7 +47,7 @@
     "Experiments.inGroup": "User belongs to experiment group '{0}'",
     "Experiments.optedOutOf": "User opted out of experiment group '{0}'",
     "Interpreters.RefreshingInterpreters": "Refreshing Python Interpreters",
-    "Interpreters.entireWorkspace": "Entire workspace",
+    "Interpreters.entireWorkspace": "Select at workspace level",
     "Interpreters.pythonInterpreterPath": "Python interpreter path: {0}",
     "Interpreters.DiscoveringInterpreters": "Discovering Python Interpreters",
     "Interpreters.condaInheritEnvMessage": "We noticed you're using a conda environment. If you are experiencing issues with this environment in the integrated terminal, we recommend that you let the Python extension change \"terminal.integrated.inheritEnv\" to false in your user settings.",

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -271,7 +271,7 @@ export namespace Interpreters {
         'Interpreters.environmentPromptMessage',
         'We noticed a new virtual environment has been created. Do you want to select it for the workspace folder?',
     );
-    export const entireWorkspace = localize('Interpreters.entireWorkspace', 'Entire workspace');
+    export const entireWorkspace = localize('Interpreters.entireWorkspace', 'Select at workspace level');
     export const selectInterpreterTip = localize(
         'Interpreters.selectInterpreterTip',
         'Tip: you can change the Python interpreter used by the Python extension by clicking on the Python version in the status bar',

--- a/src/test/configuration/interpreterSelector/commands/resetInterpreter.unit.test.ts
+++ b/src/test/configuration/interpreterSelector/commands/resetInterpreter.unit.test.ts
@@ -124,7 +124,7 @@ suite('Reset Interpreter Command', () => {
             workspace.verifyAll();
             pythonPathUpdater.verifyAll();
         });
-        test('Update entire workspace settings when there is more than one workspace folder and `Entire workspace` is selected', async () => {
+        test('Update entire workspace settings when there is more than one workspace folder and `Select at workspace level` is selected', async () => {
             workspace.setup((w) => w.workspaceFolders).returns(() => [folder1, folder2]);
             const expectedItems = [
                 {

--- a/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
+++ b/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
@@ -743,7 +743,7 @@ suite('Set Interpreter Command', () => {
             workspace.verifyAll();
             pythonPathUpdater.verifyAll();
         });
-        test('Update entire workspace settings when there is more than one workspace folder and `Entire workspace` is selected', async () => {
+        test('Update entire workspace settings when there is more than one workspace folder and `Select at workspace level` is selected', async () => {
             pythonSettings.setup((p) => p.pythonPath).returns(() => 'python');
             const selectedItem: IInterpreterQuickPickItem = {
                 description: '',


### PR DESCRIPTION
Change text to "Select at workspace level" instead of "Entire workspace" when selecting or clearing interpreters in a multiroot folder scenario 