### PR TITLE
Don't interpret `--rootdir` as a test folder

### DIFF
--- a/news/2 Fixes/16079.md
+++ b/news/2 Fixes/16079.md
@@ -1,0 +1,2 @@
+Don't interpret `--rootdir` as a test folder for `pytest`.
+(thanks [Brian Rutledge](https://github.com/bhrutledge))

--- a/src/client/testing/testController/pytest/arguments.ts
+++ b/src/client/testing/testController/pytest/arguments.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { TestDiscoveryOptions, TestFilter } from '../../common/types';
-import { getOptionValues, getPositionalArguments, filterArguments } from '../common/argumentsHelper';
+import { getPositionalArguments, filterArguments } from '../common/argumentsHelper';
 
 const OptionsWithArguments = [
     '-c',
@@ -135,11 +135,6 @@ const OptionsWithoutArguments = [
 ];
 
 export function pytestGetTestFolders(args: string[]): string[] {
-    const testDirs = getOptionValues(args, '--rootdir');
-    if (testDirs.length > 0) {
-        return testDirs;
-    }
-
     const positionalArgs = getPositionalArguments(args, OptionsWithArguments, OptionsWithoutArguments);
     // Positional args in pytest are files or directories.
     // Remove files from the args, and what's left are test directories.


### PR DESCRIPTION
For #16079 (maybe a complete fix?).

As noted in https://github.com/microsoft/vscode-python/issues/16079#issuecomment-960370579, the removed logic has been around for long time, and it's not clear to me why.

I tested using my [example workspace](https://github.com/bhrutledge/vscode-pytest-workspace/) with:

```json
    "python.testing.pytestArgs": [
        "--rootdir", "${workspaceFolder}/repo/rootdir",
        "package"
    ],
```

Before this change, running "Test: Refresh Tests" yields:

```
~/Dev/vscode-pytest-workspace/venv/bin/python ~/Dev/vscode-python/pythonFiles/testing_tools/run_adapter.py discover pytest -- -s --cache-clear --rootdir ~/Dev/vscode-pytest-workspace/repo/rootdir ~/Dev/vscode-pytest-workspace/repo/rootdir
```

i.e., the `--rootdir` value replaces the `"package"` argument.

With this change, running "Test: Refresh Tests" yields:

```
> ~/Dev/vscode-pytest-workspace/venv/bin/python ~/Dev/vscode-python/pythonFiles/testing_tools/run_adapter.py discover pytest -- -s --cache-clear --rootdir ~/Dev/vscode-pytest-workspace/repo/rootdir package
```

which is what I would expect.