### PR TITLE
Ensure install pylance prompt does not show up when starting codespaces

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,8 @@
     "recommendations": [
         "editorconfig.editorconfig",
         "esbenp.prettier-vscode",
-        "dbaeumer.vscode-eslint"
+        "dbaeumer.vscode-eslint",
+        "ms-python.python",
+        "ms-python.vscode-pylance"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,7 +56,7 @@
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": true
     },
-    "python.languageServer": "Pylance",
+    "python.languageServer": "Default",
     "python.linting.pylintEnabled": false,
     "python.linting.flake8Enabled": true,
     "cucumberautocomplete.skipDocStringsFormat": true,


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/19496

Instead of explicitly setting it to Pylance, it probably makes sense if we mention it as one of the recommended extensions of the repository. So users would still end up using Pylance, but not having an additional notification to install it.