### PR TITLE
Fix regex expression in env file

### DIFF
--- a/src/client/common/variables/environment.ts
+++ b/src/client/common/variables/environment.ts
@@ -114,13 +114,13 @@ function parseEnvLine(line: string): [string, string] {
     //   https://github.com/motdotla/dotenv/blob/master/lib/main.js#L32
     // We don't use dotenv here because it loses ordering, which is
     // significant for substitution.
-    const match = line.match(/^\s*((_?)[a-zA-Z]\w*)\s*=\s*(.*?)?\s*$/);
+    const match = line.match(/^\s*(_*[a-zA-Z]\w*)\s*=\s*(.*?)?\s*$/);
     if (!match) {
         return ['', ''];
     }
 
     const name = match[1];
-    let value = match[3];
+    let value = match[2];
     if (value && value !== '') {
         if (value[0] === "'" && value[value.length - 1] === "'") {
             value = value.substring(1, value.length - 1);

--- a/src/client/common/variables/environment.ts
+++ b/src/client/common/variables/environment.ts
@@ -114,13 +114,13 @@ function parseEnvLine(line: string): [string, string] {
     //   https://github.com/motdotla/dotenv/blob/master/lib/main.js#L32
     // We don't use dotenv here because it loses ordering, which is
     // significant for substitution.
-    const match = line.match(/^\s*(_?)([a-zA-Z]\w*)\s*=\s*(.*?)?\s*$/);
+    const match = line.match(/^\s*((_?)[a-zA-Z]\w*)\s*=\s*(.*?)?\s*$/);
     if (!match) {
         return ['', ''];
     }
 
     const name = match[1];
-    let value = match[2];
+    let value = match[3];
     if (value && value !== '') {
         if (value[0] === "'" && value[value.length - 1] === "'") {
             value = value.substring(1, value.length - 1);

--- a/src/client/common/variables/environment.ts
+++ b/src/client/common/variables/environment.ts
@@ -114,7 +114,7 @@ function parseEnvLine(line: string): [string, string] {
     //   https://github.com/motdotla/dotenv/blob/master/lib/main.js#L32
     // We don't use dotenv here because it loses ordering, which is
     // significant for substitution.
-    const match = line.match(/^\s*([a-zA-Z]\w*)\s*=\s*(.*?)?\s*$/);
+    const match = line.match(/^\s*(_?)([a-zA-Z]\w*)\s*=\s*(.*?)?\s*$/);
     if (!match) {
         return ['', ''];
     }

--- a/src/test/common/variables/envVarsService.unit.test.ts
+++ b/src/test/common/variables/envVarsService.unit.test.ts
@@ -395,7 +395,7 @@ Path=/usr/x:/usr/y
 SPAM=1234
 ham=5678
 Eggs=9012
-_bogus1=...
+_bogus1=1234
 1bogus2=...
 bogus 3=...
 bogus.4=...
@@ -406,12 +406,13 @@ VAR_2=7890
             `);
 
             expect(vars).to.not.equal(undefined, 'Variables is undefiend');
-            expect(Object.keys(vars!)).lengthOf(5, 'Incorrect number of variables');
+            expect(Object.keys(vars!)).lengthOf(6, 'Incorrect number of variables');
             expect(vars).to.have.property('SPAM', '1234', 'value is invalid');
             expect(vars).to.have.property('ham', '5678', 'value is invalid');
             expect(vars).to.have.property('Eggs', '9012', 'value is invalid');
             expect(vars).to.have.property('VAR1', '3456', 'value is invalid');
             expect(vars).to.have.property('VAR_2', '7890', 'value is invalid');
+            expect(vars).to.have.property('_bogus1', '1234', 'value is invalid');
         });
 
         test('Empty values become empty string', () => {

--- a/src/test/common/variables/envVarsService.unit.test.ts
+++ b/src/test/common/variables/envVarsService.unit.test.ts
@@ -402,7 +402,7 @@ bogus-5=...
 bogus~6=...
 VAR1=3456
 VAR_2=7890
-_VAR_3=3456
+_VAR_3=1234
             `);
 
             expect(vars).to.not.equal(undefined, 'Variables is undefiend');
@@ -412,7 +412,7 @@ _VAR_3=3456
             expect(vars).to.have.property('Eggs', '9012', 'value is invalid');
             expect(vars).to.have.property('VAR1', '3456', 'value is invalid');
             expect(vars).to.have.property('VAR_2', '7890', 'value is invalid');
-            expect(vars).to.have.property('_VAR_3', '3456', 'value is invalid');
+            expect(vars).to.have.property('_VAR_3', '1234', 'value is invalid');
         });
 
         test('Empty values become empty string', () => {

--- a/src/test/common/variables/envVarsService.unit.test.ts
+++ b/src/test/common/variables/envVarsService.unit.test.ts
@@ -395,7 +395,6 @@ Path=/usr/x:/usr/y
 SPAM=1234
 ham=5678
 Eggs=9012
-_bogus1=1234
 1bogus2=...
 bogus 3=...
 bogus.4=...
@@ -403,6 +402,7 @@ bogus-5=...
 bogus~6=...
 VAR1=3456
 VAR_2=7890
+_VAR_3=3456
             `);
 
             expect(vars).to.not.equal(undefined, 'Variables is undefiend');
@@ -412,7 +412,7 @@ VAR_2=7890
             expect(vars).to.have.property('Eggs', '9012', 'value is invalid');
             expect(vars).to.have.property('VAR1', '3456', 'value is invalid');
             expect(vars).to.have.property('VAR_2', '7890', 'value is invalid');
-            expect(vars).to.have.property('_bogus1', '1234', 'value is invalid');
+            expect(vars).to.have.property('_VAR_3', '3456', 'value is invalid');
         });
 
         test('Empty values become empty string', () => {


### PR DESCRIPTION
Allow variables in .env file to start with '_'.

Closed: https://github.com/microsoft/vscode-python/issues/19184