### PR TITLE
attempt to fix a race where new LS starts before previous LS stopped.

### DIFF
--- a/src/client/activation/jedi/manager.ts
+++ b/src/client/activation/jedi/manager.ts
@@ -59,9 +59,7 @@ export class JediLanguageServerManager implements ILanguageServerManager {
     }
 
     public dispose(): void {
-        if (this.languageProxy) {
-            this.languageProxy.dispose();
-        }
+        this.stopLanguageServer().ignoreErrors();
         JediLanguageServerManager.commandDispose.dispose();
         this.disposables.forEach((d) => d.dispose());
     }
@@ -120,9 +118,7 @@ export class JediLanguageServerManager implements ILanguageServerManager {
     @traceDecoratorError('Failed to restart language server')
     @traceDecoratorVerbose('Restarting language server')
     protected async restartLanguageServer(): Promise<void> {
-        if (this.languageProxy) {
-            this.languageProxy.dispose();
-        }
+        await this.stopLanguageServer();
         await this.startLanguageServer();
     }
 
@@ -146,5 +142,12 @@ export class JediLanguageServerManager implements ILanguageServerManager {
 
         // Then use this middleware to start a new language client.
         await this.languageServerProxy.start(this.resource, this.interpreter, options);
+    }
+
+    @traceDecoratorVerbose('Stopping language server')
+    protected async stopLanguageServer(): Promise<void> {
+        if (this.languageServerProxy) {
+            await this.languageServerProxy.stop();
+        }
     }
 }

--- a/src/client/activation/node/manager.ts
+++ b/src/client/activation/node/manager.ts
@@ -59,9 +59,7 @@ export class NodeLanguageServerManager implements ILanguageServerManager {
     }
 
     public dispose(): void {
-        if (this.languageProxy) {
-            this.languageProxy.dispose();
-        }
+        this.stopLanguageServer().ignoreErrors();
         NodeLanguageServerManager.commandDispose.dispose();
         this.disposables.forEach((d) => d.dispose());
     }
@@ -110,9 +108,7 @@ export class NodeLanguageServerManager implements ILanguageServerManager {
     @traceDecoratorError('Failed to restart language server')
     @traceDecoratorVerbose('Restarting language server')
     protected async restartLanguageServer(): Promise<void> {
-        if (this.languageProxy) {
-            this.languageProxy.dispose();
-        }
+        await this.stopLanguageServer();
         await this.startLanguageServer();
     }
 
@@ -136,5 +132,12 @@ export class NodeLanguageServerManager implements ILanguageServerManager {
 
         // Then use this middleware to start a new language client.
         await this.languageServerProxy.start(this.resource, this.interpreter, options);
+    }
+
+    @traceDecoratorVerbose('Stopping language server')
+    protected async stopLanguageServer(): Promise<void> {
+        if (this.languageServerProxy) {
+            await this.languageServerProxy.stop();
+        }
     }
 }

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -138,6 +138,7 @@ export interface ILanguageServerProxy extends IDisposable {
         interpreter: PythonEnvironment | undefined,
         options: LanguageClientOptions,
     ): Promise<void>;
+    stop(): Promise<void>;
     /**
      * Sends a request to LS so as to load other extensions.
      * This is used as a plugin loader mechanism.

--- a/src/client/languageServer/jediLSExtensionManager.ts
+++ b/src/client/languageServer/jediLSExtensionManager.ts
@@ -72,9 +72,9 @@ export class JediLSExtensionManager extends LanguageServerCapabilities
         this.serverManager.connect();
     }
 
-    stopLanguageServer(): void {
+    async stopLanguageServer(): Promise<void> {
         this.serverManager.disconnect();
-        this.serverProxy.dispose();
+        await this.serverProxy.stop();
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/src/client/languageServer/noneLSExtensionManager.ts
+++ b/src/client/languageServer/noneLSExtensionManager.ts
@@ -46,8 +46,8 @@ export class NoneLSExtensionManager implements ILanguageServer, ILanguageServerE
         return Promise.resolve();
     }
 
-    stopLanguageServer(): void {
-        // Nothing to do here.
+    stopLanguageServer(): Promise<void> {
+        return Promise.resolve();
     }
 
     canStartLanguageServer(): boolean {

--- a/src/client/languageServer/pylanceLSExtensionManager.ts
+++ b/src/client/languageServer/pylanceLSExtensionManager.ts
@@ -84,9 +84,9 @@ export class PylanceLSExtensionManager extends LanguageServerCapabilities
         this.serverManager.connect();
     }
 
-    stopLanguageServer(): void {
+    async stopLanguageServer(): Promise<void> {
         this.serverManager.disconnect();
-        this.serverProxy.dispose();
+        await this.serverProxy.stop();
     }
 
     canStartLanguageServer(): boolean {

--- a/src/client/languageServer/types.ts
+++ b/src/client/languageServer/types.ts
@@ -29,7 +29,7 @@ export interface ILanguageServerCapabilities extends ILanguageServer {
  */
 export interface ILanguageServerExtensionManager extends ILanguageServerCapabilities {
     startLanguageServer(resource: Resource, interpreter?: PythonEnvironment): Promise<void>;
-    stopLanguageServer(): void;
+    stopLanguageServer(): Promise<void>;
     canStartLanguageServer(): boolean;
     languageServerNotAvailable(): Promise<void>;
     dispose(): void;

--- a/src/client/languageServer/watcher.ts
+++ b/src/client/languageServer/watcher.ts
@@ -125,7 +125,7 @@ export class LanguageServerWatcher
 
         // Destroy the old language server if it's different.
         if (currentInterpreter && interpreter !== currentInterpreter) {
-            this.stopLanguageServer(lsResource);
+            await this.stopLanguageServer(lsResource);
         }
 
         // If the interpreter is Python 2 and the LS setting is explicitly set to Jedi, turn it off.
@@ -190,12 +190,12 @@ export class LanguageServerWatcher
 
     // Private methods
 
-    private stopLanguageServer(resource?: Resource): void {
+    private async stopLanguageServer(resource?: Resource): Promise<void> {
         const key = this.getWorkspaceKey(resource, this.languageServerType);
         const languageServerExtensionManager = this.workspaceLanguageServers.get(key);
 
         if (languageServerExtensionManager) {
-            languageServerExtensionManager.stopLanguageServer();
+            await languageServerExtensionManager.stopLanguageServer();
             languageServerExtensionManager.dispose();
             this.workspaceLanguageServers.delete(key);
         }
@@ -246,7 +246,7 @@ export class LanguageServerWatcher
         const languageServerType = this.configurationService.getSettings(lsResource).languageServer;
 
         if (languageServerType !== this.languageServerType) {
-            this.stopLanguageServer(resource);
+            await this.stopLanguageServer(resource);
             await this.startLanguageServer(languageServerType, lsResource);
         }
     }
@@ -286,9 +286,9 @@ export class LanguageServerWatcher
         // Since Jedi is the only language server type where we instantiate multiple language servers,
         // Make sure to dispose of them only in that scenario.
         if (event.removed.length && this.languageServerType === LanguageServerType.Jedi) {
-            event.removed.forEach((workspace) => {
-                this.stopLanguageServer(workspace.uri);
-            });
+            for (const workspace of event.removed) {
+                await this.stopLanguageServer(workspace.uri);
+            }
         }
     }
 

--- a/src/test/languageServer/watcher.unit.test.ts
+++ b/src/test/languageServer/watcher.unit.test.ts
@@ -723,7 +723,7 @@ suite('Language server watcher', () => {
             }
 
             const stopLanguageServerStub = sandbox.stub(extensionLSCls.prototype, 'stopLanguageServer');
-            stopLanguageServerStub.returns();
+            stopLanguageServerStub.returns(Promise.resolve());
 
             let onDidChangeWorkspaceFoldersListener: (event: WorkspaceFoldersChangeEvent) => Promise<void> = () =>
                 Promise.resolve();


### PR DESCRIPTION
From crash report, we found a possible race situation where new Pylance is started before old Pylance is disposed causing duplicate commands to be registered and error out by LSP client.

this is an attempt to fix the race by making sure LSP server stop is awaited before calling start eliminating all weird cases and we no longer assume that languge client will be reused (start/stop and start again). 