### PR TITLE
Remove `languageStatus` from `enabledApiProposals`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "languageServerVersion": "0.5.30",
     "publisher": "ms-python",
     "enabledApiProposals": [
-        "languageStatus",
         "quickPickSortByLabel",
         "testObserver",
         "notebookEditor"


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode-python/issues/18596