### PR TITLE
Revert "Only trigger auto environment discovery once in the first session for a particular scope"

### DIFF
--- a/news/1 Enhancements/19102.md
+++ b/news/1 Enhancements/19102.md
@@ -1,1 +1,0 @@
-Only trigger auto environment discovery once in the first session for a particular scope (a workspace folder or globally).


### PR DESCRIPTION
We need to provide backwards compatibility for old Jupyter APIs.

Reverts microsoft/vscode-python#19145