### PR TITLE
Add await on stopLanguageServer call

### DIFF
--- a/src/client/languageServer/watcher.ts
+++ b/src/client/languageServer/watcher.ts
@@ -189,7 +189,7 @@ export class LanguageServerWatcher
     public async restartLanguageServers(): Promise<void> {
         this.workspaceLanguageServers.forEach(async (_, resourceString) => {
             const resource = Uri.parse(resourceString);
-            this.stopLanguageServer(resource);
+            await this.stopLanguageServer(resource);
             await this.startLanguageServer(this.languageServerType, resource);
         });
     }


### PR DESCRIPTION
@heejaechang noticed that the `stopLanguageServer` call in `restartLanguageServers` was missing await.