### PR TITLE
Upgrade to latest jupyter lsp and skip intellisense when inside a cell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -760,11 +760,10 @@
             }
         },
         "@vscode/jupyter-lsp-middleware": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.5.tgz",
-            "integrity": "sha512-meBZPkGy87CTKUhKYqs2/V5BYJIuN8O+hCWtZN2fxu9JmBhbYmMkKNMsm90hxLme5yoeKy0OqyBCYsgezD5JjA==",
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.13.tgz",
+            "integrity": "sha512-IhiIwFUz9PN13rrUKQlEz+BX16ZQ8hJfLvV9hJvr9DSuioafbhjl5gAe3SXWP/3eIpdA/J4DGKL+i4Oyb1dY+Q==",
             "requires": {
-                "uuid": "^3.3.2",
                 "vscode-languageclient": "7.0.0"
             }
         },

--- a/package.json
+++ b/package.json
@@ -2046,7 +2046,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@vscode/jupyter-lsp-middleware": "^0.2.5",
+        "@vscode/jupyter-lsp-middleware": "^0.2.13",
         "arch": "^2.1.0",
         "azure-storage": "^2.10.4",
         "chokidar": "^3.4.3",

--- a/src/client/activation/jedi/manager.ts
+++ b/src/client/activation/jedi/manager.ts
@@ -142,12 +142,7 @@ export class JediLanguageServerManager implements ILanguageServerManager {
         this.languageServerProxy = this.serviceContainer.get<ILanguageServerProxy>(ILanguageServerProxy);
 
         const options = await this.analysisOptions.getAnalysisOptions();
-        this.middleware = new LanguageClientMiddleware(
-            this.serviceContainer,
-            LanguageServerType.Jedi,
-            () => this.languageServerProxy?.languageClient,
-            this.lsVersion,
-        );
+        this.middleware = new LanguageClientMiddleware(this.serviceContainer, LanguageServerType.Jedi, this.lsVersion);
         options.middleware = this.middleware;
 
         // Make sure the middleware is connected if we restart and we we're already connected.

--- a/src/client/activation/languageClientMiddleware.ts
+++ b/src/client/activation/languageClientMiddleware.ts
@@ -1,11 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { LanguageClient } from 'vscode-languageclient/node';
-import { IJupyterExtensionDependencyManager, IVSCodeNotebook } from '../common/application/types';
-import { PYTHON_LANGUAGE } from '../common/constants';
-import { traceInfo } from '../common/logger';
-import { IFileSystem } from '../common/platform/types';
+import { IJupyterExtensionDependencyManager } from '../common/application/types';
 import { IDisposableRegistry, IExtensions } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import { sendTelemetryEvent } from '../telemetry';
@@ -13,15 +9,10 @@ import { sendTelemetryEvent } from '../telemetry';
 import { LanguageClientMiddlewareBase } from './languageClientMiddlewareBase';
 import { LanguageServerType } from './types';
 
-import { createMiddlewareAddon } from '@vscode/jupyter-lsp-middleware';
+import { createHidingMiddleware } from '@vscode/jupyter-lsp-middleware';
 
 export class LanguageClientMiddleware extends LanguageClientMiddlewareBase {
-    public constructor(
-        serviceContainer: IServiceContainer,
-        serverType: LanguageServerType,
-        getClient: () => LanguageClient | undefined,
-        serverVersion?: string,
-    ) {
+    public constructor(serviceContainer: IServiceContainer, serverType: LanguageServerType, serverVersion?: string) {
         super(serviceContainer, serverType, sendTelemetryEvent, serverVersion);
 
         if (serverType === LanguageServerType.None) {
@@ -31,21 +22,12 @@ export class LanguageClientMiddleware extends LanguageClientMiddlewareBase {
         const jupyterDependencyManager = serviceContainer.get<IJupyterExtensionDependencyManager>(
             IJupyterExtensionDependencyManager,
         );
-        const notebookApi = serviceContainer.get<IVSCodeNotebook>(IVSCodeNotebook);
         const disposables = serviceContainer.get<IDisposableRegistry>(IDisposableRegistry) || [];
         const extensions = serviceContainer.get<IExtensions>(IExtensions);
-        const fileSystem = serviceContainer.get<IFileSystem>(IFileSystem);
 
         // Enable notebook support if jupyter support is installed
         if (jupyterDependencyManager && jupyterDependencyManager.isJupyterExtensionInstalled) {
-            this.notebookAddon = createMiddlewareAddon(
-                notebookApi,
-                getClient,
-                traceInfo,
-                fileSystem,
-                PYTHON_LANGUAGE,
-                /.*\.(ipynb|interactive)/m,
-            );
+            this.notebookAddon = createHidingMiddleware();
         }
         disposables.push(
             extensions?.onDidChange(() => {
@@ -53,14 +35,7 @@ export class LanguageClientMiddleware extends LanguageClientMiddlewareBase {
                     if (this.notebookAddon && !jupyterDependencyManager.isJupyterExtensionInstalled) {
                         this.notebookAddon = undefined;
                     } else if (!this.notebookAddon && jupyterDependencyManager.isJupyterExtensionInstalled) {
-                        this.notebookAddon = createMiddlewareAddon(
-                            notebookApi,
-                            getClient,
-                            traceInfo,
-                            fileSystem,
-                            PYTHON_LANGUAGE,
-                            /.*\.(ipynb|interactive)/m,
-                        );
+                        this.notebookAddon = createHidingMiddleware();
                     }
                 }
             }),

--- a/src/client/activation/languageClientMiddlewareBase.ts
+++ b/src/client/activation/languageClientMiddlewareBase.ts
@@ -12,6 +12,7 @@ import {
     Definition,
     DefinitionLink,
     Diagnostic,
+    Disposable,
     DocumentHighlight,
     DocumentLink,
     DocumentSymbol,
@@ -30,7 +31,6 @@ import {
     Middleware,
     ResponseError,
 } from 'vscode-languageclient';
-import type { MiddlewareAddon } from '@vscode/jupyter-lsp-middleware';
 
 import { HiddenFilePrefix } from '../common/constants';
 import { IConfigurationService } from '../common/types';
@@ -111,7 +111,7 @@ export class LanguageClientMiddlewareBase implements Middleware {
         },
     };
 
-    protected notebookAddon: MiddlewareAddon | undefined;
+    protected notebookAddon: (Middleware & Disposable) | undefined;
 
     private connected = false; // Default to not forwarding to VS code.
 
@@ -343,7 +343,7 @@ export class LanguageClientMiddlewareBase implements Middleware {
         }
     }
 
-    private callNext(funcName: keyof MiddlewareAddon, args: IArguments) {
+    private callNext(funcName: keyof Middleware, args: IArguments) {
         // This function uses the last argument to call the 'next' item. If we're allowing notebook
         // middleware, it calls into the notebook middleware first.
         if (this.notebookAddon) {

--- a/src/client/activation/languageServer/manager.ts
+++ b/src/client/activation/languageServer/manager.ts
@@ -124,7 +124,6 @@ export class DotNetLanguageServerManager implements ILanguageServerManager {
         options.middleware = this.middleware = new LanguageClientMiddleware(
             this.serviceContainer,
             LanguageServerType.Microsoft,
-            () => this.languageServerProxy?.languageClient,
             this.lsVersion,
         );
 

--- a/src/client/activation/node/manager.ts
+++ b/src/client/activation/node/manager.ts
@@ -120,7 +120,6 @@ export class NodeLanguageServerManager implements ILanguageServerManager {
         options.middleware = this.middleware = new LanguageClientMiddleware(
             this.serviceContainer,
             LanguageServerType.Node,
-            () => this.languageServerProxy?.languageClient,
             this.lsVersion,
         );
 

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -14,6 +14,12 @@ export const PYTHON = [
     { scheme: InteractiveInputScheme, language: PYTHON_LANGUAGE },
 ];
 
+export const PYTHON_NOTEBOOKS = [
+    { scheme: 'vscode-notebook', language: PYTHON_LANGUAGE },
+    { scheme: NotebookCellScheme, language: PYTHON_LANGUAGE },
+    { scheme: InteractiveInputScheme, language: PYTHON_LANGUAGE },
+];
+
 export const PVSC_EXTENSION_ID = 'ms-python.python';
 export const CODE_RUNNER_EXTENSION_ID = 'formulahendry.code-runner';
 export const PYLANCE_EXTENSION_ID = 'ms-python.vscode-pylance';


### PR DESCRIPTION
As a counter part to this PR: https://github.com/microsoft/vscode-jupyter/pull/7924 this PR removes notebook intellisense from the python extension.