### PR TITLE
Correctly set `failed` property when sending telemetry for TERMINAL_SHELL_IDENTIFICATION

### DIFF
--- a/src/client/common/terminal/shellDetector.ts
+++ b/src/client/common/terminal/shellDetector.ts
@@ -57,6 +57,7 @@ export class ShellDetector {
                 `${detector}. Shell identified as ${shell} ${terminal ? `(Terminal name is ${terminal.name})` : ''}`,
             );
             if (shell && shell !== TerminalShellType.other) {
+                telemetryProperties.failed = false;
                 break;
             }
         }

--- a/src/client/common/terminal/shellDetectors/vscEnvironmentShellDetector.ts
+++ b/src/client/common/terminal/shellDetectors/vscEnvironmentShellDetector.ts
@@ -36,6 +36,7 @@ export class VSCEnvironmentShellDetector extends BaseShellDetector {
         traceVerbose(`Terminal shell path '${shellPath}' identified as shell '${shell}'`);
         telemetryProperties.shellIdentificationSource =
             shell === TerminalShellType.other ? telemetryProperties.shellIdentificationSource : 'vscode';
+        telemetryProperties.failed = shell === TerminalShellType.other ? false : true;
         return shell;
     }
 }

--- a/src/test/common/terminals/shellDetectors/shellDetectors.unit.test.ts
+++ b/src/test/common/terminals/shellDetectors/shellDetectors.unit.test.ts
@@ -51,15 +51,16 @@ suite('Shell Detectors', () => {
     shellPathsAndIdentification.set('/usr/bin/xonsh', TerminalShellType.xonsh);
     shellPathsAndIdentification.set('/usr/bin/xonshx', TerminalShellType.other);
 
-    const telemetryProperties: ShellIdentificationTelemetry = {
-        failed: true,
-        shellIdentificationSource: 'default',
-        terminalProvided: false,
-        hasCustomShell: undefined,
-        hasShellInEnv: undefined,
-    };
+    let telemetryProperties: ShellIdentificationTelemetry;
 
     setup(() => {
+        telemetryProperties = {
+            failed: true,
+            shellIdentificationSource: 'default',
+            terminalProvided: false,
+            hasCustomShell: undefined,
+            hasShellInEnv: undefined,
+        };
         platformService = mock(PlatformService);
         workspaceService = mock(WorkspaceService);
         currentProcess = mock(CurrentProcess);
@@ -122,6 +123,7 @@ suite('Shell Detectors', () => {
             undefined,
             'Should be undefined when vscode.env.shell is undefined',
         );
+        expect(telemetryProperties.failed).to.equal(false);
     });
     test('Identify shell based on VSC Settings', async () => {
         const shellDetector = new SettingsShellDetector(instance(workspaceService), instance(platformService));


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/7506