### PR TITLE
Upgrade LSP to 8.0.2-next.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2022.7.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@vscode/jupyter-lsp-middleware": "^0.2.45",
+                "@vscode/jupyter-lsp-middleware": "^0.2.46",
                 "arch": "^2.1.0",
                 "diff-match-patch": "^1.0.0",
                 "fs-extra": "^10.0.1",
@@ -37,10 +37,10 @@
                 "vscode-debugadapter": "^1.28.0",
                 "vscode-debugprotocol": "^1.28.0",
                 "vscode-extension-telemetry": "0.4.5",
-                "vscode-jsonrpc": "8.0.1",
-                "vscode-languageclient": "8.0.1",
-                "vscode-languageserver": "8.0.1",
-                "vscode-languageserver-protocol": "3.17.1",
+                "vscode-jsonrpc": "8.0.2-next.1",
+                "vscode-languageclient": "8.0.2-next.3",
+                "vscode-languageserver": "8.0.2-next.3",
+                "vscode-languageserver-protocol": "3.17.2-next.3",
                 "vscode-nls": "^5.0.1",
                 "vscode-tas-client": "^0.1.22",
                 "winreg": "^1.2.4",
@@ -1022,15 +1022,15 @@
             "dev": true
         },
         "node_modules/@vscode/jupyter-lsp-middleware": {
-            "version": "0.2.45",
-            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.45.tgz",
-            "integrity": "sha512-X51dpmYuHxmgLLBv2cXVraUPvFg2OgNiMjmNHTLKEcfESbqn6IO2LG9WgP2oSqtwLH1YOzfBYgtxQh/dnjtHUA==",
+            "version": "0.2.46",
+            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.46.tgz",
+            "integrity": "sha512-xP7E8YwdwS9+pCdLaoZcvtWy6vJpuCIN990IgVjKRrGAqwpJzSojuZs1Lai7YYkOqWYfa1xjsNfZ+kw3N2gzlw==",
             "dependencies": {
-                "@vscode/lsp-notebook-concat": "^0.1.12",
+                "@vscode/lsp-notebook-concat": "^0.1.13",
                 "fast-myers-diff": "^3.0.1",
                 "sha.js": "^2.4.11",
-                "vscode-languageclient": "^8.0.1",
-                "vscode-languageserver-protocol": "^3.17.1",
+                "vscode-languageclient": "^8.0.2-next.3",
+                "vscode-languageserver-protocol": "^3.17.2-next.3",
                 "vscode-uri": "^3.0.2"
             },
             "engines": {
@@ -1038,12 +1038,12 @@
             }
         },
         "node_modules/@vscode/lsp-notebook-concat": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/@vscode/lsp-notebook-concat/-/lsp-notebook-concat-0.1.12.tgz",
-            "integrity": "sha512-8pNf5Cyw6TKqoIMHEfuJGkIq2yhycAmkEmNNL1U/x/Ct1InLIckQ9cBTVI6cAr9do8kW3jCTM8kjZocBWrU4SA==",
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/@vscode/lsp-notebook-concat/-/lsp-notebook-concat-0.1.13.tgz",
+            "integrity": "sha512-+w5AAYMc/lC3kKagLWuH0t+/0at24Fm3SsksKfWeKRH/Mg4SQC5TNv5xy3SS8nDeyxB0JIx0vp6WXmu+PUz4tA==",
             "dependencies": {
                 "object-hash": "^3.0.0",
-                "vscode-languageserver-protocol": "^3.17.1",
+                "vscode-languageserver-protocol": "^3.17.2-next.3",
                 "vscode-uri": "^3.0.2"
             }
         },
@@ -14388,21 +14388,21 @@
             }
         },
         "node_modules/vscode-jsonrpc": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
-            "integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==",
+            "version": "8.0.2-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2-next.1.tgz",
+            "integrity": "sha512-sbbvGSWja7NVBLHPGawtgezc8DHYJaP4qfr/AaJiyDapWcSFtHyPtm18+LnYMLTmB7bhOUW/lf5PeeuLpP6bKA==",
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/vscode-languageclient": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz",
-            "integrity": "sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==",
+            "version": "8.0.2-next.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2-next.3.tgz",
+            "integrity": "sha512-7vmz/K9W2GLNogvuOo8Vu3oajn26Hi5sy1jCelOknpbVJMgJhatXujbUQBYwnBOkbWYtUOyZ5/IgoN+4FrG2xQ==",
             "dependencies": {
                 "minimatch": "^3.0.4",
                 "semver": "^7.3.5",
-                "vscode-languageserver-protocol": "3.17.1"
+                "vscode-languageserver-protocol": "3.17.2-next.3"
             },
             "engines": {
                 "vscode": "^1.67.0"
@@ -14434,29 +14434,29 @@
             }
         },
         "node_modules/vscode-languageserver": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.1.tgz",
-            "integrity": "sha512-sn7SjBwWm3OlmLtgg7jbM0wBULppyL60rj8K5HF0ny/MzN+GzPBX1kCvYdybhl7UW63V5V5tRVnyB8iwC73lSQ==",
+            "version": "8.0.2-next.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2-next.3.tgz",
+            "integrity": "sha512-4ifZbP6F+QxEFpef5avHTtx12t3hMPfS+a4HUM3i02q5nHi8oEMapuQJGEkpPmHnsSWW34SfTob6SIht0UYrBA==",
             "dependencies": {
-                "vscode-languageserver-protocol": "3.17.1"
+                "vscode-languageserver-protocol": "3.17.2-next.3"
             },
             "bin": {
                 "installServerIntoExtension": "bin/installServerIntoExtension"
             }
         },
         "node_modules/vscode-languageserver-protocol": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
-            "integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
+            "version": "3.17.2-next.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2-next.3.tgz",
+            "integrity": "sha512-cgv4w2P5VcQssC0ZNr85mSYoZZ7tGjsWahRbIhyv6c6MxUbYdCH18WkD3EKhrjPYUNuCpPEIFG5mpKxPT7bOjg==",
             "dependencies": {
-                "vscode-jsonrpc": "8.0.1",
-                "vscode-languageserver-types": "3.17.1"
+                "vscode-jsonrpc": "8.0.2-next.1",
+                "vscode-languageserver-types": "3.17.2-next.2"
             }
         },
-        "node_modules/vscode-languageserver-types": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
-            "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
+        "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
+            "version": "3.17.2-next.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2-next.2.tgz",
+            "integrity": "sha512-TiAkLABgqkVWdAlC3XlOfdhdjIAdVU4YntPUm9kKGbXr+MGwpVnKz2KZMNBcvG0CFx8Hi8qliL0iq+ndPB720w=="
         },
         "node_modules/vscode-nls": {
             "version": "5.0.1",
@@ -16190,25 +16190,25 @@
             "dev": true
         },
         "@vscode/jupyter-lsp-middleware": {
-            "version": "0.2.45",
-            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.45.tgz",
-            "integrity": "sha512-X51dpmYuHxmgLLBv2cXVraUPvFg2OgNiMjmNHTLKEcfESbqn6IO2LG9WgP2oSqtwLH1YOzfBYgtxQh/dnjtHUA==",
+            "version": "0.2.46",
+            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.46.tgz",
+            "integrity": "sha512-xP7E8YwdwS9+pCdLaoZcvtWy6vJpuCIN990IgVjKRrGAqwpJzSojuZs1Lai7YYkOqWYfa1xjsNfZ+kw3N2gzlw==",
             "requires": {
-                "@vscode/lsp-notebook-concat": "^0.1.12",
+                "@vscode/lsp-notebook-concat": "^0.1.13",
                 "fast-myers-diff": "^3.0.1",
                 "sha.js": "^2.4.11",
-                "vscode-languageclient": "^8.0.1",
-                "vscode-languageserver-protocol": "^3.17.1",
+                "vscode-languageclient": "^8.0.2-next.3",
+                "vscode-languageserver-protocol": "^3.17.2-next.3",
                 "vscode-uri": "^3.0.2"
             }
         },
         "@vscode/lsp-notebook-concat": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/@vscode/lsp-notebook-concat/-/lsp-notebook-concat-0.1.12.tgz",
-            "integrity": "sha512-8pNf5Cyw6TKqoIMHEfuJGkIq2yhycAmkEmNNL1U/x/Ct1InLIckQ9cBTVI6cAr9do8kW3jCTM8kjZocBWrU4SA==",
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/@vscode/lsp-notebook-concat/-/lsp-notebook-concat-0.1.13.tgz",
+            "integrity": "sha512-+w5AAYMc/lC3kKagLWuH0t+/0at24Fm3SsksKfWeKRH/Mg4SQC5TNv5xy3SS8nDeyxB0JIx0vp6WXmu+PUz4tA==",
             "requires": {
                 "object-hash": "^3.0.0",
-                "vscode-languageserver-protocol": "^3.17.1",
+                "vscode-languageserver-protocol": "^3.17.2-next.3",
                 "vscode-uri": "^3.0.2"
             }
         },
@@ -26755,18 +26755,18 @@
             "integrity": "sha512-YhPiPcelqM5xyYWmD46jIcsxLYWkPZhAxlBkzqmpa218fMtTT17ERdOZVCXcs1S5AjvDHlq43yCgi8TaVQjjEg=="
         },
         "vscode-jsonrpc": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
-            "integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ=="
+            "version": "8.0.2-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2-next.1.tgz",
+            "integrity": "sha512-sbbvGSWja7NVBLHPGawtgezc8DHYJaP4qfr/AaJiyDapWcSFtHyPtm18+LnYMLTmB7bhOUW/lf5PeeuLpP6bKA=="
         },
         "vscode-languageclient": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz",
-            "integrity": "sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==",
+            "version": "8.0.2-next.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2-next.3.tgz",
+            "integrity": "sha512-7vmz/K9W2GLNogvuOo8Vu3oajn26Hi5sy1jCelOknpbVJMgJhatXujbUQBYwnBOkbWYtUOyZ5/IgoN+4FrG2xQ==",
             "requires": {
                 "minimatch": "^3.0.4",
                 "semver": "^7.3.5",
-                "vscode-languageserver-protocol": "3.17.1"
+                "vscode-languageserver-protocol": "3.17.2-next.3"
             },
             "dependencies": {
                 "minimatch": {
@@ -26788,26 +26788,28 @@
             }
         },
         "vscode-languageserver": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.1.tgz",
-            "integrity": "sha512-sn7SjBwWm3OlmLtgg7jbM0wBULppyL60rj8K5HF0ny/MzN+GzPBX1kCvYdybhl7UW63V5V5tRVnyB8iwC73lSQ==",
+            "version": "8.0.2-next.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2-next.3.tgz",
+            "integrity": "sha512-4ifZbP6F+QxEFpef5avHTtx12t3hMPfS+a4HUM3i02q5nHi8oEMapuQJGEkpPmHnsSWW34SfTob6SIht0UYrBA==",
             "requires": {
-                "vscode-languageserver-protocol": "3.17.1"
+                "vscode-languageserver-protocol": "3.17.2-next.3"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
-            "integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
+            "version": "3.17.2-next.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2-next.3.tgz",
+            "integrity": "sha512-cgv4w2P5VcQssC0ZNr85mSYoZZ7tGjsWahRbIhyv6c6MxUbYdCH18WkD3EKhrjPYUNuCpPEIFG5mpKxPT7bOjg==",
             "requires": {
-                "vscode-jsonrpc": "8.0.1",
-                "vscode-languageserver-types": "3.17.1"
+                "vscode-jsonrpc": "8.0.2-next.1",
+                "vscode-languageserver-types": "3.17.2-next.2"
+            },
+            "dependencies": {
+                "vscode-languageserver-types": {
+                    "version": "3.17.2-next.2",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2-next.2.tgz",
+                    "integrity": "sha512-TiAkLABgqkVWdAlC3XlOfdhdjIAdVU4YntPUm9kKGbXr+MGwpVnKz2KZMNBcvG0CFx8Hi8qliL0iq+ndPB720w=="
+                }
             }
-        },
-        "vscode-languageserver-types": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
-            "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
         },
         "vscode-nls": {
             "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -1784,7 +1784,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@vscode/jupyter-lsp-middleware": "^0.2.45",
+        "@vscode/jupyter-lsp-middleware": "^0.2.46",
         "arch": "^2.1.0",
         "diff-match-patch": "^1.0.0",
         "fs-extra": "^10.0.1",
@@ -1812,10 +1812,10 @@
         "vscode-debugadapter": "^1.28.0",
         "vscode-debugprotocol": "^1.28.0",
         "vscode-extension-telemetry": "0.4.5",
-        "vscode-jsonrpc": "8.0.1",
-        "vscode-languageclient": "8.0.1",
-        "vscode-languageserver": "8.0.1",
-        "vscode-languageserver-protocol": "3.17.1",
+        "vscode-jsonrpc": "8.0.2-next.1",
+        "vscode-languageclient": "8.0.2-next.3",
+        "vscode-languageserver": "8.0.2-next.3",
+        "vscode-languageserver-protocol": "3.17.2-next.3",
         "vscode-nls": "^5.0.1",
         "vscode-tas-client": "^0.1.22",
         "winreg": "^1.2.4",


### PR DESCRIPTION
LSP 8.0.2 contains another fix for LanguageClient start/stop scenarios. We're hoping that it will address https://github.com/microsoft/pylance-release/issues/2765.