### PR TITLE
Ensure debugger contribution points are turned off when using virtual workspaces

### DIFF
--- a/news/1 Enhancements/17493.md
+++ b/news/1 Enhancements/17493.md
@@ -1,0 +1,1 @@
+Ensure debugger contribution points are turned off when using virtual workspaces.

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
                         "description": "Choose which Python interpreter/environment you want to use for your Python project.\n[Select Python Interpreter](command:python.setInterpreter)\nTip: Reload the window if you installed Python but don't see it in the list (``Developer: Reload Window`` command in the [Command Palette](command:workbench.action.showCommands))",
                         "media": {
                             "svg": "resources/walkthrough/python-interpreter.svg",
-                            "altText": "Selecting a python interpreter from the status bar"                            
+                            "altText": "Selecting a python interpreter from the status bar"
                         },
                         "when": ""
                     },
@@ -1606,7 +1606,8 @@
                 "type": "python",
                 "variables": {
                     "pickProcess": "python.pickLocalProcess"
-                }
+                },
+                "when": "!virtualWorkspace"
             }
         ],
         "grammars": [


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/17493

Web platform is also a virtual workspace, so we're assuming this applies there as well.