### PR TITLE
Add support for base interpreter paths

### DIFF
--- a/src/client/common/process/pythonEnvironment.ts
+++ b/src/client/common/process/pythonEnvironment.ts
@@ -109,6 +109,7 @@ function createDeps(
     return {
         getPythonArgv: (python: string) => {
             if (path.basename(python) === python) {
+                // Say when python is `py -3.8` or `conda run python`
                 pythonArgv = python.split(' ');
             }
             return pythonArgv || [python];

--- a/src/client/common/process/pythonEnvironment.ts
+++ b/src/client/common/process/pythonEnvironment.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import * as path from 'path';
 import { traceError, traceInfo } from '../../logging';
 import { Conda, CondaEnvironmentInfo } from '../../pythonEnvironments/common/environmentManagers/conda';
 import { buildPythonExecInfo, PythonExecInfo } from '../../pythonEnvironments/exec';
@@ -56,7 +57,7 @@ class PythonEnvironment implements IPythonEnvironment {
             return result;
         }
         const python = this.getExecutionInfo();
-        const promise = getExecutablePath(python, this.deps.exec);
+        const promise = getExecutablePath(python, this.deps.shellExec);
         this.cachedExecutablePath.set(this.pythonPath, promise);
         return promise;
     }
@@ -106,8 +107,18 @@ function createDeps(
     shellExec: (command: string, options?: ShellOptions) => Promise<ExecutionResult<string>>,
 ) {
     return {
-        getPythonArgv: (python: string) => pythonArgv || [python],
-        getObservablePythonArgv: (python: string) => observablePythonArgv || [python],
+        getPythonArgv: (python: string) => {
+            if (path.basename(python) === python) {
+                pythonArgv = python.split(' ');
+            }
+            return pythonArgv || [python];
+        },
+        getObservablePythonArgv: (python: string) => {
+            if (path.basename(python) === python) {
+                observablePythonArgv = python.split(' ');
+            }
+            return observablePythonArgv || [python];
+        },
         isValidExecutable,
         exec: async (cmd: string, args: string[]) => exec(cmd, args, { throwOnStdErr: true }),
         shellExec: async (text: string, timeout: number) => shellExec(text, { timeout }),

--- a/src/client/pythonEnvironments/info/executable.ts
+++ b/src/client/pythonEnvironments/info/executable.ts
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { getExecutable as getPythonExecutableCommand } from '../../common/process/internal/python';
+import { getExecutable } from '../../common/process/internal/python';
+import { ExecutionResult } from '../../common/process/types';
 import { copyPythonExecInfo, PythonExecInfo } from '../exec';
 
-type ExecResult = {
-    stdout: string;
-};
-type ExecFunc = (command: string, args: string[]) => Promise<ExecResult>;
+type ShellExecFunc = (command: string, timeout: number) => Promise<ExecutionResult<string>>;
 
 /**
  * Find the filename for the corresponding Python executable.
@@ -15,11 +13,18 @@ type ExecFunc = (command: string, args: string[]) => Promise<ExecResult>;
  * Effectively, we look up `sys.executable`.
  *
  * @param python - the information to use when running Python
- * @param exec - the function to use to run Python
+ * @param shellExec - the function to use to run Python
  */
-export async function getExecutablePath(python: PythonExecInfo, exec: ExecFunc): Promise<string> {
-    const [args, parse] = getPythonExecutableCommand();
+export async function getExecutablePath(
+    python: PythonExecInfo,
+    shellExec: ShellExecFunc,
+    timeout?: number,
+): Promise<string> {
+    const [args, parse] = getExecutable();
     const info = copyPythonExecInfo(python, args);
-    const result = await exec(info.command, info.args);
-    return parse(result.stdout);
+    const argv = [info.command, ...info.args];
+    // Concat these together to make a set of quoted strings
+    const quoted = argv.reduce((p, c) => (p ? `${p} ${c.toCommandArgument()}` : `${c.toCommandArgument()}`), '');
+    const result = await shellExec(quoted, timeout ?? 15000);
+    return parse(result.stdout.trim());
 }

--- a/src/test/common/process/pythonEnvironment.unit.test.ts
+++ b/src/test/common/process/pythonEnvironment.unit.test.ts
@@ -192,9 +192,8 @@ suite('PythonEnvironment', () => {
     test('getExecutablePath should not return pythonPath if pythonPath is not a file', async () => {
         const executablePath = 'path/to/dummy/executable';
         fileSystem.setup((f) => f.pathExists(pythonPath)).returns(() => Promise.resolve(false));
-        const argv = ['-c', 'import sys;print(sys.executable)'];
         processService
-            .setup((p) => p.exec(pythonPath, argv, { throwOnStdErr: true }))
+            .setup((p) => p.shellExec(`${pythonPath} -c "import sys;print(sys.executable)"`, TypeMoq.It.isAny()))
             .returns(() => Promise.resolve({ stdout: executablePath }));
         const env = createPythonEnv(pythonPath, processService.object, fileSystem.object);
 
@@ -206,9 +205,8 @@ suite('PythonEnvironment', () => {
     test('getExecutablePath should throw if the result of exec() writes to stderr', async () => {
         const stderr = 'bar';
         fileSystem.setup((f) => f.pathExists(pythonPath)).returns(() => Promise.resolve(false));
-        const argv = ['-c', 'import sys;print(sys.executable)'];
         processService
-            .setup((p) => p.exec(pythonPath, argv, { throwOnStdErr: true }))
+            .setup((p) => p.shellExec(`${pythonPath} -c "import sys;print(sys.executable)"`, TypeMoq.It.isAny()))
             .returns(() => Promise.reject(new StdErrError(stderr)));
         const env = createPythonEnv(pythonPath, processService.object, fileSystem.object);
 


### PR DESCRIPTION
We already have support for interpreter paths like `python`, `python3`, `python3.8` etc. (https://github.com/microsoft/vscode-python/pull/18440). This PR extends support for such base paths even if they contain a space. So `conda run python` or `py -3.8` can also be valid interpreter path values.

Base interpreter paths can be defined as paths for which the basename is same as the interpreter path.

cc/ @karthiknadig 