### PR TITLE
Ensure all components in extension are correctly re-activated when a workspace is trusted

### DIFF
--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -27,16 +27,18 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
     private docOpenedHandler?: IDisposable;
 
     constructor(
-        @multiInject(IExtensionActivationService) private readonly activationServices: IExtensionActivationService[],
+        @multiInject(IExtensionActivationService) private activationServices: IExtensionActivationService[],
         @multiInject(IExtensionSingleActivationService)
-        private readonly singleActivationServices: IExtensionSingleActivationService[],
+        private singleActivationServices: IExtensionSingleActivationService[],
         @inject(IDocumentManager) private readonly documentManager: IDocumentManager,
         @inject(IInterpreterAutoSelectionService) private readonly autoSelection: IInterpreterAutoSelectionService,
         @inject(IApplicationDiagnostics) private readonly appDiagnostics: IApplicationDiagnostics,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IFileSystem) private readonly fileSystem: IFileSystem,
         @inject(IActiveResourceService) private readonly activeResourceService: IActiveResourceService,
-    ) {
+    ) {}
+
+    private filterServices() {
         if (!this.workspaceService.isTrusted) {
             this.activationServices = this.activationServices.filter(
                 (service) => service.supportedWorkspaceTypes.untrustedWorkspace,
@@ -67,6 +69,7 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
     }
 
     public async activate(): Promise<void> {
+        this.filterServices();
         await this.initialize();
 
         // Activate all activation services together.


### PR DESCRIPTION
Because objects are not re-created, constructor is only run once. Move these registrations into activate() method.