### PR TITLE
Add initial support for pytest plugins

### DIFF
--- a/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py
+++ b/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py
@@ -155,7 +155,7 @@ def parse_item(
     """
     # _debug_item(item, showsummary=True)
     kind, _ = _get_item_kind(item)
-    # Skip plugin generated tests
+    # Skip unknown tests
     if kind is None:
         return None, None
 
@@ -408,6 +408,9 @@ def _parse_node_id(
             parameterized = testid[len(funcid) :]
         elif kind == "function":
             funcname = name
+        elif kind == "other":
+            # if kind is "other", we don't have a function necessarily
+            funcname = None
         else:
             raise should_never_reach_here(
                 testid,
@@ -538,6 +541,8 @@ def _get_item_kind(item):
     elif isinstance(item, pytest.Function):
         # We *could* be more specific, e.g. "method", "subtest".
         return "function", False
+    elif isinstance(item, pytest.Item):
+        return "other", False
     else:
         return None, False
 

--- a/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py
+++ b/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py
@@ -219,6 +219,7 @@ def parse_item(
             markers.add("expected-failure")
         # We can add support for other markers as we need them?
 
+    # TODO: preserve the correct test kind here instead of always using "function"
     test = SingleTestInfo(
         id=nodeid,
         name=item.name,

--- a/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
+++ b/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
@@ -94,7 +94,7 @@ class FakeMarker(object):
         self.name = name
 
 
-class StubPytestItem(util.StubProxy):
+class StubPytestItem(util.StubProxy, pytest.Item):
 
     _debugging = False
     _hasfunc = True
@@ -521,6 +521,7 @@ class CollectorTests(unittest.TestCase):
         testroot = adapter_util.fix_path("/a/b/c")
         relfile1 = adapter_util.fix_path("./test_spam.py")
         relfile2 = adapter_util.fix_path("x/y/z/test_eggs.py")
+        non_python_path = adapter_util.fix_path("e/f/abc.test")
 
         collector.pytest_collection_modifyitems(
             session,
@@ -596,6 +597,13 @@ class CollectorTests(unittest.TestCase):
                             "timeout",
                         ]
                     ],
+                ),
+                StubSubtypedItem.from_args(
+                    stub,
+                    nodeid="test_spam.py::SpamTests::abc.test::test_one",
+                    name="test_one",
+                    location=(non_python_path, 12, "test_one"),
+                    fspath=adapter_util.PATH_JOIN(testroot, "test_spam.py"),
                 ),
             ],
         )
@@ -770,6 +778,36 @@ class CollectorTests(unittest.TestCase):
                             ),
                             markers=["expected-failure", "skip", "skip-if"],
                             parentid="./x/y/z/test_eggs.py::All::BasicTests::test_each",
+                        ),
+                    ),
+                ),
+                (
+                    "discovered.add_test",
+                    None,
+                    dict(
+                        parents=[
+                            (
+                                "./test_spam.py::SpamTests::abc.test",
+                                "abc.test",
+                                "suite",
+                            ),
+                            ("./test_spam.py::SpamTests", "SpamTests", "suite"),
+                            ("./test_spam.py", "test_spam.py", "file"),
+                            (".", testroot, "folder"),
+                        ],
+                        test=info.SingleTestInfo(
+                            id="./test_spam.py::SpamTests::abc.test::test_one",
+                            name="test_one",
+                            path=info.SingleTestPath(
+                                root=testroot,
+                                relfile=adapter_util.fix_relpath(relfile1),
+                                func=None,
+                            ),
+                            source="{}:{}".format(
+                                adapter_util.fix_relpath(non_python_path), 13
+                            ),
+                            markers=[],
+                            parentid="./test_spam.py::SpamTests::abc.test",
                         ),
                     ),
                 ),


### PR DESCRIPTION
This adds initial support for pytest plugin-generated tests, including running and debugging tests, and opening tests in the editor (even if the location is a non-Python file).

Debugging non-Python files still isn't supported.

This PR has the consequence of making nodeids not always be unique, because a plugin could always generate multiple tests with the same name in the same suite. Most of the code seems to assume that they will be unique, though, because the UI only shows only one test even when multiple tests have the same nodeid.

I don't know what the ideal solution for that is, because the current behavior has some strange consequences when interacting with tests with repeated nodeids, but repeating nodeids seems like a bug considering that the [pytest docs](https://docs.pytest.org/en/6.2.x/usage.html) say that nodeids are supposed to be unique:
> Each collected test is assigned a unique nodeid

Work on #16742 and #16852
Both of those tests mention crashes with specific plugins, but I haven't tested any of those plugins so I don't know if those crashes are fixed.