### PR TITLE
Make LSP notebooks event also trigger for those who may be on the control group

### DIFF
--- a/src/client/activation/node/lspNotebooksExperiment.ts
+++ b/src/client/activation/node/lspNotebooksExperiment.ts
@@ -66,8 +66,6 @@ export class LspNotebooksExperiment implements IExtensionSingleActivationService
         this.isInExperiment = false;
         if (languageServerType !== LanguageServerType.Node) {
             traceLog(`LSP Notebooks experiment is disabled -- not using Pylance`);
-        } else if (!isInTreatmentGroup) {
-            traceLog(`LSP Notebooks experiment is disabled -- not in treatment group`);
         } else if (!LspNotebooksExperiment.isJupyterInstalled()) {
             traceLog(`LSP Notebooks experiment is disabled -- Jupyter disabled or not installed`);
         } else if (!LspNotebooksExperiment.jupyterSupportsNotebooksExperiment()) {
@@ -76,12 +74,14 @@ export class LspNotebooksExperiment implements IExtensionSingleActivationService
             traceLog(`LSP Notebooks experiment is disabled -- Pylance disabled or not installed`);
         } else if (!LspNotebooksExperiment.pylanceSupportsNotebooksExperiment()) {
             traceLog(`LSP Notebooks experiment is disabled -- Pylance does not support experiment`);
+        } else if (!isInTreatmentGroup) {
+            traceLog(`LSP Notebooks experiment is disabled -- not in treatment group`);
+            // to avoid scorecard SRMs, we're also triggering the telemetry for users who meet
+            // the criteria to experience LSP notebooks, but may be in the control group.
+            sendTelemetryEvent(EventName.PYTHON_EXPERIMENTS_LSP_NOTEBOOKS);
         } else {
             this.isInExperiment = true;
             traceLog(`LSP Notebooks experiment is enabled`);
-        }
-
-        if (this.isInExperiment) {
             sendTelemetryEvent(EventName.PYTHON_EXPERIMENTS_LSP_NOTEBOOKS);
         }
 


### PR DESCRIPTION
To have more sensitive scorecards for the LSP notebooks experiment, I wanted to be able to add a segment for users who meet all the criteria of the experiment (i.e. those who are truly eligible to experience LSP notebooks).

I noticed the telemetry event we had (`python_experiments_lsp_notebooks`) is only triggering for those who have the `pylanceLspNotebooksEnabled` setting set to `true`. So people in the control group who haven't touched this setting won't trigger this event. If I were to use it as segment in the scorecard, it would give me an SRM (sample ratio mismatch), because only people in treatment would trigger it.

With this change, my intent is to make this event also be triggered for those who may be on the control group (so not necessarily experiencing notebooks LSP, but meeting all the criteria for it). A few of these people may have the setting set to true, and therefore be in the control group but experiencing notebooks LSP, which is noisy data, but I expect the # of people who manually flip that setting to be low and therefore am not too concerned about it :)  