### PR TITLE
Remove `python.disableInstallationCheck` setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -405,12 +405,6 @@
                     "scope": "application",
                     "type": "boolean"
                 },
-                "python.disableInstallationCheck": {
-                    "default": false,
-                    "description": "Whether to check if Python is installed (also warn when using the macOS-installed Python).",
-                    "scope": "resource",
-                    "type": "boolean"
-                },
                 "python.envFile": {
                     "default": "${workspaceFolder}/.env",
                     "description": "Absolute path to a file containing environment variable definitions.",

--- a/resources/report_issue_user_settings.json
+++ b/resources/report_issue_user_settings.json
@@ -11,7 +11,6 @@
     "pipenvPath": "placeholder",
     "poetryPath": "placeholder",
     "devOptions": false,
-    "disableInstallationChecks": false,
     "globalModuleInstallation": false,
     "languageServer": true,
     "languageServerIsDefault": false,

--- a/src/client/application/diagnostics/checks/macPythonInterpreter.ts
+++ b/src/client/application/diagnostics/checks/macPythonInterpreter.ts
@@ -68,9 +68,6 @@ export class InvalidMacPythonInterpreterService extends BaseDiagnosticsService {
         }
         const configurationService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
         const settings = configurationService.getSettings(resource);
-        if (settings.disableInstallationChecks === true) {
-            return [];
-        }
         if (!(await this.helper.isMacDefaultPythonPath(settings.pythonPath))) {
             return [];
         }

--- a/src/client/application/diagnostics/checks/pythonInterpreter.ts
+++ b/src/client/application/diagnostics/checks/pythonInterpreter.ts
@@ -6,7 +6,7 @@ import { inject, injectable } from 'inversify';
 import { DiagnosticSeverity } from 'vscode';
 import '../../../common/extensions';
 import * as nls from 'vscode-nls';
-import { IConfigurationService, IDisposableRegistry, Resource } from '../../../common/types';
+import { IDisposableRegistry, Resource } from '../../../common/types';
 import { IInterpreterService } from '../../../interpreter/contracts';
 import { IServiceContainer } from '../../../ioc/types';
 import { sendTelemetryEvent } from '../../../telemetry';
@@ -67,12 +67,6 @@ export class InvalidPythonInterpreterService extends BaseDiagnosticsService {
     }
 
     public async diagnose(resource: Resource): Promise<IDiagnostic[]> {
-        const configurationService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
-        const settings = configurationService.getSettings(resource);
-        if (settings.disableInstallationChecks === true) {
-            return [];
-        }
-
         const interpreterService = this.serviceContainer.get<IInterpreterService>(IInterpreterService);
         const hasInterpreters = await interpreterService.hasInterpreters();
 

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -112,8 +112,6 @@ export class PythonSettings implements IPythonSettings {
 
     public sortImports!: ISortImportSettings;
 
-    public disableInstallationChecks = false;
-
     public globalModuleInstallation = false;
 
     public pylanceLspNotebooksEnabled = false;
@@ -294,7 +292,6 @@ export class PythonSettings implements IPythonSettings {
             this.linting = lintingSettings;
         }
 
-        this.disableInstallationChecks = pythonSettings.get<boolean>('disableInstallationCheck') === true;
         this.globalModuleInstallation = pythonSettings.get<boolean>('globalModuleInstallation') === true;
         this.pylanceLspNotebooksEnabled = pythonSettings.get<boolean>('pylanceLspNotebooksEnabled') === true;
 

--- a/src/client/common/process/internal/python.ts
+++ b/src/client/common/process/internal/python.ts
@@ -27,16 +27,6 @@ export function execModule(name: string, moduleArgs: string[]): string[] {
     return args;
 }
 
-export function getSysPrefix(): [string[], (out: string) => string] {
-    const args = ['-c', 'import sys;print(sys.prefix)'];
-
-    function parse(out: string): string {
-        return out.trim();
-    }
-
-    return [args, parse];
-}
-
 export function getExecutable(): [string[], (out: string) => string] {
     const args = ['-c', 'import sys;print(sys.executable)'];
 

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -188,7 +188,6 @@ export interface IPythonSettings {
     readonly terminal: ITerminalSettings;
     readonly sortImports: ISortImportSettings;
     readonly envFile: string;
-    readonly disableInstallationChecks: boolean;
     readonly globalModuleInstallation: boolean;
     readonly pylanceLspNotebooksEnabled: boolean;
     readonly onDidChange: Event<void>;

--- a/src/test/application/diagnostics/checks/macPythonInterpreter.unit.test.ts
+++ b/src/test/application/diagnostics/checks/macPythonInterpreter.unit.test.ts
@@ -144,22 +144,7 @@ suite('Application Diagnostics - Checks Mac Python Interpreter', () => {
             expect(diagnostics).to.be.deep.equal([]);
             platformService.verifyAll();
         });
-        test('Should return empty diagnostics if installer check is disabled', async () => {
-            settings
-                .setup((s) => s.disableInstallationChecks)
-                .returns(() => true)
-                .verifiable(typemoq.Times.once());
-
-            const diagnostics = await diagnosticService.diagnose(undefined);
-            expect(diagnostics).to.be.deep.equal([]);
-            settings.verifyAll();
-            platformService.verifyAll();
-        });
         test('Should return empty diagnostics if platform is mac and selected interpreter is not default mac interpreter', async () => {
-            settings
-                .setup((s) => s.disableInstallationChecks)
-                .returns(() => false)
-                .verifiable(typemoq.Times.once());
             platformService
                 .setup((i) => i.isMac)
                 .returns(() => true)
@@ -176,11 +161,6 @@ suite('Application Diagnostics - Checks Mac Python Interpreter', () => {
             helper.verifyAll();
         });
         test('Should return diagnostic if platform is mac and selected interpreter is default mac interpreter', async () => {
-            settings
-                .setup((s) => s.disableInstallationChecks)
-                .returns(() => false)
-                .verifiable(typemoq.Times.once());
-
             platformService
                 .setup((i) => i.isMac)
                 .returns(() => true)

--- a/src/test/application/diagnostics/checks/pythonInterpreter.unit.test.ts
+++ b/src/test/application/diagnostics/checks/pythonInterpreter.unit.test.ts
@@ -118,21 +118,7 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
             expect(canHandle).to.be.equal(false, 'Invalid value');
             diagnostic.verifyAll();
         });
-        test('Should return empty diagnostics if installer check is disabled', async () => {
-            settings
-                .setup((s) => s.disableInstallationChecks)
-                .returns(() => true)
-                .verifiable(typemoq.Times.once());
-
-            const diagnostics = await diagnosticService.diagnose(undefined);
-            expect(diagnostics).to.be.deep.equal([]);
-            settings.verifyAll();
-        });
         test('Should return diagnostics if there are no interpreters after double-checking', async () => {
-            settings
-                .setup((s) => s.disableInstallationChecks)
-                .returns(() => false)
-                .verifiable(typemoq.Times.once());
             interpreterService
                 .setup((i) => i.hasInterpreters())
                 .returns(() => Promise.resolve(false))
@@ -149,10 +135,6 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
             );
         });
         test('Should return invalid diagnostics if there are interpreters but no current interpreter', async () => {
-            settings
-                .setup((s) => s.disableInstallationChecks)
-                .returns(() => false)
-                .verifiable(typemoq.Times.once());
             interpreterService
                 .setup((i) => i.hasInterpreters())
                 .returns(() => Promise.resolve(true))
@@ -178,10 +160,6 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
             interpreterService.verifyAll();
         });
         test('Should return empty diagnostics if there are interpreters and a current interpreter', async () => {
-            settings
-                .setup((s) => s.disableInstallationChecks)
-                .returns(() => false)
-                .verifiable(typemoq.Times.once());
             interpreterService
                 .setup((i) => i.hasInterpreters())
                 .returns(() => Promise.resolve(true))

--- a/src/test/common/configSettings/configSettings.unit.test.ts
+++ b/src/test/common/configSettings/configSettings.unit.test.ts
@@ -94,7 +94,7 @@ suite('Python Settings', async () => {
         }
 
         // boolean settings
-        for (const name of ['disableInstallationCheck', 'globalModuleInstallation']) {
+        for (const name of ['globalModuleInstallation']) {
             config
                 .setup((c) => c.get<boolean>(name))
 


### PR DESCRIPTION
Should no longer be needing as `python is not installed` prompts are now accurate, also we're trying to remove the prompt.