### PR TITLE
Add `skip news` label for all python dependencies except isort and jedi-language-server

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     labels:
       - 'skip news'
 
-  # Not skipping the news for Python dependencies in case it's actually useful to communicate to users.
+  # Not skipping the news for some Python dependencies in case it's actually useful to communicate to users.
   - package-ecosystem: 'pip'
     directory: /
     schedule:
@@ -16,7 +16,10 @@ updates:
       - dependency-name: prospector # Due to Python 2.7 and #14477.
       - dependency-name: pytest # Due to Python 2.7 and #13776.
       - dependency-name: py # Due to Python 2.7.
-    labels: []
+      - dependency-name: isort
+      - dependency-name: jedi-language-server
+    labels:
+      - 'skip news'
   # Activate when we feel ready to keep up with frequency.
   # - package-ecosystem: 'npm'
   #   directory: /


### PR DESCRIPTION
For example: https://github.com/microsoft/vscode-python/pull/19223 required the label.