### PR TITLE
Add create python file command to walkthrough and remove setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,84 +138,7 @@
                     {
                         "id": "python.createPythonFile",
                         "title": "Create a Python file",
-                        "description": "[Open](command:toSide:workbench.action.files.openFile) or [create](command:toSide:workbench.action.files.newUntitledFile) a Python file - make sure to save it as \".py\".\n[Create Python File](command:toSide:workbench.action.files.newUntitledFile)",
-                        "media": {
-                            "svg": "resources/walkthrough/open-folder.svg",
-                            "altText": "Open a Python file or a folder with a Python project."
-                        },
-                        "when": ""
-                    },
-                    {
-                        "id": "python.selectInterpreter",
-                        "title": "Select a Python Interpreter",
-                        "description": "Choose which Python interpreter/environment you want to use for your Python project.\n[Select Python Interpreter](command:python.setInterpreter)\n**Tip**: Run the ``Python: Select Interpreter`` command in the [Command Palette](command:workbench.action.showCommands).\nReload the window if you installed Python but don't see it in the list (``Developer: Reload Window`` command). ",
-                        "media": {
-                            "svg": "resources/walkthrough/python-interpreter-v2.svg",
-                            "altText": "Selecting a python interpreter from the status bar"
-                        },
-                        "when": ""
-                    },
-                    {
-                        "id": "python.runAndDebug",
-                        "title": "Run and debug your Python file",
-                        "description": "Open your Python file  and click on the play button on the top right of the editor, or press F5 when on the file and select \"Python File\" to run with the debugger. \n  \n[Learn more](https://code.visualstudio.com/docs/python/python-tutorial#_run-hello-world)",
-                        "media": {
-                            "svg": "resources/walkthrough/rundebug2.svg",
-                            "altText": "How to run and debug in VS Code with F5 or the play button on the top right."
-                        },
-                        "when": ""
-                    },
-                    {
-                        "id": "python.learnMore",
-                        "title": "Explore more resources",
-                        "description": "🎨 Explore all the features the Python extension has to offer by looking for \"Python\" in the [Command Palette](command:workbench.action.showCommands). \n  ✨ Take a look at our [Release Notes](https://aka.ms/AA8dxtb) to learn more about the latest features. \n \n[Learn More](https://aka.ms/AA8dqti)",
-                        "media": {
-                            "altText": "Image representing our documentation page and mailing list resources.",
-                            "svg": "resources/walkthrough/learnmore.svg"
-                        },
-                        "when": ""
-                    }
-                ]
-            },
-            {
-                "id": "pythonWelcomeWithDS",
-                "title": "Get started with Python development",
-                "description": "Your first steps to set up a Python project with all the powerful tools and features that the Python extension has to offer!",
-                "when": "false",
-                "steps": [
-                    {
-                        "id": "python.installPythonWin",
-                        "title": "Install Python",
-                        "description": "The Python Extension requires Python to be installed. Install Python from the [Microsoft Store](https://aka.ms/AAd9rms).\n\n[Install Python](https://aka.ms/AAd9rms)\n",
-                        "media": {
-                            "markdown": "resources/walkthrough/install-python-windows.md"
-                        },
-                        "when": "workspacePlatform == windows"
-                    },
-                    {
-                        "id": "python.installPythonMac",
-                        "title": "Install Python",
-                        "description": "The Python Extension requires Python to be installed. Install Python 3 through the terminal.\n[Open Terminal](command:workbench.action.terminal.new)\n",
-                        "media": {
-                            "markdown": "resources/walkthrough/install-python-macos.md"
-                        },
-                        "when": "workspacePlatform == mac",
-                        "command": "workbench.action.terminal.new"
-                    },
-                    {
-                        "id": "python.installPythonLinux",
-                        "title": "Install Python",
-                        "description": "The Python Extension requires Python to be installed. Install Python 3 through the terminal.\n[Open Terminal](command:workbench.action.terminal.new)\n",
-                        "media": {
-                            "markdown": "resources/walkthrough/install-python-linux.md"
-                        },
-                        "when": "workspacePlatform == linux",
-                        "command": "workbench.action.terminal.new"
-                    },
-                    {
-                        "id": "python.createPythonFile",
-                        "title": "Create a Python file",
-                        "description": "[Open](command:toSide:workbench.action.files.openFile) or [create](command:toSide:workbench.action.files.newUntitledFile) a Python file - make sure to save it as \".py\".\n[Create Python File](command:toSide:workbench.action.files.newUntitledFile)",
+                        "description": "[Open](command:toSide:workbench.action.files.openFile) or [create](command:toSide:python.createNewFile) a Python file - make sure to save it as \".py\".\n[Create Python File](command:toSide:python.createNewFile)",
                         "media": {
                             "svg": "resources/walkthrough/open-folder.svg",
                             "altText": "Open a Python file or a folder with a Python project."
@@ -323,8 +246,7 @@
                 "title": "%python.command.python.createNewFile.title%",
                 "shortTitle": "%python.menu.createNewFile.title%",
                 "category": "Python",
-                "command": "python.createNewFile",
-                "when": "config.python.createNewFileEnabled"
+                "command": "python.createNewFile"
             },
             {
                 "category": "Python",
@@ -491,15 +413,6 @@
                     "description": "Path to the conda executable to use for activation (version 4.4+).",
                     "scope": "machine",
                     "type": "string"
-                },
-                "python.createNewFileEnabled": {
-                    "default": "false",
-                    "description": "Enable the `Python: New Python File` command.",
-                    "scope": "machine",
-                    "type": "boolean",
-                    "tags": [
-                        "experimental"
-                    ]
                 },
                 "python.defaultInterpreterPath": {
                     "default": "python",
@@ -1830,7 +1743,7 @@
                 {
                     "command": "python.createNewFile",
                     "category": "file",
-                    "when": "config.python.createNewFileEnabled"
+                    "when": "!virtualWorkspace"
                 }
             ],
             "view/title": [

--- a/src/client/common/application/commands/createFileCommand.ts
+++ b/src/client/common/application/commands/createFileCommand.ts
@@ -16,9 +16,6 @@ export class CreatePythonFileCommandHandler implements IExtensionSingleActivatio
     ) {}
 
     public async activate(): Promise<void> {
-        if (!this.workspaceService.getConfiguration('python').get<boolean>('createNewFileEnabled')) {
-            return;
-        }
         this.commandManager.registerCommand(Commands.CreateNewFile, this.createPythonFile, this);
     }
 

--- a/src/test/common/application/commands/createNewFileCommand.unit.test.ts
+++ b/src/test/common/application/commands/createNewFileCommand.unit.test.ts
@@ -7,7 +7,6 @@ import { Commands } from '../../../../client/common/constants';
 import { CommandManager } from '../../../../client/common/application/commandManager';
 import { CreatePythonFileCommandHandler } from '../../../../client/common/application/commands/createFileCommand';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../../../../client/common/application/types';
-import { MockWorkspaceConfiguration } from '../../../mocks/mockWorkspaceConfig';
 import { WorkspaceService } from '../../../../client/common/application/workspace';
 import { ApplicationShell } from '../../../../client/common/application/applicationShell';
 
@@ -26,11 +25,6 @@ suite('Create New Python File Commmand', () => {
             instance(cmdManager),
             instance(workspaceService),
             instance(appShell),
-        );
-        when(workspaceService.getConfiguration('python')).thenReturn(
-            new MockWorkspaceConfiguration({
-                createNewFileEnabled: true,
-            }),
         );
         when(workspaceService.openTextDocument(deepEqual({ language: 'python' }))).thenReturn(
             Promise.resolve(({} as unknown) as TextDocument),


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/18575

This PR:

- Adds the new "Create Python File" command to the Python walkthrough 
- Removes the setting that enables/disables the command, so it's always enabled (i.e. "removes" the experiment)
- Updates the learn more tile to point to the Python for Data Science walkthrough (i.e. "removes" the Python + Data Science experiment, making the entry point to the data science walkthrough available to all users) (cc @minsa110) 

 