### PR TITLE
Don't add `cwd` argument when running all tests

### DIFF
--- a/news/2 Fixes/17546.md
+++ b/news/2 Fixes/17546.md
@@ -1,0 +1,2 @@
+Fix for `pytest` run all tests when using `pytest.ini` and `cwd`.
+(thanks [Brian Rutledge](https://github.com/bhrutledge))

--- a/src/client/testing/testController/pytest/runner.ts
+++ b/src/client/testing/testController/pytest/runner.ts
@@ -97,7 +97,7 @@ export class PytestRunner implements ITestsRunner {
             if (!rawData) {
                 throw new Error(`Trying to run unknown node: ${testNode.id}`);
             }
-            if (testNode.id !== options.workspaceFolder.fsPath) {
+            if (testNode.id !== options.cwd) {
                 testArgs.push(rawData.rawId);
             }
 


### PR DESCRIPTION
Follow-up to #17622 and #17898, attn: @karthiknadig. 

I tested this using my [example workspace](https://github.com/bhrutledge/vscode-pytest-workspace/tree/1e549d62c59a63fc4b63b89e6c34755173c416c8) with [`"python.testing.cwd"`](https://github.com/bhrutledge/vscode-pytest-workspace/blob/1e549d62c59a63fc4b63b89e6c34755173c416c8/.vscode/settings.json) set to a sub-directory, and [`testpaths` in `pytest.ini`](https://github.com/bhrutledge/vscode-pytest-workspace/blob/1e549d62c59a63fc4b63b89e6c34755173c416c8/repo/rootdir/pytest.ini) set to a sub-directory of that.

Before this change, running all tests yields:

```
Running tests (pytest): /Users/bhrutledge/Dev/vscode-pytest-workspace/repo/rootdir
Running test with arguments: --rootdir /Users/bhrutledge/Dev/vscode-pytest-workspace/repo/rootdir --override-ini junit_family=xunit1 --junit-xml=/var/folders/bw/ttgk1hcs0k989q2yzmxkzn8c0000gp/T/tmp-69875H3gF3f2niW84.xml /Users/bhrutledge/Dev/vscode-pytest-workspace/repo/rootdir
Current working directory: /Users/bhrutledge/Dev/vscode-pytest-workspace/repo/rootdir
Workspace directory: /Users/bhrutledge/Dev/vscode-pytest-workspace
Run completed, parsing output
Test result not found for: ./package/test_module.py::test_function
```

This is because the `cwd` is appended as an argument, which causes pytest to ignore `testpaths`, which causes it to collect tests that it shouldn't, causing a collection error.

With this change, running all tests yields:

```
Running tests (pytest): /Users/bhrutledge/Dev/vscode-pytest-workspace/repo/rootdir
Running test with arguments: --rootdir /Users/bhrutledge/Dev/vscode-pytest-workspace/repo/rootdir --override-ini junit_family=xunit1 --junit-xml=/var/folders/bw/ttgk1hcs0k989q2yzmxkzn8c0000gp/T/tmp-71331owgO7UMfr1MG.xml
Current working directory: /Users/bhrutledge/Dev/vscode-pytest-workspace/repo/rootdir
Workspace directory: /Users/bhrutledge/Dev/vscode-pytest-workspace
Run completed, parsing output
./package/test_module.py::test_function Passed
```

Note that `cwd` is no longer an argument.

It looks `cwd` defaults to `workspaceFolder.fsPath`, so this seems like a safe change.

