### PR TITLE
Updated _find_left_bracket function used in pytest discovery to fix bug

### DIFF
--- a/news/2 Fixes/17954.md
+++ b/news/2 Fixes/17954.md
@@ -1,0 +1,2 @@
+Pytest test discovery no longer fails when there are not the same number of open and closed brackets in testcase name
+(thanks [Smith Wilbanks](https://github.com/scwilbanks))

--- a/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py
+++ b/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py
@@ -448,16 +448,17 @@ def _find_left_bracket(nodeid):
     """
     if not nodeid.endswith("]"):
         return nodeid, "", ""
-    bracketcount = 0
-    for index, char in enumerate(nodeid[::-1]):
-        if char == "]":
-            bracketcount += 1
-        elif char == "[":
-            bracketcount -= 1
-        if bracketcount == 0:
-            n = len(nodeid) - 1 - index
-            return nodeid[:n], nodeid[n], nodeid[n + 1 :]
-    return nodeid, "", ""
+
+    testname_testcase = nodeid.split("::")[-1]
+    nodeid_base = nodeid[: -len(testname_testcase)]
+    open_bracket_n = testname_testcase.find("[")
+
+    if open_bracket_n == -1:
+        return nodeid, "", ""
+
+    n = open_bracket_n + len(nodeid_base)
+    return nodeid[:n], nodeid[n], nodeid[n + 1 :]
+    
 
 
 def _iter_nodes(

--- a/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py
+++ b/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py
@@ -458,7 +458,6 @@ def _find_left_bracket(nodeid):
 
     n = open_bracket_n + len(nodeid_base)
     return nodeid[:n], nodeid[n], nodeid[n + 1 :]
-    
 
 
 def _iter_nodes(


### PR DESCRIPTION
Fix for #17954, #17951.

Instead of assuming an equal number of open and closed brackets as the current function does, this change assumes that the first open bracket of the last double colon "::" will be the bracket it is looking for. Since the testname will correspond to a python function, which cannot contain open brackets, the first open bracket must be it.