### PR TITLE
Fix conda run output marker script

### DIFF
--- a/pythonFiles/get_output_via_markers.py
+++ b/pythonFiles/get_output_via_markers.py
@@ -10,15 +10,21 @@ import sys
 print(">>>PYTHON-EXEC-OUTPUT")
 
 module = sys.argv[1]
-if module == "-c":
-    ns = {}
-    for code in sys.argv[2:]:
-        exec(code, ns, ns)
-elif module.startswith("-"):
-    raise NotImplementedError(sys.argv)
-elif module.endswith(".py"):
-    runpy.run_path(module, run_name="__main__")
-else:
-    runpy.run_module(module, run_name="__main__", alter_sys=True)
-
-print("<<<PYTHON-EXEC-OUTPUT")
+try:
+    if module == "-c":
+        ns = {}
+        for code in sys.argv[2:]:
+            exec(code, ns, ns)
+    elif module.startswith("-m"):
+        moduleName = sys.argv[2]
+        sys.argv = sys.argv[2:]  # It should begin with the module name.
+        runpy.run_module(moduleName, run_name="__main__", alter_sys=True)
+    elif module.endswith(".py"):
+        sys.argv = sys.argv[1:]
+        runpy.run_path(module, run_name="__main__")
+    elif module.startswith("-"):
+        raise NotImplementedError(sys.argv)
+    else:
+        runpy.run_module(module, run_name="__main__", alter_sys=True)
+finally:
+    print("<<<PYTHON-EXEC-OUTPUT")

--- a/src/client/common/process/rawProcessApis.ts
+++ b/src/client/common/process/rawProcessApis.ts
@@ -164,8 +164,8 @@ function filterOutputUsingCondaRunMarkers(stdout: string) {
     // run, see `get_output_via_markers.py`.
     const regex = />>>PYTHON-EXEC-OUTPUT([\s\S]*)<<<PYTHON-EXEC-OUTPUT/;
     const match = stdout.match(regex);
-    const filteredOut = match !== null && match.length >= 2 ? match[1].trim() : '';
-    return filteredOut.length ? filteredOut : stdout;
+    const filteredOut = match !== null && match.length >= 2 ? match[1].trim() : undefined;
+    return filteredOut !== undefined ? filteredOut : stdout;
 }
 
 function removeCondaRunMarkers(out: string) {


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/18409

Adds support to handle the `-m` flag and fixes `sys.argv` when running python file via `run_path`.

cc / @brettcannon @karthiknadig If you have any other comments let me know and I can handle those later.