### PR TITLE
Allow notebook middleware to handle more stuff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -760,9 +760,9 @@
             }
         },
         "@vscode/jupyter-lsp-middleware": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.13.tgz",
-            "integrity": "sha512-IhiIwFUz9PN13rrUKQlEz+BX16ZQ8hJfLvV9hJvr9DSuioafbhjl5gAe3SXWP/3eIpdA/J4DGKL+i4Oyb1dY+Q==",
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.15.tgz",
+            "integrity": "sha512-ZwzPiaU9JjvoWrp9w4ZOcK45BkbDbYn99GINsaFKe6SzTKD331FBQ/eSlalBxhta5EVT3+WarpN9kDeGdSPr4g==",
             "requires": {
                 "vscode-languageclient": "7.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -2047,7 +2047,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@vscode/jupyter-lsp-middleware": "^0.2.13",
+        "@vscode/jupyter-lsp-middleware": "^0.2.15",
         "arch": "^2.1.0",
         "azure-storage": "^2.10.4",
         "chokidar": "^3.4.3",

--- a/src/client/activation/languageClientMiddlewareBase.ts
+++ b/src/client/activation/languageClientMiddlewareBase.ts
@@ -384,6 +384,84 @@ export class LanguageClientMiddlewareBase implements Middleware {
         }
     }
 
+    public provideTypeDefinition() {
+        if (this.connected) {
+            return this.callNext('provideTypeDefinition', arguments);
+        }
+    }
+
+    public provideImplementation() {
+        if (this.connected) {
+            return this.callNext('provideImplementation', arguments);
+        }
+    }
+
+    public provideDocumentColors() {
+        if (this.connected) {
+            return this.callNext('provideDocumentColors', arguments);
+        }
+    }
+
+    public provideColorPresentations() {
+        if (this.connected) {
+            return this.callNext('provideColorPresentations', arguments);
+        }
+    }
+
+    public provideFoldingRanges() {
+        if (this.connected) {
+            return this.callNext('provideFoldingRanges', arguments);
+        }
+    }
+
+    public provideSelectionRanges() {
+        if (this.connected) {
+            return this.callNext('provideSelectionRanges', arguments);
+        }
+    }
+
+    public prepareCallHierarchy() {
+        if (this.connected) {
+            return this.callNext('prepareCallHierarchy', arguments);
+        }
+    }
+
+    public provideCallHierarchyIncomingCalls() {
+        if (this.connected) {
+            return this.callNext('provideCallHierarchyIncomingCalls', arguments);
+        }
+    }
+
+    public provideCallHierarchyOutgoingCalls() {
+        if (this.connected) {
+            return this.callNext('provideCallHierarchyOutgoingCalls', arguments);
+        }
+    }
+
+    public provideDocumentSemanticTokens() {
+        if (this.connected) {
+            return this.callNext('provideDocumentSemanticTokens', arguments);
+        }
+    }
+
+    public provideDocumentSemanticTokensEdits() {
+        if (this.connected) {
+            return this.callNext('provideDocumentSemanticTokensEdits', arguments);
+        }
+    }
+
+    public provideDocumentRangeSemanticTokens() {
+        if (this.connected) {
+            return this.callNext('provideDocumentRangeSemanticTokens', arguments);
+        }
+    }
+
+    public provideLinkedEditingRange() {
+        if (this.connected) {
+            return this.callNext('provideLinkedEditingRange', arguments);
+        }
+    }
+
     private callNext(funcName: keyof Middleware, args: IArguments) {
         // This function uses the last argument to call the 'next' item. If we're allowing notebook
         // middleware, it calls into the notebook middleware first.


### PR DESCRIPTION
This enables a fix for https://github.com/microsoft/vscode-jupyter/issues/6799 by skipping providing semantic tokens (and other things) for notebooks.