### PR TITLE
Ensure we register for interpreter change when moving from untrusted to trusted.

### DIFF
--- a/src/client/activation/node/lspNotebooksExperiment.ts
+++ b/src/client/activation/node/lspNotebooksExperiment.ts
@@ -3,7 +3,7 @@
 import { inject, injectable } from 'inversify';
 import * as semver from 'semver';
 import { Disposable, extensions } from 'vscode';
-import { IConfigurationService } from '../../common/types';
+import { IConfigurationService, IDisposableRegistry } from '../../common/types';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { JUPYTER_EXTENSION_ID, PYLANCE_EXTENSION_ID } from '../../common/constants';
@@ -28,6 +28,7 @@ export class LspNotebooksExperiment implements IExtensionSingleActivationService
     constructor(
         @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer,
         @inject(IConfigurationService) private readonly configurationService: IConfigurationService,
+        @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
         @inject(IJupyterExtensionDependencyManager) jupyterDependencyManager: IJupyterExtensionDependencyManager,
     ) {
         this.isJupyterInstalled = jupyterDependencyManager.isJupyterExtensionInstalled;
@@ -36,6 +37,7 @@ export class LspNotebooksExperiment implements IExtensionSingleActivationService
     public async activate(): Promise<void> {
         if (!LspNotebooksExperiment.isPylanceInstalled()) {
             this.pylanceExtensionChangeHandler = extensions.onDidChange(this.pylanceExtensionsChangeHandler.bind(this));
+            this.disposables.push(this.pylanceExtensionChangeHandler);
         }
 
         this.updateExperimentSupport();

--- a/src/client/activation/node/lspNotebooksExperiment.ts
+++ b/src/client/activation/node/lspNotebooksExperiment.ts
@@ -30,14 +30,14 @@ export class LspNotebooksExperiment implements IExtensionSingleActivationService
         @inject(IConfigurationService) private readonly configurationService: IConfigurationService,
         @inject(IJupyterExtensionDependencyManager) jupyterDependencyManager: IJupyterExtensionDependencyManager,
     ) {
-        if (!LspNotebooksExperiment.isPylanceInstalled()) {
-            this.pylanceExtensionChangeHandler = extensions.onDidChange(this.pylanceExtensionsChangeHandler.bind(this));
-        }
-
         this.isJupyterInstalled = jupyterDependencyManager.isJupyterExtensionInstalled;
     }
 
     public async activate(): Promise<void> {
+        if (!LspNotebooksExperiment.isPylanceInstalled()) {
+            this.pylanceExtensionChangeHandler = extensions.onDidChange(this.pylanceExtensionsChangeHandler.bind(this));
+        }
+
         this.updateExperimentSupport();
     }
 

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -159,7 +159,7 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
 
             serviceManager.get<ICodeExecutionManager>(ICodeExecutionManager).registerCommands();
 
-            context.subscriptions.push(new LinterCommands(serviceManager));
+            disposables.push(new LinterCommands(serviceManager));
 
             if (
                 pythonSettings &&
@@ -167,19 +167,17 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
                 pythonSettings.formatting.provider !== 'internalConsole'
             ) {
                 const formatProvider = new PythonFormattingEditProvider(context, serviceContainer);
-                context.subscriptions.push(languages.registerDocumentFormattingEditProvider(PYTHON, formatProvider));
-                context.subscriptions.push(
-                    languages.registerDocumentRangeFormattingEditProvider(PYTHON, formatProvider),
-                );
+                disposables.push(languages.registerDocumentFormattingEditProvider(PYTHON, formatProvider));
+                disposables.push(languages.registerDocumentRangeFormattingEditProvider(PYTHON, formatProvider));
             }
 
-            context.subscriptions.push(new ReplProvider(serviceContainer));
+            disposables.push(new ReplProvider(serviceContainer));
 
             const terminalProvider = new TerminalProvider(serviceContainer);
             terminalProvider.initialize(window.activeTerminal).ignoreErrors();
-            context.subscriptions.push(terminalProvider);
+            disposables.push(terminalProvider);
 
-            context.subscriptions.push(
+            disposables.push(
                 languages.registerCodeActionsProvider(PYTHON, new PythonCodeActionProvider(), {
                     providedCodeActionKinds: [CodeActionKind.SourceOrganizeImports],
                 }),
@@ -188,9 +186,7 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
             serviceContainer
                 .getAll<DebugConfigurationProvider>(IDebugConfigurationService)
                 .forEach((debugConfigProvider) => {
-                    context.subscriptions.push(
-                        debug.registerDebugConfigurationProvider(DebuggerTypeName, debugConfigProvider),
-                    );
+                    disposables.push(debug.registerDebugConfigurationProvider(DebuggerTypeName, debugConfigProvider));
                 });
 
             serviceContainer.get<IDebuggerBanner>(IDebuggerBanner).initialize();
@@ -200,7 +196,7 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
     // "activate" everything else
 
     const manager = serviceContainer.get<IExtensionActivationManager>(IExtensionActivationManager);
-    context.subscriptions.push(manager);
+    disposables.push(manager);
 
     const activationPromise = manager.activate();
 

--- a/src/client/extensionInit.ts
+++ b/src/client/extensionInit.ts
@@ -54,8 +54,8 @@ export function initializeGlobals(
     serviceManager.addSingletonInstance<IExtensionContext>(IExtensionContext, context);
 
     const standardOutputChannel = window.createOutputChannel(OutputChannelNames.python);
-    context.subscriptions.push(standardOutputChannel);
-    context.subscriptions.push(registerLogger(new OutputChannelLogger(standardOutputChannel)));
+    disposables.push(standardOutputChannel);
+    disposables.push(registerLogger(new OutputChannelLogger(standardOutputChannel)));
 
     const workspaceService = new WorkspaceService();
     const unitTestOutChannel =
@@ -63,7 +63,7 @@ export function initializeGlobals(
             ? // Do not create any test related output UI when using virtual workspaces.
               instance(mock<IOutputChannel>())
             : window.createOutputChannel(OutputChannelNames.pythonTest);
-    context.subscriptions.push(unitTestOutChannel);
+    disposables.push(unitTestOutChannel);
 
     serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, standardOutputChannel, STANDARD_OUTPUT_CHANNEL);
     serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, unitTestOutChannel, TEST_OUTPUT_CHANNEL);

--- a/src/client/languageServer/watcher.ts
+++ b/src/client/languageServer/watcher.ts
@@ -95,7 +95,7 @@ export class LanguageServerWatcher
         await this.startAndGetLanguageServer(languageServerType, resource);
     }
 
-    private register(): void {
+    public register(): void {
         if (!this.registered) {
             this.registered = true;
             this.disposables.push(

--- a/src/client/languageServer/watcher.ts
+++ b/src/client/languageServer/watcher.ts
@@ -59,8 +59,6 @@ export class LanguageServerWatcher
     // When using Pylance, there will only be one language server for the project.
     private workspaceLanguageServers: Map<string, ILanguageServerExtensionManager | undefined>;
 
-    private languageServerChangeHandler: LanguageServerChangeHandler;
-
     constructor(
         @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer,
         @inject(ILanguageServerOutputChannel) private readonly lsOutputChannel: ILanguageServerOutputChannel,
@@ -81,16 +79,6 @@ export class LanguageServerWatcher
         this.workspaceInterpreters = new Map();
         this.workspaceLanguageServers = new Map();
         this.languageServerType = this.configurationService.getSettings().languageServer;
-
-        this.languageServerChangeHandler = new LanguageServerChangeHandler(
-            this.languageServerType,
-            this.extensions,
-            this.applicationShell,
-            this.commandManager,
-            this.workspaceService,
-            this.configurationService,
-        );
-        this.disposables.push(this.languageServerChangeHandler);
     }
 
     // IExtensionActivationService
@@ -114,6 +102,17 @@ export class LanguageServerWatcher
             this.extensions.onDidChange(async () => {
                 await this.extensionsChangeHandler();
             }),
+        );
+
+        this.disposables.push(
+            new LanguageServerChangeHandler(
+                this.languageServerType,
+                this.extensions,
+                this.applicationShell,
+                this.commandManager,
+                this.workspaceService,
+                this.configurationService,
+            ),
         );
 
         await this.startLanguageServer(this.languageServerType, resource);

--- a/src/client/languageServer/watcher.ts
+++ b/src/client/languageServer/watcher.ts
@@ -59,6 +59,8 @@ export class LanguageServerWatcher
     // When using Pylance, there will only be one language server for the project.
     private workspaceLanguageServers: Map<string, ILanguageServerExtensionManager | undefined>;
 
+    private registered = false;
+
     constructor(
         @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer,
         @inject(ILanguageServerOutputChannel) private readonly lsOutputChannel: ILanguageServerOutputChannel,
@@ -84,43 +86,51 @@ export class LanguageServerWatcher
     // IExtensionActivationService
 
     public async activate(resource?: Resource): Promise<void> {
-        this.disposables.push(this.workspaceService.onDidChangeConfiguration(this.onDidChangeConfiguration.bind(this)));
-
-        this.disposables.push(
-            this.workspaceService.onDidChangeWorkspaceFolders(this.onDidChangeWorkspaceFolders.bind(this)),
-        );
-
-        this.disposables.push(
-            this.interpreterService.onDidChangeInterpreterInformation(this.onDidChangeInterpreterInformation, this),
-        );
-
-        if (this.workspaceService.isTrusted) {
-            this.disposables.push(this.interpreterPathService.onDidChange(this.onDidChangeInterpreter.bind(this)));
-        }
-
-        this.disposables.push(
-            this.extensions.onDidChange(async () => {
-                await this.extensionsChangeHandler();
-            }),
-        );
-
-        this.disposables.push(
-            new LanguageServerChangeHandler(
-                this.languageServerType,
-                this.extensions,
-                this.applicationShell,
-                this.commandManager,
-                this.workspaceService,
-                this.configurationService,
-            ),
-        );
-
+        this.register();
         await this.startLanguageServer(this.languageServerType, resource);
     }
 
     // ILanguageServerWatcher
     public async startLanguageServer(languageServerType: LanguageServerType, resource?: Resource): Promise<void> {
         await this.startAndGetLanguageServer(languageServerType, resource);
+    }
+
+    private register(): void {
+        if (!this.registered) {
+            this.registered = true;
+            this.disposables.push(
+                this.workspaceService.onDidChangeConfiguration(this.onDidChangeConfiguration.bind(this)),
+            );
+
+            this.disposables.push(
+                this.workspaceService.onDidChangeWorkspaceFolders(this.onDidChangeWorkspaceFolders.bind(this)),
+            );
+
+            this.disposables.push(
+                this.interpreterService.onDidChangeInterpreterInformation(this.onDidChangeInterpreterInformation, this),
+            );
+
+            if (this.workspaceService.isTrusted) {
+                this.disposables.push(this.interpreterPathService.onDidChange(this.onDidChangeInterpreter.bind(this)));
+            }
+
+            this.disposables.push(
+                this.extensions.onDidChange(async () => {
+                    await this.extensionsChangeHandler();
+                }),
+            );
+
+            this.disposables.push(
+                new LanguageServerChangeHandler(
+                    this.languageServerType,
+                    this.extensions,
+                    this.applicationShell,
+                    this.commandManager,
+                    this.workspaceService,
+                    this.configurationService,
+                ),
+            );
+        }
     }
 
     private async startAndGetLanguageServer(

--- a/src/client/languageServer/watcher.ts
+++ b/src/client/languageServer/watcher.ts
@@ -82,20 +82,6 @@ export class LanguageServerWatcher
         this.workspaceLanguageServers = new Map();
         this.languageServerType = this.configurationService.getSettings().languageServer;
 
-        disposables.push(this.workspaceService.onDidChangeConfiguration(this.onDidChangeConfiguration.bind(this)));
-
-        disposables.push(
-            this.workspaceService.onDidChangeWorkspaceFolders(this.onDidChangeWorkspaceFolders.bind(this)),
-        );
-
-        disposables.push(
-            this.interpreterService.onDidChangeInterpreterInformation(this.onDidChangeInterpreterInformation, this),
-        );
-
-        if (this.workspaceService.isTrusted) {
-            disposables.push(this.interpreterPathService.onDidChange(this.onDidChangeInterpreter.bind(this)));
-        }
-
         this.languageServerChangeHandler = new LanguageServerChangeHandler(
             this.languageServerType,
             this.extensions,
@@ -104,18 +90,32 @@ export class LanguageServerWatcher
             this.workspaceService,
             this.configurationService,
         );
-        disposables.push(this.languageServerChangeHandler);
-
-        disposables.push(
-            extensions.onDidChange(async () => {
-                await this.extensionsChangeHandler();
-            }),
-        );
+        this.disposables.push(this.languageServerChangeHandler);
     }
 
     // IExtensionActivationService
 
     public async activate(resource?: Resource): Promise<void> {
+        this.disposables.push(this.workspaceService.onDidChangeConfiguration(this.onDidChangeConfiguration.bind(this)));
+
+        this.disposables.push(
+            this.workspaceService.onDidChangeWorkspaceFolders(this.onDidChangeWorkspaceFolders.bind(this)),
+        );
+
+        this.disposables.push(
+            this.interpreterService.onDidChangeInterpreterInformation(this.onDidChangeInterpreterInformation, this),
+        );
+
+        if (this.workspaceService.isTrusted) {
+            this.disposables.push(this.interpreterPathService.onDidChange(this.onDidChangeInterpreter.bind(this)));
+        }
+
+        this.disposables.push(
+            this.extensions.onDidChange(async () => {
+                await this.extensionsChangeHandler();
+            }),
+        );
+
         await this.startLanguageServer(this.languageServerType, resource);
     }
 

--- a/src/test/languageServer/watcher.unit.test.ts
+++ b/src/test/languageServer/watcher.unit.test.ts
@@ -83,6 +83,8 @@ suite('Language server watcher', () => {
             {} as LspNotebooksExperiment,
             disposables,
         );
+
+        watcher.register();
     });
 
     teardown(() => {
@@ -131,7 +133,7 @@ suite('Language server watcher', () => {
             {} as LspNotebooksExperiment,
             disposables,
         );
-
+        watcher.register();
         assert.strictEqual(disposables.length, 11);
     });
 
@@ -177,7 +179,7 @@ suite('Language server watcher', () => {
             {} as LspNotebooksExperiment,
             disposables,
         );
-
+        watcher.register();
         assert.strictEqual(disposables.length, 10);
     });
 
@@ -254,6 +256,7 @@ suite('Language server watcher', () => {
             {} as LspNotebooksExperiment,
             disposables,
         );
+        watcher.register();
 
         // First start, get the reference to the extension manager.
         await watcher.startLanguageServer(LanguageServerType.None);
@@ -330,6 +333,7 @@ suite('Language server watcher', () => {
             {} as LspNotebooksExperiment,
             disposables,
         );
+        watcher.register();
 
         await watcher.startLanguageServer(LanguageServerType.None);
 
@@ -409,7 +413,7 @@ suite('Language server watcher', () => {
             {} as LspNotebooksExperiment,
             disposables,
         );
-
+        watcher.register();
         const startLanguageServerSpy = sandbox.spy(watcher, 'startLanguageServer');
 
         await watcher.startLanguageServer(LanguageServerType.None);
@@ -479,6 +483,7 @@ suite('Language server watcher', () => {
             {} as LspNotebooksExperiment,
             disposables,
         );
+        watcher.register();
 
         // Use a fake here so we don't actually start up language servers.
         const startLanguageServerFake = sandbox.fake.resolves(undefined);
@@ -542,7 +547,7 @@ suite('Language server watcher', () => {
             {} as LspNotebooksExperiment,
             disposables,
         );
-
+        watcher.register();
         await watcher.startLanguageServer(LanguageServerType.Jedi);
 
         assert.ok(startLanguageServerStub.calledOnce);
@@ -606,6 +611,7 @@ suite('Language server watcher', () => {
             {} as LspNotebooksExperiment,
             disposables,
         );
+        watcher.register();
 
         await watcher.startLanguageServer(LanguageServerType.Node);
 
@@ -664,6 +670,7 @@ suite('Language server watcher', () => {
             {} as LspNotebooksExperiment,
             disposables,
         );
+        watcher.register();
 
         await watcher.startLanguageServer(LanguageServerType.Jedi);
 
@@ -753,6 +760,7 @@ suite('Language server watcher', () => {
                 {} as LspNotebooksExperiment,
                 disposables,
             );
+            watcher.register();
 
             await watcher.startLanguageServer(languageServer, Uri.parse('folder1'));
             await watcher.startLanguageServer(languageServer, Uri.parse('folder2'));
@@ -832,6 +840,7 @@ suite('Language server watcher', () => {
                 {} as LspNotebooksExperiment,
                 disposables,
             );
+            watcher.register();
 
             await watcher.startLanguageServer(languageServer, Uri.parse('workspace1'));
             await watcher.startLanguageServer(languageServer, Uri.parse('workspace2'));
@@ -920,6 +929,7 @@ suite('Language server watcher', () => {
             {} as LspNotebooksExperiment,
             disposables,
         );
+        watcher.register();
 
         const startLanguageServerSpy = sandbox.spy(watcher, 'startLanguageServer');
 
@@ -1000,6 +1010,7 @@ suite('Language server watcher', () => {
             {} as LspNotebooksExperiment,
             disposables,
         );
+        watcher.register();
 
         const startLanguageServerSpy = sandbox.spy(watcher, 'startLanguageServer');
 
@@ -1083,6 +1094,7 @@ suite('Language server watcher', () => {
             {} as LspNotebooksExperiment,
             disposables,
         );
+        watcher.register();
 
         const startLanguageServerSpy = sandbox.spy(watcher, 'startLanguageServer');
 
@@ -1166,6 +1178,7 @@ suite('Language server watcher', () => {
             {} as LspNotebooksExperiment,
             disposables,
         );
+        watcher.register();
 
         const startLanguageServerSpy = sandbox.spy(watcher, 'startLanguageServer');
 


### PR DESCRIPTION
I have moved some of the even registrations into `activate()`. This is needed because whenever we change trust we call `deactivate()` and `activate` the extension. This is to simulate the extension re-load.

The cause is that object lifetime management currently is not straightforward due to the way we use `inversify`. This is compounded by the fact that when inversify unloads, it does not call dispose on the objects. Then again inversify may not own the object that it is trying to dispose. For now hacks will have to do. Long term we will be rewriting the various parts of the extension to get rid of `inversify` and have better control over object life times. so we can actually do `deactivate` and `activate` to simulate `Windows re-load`.