### PR TITLE
Fixed regex for Pylama output

### DIFF
--- a/news/2 Fixes/15609.md
+++ b/news/2 Fixes/15609.md
@@ -1,0 +1,1 @@
+Fixes Pylama and MyPy output parsing (thanks [Nicola Marella](https://github.com/nicolamarella))

--- a/src/client/linters/pylama.ts
+++ b/src/client/linters/pylama.ts
@@ -6,7 +6,7 @@ import { BaseLinter } from './baseLinter';
 import { ILintMessage, LintMessageSeverity } from './types';
 
 const REGEX =
-    '(?<file>.py):(?<line>\\d+):(?<column>\\d+): \\[(?<type>\\w+)\\] (?<code>\\w\\d+):? (?<message>.*)\\r?(\\n|$)';
+    '(?<file>.py):(?<line>\\d+):(?<column>\\d+):? \\[(?<type>\\w+)\\] (?<code>\\w\\d+):? (?<message>.*)\\r?(\\n|$)';
 const COLUMN_OFF_SET = 1;
 
 export class PyLama extends BaseLinter {

--- a/src/client/linters/pylama.ts
+++ b/src/client/linters/pylama.ts
@@ -6,7 +6,7 @@ import { BaseLinter } from './baseLinter';
 import { ILintMessage, LintMessageSeverity } from './types';
 
 const REGEX =
-    '(?<file>.py):(?<line>\\d+):(?<column>\\d+):? \\[(?<type>\\w+)\\] (?<code>\\w\\d+):? (?<message>.*)\\r?(\\n|$)';
+    '(?<file>.py):(?<line>\\d+):(?<column>\\d+):? \\[(?<type>\\w+)\\]( (?<code>\\w\\d+)?:?)? (?<message>.*)\\r?(\\n|$)';
 const COLUMN_OFF_SET = 1;
 
 export class PyLama extends BaseLinter {


### PR DESCRIPTION
Closes #15609

Recently I couldn't see errors and warning from pylama linter. 
I believe there was a small change in the output format for `parsable` in pylama, the regex for parse the output is missing a semicolon. See https://github.com/klen/pylama/blob/227ddc94eb73638d423833075b1af2ac6bb308f7/pylama/main.py#L17https://github.com/klen/pylama/blob/227ddc94eb73638d423833075b1af2ac6bb308f7/pylama/main.py#L17
This should fix it.


### MyPy output
I added, additionally, the case of mypy output, not having that the error code. See https://github.com/microsoft/vscode-python/issues/15609#issuecomment-1019160416