### PR TITLE
Use Python 3.9 for build workflow

### DIFF
--- a/.github/actions/smoke-tests/action.yml
+++ b/.github/actions/smoke-tests/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Install Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.9'
 
     - name: Pip cache
       uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         # entry to lower the number of runners used, macOS runners are expensive,
         # and we assume that Ubuntu is enough to cover the UNIX case.
         os: [ubuntu-latest, windows-latest]
-        python: ['2.7', '3.x']
+        python: ['2.7', '3.9']
         test-suite: [ts-unit, python-unit, venv, single-workspace, multi-workspace, debugger, functional]
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Install test requirements
         run: python -m pip install --upgrade -r build/test-requirements.txt
 
-      - name: Install debugpy wheels (Python 3.x)
+      - name: Install debugpy wheels (Python ${{ matrix.python }})
         run: |
           python -m pip install wheel
           python -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt
@@ -133,7 +133,7 @@ jobs:
         shell: bash
         if: matrix.test-suite == 'debugger' && matrix.python != 2.7
 
-      - name: Install debugpy (Python 2.7)
+      - name: Install debugpy wheel (Python 2.7)
         run: |
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
         shell: bash

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Install test requirements
         run: python -m pip install --upgrade -r build/test-requirements.txt
 
-      - name: Install debugpy wheels (python 3.x)
+      - name: Install debugpy wheels (Python ${{ matrix.python }})
         run: |
           python -m pip install wheel
           python -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt
@@ -113,7 +113,7 @@ jobs:
         shell: bash
         if: matrix.test-suite == 'debugger' && matrix.python != 2.7
 
-      - name: Install debugpy (python 2.7)
+      - name: Install debugpy wheel (Python 2.7)
         run: |
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
         shell: bash


### PR DESCRIPTION
Partially addresses CI failures

Our python tests fail on Python 3.10 :(