### PR TITLE
Fix variable name for flake8Path's description

### DIFF
--- a/package.json
+++ b/package.json
@@ -614,7 +614,7 @@
                 },
                 "python.linting.flake8Path": {
                     "default": "flake8",
-                    "description": "%ython.linting.flake8Path.description%",
+                    "description": "%python.linting.flake8Path.description%",
                     "scope": "machine-overridable",
                     "type": "string"
                 },


### PR DESCRIPTION
Add missing p in variable name , probably it is gone because of copy paste error