### PR TITLE
Ensure we can change interpreters after trusting a workspace

### DIFF
--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -507,6 +507,11 @@ export class PythonSettings implements IPythonSettings {
         }
     }
 
+    public register(): void {
+        PythonSettings.pythonSettings = new Map();
+        this.initialize();
+    }
+
     public initialize(): void {
         const onDidChange = () => {
             const currentConfig = this.workspace.getConfiguration('python', this.workspaceRoot);

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -201,7 +201,7 @@ export interface IPythonSettings {
     readonly languageServerIsDefault: boolean;
     readonly defaultInterpreterPath: string;
     readonly tensorBoard: ITensorBoardSettings | undefined;
-    initialize(): void;
+    register(): void;
 }
 
 export interface ITensorBoardSettings {

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -124,7 +124,7 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
 
     const configuration = serviceManager.get<IConfigurationService>(IConfigurationService);
     // Settings are dependent on Experiment service, so we need to initialize it after experiments are activated.
-    serviceContainer.get<IConfigurationService>(IConfigurationService).getSettings().initialize();
+    serviceContainer.get<IConfigurationService>(IConfigurationService).getSettings().register();
 
     // Language feature registrations.
     appRegisterTypes(serviceManager);


### PR DESCRIPTION
`ConfigSettings` is a static class and so wasn't being deregistered properly when extension is deactivated, so it was still using the reference to older singletons before deactivation.