### PR TITLE
Add comment to query-exp event

### DIFF
--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -2003,4 +2003,11 @@ export interface IEventNamePropertyMapping {
        "tensorboard_jump_to_source_file_not_found" : { "owner": "greazer" }
      */
     [EventName.TENSORBOARD_JUMP_TO_SOURCE_FILE_NOT_FOUND]: never | undefined;
+    /* __GDPR__
+			"query-expfeature" : {
+				"owner": "luabud",
+				"comment": "Logs queries to the experiment service by feature for metric calculations",
+				"ABExp.queriedFeature": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The experimental feature being queried" }
+			}
+	*/
 }


### PR DESCRIPTION
This event is triggered when we make calls to TAS. I based the comment from the similar event triggered in VS Code: https://github.com/microsoft/vscode/blob/77055cffc0d1c749e7eaf0213b66b6d0e76d7a91/src/vs/workbench/services/assignment/common/assignmentService.ts#L67 