### PR TITLE
Allow any x.x.100 build of Jupyter to use notebooks experiment

### DIFF
--- a/src/client/activation/node/lspNotebooksExperiment.ts
+++ b/src/client/activation/node/lspNotebooksExperiment.ts
@@ -100,8 +100,7 @@ export class LspNotebooksExperiment implements IExtensionSingleActivationService
     private static jupyterSupportsNotebooksExperiment(): boolean {
         const jupyterVersion = extensions.getExtension(JUPYTER_EXTENSION_ID)?.packageJSON.version;
         return (
-            jupyterVersion &&
-            (semver.gt(jupyterVersion, '2022.5.1001391015') || semver.eq(jupyterVersion, '2022.4.100'))
+            jupyterVersion && (semver.gt(jupyterVersion, '2022.5.1001411044') || semver.patch(jupyterVersion) === 100)
         );
     }
 


### PR DESCRIPTION
Jupyter builds from dev machines have version x.x.100. Allow any such Jupyter build to use the LSP notebooks experiment.

Also updated the minimum Jupyter build version to require builds with the fix for https://github.com/microsoft/vscode-jupyter/issues/10071.