### PR TITLE
Remove output channel as a dependency

### DIFF
--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -3,14 +3,12 @@
 import '../common/extensions';
 
 import { inject, injectable } from 'inversify';
-import { ConfigurationChangeEvent, Disposable, OutputChannel, Uri } from 'vscode';
+import { ConfigurationChangeEvent, Disposable, Uri } from 'vscode';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../common/application/types';
-import { STANDARD_OUTPUT_CHANNEL } from '../common/constants';
 import {
     IConfigurationService,
     IDisposableRegistry,
     IExtensions,
-    IOutputChannel,
     IPersistentStateFactory,
     IPythonSettings,
     Resource,
@@ -31,7 +29,7 @@ import {
     LanguageServerType,
 } from './types';
 import { StopWatch } from '../common/utils/stopWatch';
-import { traceError } from '../logging';
+import { traceError, traceLog } from '../logging';
 
 const languageServerSetting: keyof IPythonSettings = 'languageServer';
 const workspacePathNameForGlobalWorkspaces = '';
@@ -40,6 +38,24 @@ interface IActivatedServer {
     key: string;
     server: ILanguageServerActivator;
     jedi: boolean;
+}
+
+function logStartup(serverType: LanguageServerType): void {
+    let outputLine;
+    switch (serverType) {
+        case LanguageServerType.Jedi:
+            outputLine = LanguageService.startingJedi();
+            break;
+        case LanguageServerType.Node:
+            outputLine = LanguageService.startingPylance();
+            break;
+        case LanguageServerType.None:
+            outputLine = LanguageService.startingNone();
+            break;
+        default:
+            throw new Error('Unknown language server type in activator.');
+    }
+    traceLog(outputLine);
 }
 
 @injectable()
@@ -52,8 +68,6 @@ export class LanguageServerExtensionActivationService
     private readonly workspaceService: IWorkspaceService;
 
     private readonly configurationService: IConfigurationService;
-
-    private readonly output: OutputChannel;
 
     private readonly interpreterService: IInterpreterService;
 
@@ -68,8 +82,6 @@ export class LanguageServerExtensionActivationService
         this.workspaceService = this.serviceContainer.get<IWorkspaceService>(IWorkspaceService);
         this.configurationService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
         this.interpreterService = this.serviceContainer.get<IInterpreterService>(IInterpreterService);
-        this.output = this.serviceContainer.get<OutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
-
         const disposables = serviceContainer.get<IDisposableRegistry>(IDisposableRegistry);
         disposables.push(this);
         disposables.push(this.workspaceService.onDidChangeConfiguration(this.onDidChangeConfiguration.bind(this)));
@@ -235,7 +247,7 @@ export class LanguageServerExtensionActivationService
 
         this.sendTelemetryForChosenLanguageServer(serverType).ignoreErrors();
 
-        await this.logStartup(serverType);
+        logStartup(serverType);
         let server = this.serviceContainer.get<ILanguageServerActivator>(ILanguageServerActivator, serverType);
         try {
             await server.start(resource, interpreter);
@@ -244,7 +256,7 @@ export class LanguageServerExtensionActivationService
                 throw ex;
             }
             traceError(ex);
-            this.output.appendLine(LanguageService.lsFailedToStart());
+            traceLog(LanguageService.lsFailedToStart());
             serverType = LanguageServerType.Jedi;
             server = this.serviceContainer.get<ILanguageServerActivator>(ILanguageServerActivator, serverType);
             await server.start(resource, interpreter);
@@ -258,24 +270,6 @@ export class LanguageServerExtensionActivationService
             // Dispose of the actual server.
             server.dispose();
         });
-    }
-
-    private async logStartup(serverType: LanguageServerType): Promise<void> {
-        let outputLine;
-        switch (serverType) {
-            case LanguageServerType.Jedi:
-                outputLine = LanguageService.startingJedi();
-                break;
-            case LanguageServerType.Node:
-                outputLine = LanguageService.startingPylance();
-                break;
-            case LanguageServerType.None:
-                outputLine = LanguageService.startingNone();
-                break;
-            default:
-                throw new Error('Unknown language server type in activator.');
-        }
-        this.output.appendLine(outputLine);
     }
 
     private async onDidChangeConfiguration(event: ConfigurationChangeEvent): Promise<void> {

--- a/src/client/application/diagnostics/applicationDiagnostics.ts
+++ b/src/client/application/diagnostics/applicationDiagnostics.ts
@@ -1,72 +1,72 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-'use strict';
-
-import { inject, injectable, named } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { DiagnosticSeverity } from 'vscode';
-import { isTestExecution, STANDARD_OUTPUT_CHANNEL } from '../../common/constants';
-import { IOutputChannel, Resource } from '../../common/types';
+import { isTestExecution } from '../../common/constants';
+import { Resource } from '../../common/types';
 import { IServiceContainer } from '../../ioc/types';
-import { traceError, traceInfo, traceWarn } from '../../logging';
+import { traceInfo, traceLog } from '../../logging';
 import { IApplicationDiagnostics } from '../types';
 import { IDiagnostic, IDiagnosticsService, ISourceMapSupportService } from './types';
 
+function log(diagnostics: IDiagnostic[]): void {
+    diagnostics.forEach((item) => {
+        const message = `Diagnostic Code: ${item.code}, Message: ${item.message}`;
+        switch (item.severity) {
+            case DiagnosticSeverity.Error: {
+                traceLog(message);
+                break;
+            }
+            case DiagnosticSeverity.Warning: {
+                traceLog(message);
+                break;
+            }
+            default: {
+                traceInfo(message);
+            }
+        }
+    });
+}
+
+async function runDiagnostics(diagnosticServices: IDiagnosticsService[], resource: Resource): Promise<void> {
+    await Promise.all(
+        diagnosticServices.map(async (diagnosticService) => {
+            const diagnostics = await diagnosticService.diagnose(resource);
+            if (diagnostics.length > 0) {
+                log(diagnostics);
+                await diagnosticService.handle(diagnostics);
+            }
+        }),
+    );
+}
+
 @injectable()
 export class ApplicationDiagnostics implements IApplicationDiagnostics {
-    constructor(
-        @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer,
-        @inject(IOutputChannel) @named(STANDARD_OUTPUT_CHANNEL) private readonly outputChannel: IOutputChannel,
-    ) {}
+    constructor(@inject(IServiceContainer) private readonly serviceContainer: IServiceContainer) {}
+
     public register() {
         this.serviceContainer.get<ISourceMapSupportService>(ISourceMapSupportService).register();
     }
+
     public async performPreStartupHealthCheck(resource: Resource): Promise<void> {
         // When testing, do not perform health checks, as modal dialogs can be displayed.
         if (isTestExecution()) {
             return;
         }
+
         const services = this.serviceContainer.getAll<IDiagnosticsService>(IDiagnosticsService);
+
         // Perform these validation checks in the foreground.
-        await this.runDiagnostics(
+        await runDiagnostics(
             services.filter((item) => !item.runInBackground),
             resource,
         );
+
         // Perform these validation checks in the background.
-        this.runDiagnostics(
+        runDiagnostics(
             services.filter((item) => item.runInBackground),
             resource,
         ).ignoreErrors();
-    }
-    private async runDiagnostics(diagnosticServices: IDiagnosticsService[], resource: Resource): Promise<void> {
-        await Promise.all(
-            diagnosticServices.map(async (diagnosticService) => {
-                const diagnostics = await diagnosticService.diagnose(resource);
-                if (diagnostics.length > 0) {
-                    this.log(diagnostics);
-                    await diagnosticService.handle(diagnostics);
-                }
-            }),
-        );
-    }
-    private log(diagnostics: IDiagnostic[]): void {
-        diagnostics.forEach((item) => {
-            const message = `Diagnostic Code: ${item.code}, Message: ${item.message}`;
-            switch (item.severity) {
-                case DiagnosticSeverity.Error: {
-                    traceError(message);
-                    this.outputChannel.appendLine(message);
-                    break;
-                }
-                case DiagnosticSeverity.Warning: {
-                    traceWarn(message);
-                    this.outputChannel.appendLine(message);
-                    break;
-                }
-                default: {
-                    traceInfo(message);
-                }
-            }
-        });
     }
 }

--- a/src/client/common/experiments/service.ts
+++ b/src/client/common/experiments/service.ts
@@ -6,11 +6,12 @@
 import { inject, injectable, named } from 'inversify';
 import { Memento } from 'vscode';
 import { getExperimentationService, IExperimentationService, TargetPopulation } from 'vscode-tas-client';
+import { traceLog } from '../../logging';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { IApplicationEnvironment, IWorkspaceService } from '../application/types';
-import { PVSC_EXTENSION_ID, STANDARD_OUTPUT_CHANNEL } from '../constants';
-import { GLOBAL_MEMENTO, IExperimentService, IMemento, IOutputChannel } from '../types';
+import { PVSC_EXTENSION_ID } from '../constants';
+import { GLOBAL_MEMENTO, IExperimentService, IMemento } from '../types';
 import { Experiments } from '../utils/localize';
 import { ExperimentationTelemetry } from './telemetry';
 
@@ -37,7 +38,6 @@ export class ExperimentService implements IExperimentService {
         @inject(IWorkspaceService) readonly workspaceService: IWorkspaceService,
         @inject(IApplicationEnvironment) private readonly appEnvironment: IApplicationEnvironment,
         @inject(IMemento) @named(GLOBAL_MEMENTO) private readonly globalState: Memento,
-        @inject(IOutputChannel) @named(STANDARD_OUTPUT_CHANNEL) private readonly output: IOutputChannel,
     ) {
         const settings = this.workspaceService.getConfiguration('python');
         // Users can only opt in or out of experiment groups, not control groups.
@@ -145,22 +145,22 @@ export class ExperimentService implements IExperimentService {
         const telemetrySettings = this.workspaceService.getConfiguration('telemetry');
         let experimentsDisabled = false;
         if (telemetrySettings && telemetrySettings.get<boolean>('enableTelemetry') === false) {
-            this.output.appendLine('Telemetry is disabled');
+            traceLog('Telemetry is disabled');
             experimentsDisabled = true;
         }
 
         if (telemetrySettings && telemetrySettings.get<string>('telemetryLevel') === 'off') {
-            this.output.appendLine('Telemetry level is off');
+            traceLog('Telemetry level is off');
             experimentsDisabled = true;
         }
 
         if (experimentsDisabled) {
-            this.output.appendLine('Experiments are disabled, logging experiments for info.');
+            traceLog('Experiments are disabled, logging experiments for info.');
         }
 
         if (this._optOutFrom.includes('All')) {
             // We prioritize opt out first
-            this.output.appendLine(Experiments.optedOutOf().format('All'));
+            traceLog(Experiments.optedOutOf().format('All'));
 
             // Since we are in the Opt Out all case, this means when checking for experiment we
             // short circuit and return. So, printing out additional experiment info might cause
@@ -169,7 +169,7 @@ export class ExperimentService implements IExperimentService {
         }
         if (this._optInto.includes('All')) {
             // Only if 'All' is not in optOut then check if it is in Opt In.
-            this.output.appendLine(Experiments.inGroup().format('All'));
+            traceLog(Experiments.inGroup().format('All'));
 
             // Similar to the opt out case. If user is opting into to all experiments we short
             // circuit the experiment checks. So, skip printing any additional details to the logs.
@@ -182,14 +182,14 @@ export class ExperimentService implements IExperimentService {
         this._optOutFrom
             .filter((exp) => exp !== 'All' && exp.toLowerCase().startsWith('python'))
             .forEach((exp) => {
-                this.output.appendLine(Experiments.optedOutOf().format(exp));
+                traceLog(Experiments.optedOutOf().format(exp));
             });
 
         // Log experiments that users manually opt into, these are experiments which are added using the exp framework.
         this._optInto
             .filter((exp) => exp !== 'All' && exp.toLowerCase().startsWith('python'))
             .forEach((exp) => {
-                this.output.appendLine(Experiments.inGroup().format(exp));
+                traceLog(Experiments.inGroup().format(exp));
             });
 
         // Log experiments that users are added to by the exp framework
@@ -201,7 +201,7 @@ export class ExperimentService implements IExperimentService {
                 !this._optOutFrom.includes(exp) &&
                 !this._optInto.includes(exp)
             ) {
-                this.output.appendLine(Experiments.inGroup().format(exp));
+                traceLog(Experiments.inGroup().format(exp));
             }
         });
     }

--- a/src/client/logging/fileLogger.ts
+++ b/src/client/logging/fileLogger.ts
@@ -7,12 +7,18 @@ import { Disposable } from 'vscode-jsonrpc';
 import { Arguments, ILogging } from './types';
 import { getTimeForLogging } from './util';
 
-function formatMessage(level: string, ...data: Arguments): string {
-    return `[${level.toUpperCase()} ${getTimeForLogging()}]: ${util.format(...data)}\r\n`;
+function formatMessage(level?: string, ...data: Arguments): string {
+    return level
+        ? `[${level.toUpperCase()} ${getTimeForLogging()}]: ${util.format(...data)}\r\n`
+        : `${util.format(...data)}\r\n`;
 }
 
 export class FileLogger implements ILogging, Disposable {
     constructor(private readonly stream: WriteStream) {}
+
+    public traceLog(...data: Arguments): void {
+        this.stream.write(formatMessage(undefined, ...data));
+    }
 
     public traceError(...data: Arguments): void {
         this.stream.write(formatMessage('error', ...data));

--- a/src/client/logging/index.ts
+++ b/src/client/logging/index.ts
@@ -49,6 +49,10 @@ export function initializeFileLogging(disposables: Disposable[]): void {
     }
 }
 
+export function traceLog(...args: Arguments): void {
+    loggers.forEach((l) => l.traceLog(...args));
+}
+
 export function traceError(...args: Arguments): void {
     if (globalLoggingLevel >= LogLevel.Error) {
         loggers.forEach((l) => l.traceError(...args));

--- a/src/client/logging/outputChannelLogger.ts
+++ b/src/client/logging/outputChannelLogger.ts
@@ -6,12 +6,16 @@ import { OutputChannel } from 'vscode';
 import { Arguments, ILogging } from './types';
 import { getTimeForLogging } from './util';
 
-function formatMessage(level: string, ...data: Arguments): string {
-    return `[${level.toUpperCase()} ${getTimeForLogging()}]: ${util.format(...data)}`;
+function formatMessage(level?: string, ...data: Arguments): string {
+    return level ? `[${level.toUpperCase()} ${getTimeForLogging()}]: ${util.format(...data)}` : util.format(...data);
 }
 
 export class OutputChannelLogger implements ILogging {
     constructor(private readonly channel: OutputChannel) {}
+
+    public traceLog(...data: Arguments): void {
+        this.channel.appendLine(formatMessage(undefined, ...data));
+    }
 
     public traceError(...data: Arguments): void {
         this.channel.appendLine(formatMessage('error', ...data));

--- a/src/client/logging/types.ts
+++ b/src/client/logging/types.ts
@@ -16,6 +16,7 @@ export enum LogLevel {
 export type Arguments = unknown[];
 
 export interface ILogging {
+    traceLog(...data: Arguments): void;
     traceError(...data: Arguments): void;
     traceWarn(...data: Arguments): void;
     traceInfo(...data: Arguments): void;

--- a/src/test/application/diagnostics/applicationDiagnostics.unit.test.ts
+++ b/src/test/application/diagnostics/applicationDiagnostics.unit.test.ts
@@ -17,8 +17,6 @@ import {
     ISourceMapSupportService,
 } from '../../../client/application/diagnostics/types';
 import { IApplicationDiagnostics } from '../../../client/application/types';
-import { STANDARD_OUTPUT_CHANNEL } from '../../../client/common/constants';
-import { IOutputChannel } from '../../../client/common/types';
 import { createDeferred, createDeferredFromPromise } from '../../../client/common/utils/async';
 import { ServiceContainer } from '../../../client/ioc/container';
 import { IServiceContainer } from '../../../client/ioc/types';
@@ -29,7 +27,6 @@ suite('Application Diagnostics - ApplicationDiagnostics', () => {
     let envHealthCheck: typemoq.IMock<IDiagnosticsService>;
     let lsNotSupportedCheck: typemoq.IMock<IDiagnosticsService>;
     let pythonInterpreterCheck: typemoq.IMock<IDiagnosticsService>;
-    let outputChannel: typemoq.IMock<IOutputChannel>;
     let appDiagnostics: IApplicationDiagnostics;
     const oldValueOfVSC_PYTHON_UNIT_TEST = process.env.VSC_PYTHON_UNIT_TEST;
     const oldValueOfVSC_PYTHON_CI_TEST = process.env.VSC_PYTHON_CI_TEST;
@@ -44,16 +41,12 @@ suite('Application Diagnostics - ApplicationDiagnostics', () => {
         lsNotSupportedCheck.setup((service) => service.runInBackground).returns(() => false);
         pythonInterpreterCheck = typemoq.Mock.ofType<IDiagnosticsService>();
         pythonInterpreterCheck.setup((service) => service.runInBackground).returns(() => false);
-        outputChannel = typemoq.Mock.ofType<IOutputChannel>();
 
         serviceContainer
             .setup((d) => d.getAll(typemoq.It.isValue(IDiagnosticsService)))
             .returns(() => [envHealthCheck.object, lsNotSupportedCheck.object, pythonInterpreterCheck.object]);
-        serviceContainer
-            .setup((d) => d.get(typemoq.It.isValue(IOutputChannel), typemoq.It.isValue(STANDARD_OUTPUT_CHANNEL)))
-            .returns(() => outputChannel.object);
 
-        appDiagnostics = new ApplicationDiagnostics(serviceContainer.object, outputChannel.object);
+        appDiagnostics = new ApplicationDiagnostics(serviceContainer.object);
     });
 
     teardown(() => {
@@ -173,23 +166,6 @@ suite('Application Diagnostics - ApplicationDiagnostics', () => {
             diagnostics.push(diagnostic);
         }
 
-        for (const diagnostic of diagnostics) {
-            const message = `Diagnostic Code: ${diagnostic.code}, Message: ${diagnostic.message}`;
-            switch (diagnostic.severity) {
-                case DiagnosticSeverity.Error: {
-                    outputChannel.setup((o) => o.appendLine(message)).verifiable(typemoq.Times.once());
-                    break;
-                }
-                case DiagnosticSeverity.Warning: {
-                    outputChannel.setup((o) => o.appendLine(message)).verifiable(typemoq.Times.once());
-                    break;
-                }
-                default: {
-                    break;
-                }
-            }
-        }
-
         envHealthCheck
             .setup((e) => e.diagnose(typemoq.It.isAny()))
             .returns(() => Promise.resolve(diagnostics))
@@ -209,7 +185,6 @@ suite('Application Diagnostics - ApplicationDiagnostics', () => {
         envHealthCheck.verifyAll();
         lsNotSupportedCheck.verifyAll();
         pythonInterpreterCheck.verifyAll();
-        outputChannel.verifyAll();
     });
     test('Ensure diagnostics run in foreground and background', async () => {
         const foreGroundService = mock(InvalidPythonInterpreterService);
@@ -228,7 +203,7 @@ suite('Application Diagnostics - ApplicationDiagnostics', () => {
         when(foreGroundService.diagnose(anything())).thenReturn(foreGroundDeferred.promise);
         when(backGroundService.diagnose(anything())).thenReturn(backgroundGroundDeferred.promise);
 
-        const service = new ApplicationDiagnostics(instance(svcContainer), outputChannel.object);
+        const service = new ApplicationDiagnostics(instance(svcContainer));
 
         const promise = service.performPreStartupHealthCheck(undefined);
         const deferred = createDeferredFromPromise(promise);

--- a/src/test/common/experiments/service.unit.test.ts
+++ b/src/test/common/experiments/service.unit.test.ts
@@ -7,6 +7,7 @@
 import { assert } from 'chai';
 import * as sinon from 'sinon';
 import { anything, instance, mock, when } from 'ts-mockito';
+import { Disposable } from 'vscode-jsonrpc';
 import * as tasClient from 'vscode-tas-client';
 import { ApplicationEnvironment } from '../../../client/common/application/applicationEnvironment';
 import { IApplicationEnvironment, IWorkspaceService } from '../../../client/common/application/types';
@@ -14,6 +15,8 @@ import { WorkspaceService } from '../../../client/common/application/workspace';
 import { Channel } from '../../../client/common/constants';
 import { ExperimentService } from '../../../client/common/experiments/service';
 import { Experiments } from '../../../client/common/utils/localize';
+import { registerLogger } from '../../../client/logging';
+import { OutputChannelLogger } from '../../../client/logging/outputChannelLogger';
 import * as Telemetry from '../../../client/telemetry';
 import { EventName } from '../../../client/telemetry/constants';
 import { PVSC_EXTENSION_ID_FOR_TESTS } from '../../constants';
@@ -27,17 +30,20 @@ suite('Experimentation service', () => {
     let appEnvironment: IApplicationEnvironment;
     let globalMemento: MockMemento;
     let outputChannel: MockOutputChannel;
+    let disposeLogger: Disposable;
 
     setup(() => {
         appEnvironment = mock(ApplicationEnvironment);
         workspaceService = mock(WorkspaceService);
         globalMemento = new MockMemento();
         outputChannel = new MockOutputChannel('');
+        disposeLogger = registerLogger(new OutputChannelLogger(outputChannel));
     });
 
     teardown(() => {
         sinon.restore();
         Telemetry._resetSharedProperties();
+        disposeLogger.dispose();
     });
 
     function configureSettings(enabled: boolean, optInto: string[], optOutFrom: string[]) {
@@ -72,7 +78,7 @@ suite('Experimentation service', () => {
             configureApplicationEnvironment('stable', extensionVersion);
 
             // eslint-disable-next-line no-new
-            new ExperimentService(instance(workspaceService), instance(appEnvironment), globalMemento, outputChannel);
+            new ExperimentService(instance(workspaceService), instance(appEnvironment), globalMemento);
 
             sinon.assert.calledWithExactly(
                 getExperimentationServiceStub,
@@ -91,7 +97,7 @@ suite('Experimentation service', () => {
             configureApplicationEnvironment('insiders', extensionVersion);
 
             // eslint-disable-next-line no-new
-            new ExperimentService(instance(workspaceService), instance(appEnvironment), globalMemento, outputChannel);
+            new ExperimentService(instance(workspaceService), instance(appEnvironment), globalMemento);
 
             sinon.assert.calledWithExactly(
                 getExperimentationServiceStub,
@@ -113,7 +119,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
 
             assert.deepEqual(experimentService._optInto, ['Foo - experiment']);
@@ -128,7 +133,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
 
             assert.deepEqual(experimentService._optOutFrom, ['Foo - experiment']);
@@ -143,12 +147,7 @@ suite('Experimentation service', () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             when(globalMemento.get(anything(), anything())).thenReturn({ features: experiments } as any);
 
-            new ExperimentService(
-                instance(workspaceService),
-                instance(appEnvironment),
-                instance(globalMemento),
-                outputChannel,
-            );
+            new ExperimentService(instance(workspaceService), instance(appEnvironment), instance(globalMemento));
             const output = `${Experiments.inGroup().format('pythonExperiment')}\n`;
 
             assert.strictEqual(outputChannel.output, output);
@@ -189,7 +188,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
             const result = experimentService.inExperimentSync(experiment);
 
@@ -205,7 +203,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
             const result = experimentService.inExperimentSync(experiment);
 
@@ -221,7 +218,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
             const result = experimentService.inExperimentSync(experiment);
 
@@ -236,7 +232,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
             const result = experimentService.inExperimentSync(experiment);
 
@@ -252,7 +247,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
             const result = experimentService.inExperimentSync(experiment);
 
@@ -268,7 +262,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
             const result = experimentService.inExperimentSync(experiment);
 
@@ -284,7 +277,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
             const result = experimentService.inExperimentSync(experiment);
 
@@ -300,7 +292,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
             const result = experimentService.inExperimentSync(experiment);
 
@@ -316,7 +307,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
             const result = experimentService.inExperimentSync(experiment);
 
@@ -346,7 +336,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
             const result = await experimentService.getExperimentValue(experiment);
 
@@ -361,7 +350,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
             const result = await experimentService.getExperimentValue(experiment);
 
@@ -376,7 +364,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
             const result = await experimentService.getExperimentValue(experiment);
 
@@ -391,7 +378,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
             const result = await experimentService.getExperimentValue(experiment);
 
@@ -427,7 +413,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
 
             await experimentService.activate();
@@ -461,7 +446,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
 
             await experimentService.activate();
@@ -494,7 +478,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
 
             await experimentService.activate();
@@ -527,7 +510,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
 
             await experimentService.activate();
@@ -550,7 +532,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
 
             await experimentService.activate();
@@ -582,7 +563,6 @@ suite('Experimentation service', () => {
                 instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel,
             );
 
             await experimentService.activate();


### PR DESCRIPTION
This is just a sample of how the removal will look like. Let me know your thoughts. 

I also plan on adding a custom logger, so we can use it for LS logging, and test output logging where we currently rely on creating separate logging channels.