### PR TITLE
Add python-insider and python-public target populations

### DIFF
--- a/src/client/common/experiments/service.ts
+++ b/src/client/common/experiments/service.ts
@@ -19,6 +19,11 @@ const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 const EXP_MEMENTO_KEY = 'VSCode.ABExp.FeatureData';
 const EXP_CONFIG_ID = 'vscode';
 
+/**
+ * We're defining a custom TargetPopulation specific for the Python extension.
+ * This is done so ExP's Control Tower is able to differentiate between
+ * VS Code insiders users and Python extension insiders (pre-release) users.
+ */
 export enum TargetPopulation {
     Insiders = 'python-insider',
     Public = 'python-public',

--- a/src/client/common/experiments/service.ts
+++ b/src/client/common/experiments/service.ts
@@ -21,8 +21,8 @@ const EXP_CONFIG_ID = 'vscode';
 
 /**
  * We're defining a custom TargetPopulation specific for the Python extension.
- * This is done so ExP's Control Tower is able to differentiate between
- * VS Code insiders users and Python extension insiders (pre-release) users.
+ * This is done so the exp framework is able to differentiate between
+ * VS Code insiders/public users and Python extension insiders (pre-release)/public users.
  */
 export enum TargetPopulation {
     Insiders = 'python-insider',

--- a/src/client/common/experiments/service.ts
+++ b/src/client/common/experiments/service.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { getExperimentationService, IExperimentationService, TargetPopulation } from 'vscode-tas-client';
+import { getExperimentationService, IExperimentationService } from 'vscode-tas-client';
 import * as nls from 'vscode-nls';
 import { traceLog } from '../../logging';
 import { sendTelemetryEvent } from '../../telemetry';
@@ -18,6 +18,11 @@ const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 const EXP_MEMENTO_KEY = 'VSCode.ABExp.FeatureData';
 const EXP_CONFIG_ID = 'vscode';
+
+export enum TargetPopulation {
+    Insiders = 'python-insider',
+    Public = 'python-public',
+}
 
 @injectable()
 export class ExperimentService implements IExperimentService {

--- a/src/test/common/experiments/service.unit.test.ts
+++ b/src/test/common/experiments/service.unit.test.ts
@@ -13,7 +13,7 @@ import { ApplicationEnvironment } from '../../../client/common/application/appli
 import { IApplicationEnvironment, IWorkspaceService } from '../../../client/common/application/types';
 import { WorkspaceService } from '../../../client/common/application/workspace';
 import { Channel } from '../../../client/common/constants';
-import { ExperimentService } from '../../../client/common/experiments/service';
+import { ExperimentService, TargetPopulation } from '../../../client/common/experiments/service';
 import { PersistentState } from '../../../client/common/persistentState';
 import { IPersistentStateFactory } from '../../../client/common/types';
 import { registerLogger } from '../../../client/logging';
@@ -80,18 +80,18 @@ suite('Experimentation service', () => {
     suite('Initialization', () => {
         test('Users with a release version of the extension should be in the Public target population', () => {
             const getExperimentationServiceStub = sinon.stub(tasClient, 'getExperimentationService');
-
             configureSettings(true, [], []);
             configureApplicationEnvironment('stable', extensionVersion);
 
             // eslint-disable-next-line no-new
             new ExperimentService(instance(workspaceService), instance(appEnvironment), instance(stateFactory));
 
+            // @ts-ignore I dont know how else to ignore this issue.
             sinon.assert.calledWithExactly(
                 getExperimentationServiceStub,
                 PVSC_EXTENSION_ID_FOR_TESTS,
                 extensionVersion,
-                tasClient.TargetPopulation.Public,
+                sinon.match(TargetPopulation.Public),
                 sinon.match.any,
                 globalMemento,
             );
@@ -110,7 +110,7 @@ suite('Experimentation service', () => {
                 getExperimentationServiceStub,
                 PVSC_EXTENSION_ID_FOR_TESTS,
                 extensionVersion,
-                tasClient.TargetPopulation.Insiders,
+                sinon.match(TargetPopulation.Insiders),
                 sinon.match.any,
                 globalMemento,
             );


### PR DESCRIPTION
This is to fix a long-standing issue of the TAS client getting "confused" as to what "insiders" and "public" means when it comes to VS Code and VS Code extensions. We're setting up these two "new" target populations in Control Tower for the Python management group to specify what it means to be Python insider (aka pre-release) vs public (aka stable).  