### PR TITLE
Fix dismiss show error dialog for linter error

### DIFF
--- a/news/2 Fixes/18553.md
+++ b/news/2 Fixes/18553.md
@@ -1,0 +1,1 @@
+Properly dismiss the error popup dialog when having a linter error. (Thanks [Virgil Sisoe](https://github.com/sisoe24))

--- a/src/client/linters/errorHandlers/standard.ts
+++ b/src/client/linters/errorHandlers/standard.ts
@@ -29,8 +29,10 @@ export class StandardErrorHandler extends BaseErrorHandler {
     private async displayLinterError(linterId: LinterId) {
         const message = `There was an error in running the linter '${linterId}'`;
         const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
-        await appShell.showErrorMessage(message, 'View Errors');
         const outputChannel = this.serviceContainer.get<IOutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
-        outputChannel.show();
+        const action = await appShell.showErrorMessage(message, 'View Errors');
+        if (action === 'View Errors') {
+            outputChannel.show();
+        }
     }
 }


### PR DESCRIPTION
Closes #18553 

* Properly dismiss the error popup dialog for linter errors.