### PR TITLE
Ensures python 2.x are discovered even when running `interpreterInfo.py` script prints more than just the script output

### DIFF
--- a/pythonFiles/get_output_via_markers.py
+++ b/pythonFiles/get_output_via_markers.py
@@ -7,7 +7,7 @@ import sys
 # Sometimes executing scripts can print out stuff before the actual output is
 # printed. For eg. when activating conda. Hence, printing out markers to make
 # it more resilient to pull the output.
-print(">>>PYTHON-EXEC-OUTPUT", end="")
+print(">>>PYTHON-EXEC-OUTPUT")
 
 module = sys.argv[1]
 if module == "-c":
@@ -21,4 +21,4 @@ elif module.endswith(".py"):
 else:
     runpy.run_module(module, run_name="__main__", alter_sys=True)
 
-print("<<<PYTHON-EXEC-OUTPUT", end="")
+print("<<<PYTHON-EXEC-OUTPUT")

--- a/src/client/common/process/rawProcessApis.ts
+++ b/src/client/common/process/rawProcessApis.ts
@@ -164,7 +164,7 @@ function filterOutputUsingCondaRunMarkers(stdout: string) {
     // run, see `get_output_via_markers.py`.
     const regex = />>>PYTHON-EXEC-OUTPUT([\s\S]*)<<<PYTHON-EXEC-OUTPUT/;
     const match = stdout.match(regex);
-    const filteredOut = match !== null && match.length >= 2 ? match[1] : '';
+    const filteredOut = match !== null && match.length >= 2 ? match[1].trim() : '';
     return filteredOut.length ? filteredOut : stdout;
 }
 


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/18234