### PR TITLE
Log as error when we fail to validate an interpreter

### DIFF
--- a/src/client/pythonEnvironments/base/info/environmentInfoService.ts
+++ b/src/client/pythonEnvironments/base/info/environmentInfoService.ts
@@ -6,7 +6,7 @@ import { createDeferred, Deferred } from '../../../common/utils/async';
 import { createRunningWorkerPool, IWorkerPool, QueuePosition } from '../../../common/utils/workerPool';
 import { getInterpreterInfo, InterpreterInformation } from './interpreter';
 import { buildPythonExecInfo } from '../../exec';
-import { traceVerbose } from '../../../logging';
+import { traceError } from '../../../logging';
 import { Conda } from '../../common/environmentManagers/conda';
 import { PythonEnvInfo, PythonEnvKind } from '.';
 
@@ -35,7 +35,7 @@ async function buildEnvironmentInfo(env: PythonEnvInfo): Promise<InterpreterInfo
     const interpreterInfo = await getInterpreterInfo(
         buildPythonExecInfo(python, undefined, env.executable.filename),
     ).catch((reason) => {
-        traceVerbose(reason);
+        traceError(reason);
         return undefined;
     });
 


### PR DESCRIPTION
```
[DEBUG 2021-11-9 14:47:26.679]: [Error: spawn cmd.exe ENOENT
	at Process.ChildProcess._handle.onexit (internal/child_process.js:269:19)
	at onErrorNT (internal/child_process.js:465:16)
	at processTicksAndRejections (internal/process/task_queues.js:80:21)] {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawn cmd.exe',
  path: 'cmd.exe',
  spawnargs: [
    '/d',
    '/s',
    '/c',
    '""C:\\Users\\Christopher\\AppData\\Local\\Programs\\Python\\Python310\\python.exe" "c:\\Users\\Christopher\\.vscode\\extensions\\ms-python.python-2021.12.1559732655\\pythonFiles\\interpreterInfo.py""'
  ],
  cmd: '"C:\\Users\\Christopher\\AppData\\Local\\Programs\\Python\\Python310\\python.exe" "c:\\Users\\Christopher\\.vscode\\extensions\\ms-python.python-2021.12.1559732655\\pythonFiles\\interpreterInfo.py"'
}
```

Currently errors like this https://github.com/microsoft/vscode-python/issues/18138#issuecomment-990181188 only appear in debug level.