### PR TITLE
Intercept `conda run` output to filter out stdout from the script which is run

### DIFF
--- a/pythonFiles/conda_run_script.py
+++ b/pythonFiles/conda_run_script.py
@@ -10,7 +10,7 @@ import sys
 # Activating conda can print out stuff before the actual output is
 # printed. Hence, printing out markers to make it more resilient to
 # pull the output.
-print(">>>CONDARUNOUTPUT")
+print(">>>CONDARUNOUTPUT", end="")
 
 module = sys.argv[1]
 if module == "-c":
@@ -24,4 +24,4 @@ elif module.endswith(".py"):
 else:
     runpy.run_module(module, run_name="__main__", alter_sys=True)
 
-print("<<<CONDARUNOUTPUT")
+print("<<<CONDARUNOUTPUT", end="")

--- a/pythonFiles/conda_run_script.py
+++ b/pythonFiles/conda_run_script.py
@@ -10,7 +10,7 @@ import sys
 # Activating conda can print out stuff before the actual output is
 # printed. Hence, printing out markers to make it more resilient to
 # pull the output.
-print(">>>EXTENSIONOUTPUT")
+print(">>>CONDARUNOUTPUT")
 
 module = sys.argv[1]
 if module == "-c":
@@ -24,4 +24,4 @@ elif module.endswith(".py"):
 else:
     runpy.run_module(module, run_name="__main__", alter_sys=True)
 
-print("<<<EXTENSIONOUTPUT")
+print("<<<CONDARUNOUTPUT")

--- a/pythonFiles/conda_run_script.py
+++ b/pythonFiles/conda_run_script.py
@@ -7,7 +7,9 @@ if __name__ != "__main__":
 import runpy
 import sys
 
-# Printing out markers to make it more resilient to pull the output.
+# Activating conda can print out stuff before the actual output is
+# printed. Hence, printing out markers to make it more resilient to
+# pull the output.
 print(">>>EXTENSIONOUTPUT")
 
 module = sys.argv[1]

--- a/pythonFiles/conda_run_script.py
+++ b/pythonFiles/conda_run_script.py
@@ -4,19 +4,13 @@
 if __name__ != "__main__":
     raise Exception("{} cannot be imported".format(__name__))
 
-import os
-import os.path
 import runpy
 import sys
 
-
-def normalize(path):
-    return os.path.normcase(os.path.normpath(path))
-
+# Printing out markers to make it more resilient to pull the output.
+print(">>>EXTENSIONOUTPUT")
 
 module = sys.argv[1]
-# Printing out markers to make it more resilient to pull the output. Especially useful for `conda run`.
-print(">>>EXTENSIONOUTPUT")
 if module == "-c":
     ns = {}
     for code in sys.argv[2:]:
@@ -27,4 +21,5 @@ elif module.endswith(".py"):
     runpy.run_path(module, run_name="__main__")
 else:
     runpy.run_module(module, run_name="__main__", alter_sys=True)
+
 print("<<<EXTENSIONOUTPUT")

--- a/pythonFiles/conda_run_script.py
+++ b/pythonFiles/conda_run_script.py
@@ -15,6 +15,7 @@ def normalize(path):
 
 
 module = sys.argv[1]
+# Printing out markers to make it more resilient to pull the output. Especially useful for `conda run`.
 print(">>>EXTENSIONOUTPUT")
 if module == "-c":
     ns = {}

--- a/pythonFiles/conda_run_script.py
+++ b/pythonFiles/conda_run_script.py
@@ -1,16 +1,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-if __name__ != "__main__":
-    raise Exception("{} cannot be imported".format(__name__))
-
 import runpy
 import sys
 
 # Activating conda can print out stuff before the actual output is
 # printed. Hence, printing out markers to make it more resilient to
 # pull the output.
-print(">>>CONDARUNOUTPUT", end="")
+print(">>>CONDA-RUN-OUTPUT", end="")
 
 module = sys.argv[1]
 if module == "-c":
@@ -24,4 +21,4 @@ elif module.endswith(".py"):
 else:
     runpy.run_module(module, run_name="__main__", alter_sys=True)
 
-print("<<<CONDARUNOUTPUT", end="")
+print("<<<CONDA-RUN-OUTPUT", end="")

--- a/pythonFiles/conda_run_script.py
+++ b/pythonFiles/conda_run_script.py
@@ -1,0 +1,29 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+if __name__ != "__main__":
+    raise Exception("{} cannot be imported".format(__name__))
+
+import os
+import os.path
+import runpy
+import sys
+
+
+def normalize(path):
+    return os.path.normcase(os.path.normpath(path))
+
+
+module = sys.argv[1]
+print(">>>EXTENSIONOUTPUT")
+if module == "-c":
+    ns = {}
+    for code in sys.argv[2:]:
+        exec(code, ns, ns)
+elif module.startswith("-"):
+    raise NotImplementedError(sys.argv)
+elif module.endswith(".py"):
+    runpy.run_path(module, run_name="__main__")
+else:
+    runpy.run_module(module, run_name="__main__", alter_sys=True)
+print("<<<EXTENSIONOUTPUT")

--- a/pythonFiles/interpreterInfo.py
+++ b/pythonFiles/interpreterInfo.py
@@ -10,7 +10,4 @@ obj["sysPrefix"] = sys.prefix
 obj["sysVersion"] = sys.version
 obj["is64Bit"] = sys.maxsize > 2 ** 32
 
-# Printing out markers for our JSON to make it more resilient to pull the output.
-print(">>>JSON")
 print(json.dumps(obj))
-print("<<<JSON")

--- a/src/client/common/process/internal/scripts/index.ts
+++ b/src/client/common/process/internal/scripts/index.ts
@@ -46,14 +46,11 @@ export function interpreterInfo(): [string[], (out: string) => InterpreterInfoJs
     const args = [script];
 
     function parse(out: string): InterpreterInfoJson | undefined {
-        const regex = />>>JSON([\s\S]*)<<<JSON/;
-        const match = out.match(regex);
-        const filteredOut = match !== null && match.length >= 2 ? match[1].trim() : '';
         let json: InterpreterInfoJson | undefined;
         try {
-            json = JSON.parse(filteredOut);
+            json = JSON.parse(out);
         } catch (ex) {
-            throw Error(`python ${args} returned bad JSON (${out}) (${filteredOut}) (${ex})`);
+            throw Error(`python ${args} returned bad JSON (${out}) (${ex})`);
         }
         return json;
     }

--- a/src/client/common/process/rawProcessApis.ts
+++ b/src/client/common/process/rawProcessApis.ts
@@ -163,7 +163,7 @@ function filterOutputUsingCondaRunMarkers(stdout: string) {
     // These markers are added if conda run is used, see `conda_run_script.py`.
     const regex = />>>CONDARUNOUTPUT([\s\S]*)<<<CONDARUNOUTPUT/;
     const match = stdout.match(regex);
-    const filteredOut = match !== null && match.length >= 2 ? match[1].trim() : '';
+    const filteredOut = match !== null && match.length >= 2 ? match[1] : '';
     return filteredOut.length ? filteredOut : stdout;
 }
 

--- a/src/client/common/process/rawProcessApis.ts
+++ b/src/client/common/process/rawProcessApis.ts
@@ -161,15 +161,15 @@ export function plainExec(
 
 function filterOutputUsingCondaRunMarkers(stdout: string) {
     // These markers are added if conda run is used, see `conda_run_script.py`.
-    const regex = />>>CONDARUNOUTPUT([\s\S]*)<<<CONDARUNOUTPUT/;
+    const regex = />>>CONDA-RUN-OUTPUT([\s\S]*)<<<CONDA-RUN-OUTPUT/;
     const match = stdout.match(regex);
     const filteredOut = match !== null && match.length >= 2 ? match[1] : '';
     return filteredOut.length ? filteredOut : stdout;
 }
 
 function removeCondaRunMarkers(out: string) {
-    out = out.replace('>>>CONDARUNOUTPUT', '');
-    return out.replace('<<<CONDARUNOUTPUT', '');
+    out = out.replace('>>>CONDA-RUN-OUTPUT', '');
+    return out.replace('<<<CONDA-RUN-OUTPUT', '');
 }
 
 export function execObservable(

--- a/src/client/common/process/rawProcessApis.ts
+++ b/src/client/common/process/rawProcessApis.ts
@@ -68,6 +68,10 @@ export function shellExec(
             } else {
                 // Make sure stderr is undefined if we actually had none. This is checked
                 // elsewhere because that's how exec behaves.
+                const regex = />>>EXTENSIONOUTPUT([\s\S]*)<<<EXTENSIONOUTPUT/;
+                const match = stdout.match(regex);
+                const filteredOut = match !== null && match.length >= 2 ? match[1].trim() : '';
+                stdout = filteredOut.length ? filteredOut : stdout;
                 resolve({ stderr: stderr && stderr.length > 0 ? stderr : undefined, stdout });
             }
         };
@@ -144,7 +148,11 @@ export function plainExec(
         if (stderr && stderr.length > 0 && options.throwOnStdErr) {
             deferred.reject(new StdErrError(stderr));
         } else {
-            const stdout = decoder ? decoder.decode(stdoutBuffers, encoding) : '';
+            let stdout = decoder ? decoder.decode(stdoutBuffers, encoding) : '';
+            const regex = />>>EXTENSIONOUTPUT([\s\S]*)<<<EXTENSIONOUTPUT/;
+            const match = stdout.match(regex);
+            const filteredOut = match !== null && match.length >= 2 ? match[1].trim() : '';
+            stdout = filteredOut.length ? filteredOut : stdout;
             deferred.resolve({ stdout, stderr });
         }
         internalDisposables.forEach((d) => d.dispose());

--- a/src/client/common/process/rawProcessApis.ts
+++ b/src/client/common/process/rawProcessApis.ts
@@ -66,7 +66,7 @@ export function shellExec(
             } else if (shellOptions.throwOnStdErr && stderr && stderr.length) {
                 reject(new Error(stderr));
             } else {
-                stdout = filterOutputUsingMarkers(stdout);
+                stdout = filterOutputUsingCondaRunMarkers(stdout);
                 // Make sure stderr is undefined if we actually had none. This is checked
                 // elsewhere because that's how exec behaves.
                 resolve({ stderr: stderr && stderr.length > 0 ? stderr : undefined, stdout });
@@ -146,7 +146,7 @@ export function plainExec(
             deferred.reject(new StdErrError(stderr));
         } else {
             let stdout = decoder ? decoder.decode(stdoutBuffers, encoding) : '';
-            stdout = filterOutputUsingMarkers(stdout);
+            stdout = filterOutputUsingCondaRunMarkers(stdout);
             deferred.resolve({ stdout, stderr });
         }
         internalDisposables.forEach((d) => d.dispose());
@@ -159,12 +159,17 @@ export function plainExec(
     return deferred.promise;
 }
 
-function filterOutputUsingMarkers(stdout: string) {
+function filterOutputUsingCondaRunMarkers(stdout: string) {
     // These markers are added if conda run is used, see `conda_run_script.py`.
-    const regex = />>>EXTENSIONOUTPUT([\s\S]*)<<<EXTENSIONOUTPUT/;
+    const regex = />>>CONDARUNOUTPUT([\s\S]*)<<<CONDARUNOUTPUT/;
     const match = stdout.match(regex);
     const filteredOut = match !== null && match.length >= 2 ? match[1].trim() : '';
     return filteredOut.length ? filteredOut : stdout;
+}
+
+function removeCondaRunMarkers(out: string) {
+    out = out.replace('>>>CONDARUNOUTPUT', '');
+    return out.replace('<<<CONDARUNOUTPUT', '');
 }
 
 export function execObservable(
@@ -214,10 +219,14 @@ export function execObservable(
         }
 
         const sendOutput = (source: 'stdout' | 'stderr', data: Buffer) => {
-            const out = decoder ? decoder.decode([data], encoding) : '';
+            let out = decoder ? decoder.decode([data], encoding) : '';
             if (source === 'stderr' && options.throwOnStdErr) {
                 subscriber.error(new StdErrError(out));
             } else {
+                // Because all of output is not retrieved at once, filtering out the
+                // actual output using markers is not possible. Hence simply remove
+                // the markers and return original output.
+                out = removeCondaRunMarkers(out);
                 subscriber.next({ source, out });
             }
         };

--- a/src/client/common/process/rawProcessApis.ts
+++ b/src/client/common/process/rawProcessApis.ts
@@ -160,6 +160,7 @@ export function plainExec(
 }
 
 function filterOutputUsingMarkers(stdout: string) {
+    // These markers are added if conda run is used, see `conda_run_script.py`.
     const regex = />>>EXTENSIONOUTPUT([\s\S]*)<<<EXTENSIONOUTPUT/;
     const match = stdout.match(regex);
     const filteredOut = match !== null && match.length >= 2 ? match[1].trim() : '';

--- a/src/client/pythonEnvironments/base/info/environmentInfoService.ts
+++ b/src/client/pythonEnvironments/base/info/environmentInfoService.ts
@@ -7,7 +7,7 @@ import { createRunningWorkerPool, IWorkerPool, QueuePosition } from '../../../co
 import { getInterpreterInfo, InterpreterInformation } from './interpreter';
 import { buildPythonExecInfo } from '../../exec';
 import { traceError } from '../../../logging';
-import { Conda, CONDA_RUN_TIMEOUT } from '../../common/environmentManagers/conda';
+import { Conda, CONDA_RUN_TIMEOUT, CONDA_RUN_SCRIPT } from '../../common/environmentManagers/conda';
 import { PythonEnvInfo, PythonEnvKind } from '.';
 
 export enum EnvironmentInfoServiceQueuePriority {
@@ -30,7 +30,7 @@ async function buildEnvironmentInfo(env: PythonEnvInfo): Promise<InterpreterInfo
         const conda = await Conda.getConda();
         const runArgs = await conda?.getRunArgs({ name: env.name, prefix: env.location });
         if (runArgs) {
-            python = [...runArgs, 'python'];
+            python = [...runArgs, 'python', CONDA_RUN_SCRIPT];
         }
     }
     const interpreterInfo = await getInterpreterInfo(

--- a/src/client/pythonEnvironments/common/environmentManagers/conda.ts
+++ b/src/client/pythonEnvironments/common/environmentManagers/conda.ts
@@ -12,6 +12,7 @@ import { EnvironmentType, PythonEnvironment } from '../../info';
 import { cache } from '../../../common/utils/decorators';
 import { isTestExecution } from '../../../common/constants';
 import { traceError, traceVerbose } from '../../../logging';
+import { _SCRIPTS_DIR } from '../../../common/process/internal/scripts/constants';
 
 export const AnacondaCompanyName = 'Anaconda, Inc.';
 
@@ -202,6 +203,8 @@ export async function getPythonVersionFromConda(interpreterPath: string): Promis
 // Minimum version number of conda required to be able to use 'conda run' with '--no-capture-output' flag.
 export const CONDA_RUN_VERSION = '4.9.0';
 export const CONDA_RUN_TIMEOUT = 45000;
+
+export const CONDA_RUN_SCRIPT = path.join(_SCRIPTS_DIR, 'conda_run_script.py');
 
 /** Wraps the "conda" utility, and exposes its functionality.
  */

--- a/src/test/common/process/proc.exec.test.ts
+++ b/src/test/common/process/proc.exec.test.ts
@@ -134,7 +134,7 @@ suite('ProcessService Observable', () => {
         this.timeout(7000);
         const procService = new ProcessService(new BufferDecoder());
         const pythonCode = [
-            'print(">>>CONDARUNOUTPUT")',
+            'print(">>>CONDA-RUN-OUTPUT")',
             'import sys',
             'import time',
             'print("1")',
@@ -154,7 +154,7 @@ suite('ProcessService Observable', () => {
             'time.sleep(1)',
             'sys.stderr.write("c")',
             'sys.stderr.flush()',
-            'print("<<<CONDARUNOUTPUT")',
+            'print("<<<CONDA-RUN-OUTPUT")',
         ];
         const result = await procService.exec(pythonPath, ['-c', pythonCode.join(';')]);
         const expectedStdout = ['1', '2', '3'];
@@ -234,7 +234,7 @@ suite('ProcessService Observable', () => {
         const procService = new ProcessService(new BufferDecoder());
         const printOutput = '1234';
         const result = await procService.shellExec(
-            `"${pythonPath}" -c "print('>>>CONDARUNOUTPUT');print('${printOutput}');print('<<<CONDARUNOUTPUT')"`,
+            `"${pythonPath}" -c "print('>>>CONDA-RUN-OUTPUT');print('${printOutput}');print('<<<CONDA-RUN-OUTPUT')"`,
         );
 
         expect(result).not.to.be.an('undefined', 'result is undefined');

--- a/src/test/common/process/proc.exec.test.ts
+++ b/src/test/common/process/proc.exec.test.ts
@@ -130,10 +130,11 @@ suite('ProcessService Observable', () => {
         expect(result.stderr).to.equal(undefined, 'stderr not undefined');
     });
 
-    test('exec should stream stdout and stderr separately', async function () {
+    test('exec should stream stdout and stderr separately and filter output using conda related markers', async function () {
         this.timeout(7000);
         const procService = new ProcessService(new BufferDecoder());
         const pythonCode = [
+            'print(">>>CONDARUNOUTPUT")',
             'import sys',
             'import time',
             'print("1")',
@@ -153,6 +154,7 @@ suite('ProcessService Observable', () => {
             'time.sleep(1)',
             'sys.stderr.write("c")',
             'sys.stderr.flush()',
+            'print("<<<CONDARUNOUTPUT")',
         ];
         const result = await procService.exec(pythonPath, ['-c', pythonCode.join(';')]);
         const expectedStdout = ['1', '2', '3'];
@@ -228,10 +230,12 @@ suite('ProcessService Observable', () => {
         expect(result.stdout).equals('', 'stdout is invalid');
         expect(result.stderr).equals(undefined, 'stderr is invalid');
     });
-    test('shellExec should be able to run python too', async () => {
+    test('shellExec should be able to run python and filter output using conda related markers', async () => {
         const procService = new ProcessService(new BufferDecoder());
         const printOutput = '1234';
-        const result = await procService.shellExec(`"${pythonPath}" -c "print('${printOutput}')"`);
+        const result = await procService.shellExec(
+            `"${pythonPath}" -c "print('>>>CONDARUNOUTPUT');print('${printOutput}');print('<<<CONDARUNOUTPUT')"`,
+        );
 
         expect(result).not.to.be.an('undefined', 'result is undefined');
         expect(result.stderr).to.equal(undefined, 'stderr not empty');

--- a/src/test/common/process/proc.observable.test.ts
+++ b/src/test/common/process/proc.observable.test.ts
@@ -194,10 +194,11 @@ suite('ProcessService', () => {
         );
     });
 
-    test('execObservable should stream stdout and stderr separately', function (done) {
+    test('execObservable should stream stdout and stderr separately and removes markers related to conda run', function (done) {
         this.timeout(20000);
         const procService = new ProcessService(new BufferDecoder());
         const pythonCode = [
+            'print(">>>CONDARUNOUTPUT")',
             'import sys',
             'import time',
             'print("1")',
@@ -218,6 +219,7 @@ suite('ProcessService', () => {
             'sys.stderr.write("c")',
             'sys.stderr.flush()',
             'time.sleep(2)',
+            'print("<<<CONDARUNOUTPUT")',
         ];
         const result = procService.execObservable(pythonPath, ['-c', pythonCode.join(';')]);
         const outputs = [
@@ -246,7 +248,6 @@ suite('ProcessService', () => {
             done,
         );
     });
-
     test('execObservable should send stdout and stderr streams separately', async function () {
         // This test is failing on Windows. Tracked by GH #4755.
         if (isOs(OSType.Windows)) {

--- a/src/test/common/process/proc.observable.test.ts
+++ b/src/test/common/process/proc.observable.test.ts
@@ -198,7 +198,7 @@ suite('ProcessService', () => {
         this.timeout(20000);
         const procService = new ProcessService(new BufferDecoder());
         const pythonCode = [
-            'print(">>>CONDARUNOUTPUT")',
+            'print(">>>CONDA-RUN-OUTPUT")',
             'import sys',
             'import time',
             'print("1")',
@@ -219,7 +219,7 @@ suite('ProcessService', () => {
             'sys.stderr.write("c")',
             'sys.stderr.flush()',
             'time.sleep(2)',
-            'print("<<<CONDARUNOUTPUT")',
+            'print("<<<CONDA-RUN-OUTPUT")',
         ];
         const result = procService.execObservable(pythonPath, ['-c', pythonCode.join(';')]);
         const outputs = [

--- a/src/test/common/process/pythonEnvironment.unit.test.ts
+++ b/src/test/common/process/pythonEnvironment.unit.test.ts
@@ -38,9 +38,7 @@ suite('PythonEnvironment', () => {
             .setup((p) => p.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() =>
                 Promise.resolve({
-                    stdout: `>>>JSON
-${JSON.stringify(json)}
-<<<JSON`,
+                    stdout: JSON.stringify(json),
                 }),
             );
         const env = createPythonEnv(pythonPath, processService.object, fileSystem.object);
@@ -69,9 +67,7 @@ ${JSON.stringify(json)}
             .setup((p) => p.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() =>
                 Promise.resolve({
-                    stdout: `>>>JSON
-${JSON.stringify(json)}
-<<<JSON`,
+                    stdout: JSON.stringify(json),
                 }),
             );
         const env = createPythonEnv(pythonPath, processService.object, fileSystem.object);
@@ -103,9 +99,7 @@ ${JSON.stringify(json)}
             .setup((p) => p.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() =>
                 Promise.resolve({
-                    stdout: `>>>JSON
-${JSON.stringify(json)}
-<<<JSON`,
+                    stdout: JSON.stringify(json),
                 }),
             );
         const env = createPythonEnv(pythonPath, processService.object, fileSystem.object);
@@ -137,9 +131,7 @@ ${JSON.stringify(json)}
             .setup((p) => p.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() =>
                 Promise.resolve({
-                    stdout: `>>>JSON
-${JSON.stringify(json)}
-<<<JSON`,
+                    stdout: JSON.stringify(json),
                 }),
             );
         const env = createPythonEnv(pythonPath, processService.object, fileSystem.object);

--- a/src/test/pythonEnvironments/base/info/environmentInfoService.functional.test.ts
+++ b/src/test/pythonEnvironments/base/info/environmentInfoService.functional.test.ts
@@ -49,7 +49,7 @@ suite('Environment Info Service', () => {
             new Promise<ExecutionResult<string>>((resolve) => {
                 resolve({
                     stdout:
-                        'SomeGarbage>>>JSON\n{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}\n<<<JSON_SomeGarbage',
+                        '{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}',
                     stderr: 'Some std error', // This should be ignored.
                 });
             }),

--- a/src/test/pythonEnvironments/base/locators/composite/envsResolver.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/composite/envsResolver.unit.test.ts
@@ -96,7 +96,7 @@ suite('Python envs locator - Environments Resolver', () => {
                 new Promise<ExecutionResult<string>>((resolve) => {
                     resolve({
                         stdout:
-                            'SomeGarbage>>>JSON\n{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}\n<<<JSON_SomeGarbage',
+                            '{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}',
                     });
                 }),
             );
@@ -250,7 +250,7 @@ suite('Python envs locator - Environments Resolver', () => {
                 new Promise<ExecutionResult<string>>((resolve) => {
                     resolve({
                         stdout:
-                            'SomeGarbage>>>JSON\n{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}\n<<<JSON_SomeGarbage',
+                            '{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}',
                     });
                 }),
             );

--- a/src/test/pythonEnvironments/info/interpreter.unit.test.ts
+++ b/src/test/pythonEnvironments/info/interpreter.unit.test.ts
@@ -46,9 +46,7 @@ suite('getInterpreterInfo()', () => {
             .setup((d) => d.shellExec(cmd, 15000))
             .returns(() =>
                 Promise.resolve({
-                    stdout: `>>>JSON
-${JSON.stringify(json)}
-<<<JSON`,
+                    stdout: JSON.stringify(json),
                 }),
             );
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
@@ -72,9 +70,7 @@ ${JSON.stringify(json)}
             .setup((d) => d.shellExec(cmd, 15000))
             .returns(() =>
                 Promise.resolve({
-                    stdout: `>>>JSON
-${JSON.stringify(json)}
-<<<JSON`,
+                    stdout: JSON.stringify(json),
                 }),
             );
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
@@ -98,9 +94,7 @@ ${JSON.stringify(json)}
             .setup((d) => d.shellExec(cmd, 15000))
             .returns(() =>
                 Promise.resolve({
-                    stdout: `>>>JSON
-${JSON.stringify(json)}
-<<<JSON`,
+                    stdout: JSON.stringify(json),
                 }),
             );
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
@@ -129,9 +123,7 @@ ${JSON.stringify(json)}
             .setup((d) => d.shellExec(TypeMoqIt.isAny(), TypeMoqIt.isAny()))
             .returns(() =>
                 Promise.resolve({
-                    stdout: `>>>JSON
-${JSON.stringify(json)}
-<<<JSON`,
+                    stdout: JSON.stringify(json),
                 }),
             );
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
@@ -161,9 +153,7 @@ ${JSON.stringify(json)}
             .setup((d) => d.shellExec(TypeMoqIt.isAny(), TypeMoqIt.isAny()))
             .returns(() =>
                 Promise.resolve({
-                    stdout: `>>>JSON
-${JSON.stringify(json)}
-<<<JSON`,
+                    stdout: JSON.stringify(json),
                 }),
             );
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
@@ -193,9 +183,7 @@ ${JSON.stringify(json)}
             .setup((d) => d.shellExec(TypeMoqIt.isAny(), TypeMoqIt.isAny()))
             .returns(() =>
                 Promise.resolve({
-                    stdout: `>>>JSON
-${JSON.stringify(json)}
-<<<JSON`,
+                    stdout: JSON.stringify(json),
                 }),
             );
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);


### PR DESCRIPTION
Instead of printing out markers just for the `interpreterInfo.py` script, intercept output of every script run via `conda run` and add the markers. This ensures pytest discovery etc. works with [these types of conda envs](https://github.com/microsoft/vscode-python/issues/18173). 