### PR TITLE
Fix pip-requirements filename patterns

### DIFF
--- a/news/1 Enhancements/18498.md
+++ b/news/1 Enhancements/18498.md
@@ -1,0 +1,1 @@
+Better filename patterns for pip-requirements. (thanks [Baptiste Darthenay](https://github.com/batisteo))

--- a/package.json
+++ b/package.json
@@ -1574,13 +1574,12 @@
                 ],
                 "configuration": "./languages/pip-requirements.json",
                 "filenamePatterns": [
-                    "*-constraints.txt",
-                    "*-requirements.in",
-                    "*-requirements.txt",
-                    "constraints-*.txt",
-                    "requirements-*.in",
-                    "requirements-*.txt"
-                ],
+                    "**/*-requirements.{txt, in}",
+                    "**/*-contstraints.txt",
+                    "**/requirements-*.{txt, in}",
+                    "**/constraints-*.txt",
+                    "**/requirements/*.{txt,in}",
+                    "**/constraints/*.txt"                ],
                 "filenames": [
                     "constraints.txt",
                     "requirements.in",


### PR DESCRIPTION
This fix is for projects that uses a `requirements` folder with files named `base.txt`, `production.txt` and such.

Fixes #18498.