### PR TITLE
Ensure we dispose objects on deactivate.

### DIFF
--- a/src/client/common/application/commands/createFileCommand.ts
+++ b/src/client/common/application/commands/createFileCommand.ts
@@ -4,6 +4,7 @@ import { Commands } from '../../constants';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../types';
 import { sendTelemetryEvent } from '../../../telemetry';
 import { EventName } from '../../../telemetry/constants';
+import { IDisposableRegistry } from '../../types';
 
 @injectable()
 export class CreatePythonFileCommandHandler implements IExtensionSingleActivationService {
@@ -13,10 +14,11 @@ export class CreatePythonFileCommandHandler implements IExtensionSingleActivatio
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
+        @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
     ) {}
 
     public async activate(): Promise<void> {
-        this.commandManager.registerCommand(Commands.CreateNewFile, this.createPythonFile, this);
+        this.disposables.push(this.commandManager.registerCommand(Commands.CreateNewFile, this.createPythonFile, this));
     }
 
     public async createPythonFile(): Promise<void> {

--- a/src/client/common/asyncDisposableRegistry.ts
+++ b/src/client/common/asyncDisposableRegistry.ts
@@ -3,18 +3,40 @@
 'use strict';
 import { injectable } from 'inversify';
 import { IAsyncDisposableRegistry } from './types';
-import { Disposables, IDisposable } from './utils/resourceLifecycle';
+import { IDisposable } from './utils/resourceLifecycle';
 
 // List of disposables that need to run a promise.
 @injectable()
 export class AsyncDisposableRegistry implements IAsyncDisposableRegistry {
-    private readonly disposables = new Disposables();
+    private disposables: IDisposable[] = [];
+
+    constructor(...disposables: IDisposable[]) {
+        this.disposables.push(...disposables);
+    }
 
     public push(...disposables: IDisposable[]): void {
         this.disposables.push(...disposables);
     }
 
+    public length(): number {
+        return this.disposables.length;
+    }
+
     public async dispose(): Promise<void> {
-        return this.disposables.dispose();
+        const { disposables } = this;
+        this.disposables = [];
+        await Promise.all(
+            disposables.map(async (d) => {
+                try {
+                    const promise = d.dispose();
+                    if (promise) {
+                        return promise;
+                    }
+                } catch (ex) {
+                    // Don't do anything here
+                }
+                return Promise.resolve();
+            }),
+        );
     }
 }

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -448,6 +448,7 @@ export interface IHashFormat {
 export const IAsyncDisposableRegistry = Symbol('IAsyncDisposableRegistry');
 export interface IAsyncDisposableRegistry extends IAsyncDisposable {
     push(disposable: IDisposable | IAsyncDisposable): void;
+    length(): number;
 }
 
 /**

--- a/src/client/common/utils/resourceLifecycle.ts
+++ b/src/client/common/utils/resourceLifecycle.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { traceWarn } from '../../logging';
-
 /**
  * An object that can be disposed, like vscode.Disposable.
  */
@@ -22,11 +20,11 @@ interface IDisposables extends IDisposable {
  */
 async function disposeAll(disposables: IDisposable[]): Promise<void> {
     await Promise.all(
-        disposables.map(async (d, index) => {
+        disposables.map(async (d) => {
             try {
                 await d.dispose();
             } catch (err) {
-                traceWarn(`dispose() #${index} failed (${err})`);
+                // do nothing
             }
         }),
     );

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -92,6 +92,7 @@ export async function deactivate(): Promise<void> {
         const disposables = activatedServiceContainer.get<IDisposableRegistry>(IDisposableRegistry);
         await Promise.all(disposables.map((d) => Promise.resolve(d.dispose())));
         await registry.dispose();
+        // Remove everything that is already disposed.
         while (disposables.pop());
     }
 }

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -85,20 +85,15 @@ export async function activate(context: IExtensionContext): Promise<IExtensionAp
     return api;
 }
 
-export function deactivate(): Thenable<void> {
+export async function deactivate(): Promise<void> {
     // Make sure to shutdown anybody who needs it.
     if (activatedServiceContainer) {
         const registry = activatedServiceContainer.get<IAsyncDisposableRegistry>(IAsyncDisposableRegistry);
         const disposables = activatedServiceContainer.get<IDisposableRegistry>(IDisposableRegistry);
-        const promises = Promise.all(disposables.map((d) => d.dispose()));
-        return promises.then(() => {
-            if (registry) {
-                return registry.dispose();
-            }
-        });
+        await Promise.all(disposables.map((d) => Promise.resolve(d.dispose())));
+        await registry.dispose();
+        while (disposables.pop());
     }
-
-    return Promise.resolve();
 }
 
 /////////////////////////////

--- a/src/client/extensionInit.ts
+++ b/src/client/extensionInit.ts
@@ -40,10 +40,10 @@ export function initializeGlobals(
     // This is stored in ExtensionState.
     context: IExtensionContext,
 ): ExtensionState {
+    const disposables: IDisposableRegistry = context.subscriptions;
     const cont = new Container({ skipBaseClassChecks: true });
     const serviceManager = new ServiceManager(cont);
     const serviceContainer = new ServiceContainer(cont);
-    const disposables: IDisposableRegistry = context.subscriptions;
 
     serviceManager.addSingletonInstance<IServiceContainer>(IServiceContainer, serviceContainer);
     serviceManager.addSingletonInstance<IServiceManager>(IServiceManager, serviceManager);

--- a/src/client/extensionInit.ts
+++ b/src/client/extensionInit.ts
@@ -54,6 +54,7 @@ export function initializeGlobals(
     serviceManager.addSingletonInstance<IExtensionContext>(IExtensionContext, context);
 
     const standardOutputChannel = window.createOutputChannel(OutputChannelNames.python);
+    context.subscriptions.push(standardOutputChannel);
     context.subscriptions.push(registerLogger(new OutputChannelLogger(standardOutputChannel)));
 
     const workspaceService = new WorkspaceService();
@@ -62,6 +63,8 @@ export function initializeGlobals(
             ? // Do not create any test related output UI when using virtual workspaces.
               instance(mock<IOutputChannel>())
             : window.createOutputChannel(OutputChannelNames.pythonTest);
+    context.subscriptions.push(unitTestOutChannel);
+
     serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, standardOutputChannel, STANDARD_OUTPUT_CHANNEL);
     serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, unitTestOutChannel, TEST_OUTPUT_CHANNEL);
 

--- a/src/client/interpreter/autoSelection/proxy.ts
+++ b/src/client/interpreter/autoSelection/proxy.ts
@@ -5,7 +5,7 @@
 
 import { inject, injectable } from 'inversify';
 import { Event, EventEmitter, Uri } from 'vscode';
-import { IAsyncDisposableRegistry, IDisposableRegistry, Resource } from '../../common/types';
+import { IDisposableRegistry, Resource } from '../../common/types';
 import { PythonEnvironment } from '../../pythonEnvironments/info';
 import { IInterpreterAutoSelectionProxyService } from './types';
 
@@ -15,7 +15,7 @@ export class InterpreterAutoSelectionProxyService implements IInterpreterAutoSel
 
     private instance?: IInterpreterAutoSelectionProxyService;
 
-    constructor(@inject(IDisposableRegistry) private readonly disposables: IAsyncDisposableRegistry) {}
+    constructor(@inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry) {}
 
     public registerInstance(instance: IInterpreterAutoSelectionProxyService): void {
         this.instance = instance;

--- a/src/client/languageServer/watcher.ts
+++ b/src/client/languageServer/watcher.ts
@@ -222,9 +222,10 @@ export class LanguageServerWatcher
     }
 
     private createLanguageServer(languageServerType: LanguageServerType): ILanguageServerExtensionManager {
+        let lsManager: ILanguageServerExtensionManager;
         switch (languageServerType) {
             case LanguageServerType.Jedi:
-                this.languageServerExtensionManager = new JediLSExtensionManager(
+                lsManager = new JediLSExtensionManager(
                     this.serviceContainer,
                     this.lsOutputChannel,
                     this.experimentService,
@@ -237,7 +238,7 @@ export class LanguageServerWatcher
                 );
                 break;
             case LanguageServerType.Node:
-                this.languageServerExtensionManager = new PylanceLSExtensionManager(
+                lsManager = new PylanceLSExtensionManager(
                     this.serviceContainer,
                     this.lsOutputChannel,
                     this.experimentService,
@@ -255,11 +256,12 @@ export class LanguageServerWatcher
                 break;
             case LanguageServerType.None:
             default:
-                this.languageServerExtensionManager = new NoneLSExtensionManager();
+                lsManager = new NoneLSExtensionManager();
                 break;
         }
 
-        return this.languageServerExtensionManager;
+        this.disposables.push(lsManager);
+        return lsManager;
     }
 
     private async refreshLanguageServer(resource?: Resource): Promise<void> {

--- a/src/client/languageServer/watcher.ts
+++ b/src/client/languageServer/watcher.ts
@@ -16,8 +16,8 @@ import {
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../common/application/types';
 import { IFileSystem } from '../common/platform/types';
 import {
+    IAsyncDisposableRegistry,
     IConfigurationService,
-    IDisposableRegistry,
     IExperimentService,
     IExtensions,
     IInterpreterPathService,
@@ -76,7 +76,7 @@ export class LanguageServerWatcher
         @inject(IExtensions) private readonly extensions: IExtensions,
         @inject(IApplicationShell) readonly applicationShell: IApplicationShell,
         @inject(LspNotebooksExperiment) private readonly lspNotebooksExperiment: LspNotebooksExperiment,
-        @inject(IDisposableRegistry) readonly disposables: IDisposableRegistry,
+        @inject(IAsyncDisposableRegistry) readonly disposables: IAsyncDisposableRegistry,
     ) {
         this.workspaceInterpreters = new Map();
         this.workspaceLanguageServers = new Map();
@@ -88,10 +88,8 @@ export class LanguageServerWatcher
             this.workspaceService.onDidChangeWorkspaceFolders(this.onDidChangeWorkspaceFolders.bind(this)),
         );
 
-        this.interpreterService.onDidChangeInterpreterInformation(
-            this.onDidChangeInterpreterInformation,
-            this,
-            disposables,
+        disposables.push(
+            this.interpreterService.onDidChangeInterpreterInformation(this.onDidChangeInterpreterInformation, this),
         );
 
         if (this.workspaceService.isTrusted) {
@@ -260,7 +258,12 @@ export class LanguageServerWatcher
                 break;
         }
 
-        this.disposables.push(lsManager);
+        this.disposables.push({
+            dispose: async () => {
+                await lsManager.stopLanguageServer();
+                lsManager.dispose();
+            },
+        });
         return lsManager;
     }
 

--- a/src/test/activation/outputChannel.unit.test.ts
+++ b/src/test/activation/outputChannel.unit.test.ts
@@ -20,7 +20,7 @@ suite('Language Server Output Channel', () => {
         appShell = TypeMoq.Mock.ofType<IApplicationShell>();
         output = TypeMoq.Mock.ofType<IOutputChannel>();
         commandManager = TypeMoq.Mock.ofType<ICommandManager>();
-        languageServerOutputChannel = new LanguageServerOutputChannel(appShell.object, commandManager.object);
+        languageServerOutputChannel = new LanguageServerOutputChannel(appShell.object, commandManager.object, []);
     });
 
     test('Create output channel if one does not exist before and return it', async () => {

--- a/src/test/common/application/commands/createNewFileCommand.unit.test.ts
+++ b/src/test/common/application/commands/createNewFileCommand.unit.test.ts
@@ -25,6 +25,7 @@ suite('Create New Python File Commmand', () => {
             instance(cmdManager),
             instance(workspaceService),
             instance(appShell),
+            [],
         );
         when(workspaceService.openTextDocument(deepEqual({ language: 'python' }))).thenReturn(
             Promise.resolve(({} as unknown) as TextDocument),

--- a/src/test/languageServer/watcher.unit.test.ts
+++ b/src/test/languageServer/watcher.unit.test.ts
@@ -23,6 +23,7 @@ import { IServiceContainer } from '../../client/ioc/types';
 import { JediLSExtensionManager } from '../../client/languageServer/jediLSExtensionManager';
 import { NoneLSExtensionManager } from '../../client/languageServer/noneLSExtensionManager';
 import { PylanceLSExtensionManager } from '../../client/languageServer/pylanceLSExtensionManager';
+import { ILanguageServerExtensionManager } from '../../client/languageServer/types';
 import { LanguageServerWatcher } from '../../client/languageServer/watcher';
 import * as Logging from '../../client/logging';
 import { PythonEnvironment } from '../../client/pythonEnvironments/info';
@@ -184,9 +185,11 @@ suite('Language server watcher', () => {
     test(`When starting the language server, the language server extension manager should not be undefined`, async () => {
         // First start
         await watcher.startLanguageServer(LanguageServerType.None);
-        const extensionManager = watcher.languageServerExtensionManager!;
+        // get should return the None LS (the noop LS).
+        // This LS is returned by the None LS manager in get().
+        const languageServer = await watcher.get();
 
-        assert.notStrictEqual(extensionManager, undefined);
+        assert.notStrictEqual(languageServer, undefined);
     });
 
     test(`If the interpreter changed, the existing language server should be stopped if there is one`, async () => {
@@ -256,7 +259,8 @@ suite('Language server watcher', () => {
         // First start, get the reference to the extension manager.
         await watcher.startLanguageServer(LanguageServerType.None);
 
-        const extensionManager = watcher.languageServerExtensionManager!;
+        // For None case the object implements both ILanguageServer and ILanguageServerManager.
+        const extensionManager = (await watcher.get()) as ILanguageServerExtensionManager;
         const stopLanguageServerSpy = sandbox.spy(extensionManager, 'stopLanguageServer');
 
         // Second start, check if the first server manager was stopped and disposed of.

--- a/src/test/languageServer/watcher.unit.test.ts
+++ b/src/test/languageServer/watcher.unit.test.ts
@@ -133,7 +133,7 @@ suite('Language server watcher', () => {
             disposables,
         );
 
-        assert.strictEqual(disposables.length(), 5);
+        assert.strictEqual(disposables.length(), 11);
     });
 
     test('The constructor should not add a listener to onDidChange to the list of disposables if it is not a trusted workspace', () => {
@@ -179,7 +179,7 @@ suite('Language server watcher', () => {
             disposables,
         );
 
-        assert.strictEqual(disposables.length(), 4);
+        assert.strictEqual(disposables.length(), 10);
     });
 
     test(`When starting the language server, the language server extension manager should not be undefined`, async () => {

--- a/src/test/languageServer/watcher.unit.test.ts
+++ b/src/test/languageServer/watcher.unit.test.ts
@@ -3,14 +3,16 @@
 
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { ConfigurationChangeEvent, Disposable, Uri, WorkspaceFolder, WorkspaceFoldersChangeEvent } from 'vscode';
+import { ConfigurationChangeEvent, Uri, WorkspaceFolder, WorkspaceFoldersChangeEvent } from 'vscode';
 import { JediLanguageServerManager } from '../../client/activation/jedi/manager';
 import { LspNotebooksExperiment } from '../../client/activation/node/lspNotebooksExperiment';
 import { NodeLanguageServerManager } from '../../client/activation/node/manager';
 import { ILanguageServerOutputChannel, LanguageServerType } from '../../client/activation/types';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../../client/common/application/types';
+import { AsyncDisposableRegistry } from '../../client/common/asyncDisposableRegistry';
 import { IFileSystem } from '../../client/common/platform/types';
 import {
+    IAsyncDisposableRegistry,
     IConfigurationService,
     IExperimentService,
     IExtensions,
@@ -30,9 +32,11 @@ import { PythonEnvironment } from '../../client/pythonEnvironments/info';
 
 suite('Language server watcher', () => {
     let watcher: LanguageServerWatcher;
+    let disposables: IAsyncDisposableRegistry;
     const sandbox = sinon.createSandbox();
 
     setup(() => {
+        disposables = new AsyncDisposableRegistry();
         watcher = new LanguageServerWatcher(
             {} as IServiceContainer,
             {} as ILanguageServerOutputChannel,
@@ -78,7 +82,7 @@ suite('Language server watcher', () => {
             } as unknown) as IExtensions,
             {} as IApplicationShell,
             {} as LspNotebooksExperiment,
-            [] as Disposable[],
+            disposables,
         );
     });
 
@@ -87,8 +91,6 @@ suite('Language server watcher', () => {
     });
 
     test('The constructor should add a listener to onDidChange to the list of disposables if it is a trusted workspace', () => {
-        const disposables: Disposable[] = [];
-
         watcher = new LanguageServerWatcher(
             {} as IServiceContainer,
             {} as ILanguageServerOutputChannel,
@@ -131,12 +133,10 @@ suite('Language server watcher', () => {
             disposables,
         );
 
-        assert.strictEqual(disposables.length, 5);
+        assert.strictEqual(disposables.length(), 5);
     });
 
     test('The constructor should not add a listener to onDidChange to the list of disposables if it is not a trusted workspace', () => {
-        const disposables: Disposable[] = [];
-
         watcher = new LanguageServerWatcher(
             {} as IServiceContainer,
             {} as ILanguageServerOutputChannel,
@@ -179,7 +179,7 @@ suite('Language server watcher', () => {
             disposables,
         );
 
-        assert.strictEqual(disposables.length, 4);
+        assert.strictEqual(disposables.length(), 4);
     });
 
     test(`When starting the language server, the language server extension manager should not be undefined`, async () => {
@@ -253,7 +253,7 @@ suite('Language server watcher', () => {
             } as unknown) as IExtensions,
             {} as IApplicationShell,
             {} as LspNotebooksExperiment,
-            [] as Disposable[],
+            disposables,
         );
 
         // First start, get the reference to the extension manager.
@@ -329,7 +329,7 @@ suite('Language server watcher', () => {
             } as unknown) as IExtensions,
             {} as IApplicationShell,
             {} as LspNotebooksExperiment,
-            [] as Disposable[],
+            disposables,
         );
 
         await watcher.startLanguageServer(LanguageServerType.None);
@@ -408,7 +408,7 @@ suite('Language server watcher', () => {
             } as unknown) as IExtensions,
             {} as IApplicationShell,
             {} as LspNotebooksExperiment,
-            [] as Disposable[],
+            disposables,
         );
 
         const startLanguageServerSpy = sandbox.spy(watcher, 'startLanguageServer');
@@ -478,7 +478,7 @@ suite('Language server watcher', () => {
             } as unknown) as IExtensions,
             {} as IApplicationShell,
             {} as LspNotebooksExperiment,
-            [] as Disposable[],
+            disposables,
         );
 
         // Use a fake here so we don't actually start up language servers.
@@ -541,7 +541,7 @@ suite('Language server watcher', () => {
             } as unknown) as IExtensions,
             {} as IApplicationShell,
             {} as LspNotebooksExperiment,
-            [] as Disposable[],
+            disposables,
         );
 
         await watcher.startLanguageServer(LanguageServerType.Jedi);
@@ -605,7 +605,7 @@ suite('Language server watcher', () => {
                 showWarningMessage: () => Promise.resolve(undefined),
             } as unknown) as IApplicationShell,
             {} as LspNotebooksExperiment,
-            [] as Disposable[],
+            disposables,
         );
 
         await watcher.startLanguageServer(LanguageServerType.Node);
@@ -663,7 +663,7 @@ suite('Language server watcher', () => {
             } as unknown) as IExtensions,
             {} as IApplicationShell,
             {} as LspNotebooksExperiment,
-            [] as Disposable[],
+            disposables,
         );
 
         await watcher.startLanguageServer(LanguageServerType.Jedi);
@@ -752,7 +752,7 @@ suite('Language server watcher', () => {
                     showWarningMessage: () => Promise.resolve(undefined),
                 } as unknown) as IApplicationShell,
                 {} as LspNotebooksExperiment,
-                [] as Disposable[],
+                disposables,
             );
 
             await watcher.startLanguageServer(languageServer, Uri.parse('folder1'));
@@ -831,7 +831,7 @@ suite('Language server watcher', () => {
                     showWarningMessage: () => Promise.resolve(undefined),
                 } as unknown) as IApplicationShell,
                 {} as LspNotebooksExperiment,
-                [] as Disposable[],
+                disposables,
             );
 
             await watcher.startLanguageServer(languageServer, Uri.parse('workspace1'));
@@ -919,7 +919,7 @@ suite('Language server watcher', () => {
             } as unknown) as IExtensions,
             {} as IApplicationShell,
             {} as LspNotebooksExperiment,
-            [] as Disposable[],
+            disposables,
         );
 
         const startLanguageServerSpy = sandbox.spy(watcher, 'startLanguageServer');
@@ -999,7 +999,7 @@ suite('Language server watcher', () => {
             } as unknown) as IExtensions,
             {} as IApplicationShell,
             {} as LspNotebooksExperiment,
-            [] as Disposable[],
+            disposables,
         );
 
         const startLanguageServerSpy = sandbox.spy(watcher, 'startLanguageServer');
@@ -1082,7 +1082,7 @@ suite('Language server watcher', () => {
             } as unknown) as IExtensions,
             {} as IApplicationShell,
             {} as LspNotebooksExperiment,
-            [] as Disposable[],
+            disposables,
         );
 
         const startLanguageServerSpy = sandbox.spy(watcher, 'startLanguageServer');
@@ -1165,7 +1165,7 @@ suite('Language server watcher', () => {
             } as unknown) as IExtensions,
             {} as IApplicationShell,
             {} as LspNotebooksExperiment,
-            [] as Disposable[],
+            disposables,
         );
 
         const startLanguageServerSpy = sandbox.spy(watcher, 'startLanguageServer');


### PR DESCRIPTION
Closes #19339

This is a hack to get around the dispose issue. The extension handles object lifetimes in unclear ways. So, to actually address this we might have to get rid of `inversify`. Currently, disposing the inversify container and re-creating objects seems to cause issues due to the fact the extension itself on not entirely unloaded.

Another option would be to ask for de-activation API. Another option that handles this cleanly but has bad UX is extension reload on trust change.