### PR TITLE
Use conda-forge when installing into conda envs

### DIFF
--- a/news/2 Fixes/17628.md
+++ b/news/2 Fixes/17628.md
@@ -1,0 +1,1 @@
+Use `conda-forge` channel when installing packages into conda environments.

--- a/src/client/common/installer/condaInstaller.ts
+++ b/src/client/common/installer/condaInstaller.ts
@@ -84,7 +84,7 @@ export class CondaInstaller extends ModuleInstaller {
         const info = await condaLocatorService.getCondaEnvironment(pythonPath);
         const args = [flags & ModuleInstallFlags.upgrade ? 'update' : 'install'];
 
-        // Found that using conda-forge is best as packages like tensorboard, ipykenrle seem to get updated first on conda-forge
+        // Found that using conda-forge is best at packages like tensorboard & ipykernel which seem to get updated first on conda-forge
         // https://github.com/microsoft/vscode-jupyter/issues/7787 & https://github.com/microsoft/vscode-python/issues/17628
         // Do this just for the datascience packages.
         if (

--- a/src/client/common/installer/condaInstaller.ts
+++ b/src/client/common/installer/condaInstaller.ts
@@ -84,11 +84,9 @@ export class CondaInstaller extends ModuleInstaller {
         const info = await condaLocatorService.getCondaEnvironment(pythonPath);
         const args = [flags & ModuleInstallFlags.upgrade ? 'update' : 'install'];
 
-        // Temporarily ensure tensorboard is installed from the conda-forge
-        // channel since 2.4.1 is not yet available in the default index
-        if (moduleName === 'tensorboard') {
-            args.push('-c', 'conda-forge');
-        }
+        // Found that using conda-forge is best as packages like tensorboard, ipykenrle seem to get updated first on conda-forge
+        // https://github.com/microsoft/vscode-jupyter/issues/7787 & https://github.com/microsoft/vscode-python/issues/17628
+        args.push('-c', 'conda-forge');
         if (info && info.name) {
             // If we have the name of the conda environment, then use that.
             args.push('--name');

--- a/src/client/common/installer/condaInstaller.ts
+++ b/src/client/common/installer/condaInstaller.ts
@@ -7,9 +7,9 @@ import { ICondaService, ICondaLocatorService, IComponentAdapter } from '../../in
 import { IServiceContainer } from '../../ioc/types';
 import { ModuleInstallerType } from '../../pythonEnvironments/info';
 import { inDiscoveryExperiment } from '../experiments/helpers';
-import { ExecutionInfo, IConfigurationService, IExperimentService } from '../types';
+import { ExecutionInfo, IConfigurationService, IExperimentService, Product } from '../types';
 import { isResource } from '../utils/misc';
-import { ModuleInstaller } from './moduleInstaller';
+import { ModuleInstaller, translateProductToModule } from './moduleInstaller';
 import { InterpreterUri, ModuleInstallFlags } from './types';
 
 /**
@@ -86,7 +86,21 @@ export class CondaInstaller extends ModuleInstaller {
 
         // Found that using conda-forge is best as packages like tensorboard, ipykenrle seem to get updated first on conda-forge
         // https://github.com/microsoft/vscode-jupyter/issues/7787 & https://github.com/microsoft/vscode-python/issues/17628
-        args.push('-c', 'conda-forge');
+        // Do this just for the datascience packages.
+        if (
+            [
+                Product.tensorboard,
+                Product.ipykernel,
+                Product.pandas,
+                Product.nbconvert,
+                Product.jupyter,
+                Product.notebook,
+            ]
+                .map(translateProductToModule)
+                .includes(moduleName)
+        ) {
+            args.push('-c', 'conda-forge');
+        }
         if (info && info.name) {
             // If we have the name of the conda environment, then use that.
             args.push('--name');

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -68,7 +68,7 @@ Combinations of:
 6. Conda environments with names and without names.
 7. All installers.
 */
-suite('Module Installer', () => {
+suite.only('Module Installer', () => {
     class TestModuleInstaller extends ModuleInstaller {
         public get priority(): number {
             return 0;
@@ -621,7 +621,18 @@ suite('Module Installer', () => {
                                     test(`Test args (${product.name})`, async () => {
                                         setActiveInterpreter();
                                         const expectedArgs = [isUpgrade ? 'update' : 'install'];
-                                        expectedArgs.push('-c', 'conda-forge');
+                                        if (
+                                            [
+                                                'pandas',
+                                                'tensorboard',
+                                                'ipykernel',
+                                                'jupyter',
+                                                'notebook',
+                                                'nbconvert',
+                                            ].includes(product.name)
+                                        ) {
+                                            expectedArgs.push('-c', 'conda-forge');
+                                        }
                                         if (condaEnvInfo && condaEnvInfo.name) {
                                             expectedArgs.push('--name');
                                             expectedArgs.push(condaEnvInfo.name.toCommandArgument());

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -621,9 +621,7 @@ suite('Module Installer', () => {
                                     test(`Test args (${product.name})`, async () => {
                                         setActiveInterpreter();
                                         const expectedArgs = [isUpgrade ? 'update' : 'install'];
-                                        if (product.name === 'tensorboard') {
-                                            expectedArgs.push('-c', 'conda-forge');
-                                        }
+                                        expectedArgs.push('-c', 'conda-forge');
                                         if (condaEnvInfo && condaEnvInfo.name) {
                                             expectedArgs.push('--name');
                                             expectedArgs.push(condaEnvInfo.name.toCommandArgument());

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -68,7 +68,7 @@ Combinations of:
 6. Conda environments with names and without names.
 7. All installers.
 */
-suite.only('Module Installer', () => {
+suite('Module Installer', () => {
     class TestModuleInstaller extends ModuleInstaller {
         public get priority(): number {
             return 0;


### PR DESCRIPTION
Will discuss this on teams (basically anyone using conda on any platform will be unable to install ipykenrel & get things working unless they setup conda-forge as they default channel).

Basically breaks a very large number of jupyter users using conda in VS Code.
microsoft/vscode-jupyter#7787