### PR TITLE
Fix insiders definition 

### DIFF
--- a/src/client/common/application/applicationEnvironment.ts
+++ b/src/client/common/application/applicationEnvironment.ts
@@ -88,6 +88,7 @@ export class ApplicationEnvironment implements IApplicationEnvironment {
     }
     public get extensionChannel(): Channel {
         const version = parse(this.packageJson.version);
+        // Insiders versions are those that end with '-dev' or whose minor versions are odd (even is for stable)
         return !version || version.prerelease.length > 0 || version.minor % 2 == 1 ? 'insiders' : 'stable';
     }
     public get uriScheme(): string {

--- a/src/client/common/application/applicationEnvironment.ts
+++ b/src/client/common/application/applicationEnvironment.ts
@@ -88,7 +88,7 @@ export class ApplicationEnvironment implements IApplicationEnvironment {
     }
     public get extensionChannel(): Channel {
         const version = parse(this.packageJson.version);
-        return !version || version.prerelease.length > 0 ? 'insiders' : 'stable';
+        return !version || version.prerelease.length > 0 || version.minor % 2 == 1 ? 'insiders' : 'stable';
     }
     public get uriScheme(): string {
         return vscode.env.uriScheme;


### PR DESCRIPTION
Now that we have the odd minor versions representing the pre-release versions, we just need to update the extension channel definition for insiders/stable. 
Refs:
- https://github.com/microsoft/vscode-python/blob/3698950c97982f31bb9dbfc19c4cd8308acda284/src/client/common/experiments/service.ts#L62
