### PR TITLE
Add auto-generated release notes.

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+changelog:
+  exclude:
+    labels:
+      - 'skip news'
+    authors:
+      - 'dependabot'
+
+  categories:
+    - title: Bug Fixes
+      labels:
+        - 'bug'
+
+    - title: Enhancements
+      labels:
+        - 'feature-request'
+
+    - title: Code Health
+      labels:
+        - 'debt'


### PR DESCRIPTION
Adding configuration YML for github automatic release notes generation.

This is a sample generated using the release.xml:
![image](https://user-images.githubusercontent.com/3840081/172520654-481e46f4-6886-4032-ab27-ff8bdf37d630.png)
