### PR TITLE
Handle scenarios where validating interpreters via `conda run` emits more than just the validation script output

### DIFF
--- a/pythonFiles/interpreterInfo.py
+++ b/pythonFiles/interpreterInfo.py
@@ -10,6 +10,7 @@ obj["sysPrefix"] = sys.prefix
 obj["sysVersion"] = sys.version
 obj["is64Bit"] = sys.maxsize > 2 ** 32
 
-print('>>>JSON') # Printing out markers for our JSON to make it more resilient to pull it out.
+# Printing out markers for our JSON to make it more resilient to pull the output.
+print(">>>JSON")
 print(json.dumps(obj))
-print('<<<JSON')
+print("<<<JSON")

--- a/pythonFiles/interpreterInfo.py
+++ b/pythonFiles/interpreterInfo.py
@@ -10,6 +10,6 @@ obj["sysPrefix"] = sys.prefix
 obj["sysVersion"] = sys.version
 obj["is64Bit"] = sys.maxsize > 2 ** 32
 
-print('>>>JSON')
+print('>>>JSON') # Printing out markers for our JSON to make it more resilient to pull it out.
 print(json.dumps(obj))
 print('<<<JSON')

--- a/pythonFiles/interpreterInfo.py
+++ b/pythonFiles/interpreterInfo.py
@@ -10,4 +10,6 @@ obj["sysPrefix"] = sys.prefix
 obj["sysVersion"] = sys.version
 obj["is64Bit"] = sys.maxsize > 2 ** 32
 
+print('>>>JSON')
 print(json.dumps(obj))
+print('<<<JSON')

--- a/src/client/common/process/internal/scripts/index.ts
+++ b/src/client/common/process/internal/scripts/index.ts
@@ -41,15 +41,15 @@ export type InterpreterInfoJson = {
     is64Bit: boolean;
 };
 
-export function interpreterInfo(): [string[], (out: string) => InterpreterInfoJson] {
+export function interpreterInfo(): [string[], (out: string) => InterpreterInfoJson | undefined] {
     const script = path.join(SCRIPTS_DIR, 'interpreterInfo.py');
     const args = [script];
 
-    function parse(out: string): InterpreterInfoJson {
+    function parse(out: string): InterpreterInfoJson | undefined {
         const regex = />>>JSON([\s\S]*)<<<JSON/;
         const match = out.match(regex);
         const filteredOut = match !== null && match.length >= 2 ? match[1].trim() : '';
-        let json: InterpreterInfoJson;
+        let json: InterpreterInfoJson | undefined;
         try {
             json = JSON.parse(filteredOut);
         } catch (ex) {

--- a/src/client/common/process/internal/scripts/index.ts
+++ b/src/client/common/process/internal/scripts/index.ts
@@ -46,11 +46,14 @@ export function interpreterInfo(): [string[], (out: string) => InterpreterInfoJs
     const args = [script];
 
     function parse(out: string): InterpreterInfoJson {
+        const regex = />>>JSON([\s\S]*)<<<JSON/;
+        const match = out.match(regex);
+        const filteredOut = match !== null && match.length >= 2 ? match[1].trim() : '';
         let json: InterpreterInfoJson;
         try {
-            json = JSON.parse(out);
+            json = JSON.parse(filteredOut);
         } catch (ex) {
-            throw Error(`python ${args} returned bad JSON (${out}) (${ex})`);
+            throw Error(`python ${args} returned bad JSON (${out}) (${filteredOut}) (${ex})`);
         }
         return json;
     }

--- a/src/client/pythonEnvironments/base/info/interpreter.ts
+++ b/src/client/pythonEnvironments/base/info/interpreter.ts
@@ -83,10 +83,14 @@ export async function getInterpreterInfo(python: PythonExecInfo): Promise<Interp
     // https://github.com/microsoft/vscode-python/issues/7760
     const result = await shellExecute(quoted, { timeout: 15000 });
     if (result.stderr) {
-        traceError(`Failed to parse interpreter information for ${argv} stderr: ${result.stderr}`);
-        return undefined;
+        traceError(
+            `Stderr when executing script with ${argv} stderr: ${result.stderr}, still attempting to parse output`,
+        );
     }
     const json = parse(result.stdout);
+    if (!json) {
+        return undefined;
+    }
     traceInfo(`Found interpreter for ${argv}`);
     return extractInterpreterInfo(python.pythonExecutable, json);
 }

--- a/src/client/pythonEnvironments/info/interpreter.ts
+++ b/src/client/pythonEnvironments/info/interpreter.ts
@@ -86,11 +86,13 @@ export async function getInterpreterInfo(
         if (logger) {
             logger.error(`Failed to parse interpreter information for ${argv} stderr: ${result.stderr}`);
         }
-        return undefined;
     }
     const json = parse(result.stdout);
     if (logger) {
         logger.info(`Found interpreter for ${argv}`);
+    }
+    if (!json) {
+        return undefined;
     }
     return extractInterpreterInfo(python.pythonExecutable, json);
 }

--- a/src/test/common/process/pythonEnvironment.unit.test.ts
+++ b/src/test/common/process/pythonEnvironment.unit.test.ts
@@ -36,7 +36,13 @@ suite('PythonEnvironment', () => {
 
         processService
             .setup((p) => p.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-            .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
+            .returns(() =>
+                Promise.resolve({
+                    stdout: `>>>JSON
+${JSON.stringify(json)}
+<<<JSON`,
+                }),
+            );
         const env = createPythonEnv(pythonPath, processService.object, fileSystem.object);
 
         const result = await env.getInterpreterInformation();
@@ -61,7 +67,13 @@ suite('PythonEnvironment', () => {
 
         processService
             .setup((p) => p.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-            .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
+            .returns(() =>
+                Promise.resolve({
+                    stdout: `>>>JSON
+${JSON.stringify(json)}
+<<<JSON`,
+                }),
+            );
         const env = createPythonEnv(pythonPath, processService.object, fileSystem.object);
 
         const result = await env.getInterpreterInformation();
@@ -89,7 +101,13 @@ suite('PythonEnvironment', () => {
 
         processService
             .setup((p) => p.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-            .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
+            .returns(() =>
+                Promise.resolve({
+                    stdout: `>>>JSON
+${JSON.stringify(json)}
+<<<JSON`,
+                }),
+            );
         const env = createPythonEnv(pythonPath, processService.object, fileSystem.object);
 
         const result = await env.getInterpreterInformation();
@@ -117,7 +135,13 @@ suite('PythonEnvironment', () => {
 
         processService
             .setup((p) => p.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-            .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
+            .returns(() =>
+                Promise.resolve({
+                    stdout: `>>>JSON
+${JSON.stringify(json)}
+<<<JSON`,
+                }),
+            );
         const env = createPythonEnv(pythonPath, processService.object, fileSystem.object);
 
         const result = await env.getInterpreterInformation();

--- a/src/test/pythonEnvironments/base/info/environmentInfoService.functional.test.ts
+++ b/src/test/pythonEnvironments/base/info/environmentInfoService.functional.test.ts
@@ -50,6 +50,7 @@ suite('Environment Info Service', () => {
                 resolve({
                     stdout:
                         'SomeGarbage>>>JSON\n{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}\n<<<JSON_SomeGarbage',
+                    stderr: 'Some std error', // This should be ignored.
                 });
             }),
         );

--- a/src/test/pythonEnvironments/base/info/environmentInfoService.functional.test.ts
+++ b/src/test/pythonEnvironments/base/info/environmentInfoService.functional.test.ts
@@ -49,7 +49,7 @@ suite('Environment Info Service', () => {
             new Promise<ExecutionResult<string>>((resolve) => {
                 resolve({
                     stdout:
-                        '{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}',
+                        'SomeGarbage>>>JSON\n{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}\n<<<JSON_SomeGarbage',
                 });
             }),
         );

--- a/src/test/pythonEnvironments/base/locators/composite/envsResolver.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/composite/envsResolver.unit.test.ts
@@ -160,7 +160,6 @@ suite('Python envs locator - Environments Resolver', () => {
             stubShellExec.returns(
                 new Promise<ExecutionResult<string>>((resolve) => {
                     resolve({
-                        stderr: 'Kaboom',
                         stdout: '',
                     });
                 }),
@@ -295,7 +294,7 @@ suite('Python envs locator - Environments Resolver', () => {
             assert.deepEqual(expected, undefined);
         });
 
-        test('If fetching interpreter info fails with stderr, return undefined', async () => {
+        test('If parsing interpreter info fails, return undefined', async () => {
             stubShellExec.returns(
                 new Promise<ExecutionResult<string>>((resolve) => {
                     resolve({

--- a/src/test/pythonEnvironments/base/locators/composite/envsResolver.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/composite/envsResolver.unit.test.ts
@@ -96,7 +96,7 @@ suite('Python envs locator - Environments Resolver', () => {
                 new Promise<ExecutionResult<string>>((resolve) => {
                     resolve({
                         stdout:
-                            '{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}',
+                            'SomeGarbage>>>JSON\n{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}\n<<<JSON_SomeGarbage',
                     });
                 }),
             );
@@ -251,7 +251,7 @@ suite('Python envs locator - Environments Resolver', () => {
                 new Promise<ExecutionResult<string>>((resolve) => {
                     resolve({
                         stdout:
-                            '{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}',
+                            'SomeGarbage>>>JSON\n{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}\n<<<JSON_SomeGarbage',
                     });
                 }),
             );

--- a/src/test/pythonEnvironments/info/interpreter.unit.test.ts
+++ b/src/test/pythonEnvironments/info/interpreter.unit.test.ts
@@ -44,7 +44,13 @@ suite('getInterpreterInfo()', () => {
         deps
             // Checking the args is the key point of this test.
             .setup((d) => d.shellExec(cmd, 15000))
-            .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
+            .returns(() =>
+                Promise.resolve({
+                    stdout: `>>>JSON
+${JSON.stringify(json)}
+<<<JSON`,
+                }),
+            );
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
         await getInterpreterInfo(python, shellExec);
@@ -64,7 +70,13 @@ suite('getInterpreterInfo()', () => {
         deps
             // Checking the args is the key point of this test.
             .setup((d) => d.shellExec(cmd, 15000))
-            .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
+            .returns(() =>
+                Promise.resolve({
+                    stdout: `>>>JSON
+${JSON.stringify(json)}
+<<<JSON`,
+                }),
+            );
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
         await getInterpreterInfo(_python, shellExec);
@@ -84,7 +96,13 @@ suite('getInterpreterInfo()', () => {
         deps
             // Checking the args is the key point of this test.
             .setup((d) => d.shellExec(cmd, 15000))
-            .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
+            .returns(() =>
+                Promise.resolve({
+                    stdout: `>>>JSON
+${JSON.stringify(json)}
+<<<JSON`,
+                }),
+            );
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
         await getInterpreterInfo(_python, shellExec);
@@ -109,7 +127,13 @@ suite('getInterpreterInfo()', () => {
         deps
             // We check the args in other tests.
             .setup((d) => d.shellExec(TypeMoqIt.isAny(), TypeMoqIt.isAny()))
-            .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
+            .returns(() =>
+                Promise.resolve({
+                    stdout: `>>>JSON
+${JSON.stringify(json)}
+<<<JSON`,
+                }),
+            );
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
         const result = await getInterpreterInfo(python, shellExec);
@@ -135,7 +159,13 @@ suite('getInterpreterInfo()', () => {
         deps
             // We check the args in other tests.
             .setup((d) => d.shellExec(TypeMoqIt.isAny(), TypeMoqIt.isAny()))
-            .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
+            .returns(() =>
+                Promise.resolve({
+                    stdout: `>>>JSON
+${JSON.stringify(json)}
+<<<JSON`,
+                }),
+            );
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
         const result = await getInterpreterInfo(python, shellExec);
@@ -161,7 +191,13 @@ suite('getInterpreterInfo()', () => {
         deps
             // We check the args in other tests.
             .setup((d) => d.shellExec(TypeMoqIt.isAny(), TypeMoqIt.isAny()))
-            .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
+            .returns(() =>
+                Promise.resolve({
+                    stdout: `>>>JSON
+${JSON.stringify(json)}
+<<<JSON`,
+                }),
+            );
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
         const result = await getInterpreterInfo(python, shellExec);


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/18173

`conda run` activates conda env before running the desired script, which can print out more than just what the script prints.