### PR TITLE
Assume the executable for conda envs lacking an interpreter to be `python`

### DIFF
--- a/news/1 Enhancements/18934.md
+++ b/news/1 Enhancements/18934.md
@@ -1,0 +1,1 @@
+Ensure conda envs lacking an interpreter which do not use a valid python binary are also discovered and is selectable, so that `conda env list` matches with what the extension reports.

--- a/src/client/pythonEnvironments/base/info/env.ts
+++ b/src/client/pythonEnvironments/base/info/env.ts
@@ -251,12 +251,18 @@ export function areSameEnv(
         return true;
     }
 
-    if (allowPartialMatch && arePathsSame(path.dirname(leftFilename), path.dirname(rightFilename))) {
-        const leftVersion = typeof left === 'string' ? undefined : leftInfo.version;
-        const rightVersion = typeof right === 'string' ? undefined : rightInfo.version;
-        if (leftVersion && rightVersion) {
-            if (areIdenticalVersion(leftVersion, rightVersion) || areSimilarVersions(leftVersion, rightVersion)) {
-                return true;
+    if (allowPartialMatch) {
+        const isSameDirectory =
+            leftFilename !== 'python' &&
+            rightFilename !== 'python' &&
+            arePathsSame(path.dirname(leftFilename), path.dirname(rightFilename));
+        if (isSameDirectory) {
+            const leftVersion = typeof left === 'string' ? undefined : leftInfo.version;
+            const rightVersion = typeof right === 'string' ? undefined : rightInfo.version;
+            if (leftVersion && rightVersion) {
+                if (areIdenticalVersion(leftVersion, rightVersion) || areSimilarVersions(leftVersion, rightVersion)) {
+                    return true;
+                }
             }
         }
     }

--- a/src/client/pythonEnvironments/base/info/environmentInfoService.ts
+++ b/src/client/pythonEnvironments/base/info/environmentInfoService.ts
@@ -11,6 +11,8 @@ import { Conda, CONDA_ACTIVATION_TIMEOUT, isCondaEnvironment } from '../../commo
 import { PythonEnvInfo, PythonEnvKind } from '.';
 import { normCasePath } from '../../common/externalDependencies';
 import { OUTPUT_MARKER_SCRIPT } from '../../../common/process/internal/scripts';
+import { Architecture } from '../../../common/utils/platform';
+import { getEmptyVersion } from './pythonVersion';
 
 export enum EnvironmentInfoServiceQueuePriority {
     Default,
@@ -100,6 +102,20 @@ class EnvironmentInfoService implements IEnvironmentInfoService {
         env: PythonEnvInfo,
         priority?: EnvironmentInfoServiceQueuePriority,
     ): Promise<InterpreterInformation | undefined> {
+        if (env.kind === PythonEnvKind.Conda && env.executable.filename === 'python') {
+            const emptyInterpreterInfo: InterpreterInformation = {
+                arch: Architecture.Unknown,
+                executable: {
+                    filename: 'python',
+                    ctime: -1,
+                    mtime: -1,
+                    sysPrefix: '',
+                },
+                version: getEmptyVersion(),
+            };
+
+            return emptyInterpreterInfo;
+        }
         if (this.workerPool === undefined) {
             this.workerPool = createRunningWorkerPool<PythonEnvInfo, InterpreterInformation | undefined>(
                 buildEnvironmentInfo,

--- a/src/client/pythonEnvironments/base/locators/composite/envsCollectionCache.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/envsCollectionCache.ts
@@ -86,7 +86,9 @@ export class PythonEnvInfoCache extends PythonEnvsWatcher<PythonEnvCollectionCha
          * we avoid the cost of running lstat. So simply remove envs which no longer
          * exist.
          */
-        const areEnvsValid = await Promise.all(this.envs.map((e) => pathExists(e.executable.filename)));
+        const areEnvsValid = await Promise.all(
+            this.envs.map((e) => (e.executable.filename === 'python' ? true : pathExists(e.executable.filename))),
+        );
         const invalidIndexes = areEnvsValid
             .map((isValid, index) => (isValid ? -1 : index))
             .filter((i) => i !== -1)

--- a/src/test/pythonEnvironments/base/locators/composite/envsCollectionService.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/composite/envsCollectionService.unit.test.ts
@@ -78,7 +78,8 @@ suite('Python envs locator - Environments Collection', async () => {
             path.join(TEST_LAYOUT_ROOT, 'pipenv', 'project1', '.venv', 'Scripts', 'python.exe'),
             Uri.file(TEST_LAYOUT_ROOT),
         );
-        return [envCached1, envCached2];
+        const envCached3 = createEnv('python');
+        return [envCached1, envCached2, envCached3];
     }
 
     function getCachedEnvs() {
@@ -89,6 +90,7 @@ suite('Python envs locator - Environments Collection', async () => {
     function getExpectedEnvs(doNotIncludeCached?: boolean) {
         const fakeLocalAppDataPath = path.join(TEST_LAYOUT_ROOT, 'storeApps');
         const envCached1 = createEnv(path.join(fakeLocalAppDataPath, 'Microsoft', 'WindowsApps', 'python.exe'));
+        const envCached2 = createEnv('python');
         const env1 = createEnv(path.join(TEST_LAYOUT_ROOT, 'conda1', 'python.exe'), undefined, updatedName);
         const env2 = createEnv(
             path.join(TEST_LAYOUT_ROOT, 'pipenv', 'project1', '.venv', 'Scripts', 'python.exe'),
@@ -106,7 +108,7 @@ suite('Python envs locator - Environments Collection', async () => {
                 return e;
             });
         }
-        return [envCached1, env1, env2, env3].map((e: PythonEnvLatestInfo) => {
+        return [envCached1, envCached2, env1, env2, env3].map((e: PythonEnvLatestInfo) => {
             e.hasLatestInfo = true;
             return e;
         });

--- a/src/test/pythonEnvironments/common/environmentManagers/conda.unit.test.ts
+++ b/src/test/pythonEnvironments/common/environmentManagers/conda.unit.test.ts
@@ -622,21 +622,22 @@ suite('Conda and its environments are located correctly', () => {
         test('Must iterate conda environments correctly', async () => {
             const locator = new CondaEnvironmentLocator();
             const envs = await getEnvs(locator.iterEnvs());
-
-            assertBasicEnvsEqual(
-                envs,
-                [
-                    '/home/user/miniconda3',
-                    '/home/user/miniconda3/envs/env1',
-                    // no env2, because there's no bin/python* under it
-                    '/home/user/miniconda3/envs/dir/env3',
-                    '/home/user/.conda/envs/env4',
-                    // no env5, because there's no bin/python* under it
-                    '/env6',
-                ].map((envPath) =>
-                    createBasicEnv(PythonEnvKind.Conda, path.join(envPath, 'bin', 'python'), undefined, envPath),
-                ),
+            const expected = [
+                '/home/user/miniconda3',
+                '/home/user/miniconda3/envs/env1',
+                '/home/user/miniconda3/envs/dir/env3',
+                '/home/user/.conda/envs/env4',
+                '/env6',
+            ].map((envPath) =>
+                createBasicEnv(PythonEnvKind.Conda, path.join(envPath, 'bin', 'python'), undefined, envPath),
             );
+            expected.push(
+                ...[
+                    '/home/user/miniconda3/envs/env2', // Show env2 despite there's no bin/python* under it
+                    '/home/user/.conda/envs/env5', // Show env5 despite there's no bin/python* under it
+                ].map((envPath) => createBasicEnv(PythonEnvKind.Conda, 'python', undefined, envPath)),
+            );
+            assertBasicEnvsEqual(envs, expected);
         });
     });
 });


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/18934

Also, do not validate conda envs lacking an interpreter so they're displayed and are selectable.