### PR TITLE
Wrap file paths containg an ampersand in double quotation marks for running commands in a shell

### DIFF
--- a/news/2 Fixes/18722.md
+++ b/news/2 Fixes/18722.md
@@ -1,0 +1,1 @@
+Wrap file paths containg an ampersand in double quotation marks for running commands in a shell.

--- a/src/client/common/extensions.ts
+++ b/src/client/common/extensions.ts
@@ -73,7 +73,9 @@ String.prototype.toCommandArgument = function (this: string): string {
     if (!this) {
         return this;
     }
-    return this.indexOf(' ') >= 0 && !this.startsWith('"') && !this.endsWith('"') ? `"${this}"` : this.toString();
+    return (this.indexOf(' ') >= 0 || this.indexOf('&') >= 0) && !this.startsWith('"') && !this.endsWith('"')
+        ? `"${this}"`
+        : this.toString();
 };
 
 /**

--- a/src/test/common/extensions.unit.test.ts
+++ b/src/test/common/extensions.unit.test.ts
@@ -20,6 +20,10 @@ suite('String Extensions', () => {
         const argTotest = 'one two three';
         expect(argTotest.toCommandArgument()).to.be.equal(`"${argTotest}"`);
     });
+    test('Should quote command arguments containing ampersand', () => {
+        const argTotest = 'one&twothree';
+        expect(argTotest.toCommandArgument()).to.be.equal(`"${argTotest}"`);
+    });
     test('Should return empty string for empty path', () => {
         const fileToTest = '';
         expect(fileToTest.fileToCommandArgument()).to.be.equal('');


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/18722