### PR TITLE
Do not trigger test discovery if an invalid interpreter is selected for the workspace

### DIFF
--- a/src/client/testing/main.ts
+++ b/src/client/testing/main.ts
@@ -146,6 +146,12 @@ export class UnitTestManagementService implements IExtensionActivationService {
         if (!wkspace) {
             return;
         }
+        const interpreterService = this.serviceContainer.get<IInterpreterService>(IInterpreterService);
+        const commandManager = this.serviceContainer.get<ICommandManager>(ICommandManager);
+        if (!(await interpreterService.getActiveInterpreter(wkspace))) {
+            commandManager.executeCommand('python.triggerEnvSelection', wkspace);
+            return;
+        }
         const configurationService = this.serviceContainer.get<ITestConfigurationService>(ITestConfigurationService);
         await configurationService.promptToEnableAndConfigureTestFramework(wkspace!);
     }


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/19465

Instead, trigger the environment prompts. And in case of auto discovery, log error.