### PR TITLE
WIP - language status for partial mode

### DIFF
--- a/src/client/browser/extension.ts
+++ b/src/client/browser/extension.ts
@@ -109,6 +109,18 @@ async function runPylance(
                     telemetryEvent.Exception,
                 );
             });
+
+            // show language status
+            const item = vscode.languages.createLanguageStatusItem('pylance.status', clientOptions.documentSelector!);
+            item.severity = vscode.LanguageStatusSeverity.Warning;
+            item.text = 'Partial Mode';
+            item.detail = 'Project Wide IntelliSense not available'; // todo tweak wording, add "continue on"-link
+            item.command = {
+                title: 'Learn More',
+                command: 'vscode.open',
+                arguments: [vscode.Uri.parse('https://github.com/microsoft/vscode-python')], // todo define proper aka.ms-link
+            };
+            context.subscriptions.push(item);
         });
 
         const disposable = languageClient.start();

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -1,6 +1,7 @@
 {
         "extends": "./tsconfig.json",
         "include": [
-            "./src/client/browser"
+            "./src/client/browser",
+            "./types/vscode.proposed.d.ts"
         ]
 }

--- a/types/vscode.proposed.d.ts
+++ b/types/vscode.proposed.d.ts
@@ -942,6 +942,34 @@ declare module 'vscode' {
     }
 
     //#endregion
+
+    //#region https://github.com/microsoft/vscode/issues/129037
+
+    enum LanguageStatusSeverity {
+        Information = 0,
+        Warning = 1,
+        Error = 2
+    }
+
+    interface LanguageStatusItem {
+        readonly id: string;
+        selector: DocumentSelector;
+        // todo@jrieken replace with boolean ala needsAttention
+        severity: LanguageStatusSeverity;
+        name: string | undefined;
+        text: string;
+        detail?: string;
+        command: Command | undefined;
+        accessibilityInformation?: AccessibilityInformation;
+        dispose(): void;
+    }
+
+    namespace languages {
+        export function createLanguageStatusItem(id: string, selector: DocumentSelector): LanguageStatusItem;
+    }
+
+    //#endregion
+
     //#region proposed test APIs https://github.com/microsoft/vscode/issues/107467
     export namespace tests {
         /**


### PR DESCRIPTION
When running in a limited context, like github.dev, it should be made clear that language support isn't at the same level as in desktop or codespaces. With TypeScript and anycode we have settled on some best practice and wording. This PR is WIP towards that uniform UX/language (more details at https://github.com/microsoft/vscode-dev/issues/300)

There is still a few open questions, namely 

* the wording for "details" needs to be tweaked
* create aka.ms-link for the "Learn More" and fill it with content
* (engineering) I wasn't able to use the localize-util, importing `src/client/common/utils/localize.ts` fails to webpack
* (engineering) unsure if I am updating/using that API proposal correcty