### PR TITLE
Fix pip-requirements filename pattern for `constraints.txt`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1562,7 +1562,7 @@
                 "configuration": "./languages/pip-requirements.json",
                 "filenamePatterns": [
                     "**/*-requirements.{txt, in}",
-                    "**/*-contstraints.txt",
+                    "**/*-constraints.txt",
                     "**/requirements-*.{txt, in}",
                     "**/constraints-*.txt",
                     "**/requirements/*.{txt,in}",


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/pull/18487#discussion_r819636695