### PR TITLE
Ensure virtual environment created using `python -m venv .` is recognized

### DIFF
--- a/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
@@ -70,12 +70,10 @@ function getSearchLocation(env: PythonEnvInfo): Uri | undefined {
     const isRootedEnv = folders.some((f) => isParentPath(env.executable.filename, f));
     if (isRootedEnv) {
         // For environments inside roots, we need to set search location so they can be queried accordingly.
-        // Search location particularly for virtual environments is intended as the directory in which the
-        // environment was found in.
-        // For eg.the default search location for an env containing 'bin' or 'Scripts' directory is:
+        // In certain usecases environment directory can itself be a root, for eg. `python -m venv .`.
+        // So choose folder to environment path to search for this env.
         //
-        // searchLocation <--- Default search location directory
-        // |__ env
+        // |__ env <--- Default search location directory
         //    |__ bin or Scripts
         //        |__ python  <--- executable
         return Uri.file(env.location);

--- a/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
@@ -78,7 +78,7 @@ function getSearchLocation(env: PythonEnvInfo): Uri | undefined {
         // |__ env
         //    |__ bin or Scripts
         //        |__ python  <--- executable
-        return Uri.file(path.dirname(env.location));
+        return Uri.file(env.location);
     }
     return undefined;
 }

--- a/src/test/pythonEnvironments/base/locators/composite/envsResolver.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/composite/envsResolver.unit.test.ts
@@ -92,7 +92,7 @@ suite('Python envs locator - Environments Resolver', () => {
             version,
             arch: Architecture.Unknown,
             distro: { org: '' },
-            searchLocation: Uri.file(path.dirname(location)),
+            searchLocation: Uri.file(location),
             source: [],
         };
     }

--- a/src/test/pythonEnvironments/base/locators/composite/resolverUtils.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/composite/resolverUtils.unit.test.ts
@@ -331,7 +331,7 @@ suite('Resolver Utils', () => {
                 version,
                 arch: Architecture.Unknown,
                 distro: { org: '' },
-                searchLocation: Uri.file(path.dirname(location)),
+                searchLocation: Uri.file(location),
                 source: [],
             };
             setEnvDisplayString(info);


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/19542

Set searchLocation for environments as the location of environment folder for rooted envs.