### PR TITLE
fix typo

### DIFF
--- a/news/README.md
+++ b/news/README.md
@@ -20,7 +20,7 @@ change corresponds to. External contributors should also make sure to
 thank themselves for taking the time and effort to contribute.
 
 As an example, a change corresponding to a bug reported in issue #42
-would be saved in the `1 Fixes` directory and named `42.md`
+would be saved in the `2 Fixes` directory and named `42.md`
 (or `42-nonce_value.md` if there was a need for multiple entries
 regarding issue #42) and could contain the following:
 


### PR DESCRIPTION
Fix typo

Directory `1 Fixes` have been moved to `2 Fixes`, update it in README.md

This PR does not need a news entry, But it seems that I don't have  permission to add a `skip news` label.