### PR TITLE
No longer test against Pylint for Python 2.7

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -5,7 +5,7 @@ autopep8
 bandit ; python_version >= '3.5'
 black ; python_version > '2.7'
 yapf
-pylint
+pylint ; python_version > '2.7'
 pycodestyle
 pydocstyle
 prospector ; python_version > '2.7'


### PR DESCRIPTION
`lazy-object-proxy` no longer supports Python 2 and Pylint didn't lock down its dependencies in its list Python 2-supported release.