### PR TITLE
Dont send pylance telemetry when skipping it for notebooks

### DIFF
--- a/src/client/activation/languageClientMiddlewareBase.ts
+++ b/src/client/activation/languageClientMiddlewareBase.ts
@@ -115,7 +115,7 @@ export class LanguageClientMiddlewareBase implements Middleware {
 
     private connected = false; // Default to not forwarding to VS code.
 
-    // Stack of flags indicating if we should skip sending telemetry or not.
+    // Flag indicating if we should skip sending telemetry or not.
     public skipTelemetry = false;
 
     public constructor(


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/issues/7943

Don't send pylance telemetry when the middleware skips it.