### PR TITLE
Trigger refresh when using `Select Interpreter` command if no envs were found previously

### DIFF
--- a/src/client/pythonEnvironments/base/locator.ts
+++ b/src/client/pythonEnvironments/base/locator.ts
@@ -199,7 +199,7 @@ export type TriggerRefreshOptions = {
      */
     clearCache?: boolean;
     /**
-     * Only trigger a refresh if it hasn't already been triggered for this session.
+     * Only trigger a refresh if it hasn't already been triggered for this session, or if no envs were found previously.
      */
     ifNotTriggerredAlready?: boolean;
 };


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/19099

This will ensure when users finish installing Python from windows store, it shows up without reload when re-opening the list.