### PR TITLE
Changes to conda paths not detected

### DIFF
--- a/src/test/pythonEnvironments/discovery/locators/condaService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaService.unit.test.ts
@@ -2,19 +2,16 @@ import * as assert from 'assert';
 import * as path from 'path';
 import * as TypeMoq from 'typemoq';
 import * as sinon from 'sinon';
-import { IWorkspaceService } from '../../../../client/common/application/types';
 import { FileSystemPaths, FileSystemPathUtils } from '../../../../client/common/platform/fs-paths';
 import { IFileSystem, IPlatformService } from '../../../../client/common/platform/types';
 import { CondaService } from '../../../../client/pythonEnvironments/common/environmentManagers/condaService';
 import { Conda } from '../../../../client/pythonEnvironments/common/environmentManagers/conda';
 
-suite('Interpreters Conda Service', () => {
+suite.only('Interpreters Conda Service', () => {
     let platformService: TypeMoq.IMock<IPlatformService>;
     let condaService: CondaService;
     let fileSystem: TypeMoq.IMock<IFileSystem>;
-    let workspaceService: TypeMoq.IMock<IWorkspaceService>;
     setup(async () => {
-        workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
         platformService = TypeMoq.Mock.ofType<IPlatformService>();
         fileSystem = TypeMoq.Mock.ofType<IFileSystem>();
 
@@ -27,7 +24,7 @@ suite('Interpreters Conda Service', () => {
                 return utils.arePathsSame(p1, p2);
             });
 
-        condaService = new CondaService(platformService.object, fileSystem.object, [], workspaceService.object);
+        condaService = new CondaService(platformService.object, fileSystem.object);
         sinon.stub(Conda, 'getConda').callsFake(() => Promise.resolve(undefined));
     });
     teardown(() => sinon.restore());

--- a/src/test/pythonEnvironments/discovery/locators/condaService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaService.unit.test.ts
@@ -7,7 +7,7 @@ import { IFileSystem, IPlatformService } from '../../../../client/common/platfor
 import { CondaService } from '../../../../client/pythonEnvironments/common/environmentManagers/condaService';
 import { Conda } from '../../../../client/pythonEnvironments/common/environmentManagers/conda';
 
-suite.only('Interpreters Conda Service', () => {
+suite('Interpreters Conda Service', () => {
     let platformService: TypeMoq.IMock<IPlatformService>;
     let condaService: CondaService;
     let fileSystem: TypeMoq.IMock<IFileSystem>;


### PR DESCRIPTION
Found that there are two implementations for conda location.
Conda.ts and CondaService.ts.
I'm assuming one of them will be deprecated
Either way, conda.ts doesn't monitor for changes to configuration, hence if the condaPath is updated, we don't use that new setting, unless we reload VS Code.