### PR TITLE
Make middleware wait for connection

### DIFF
--- a/news/2 Fixes/17878.md
+++ b/news/2 Fixes/17878.md
@@ -1,0 +1,1 @@
+Semantic colorization can sometimes require reopening or scrolling of a file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13978,7 +13978,8 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "5.0.0",
-                    "resolved": "",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
                     "dev": true
                 },
                 "ansi-styles": {


### PR DESCRIPTION
Fixes #17878

We can't skip token requests just because the python interpreter isn't set yet in pylance. Instead we should wait for the interpreter to be set.