### PR TITLE
Use `Microsoft Store` instead of `Windows Store` to represent store related utilities

### DIFF
--- a/src/client/common/process/pythonEnvironment.ts
+++ b/src/client/common/process/pythonEnvironment.ts
@@ -171,18 +171,18 @@ export async function createCondaEnv(
     return new PythonEnvironment(interpreterPath, deps);
 }
 
-export function createWindowsStoreEnv(
+export function createMicrosoftStoreEnv(
     pythonPath: string,
     // These are used to generate the deps.
     procs: IProcessService,
 ): PythonEnvironment {
     const deps = createDeps(
         /**
-         * With windows store python apps, we have generally use the
+         * With microsoft store python apps, we have generally use the
          * symlinked python executable.  The actual file is not accessible
          * by the user due to permission issues (& rest of exension fails
          * when using that executable).  Hence lets not resolve the
-         * executable using sys.executable for windows store python
+         * executable using sys.executable for microsoft store python
          * interpreters.
          */
         async (_f: string) => true,

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -10,7 +10,7 @@ import { EventName } from '../../telemetry/constants';
 import { IFileSystem } from '../platform/types';
 import { IConfigurationService, IDisposableRegistry, IInterpreterPathService } from '../types';
 import { ProcessService } from './proc';
-import { createCondaEnv, createPythonEnv, createWindowsStoreEnv } from './pythonEnvironment';
+import { createCondaEnv, createPythonEnv, createMicrosoftStoreEnv } from './pythonEnvironment';
 import { createPythonProcessService } from './pythonProcess';
 import {
     ExecutionFactoryCreateWithEnvironmentOptions,
@@ -82,10 +82,10 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
             return condaExecutionService;
         }
 
-        const windowsStoreInterpreterCheck = this.pyenvs.isWindowsStoreInterpreter.bind(this.pyenvs);
+        const windowsStoreInterpreterCheck = this.pyenvs.isMicrosoftStoreInterpreter.bind(this.pyenvs);
 
         const env = (await windowsStoreInterpreterCheck(pythonPath))
-            ? createWindowsStoreEnv(pythonPath, processService)
+            ? createMicrosoftStoreEnv(pythonPath, processService)
             : createPythonEnv(pythonPath, processService, this.fileSystem);
 
         return createPythonService(processService, env);

--- a/src/client/interpreter/configuration/environmentTypeComparer.ts
+++ b/src/client/interpreter/configuration/environmentTypeComparer.ts
@@ -36,7 +36,7 @@ export class EnvironmentTypeComparer implements IInterpreterComparer {
      * The comparison guidelines are:
      * 1. Local environments first (same path as the workspace root);
      * 2. Global environments next (anything not local), with conda environments at a lower priority, and "base" being last;
-     * 3. Globally-installed interpreters (/usr/bin/python3, Windows Store).
+     * 3. Globally-installed interpreters (/usr/bin/python3, Microsoft Store).
      *
      * Always sort with newest version of Python first within each subgroup.
      */
@@ -236,7 +236,7 @@ function getPrioritizedEnvironmentType(): EnvironmentType[] {
         EnvironmentType.VirtualEnv,
         EnvironmentType.Conda,
         EnvironmentType.Pyenv,
-        EnvironmentType.WindowsStore,
+        EnvironmentType.MicrosoftStore,
         EnvironmentType.Global,
         EnvironmentType.System,
         EnvironmentType.Unknown,

--- a/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -543,7 +543,7 @@ function getGroup(item: IInterpreterQuickPickItem, workspacePath?: string) {
         case EnvironmentType.Global:
         case EnvironmentType.System:
         case EnvironmentType.Unknown:
-        case EnvironmentType.WindowsStore:
+        case EnvironmentType.MicrosoftStore:
             return EnvGroups.Global;
         default:
             return EnvGroups[item.interpreter.envType];

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -50,7 +50,7 @@ export interface IComponentAdapter {
     // Undefined is expected on this API, if the environment is not conda env.
     getCondaEnvironment(interpreterPath: string): Promise<CondaEnvironmentInfo | undefined>;
 
-    isWindowsStoreInterpreter(pythonPath: string): Promise<boolean>;
+    isMicrosoftStoreInterpreter(pythonPath: string): Promise<boolean>;
 }
 
 export const ICondaService = Symbol('ICondaService');

--- a/src/client/jupyter/jupyterIntegration.ts
+++ b/src/client/jupyter/jupyterIntegration.ts
@@ -106,7 +106,7 @@ type PythonApiForJupyterExtension = {
         interpreter?: PythonEnvironment,
         allowExceptions?: boolean,
     ): Promise<NodeJS.ProcessEnv | undefined>;
-    isWindowsStoreInterpreter(pythonPath: string): Promise<boolean>;
+    isMicrosoftStoreInterpreter(pythonPath: string): Promise<boolean>;
     suggestionToQuickPickItem(suggestion: PythonEnvironment, workspaceUri?: Uri | undefined): IInterpreterQuickPickItem;
     getKnownSuggestions(resource: Resource): IInterpreterQuickPickItem[];
     /**
@@ -234,8 +234,8 @@ export class JupyterExtensionIntegration {
                 interpreter?: PythonEnvironment,
                 allowExceptions?: boolean,
             ) => this.envActivation.getActivatedEnvironmentVariables(resource, interpreter, allowExceptions),
-            isWindowsStoreInterpreter: async (pythonPath: string): Promise<boolean> =>
-                this.pyenvs.isWindowsStoreInterpreter(pythonPath),
+            isMicrosoftStoreInterpreter: async (pythonPath: string): Promise<boolean> =>
+                this.pyenvs.isMicrosoftStoreInterpreter(pythonPath),
             getSuggestions: async (resource: Resource): Promise<IInterpreterQuickPickItem[]> =>
                 this.interpreterSelector.getAllSuggestions(resource),
             getKnownSuggestions: (resource: Resource): IInterpreterQuickPickItem[] =>

--- a/src/client/pythonEnvironments/base/info/env.ts
+++ b/src/client/pythonEnvironments/base/info/env.ts
@@ -231,7 +231,7 @@ export function getEnvID(interpreterPath: string, envFolderPath?: string): strin
  * Remarks: The current comparison assumes that if the path to the executables are the same
  * then it is the same environment. Additionally, if the paths are not same but executables
  * are in the same directory and the version of python is the same than we can assume it
- * to be same environment. This later case is needed for comparing windows store python,
+ * to be same environment. This later case is needed for comparing microsoft store python,
  * where multiple versions of python executables are all put in the same directory.
  */
 export function areSameEnv(

--- a/src/client/pythonEnvironments/base/info/envKind.ts
+++ b/src/client/pythonEnvironments/base/info/envKind.ts
@@ -12,7 +12,7 @@ export function getKindDisplayName(kind: PythonEnvKind): string {
     for (const [candidate, value] of [
         // Note that Unknown is excluded here.
         [PythonEnvKind.System, 'system'],
-        [PythonEnvKind.WindowsStore, 'windows store'],
+        [PythonEnvKind.MicrosoftStore, 'microsoft store'],
         [PythonEnvKind.Pyenv, 'pyenv'],
         [PythonEnvKind.Poetry, 'poetry'],
         [PythonEnvKind.Custom, 'custom'],
@@ -40,7 +40,7 @@ export function getKindDisplayName(kind: PythonEnvKind): string {
  * Top level we have the following environment types, since they leave a unique signature
  * in the environment or * use a unique path for the environments they create.
  *  1. Conda
- *  2. Windows Store
+ *  2. Microsoft Store
  *  3. PipEnv
  *  4. Pyenv
  *  5. Poetry
@@ -57,7 +57,7 @@ export function getPrioritizedEnvKinds(): PythonEnvKind[] {
     return [
         PythonEnvKind.Pyenv,
         PythonEnvKind.Conda,
-        PythonEnvKind.WindowsStore,
+        PythonEnvKind.MicrosoftStore,
         PythonEnvKind.Pipenv,
         PythonEnvKind.Poetry,
         PythonEnvKind.Venv,

--- a/src/client/pythonEnvironments/base/info/index.ts
+++ b/src/client/pythonEnvironments/base/info/index.ts
@@ -12,7 +12,7 @@ export enum PythonEnvKind {
     Unknown = 'unknown',
     // "global"
     System = 'global-system',
-    WindowsStore = 'global-windows-store',
+    MicrosoftStore = 'global-microsoft-store',
     Pyenv = 'global-pyenv',
     Poetry = 'poetry',
     Custom = 'global-custom',
@@ -48,7 +48,7 @@ export const virtualEnvKinds = [
 export const globallyInstalledEnvKinds = [
     PythonEnvKind.OtherGlobal,
     PythonEnvKind.Unknown,
-    PythonEnvKind.WindowsStore,
+    PythonEnvKind.MicrosoftStore,
     PythonEnvKind.System,
     PythonEnvKind.Custom,
 ];

--- a/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
@@ -36,7 +36,7 @@ function getResolvers(): Map<PythonEnvKind, (env: BasicEnvInfo, useCache?: boole
         resolvers.set(k, resolveSimpleEnv);
     });
     resolvers.set(PythonEnvKind.Conda, resolveCondaEnv);
-    resolvers.set(PythonEnvKind.WindowsStore, resolveWindowsStoreEnv);
+    resolvers.set(PythonEnvKind.MicrosoftStore, resolveMicrosoftStoreEnv);
     resolvers.set(PythonEnvKind.Pyenv, resolvePyenvEnv);
     return resolvers;
 }
@@ -231,10 +231,10 @@ async function isBaseCondaPyenvEnvironment(executablePath: string) {
     return arePathsSame(path.dirname(location), pyenvVersionDir);
 }
 
-async function resolveWindowsStoreEnv(env: BasicEnvInfo): Promise<PythonEnvInfo> {
+async function resolveMicrosoftStoreEnv(env: BasicEnvInfo): Promise<PythonEnvInfo> {
     const { executablePath } = env;
     return buildEnvInfo({
-        kind: PythonEnvKind.WindowsStore,
+        kind: PythonEnvKind.MicrosoftStore,
         executable: executablePath,
         version: parsePythonVersionFromPath(executablePath),
         org: 'Microsoft',

--- a/src/client/pythonEnvironments/base/locators/lowLevel/windowsKnownPathsLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/lowLevel/windowsKnownPathsLocator.ts
@@ -9,7 +9,7 @@ import { getSearchPathEntries } from '../../../../common/utils/exec';
 import { Disposables } from '../../../../common/utils/resourceLifecycle';
 import { iterPythonExecutablesInDir, looksLikeBasicGlobalPython } from '../../../common/commonUtils';
 import { isPyenvShimDir } from '../../../common/environmentManagers/pyenv';
-import { isWindowsStoreDir } from '../../../common/environmentManagers/windowsStoreEnv';
+import { isMicrosoftStoreDir } from '../../../common/environmentManagers/microsoftStoreEnv';
 import { PythonEnvKind, PythonEnvSource } from '../../info';
 import { BasicEnvInfo, ILocator, IPythonEnvsIterator, PythonLocatorQuery } from '../../locator';
 import { Locators } from '../../locators';
@@ -35,14 +35,14 @@ export class WindowsPathEnvVarLocator implements ILocator<BasicEnvInfo>, IDispos
             .filter(
                 (dirname) =>
                     // Filter out following directories:
-                    // 1. Windows Store app directories: We have a store app locator that handles this. The
+                    // 1. Microsoft Store app directories: We have a store app locator that handles this. The
                     //    python.exe available in these directories might not be python. It can be a store
-                    //    install shortcut that takes you to windows store.
+                    //    install shortcut that takes you to microsoft store.
                     //
                     // 2. Filter out pyenv shims: They are not actual python binaries, they are used to launch
                     //    the binaries specified in .python-version file in the cwd. We should not be reporting
                     //    those binaries as environments.
-                    !isWindowsStoreDir(dirname) && !isPyenvShimDir(dirname),
+                    !isMicrosoftStoreDir(dirname) && !isPyenvShimDir(dirname),
             )
             // Build a locator for each directory.
             .map((dirname) => getDirFilesLocator(dirname, PythonEnvKind.System, [PythonEnvSource.PathEnvVar]));

--- a/src/client/pythonEnvironments/common/environmentIdentifier.ts
+++ b/src/client/pythonEnvironments/common/environmentIdentifier.ts
@@ -14,7 +14,7 @@ import {
     isVirtualenvEnvironment as isVirtualEnvEnvironment,
     isVirtualenvwrapperEnvironment as isVirtualEnvWrapperEnvironment,
 } from './environmentManagers/simplevirtualenvs';
-import { isWindowsStoreEnvironment } from './environmentManagers/windowsStoreEnv';
+import { isMicrosoftStoreEnvironment } from './environmentManagers/microsoftStoreEnv';
 
 function getIdentifiers(): Map<PythonEnvKind, (path: string) => Promise<boolean>> {
     const notImplemented = () => Promise.resolve(false);
@@ -25,7 +25,7 @@ function getIdentifiers(): Map<PythonEnvKind, (path: string) => Promise<boolean>
     });
 
     identifier.set(PythonEnvKind.Conda, isCondaEnvironment);
-    identifier.set(PythonEnvKind.WindowsStore, isWindowsStoreEnvironment);
+    identifier.set(PythonEnvKind.MicrosoftStore, isMicrosoftStoreEnvironment);
     identifier.set(PythonEnvKind.Pipenv, isPipenvEnvironment);
     identifier.set(PythonEnvKind.Pyenv, isPyenvEnvironment);
     identifier.set(PythonEnvKind.Poetry, isPoetryEnvironment);

--- a/src/client/pythonEnvironments/common/environmentManagers/microsoftStoreEnv.ts
+++ b/src/client/pythonEnvironments/common/environmentManagers/microsoftStoreEnv.ts
@@ -11,12 +11,12 @@ import { pathExists } from '../externalDependencies';
  * @returns {string} : Returns path to the Windows Apps directory under
  * `%LOCALAPPDATA%/Microsoft/WindowsApps`.
  */
-export function getWindowsStoreAppsRoot(): string {
+export function getMicrosoftStoreAppsRoot(): string {
     const localAppData = getEnvironmentVariable('LOCALAPPDATA') || '';
     return path.join(localAppData, 'Microsoft', 'WindowsApps');
 }
 /**
- * Checks if a given path is under the forbidden windows store directory.
+ * Checks if a given path is under the forbidden microsoft store directory.
  * @param {string} absPath : Absolute path to a file or directory.
  * @returns {boolean} : Returns true if `interpreterPath` is under
  * `%ProgramFiles%/WindowsApps`.
@@ -29,7 +29,7 @@ function isForbiddenStorePath(absPath: string): boolean {
     return path.normalize(absPath).toUpperCase().includes(programFilesStorePath);
 }
 /**
- * Checks if a given directory is any one of the possible windows store directories, or
+ * Checks if a given directory is any one of the possible microsoft store directories, or
  * its sub-directory.
  * @param {string} dirPath : Absolute path to a directory.
  *
@@ -39,8 +39,8 @@ function isForbiddenStorePath(absPath: string): boolean {
  * 2. %ProgramFiles%/WindowsApps
  */
 
-export function isWindowsStoreDir(dirPath: string): boolean {
-    const storeRootPath = path.normalize(getWindowsStoreAppsRoot()).toUpperCase();
+export function isMicrosoftStoreDir(dirPath: string): boolean {
+    const storeRootPath = path.normalize(getMicrosoftStoreAppsRoot()).toUpperCase();
     return path.normalize(dirPath).toUpperCase().includes(storeRootPath) || isForbiddenStorePath(dirPath);
 }
 /**
@@ -53,8 +53,8 @@ export function isWindowsStoreDir(dirPath: string): boolean {
  */
 export async function isStorePythonInstalled(interpreterPath?: string): Promise<boolean> {
     let results = await Promise.all([
-        pathExists(path.join(getWindowsStoreAppsRoot(), 'idle.exe')),
-        pathExists(path.join(getWindowsStoreAppsRoot(), 'pip.exe')),
+        pathExists(path.join(getMicrosoftStoreAppsRoot(), 'idle.exe')),
+        pathExists(path.join(getMicrosoftStoreAppsRoot(), 'pip.exe')),
     ]);
 
     if (results.includes(true)) {
@@ -71,7 +71,7 @@ export async function isStorePythonInstalled(interpreterPath?: string): Promise<
     return false;
 }
 /**
- * Checks if the given interpreter belongs to Windows Store Python environment.
+ * Checks if the given interpreter belongs to Microsoft Store Python environment.
  * @param interpreterPath: Absolute path to any python interpreter.
  *
  * Remarks:
@@ -79,7 +79,7 @@ export async function isStorePythonInstalled(interpreterPath?: string): Promise<
  * NOT enough. In WSL, `/mnt/c/users/user/AppData/Local/Microsoft/WindowsApps` is available as a search
  * path. It is possible to get a false positive for that path. So the comparison should check if the
  * absolute path to 'WindowsApps' directory is present in the given interpreter path. The WSL path to
- * 'WindowsApps' is not a valid path to access, Windows Store Python.
+ * 'WindowsApps' is not a valid path to access, Microsoft Store Python.
  *
  * 2. 'startsWith' comparison may not be right, user can provide '\\?\C:\users\' style long paths in windows.
  *
@@ -103,10 +103,10 @@ export async function isStorePythonInstalled(interpreterPath?: string): Promise<
  *
  */
 
-export async function isWindowsStoreEnvironment(interpreterPath: string): Promise<boolean> {
+export async function isMicrosoftStoreEnvironment(interpreterPath: string): Promise<boolean> {
     if (await isStorePythonInstalled(interpreterPath)) {
         const pythonPathToCompare = path.normalize(interpreterPath).toUpperCase();
-        const localAppDataStorePath = path.normalize(getWindowsStoreAppsRoot()).toUpperCase();
+        const localAppDataStorePath = path.normalize(getMicrosoftStoreAppsRoot()).toUpperCase();
         if (pythonPathToCompare.includes(localAppDataStorePath)) {
             return true;
         }
@@ -114,7 +114,7 @@ export async function isWindowsStoreEnvironment(interpreterPath: string): Promis
         // Program Files store path is a forbidden path. Only admins and system has access this path.
         // We should never have to look at this path or even execute python from this path.
         if (isForbiddenStorePath(pythonPathToCompare)) {
-            traceWarn('isWindowsStoreEnvironment called with Program Files store path.');
+            traceWarn('isMicrosoftStoreEnvironment called with Program Files store path.');
             return true;
         }
     }

--- a/src/client/pythonEnvironments/index.ts
+++ b/src/client/pythonEnvironments/index.ts
@@ -22,7 +22,7 @@ import { GlobalVirtualEnvironmentLocator } from './base/locators/lowLevel/global
 import { PosixKnownPathsLocator } from './base/locators/lowLevel/posixKnownPathsLocator';
 import { PyenvLocator } from './base/locators/lowLevel/pyenvLocator';
 import { WindowsRegistryLocator } from './base/locators/lowLevel/windowsRegistryLocator';
-import { WindowsStoreLocator } from './base/locators/lowLevel/windowsStoreLocator';
+import { MicrosoftStoreLocator } from './base/locators/lowLevel/microsoftStoreLocator';
 import { getEnvironmentInfoService } from './base/info/environmentInfoService';
 import { registerNewDiscoveryForIOC } from './legacyIOC';
 import { PoetryLocator } from './base/locators/lowLevel/poetryLocator';
@@ -144,7 +144,7 @@ function createNonWorkspaceLocators(ext: ExtensionState): ILocator<BasicEnvInfo>
         locators.push(
             // Windows specific locators go here.
             new WindowsRegistryLocator(),
-            new WindowsStoreLocator(),
+            new MicrosoftStoreLocator(),
             new WindowsPathEnvVarLocator(),
         );
     } else {

--- a/src/client/pythonEnvironments/info/index.ts
+++ b/src/client/pythonEnvironments/info/index.ts
@@ -16,7 +16,7 @@ export enum EnvironmentType {
     Pipenv = 'PipEnv',
     Pyenv = 'Pyenv',
     Venv = 'Venv',
-    WindowsStore = 'WindowsStore',
+    MicrosoftStore = 'MicrosoftStore',
     Poetry = 'Poetry',
     VirtualEnvWrapper = 'VirtualEnvWrapper',
     Global = 'Global',
@@ -105,8 +105,8 @@ export function getEnvironmentTypeName(environmentType: EnvironmentType): string
         case EnvironmentType.VirtualEnv: {
             return 'virtualenv';
         }
-        case EnvironmentType.WindowsStore: {
-            return 'windows store';
+        case EnvironmentType.MicrosoftStore: {
+            return 'microsoft store';
         }
         case EnvironmentType.Poetry: {
             return 'poetry';

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -19,7 +19,7 @@ import { createDeferred } from '../common/utils/async';
 import { PythonEnvCollectionChangedEvent } from './base/watcher';
 import { asyncFilter } from '../common/utils/arrayUtils';
 import { CondaEnvironmentInfo, isCondaEnvironment } from './common/environmentManagers/conda';
-import { isWindowsStoreEnvironment } from './common/environmentManagers/windowsStoreEnv';
+import { isMicrosoftStoreEnvironment } from './common/environmentManagers/microsoftStoreEnv';
 import { CondaService } from './common/environmentManagers/condaService';
 import { traceVerbose } from '../logging';
 
@@ -27,7 +27,7 @@ const convertedKinds = new Map(
     Object.entries({
         [PythonEnvKind.OtherGlobal]: EnvironmentType.Global,
         [PythonEnvKind.System]: EnvironmentType.System,
-        [PythonEnvKind.WindowsStore]: EnvironmentType.WindowsStore,
+        [PythonEnvKind.MicrosoftStore]: EnvironmentType.MicrosoftStore,
         [PythonEnvKind.Pyenv]: EnvironmentType.Pyenv,
         [PythonEnvKind.Conda]: EnvironmentType.Conda,
         [PythonEnvKind.VirtualEnv]: EnvironmentType.VirtualEnv,
@@ -199,10 +199,10 @@ class ComponentAdapter implements IComponentAdapter {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    public async isWindowsStoreInterpreter(pythonPath: string): Promise<boolean> {
-        // Eventually we won't be calling 'isWindowsStoreInterpreter' in the component adapter, so we won't
-        // need to use 'isWindowsStoreEnvironment' directly here. This is just a temporary implementation.
-        return isWindowsStoreEnvironment(pythonPath);
+    public async isMicrosoftStoreInterpreter(pythonPath: string): Promise<boolean> {
+        // Eventually we won't be calling 'isMicrosoftStoreInterpreter' in the component adapter, so we won't
+        // need to use 'isMicrosoftStoreEnvironment' directly here. This is just a temporary implementation.
+        return isMicrosoftStoreEnvironment(pythonPath);
     }
 
     // Implements IInterpreterLocatorService

--- a/src/test/common/process/pythonEnvironment.unit.test.ts
+++ b/src/test/common/process/pythonEnvironment.unit.test.ts
@@ -10,7 +10,7 @@ import { IFileSystem } from '../../../client/common/platform/types';
 import {
     createCondaEnv,
     createPythonEnv,
-    createWindowsStoreEnv,
+    createMicrosoftStoreEnv,
 } from '../../../client/common/process/pythonEnvironment';
 import { IProcessService, StdErrError } from '../../../client/common/process/types';
 import { Architecture } from '../../../client/common/utils/platform';
@@ -343,7 +343,7 @@ suite('CondaEnvironment', () => {
     });
 });
 
-suite('WindowsStoreEnvironment', () => {
+suite('MicrosoftStoreEnvironment', () => {
     let processService: TypeMoq.IMock<IProcessService>;
     const pythonPath = 'foo';
 
@@ -351,8 +351,8 @@ suite('WindowsStoreEnvironment', () => {
         processService = TypeMoq.Mock.ofType<IProcessService>(undefined, TypeMoq.MockBehavior.Strict);
     });
 
-    test('Should return pythonPath if it is the path to the windows store interpreter', async () => {
-        const env = createWindowsStoreEnv(pythonPath, processService.object);
+    test('Should return pythonPath if it is the path to the microsoft store interpreter', async () => {
+        const env = createMicrosoftStoreEnv(pythonPath, processService.object);
 
         const executablePath = await env.getExecutablePath();
 

--- a/src/test/common/process/pythonExecutionFactory.unit.test.ts
+++ b/src/test/common/process/pythonExecutionFactory.unit.test.ts
@@ -99,7 +99,7 @@ suite('Process - PythonExecutionFactory', () => {
                 when(interpreterPathExpHelper.get(anything())).thenReturn('selected interpreter path');
 
                 pyenvs = mock<IComponentAdapter>();
-                when(pyenvs.isWindowsStoreInterpreter(anyString())).thenResolve(true);
+                when(pyenvs.isMicrosoftStoreInterpreter(anyString())).thenResolve(true);
 
                 executionService = typemoq.Mock.ofType<IPythonExecutionService>();
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -170,7 +170,7 @@ suite('Process - PythonExecutionFactory', () => {
                 const service = await factory.create({ resource, pythonPath: 'HELLO' });
 
                 expect(service).to.not.equal(undefined);
-                verify(pyenvs.isWindowsStoreInterpreter('HELLO')).once();
+                verify(pyenvs.isMicrosoftStoreInterpreter('HELLO')).once();
                 verify(pythonSettings.pythonPath).never();
             });
 

--- a/src/test/configuration/environmentTypeComparer.unit.test.ts
+++ b/src/test/configuration/environmentTypeComparer.unit.test.ts
@@ -150,9 +150,9 @@ suite('Environment sorting', () => {
             expected: 1,
         },
         {
-            title: 'Windows Store environment should not come first when there are global envs',
+            title: 'Microsoft Store environment should not come first when there are global envs',
             envA: {
-                envType: EnvironmentType.WindowsStore,
+                envType: EnvironmentType.MicrosoftStore,
                 version: { major: 3, minor: 10, patch: 2 },
             } as PythonEnvironment,
             envB: {
@@ -310,7 +310,7 @@ suite('getEnvTypeHeuristic tests', () => {
 
     const globalInterpretersEnvTypes = [
         EnvironmentType.System,
-        EnvironmentType.WindowsStore,
+        EnvironmentType.MicrosoftStore,
         EnvironmentType.Global,
         EnvironmentType.Unknown,
         EnvironmentType.Pyenv,

--- a/src/test/configuration/interpreterSelector/commands/installPython.unit.test.ts
+++ b/src/test/configuration/interpreterSelector/commands/installPython.unit.test.ts
@@ -111,7 +111,7 @@ suite('Install Python Command', () => {
         assert.deepEqual(walkthroughID, expectedWalkthroughID);
     });
 
-    test('Opens windows store app on Windows otherwise', async () => {
+    test('Opens microsoft store app on Windows otherwise', async () => {
         when(platformService.isWindows).thenReturn(true);
         when(platformService.isLinux).thenReturn(false);
         when(platformService.isMac).thenReturn(false);

--- a/src/test/pythonEnvironments/base/info/envKind.unit.test.ts
+++ b/src/test/pythonEnvironments/base/info/envKind.unit.test.ts
@@ -10,7 +10,7 @@ import { getKindDisplayName, getPrioritizedEnvKinds } from '../../../../client/p
 const KIND_NAMES: [PythonEnvKind, string][] = [
     // We handle PythonEnvKind.Unknown separately.
     [PythonEnvKind.System, 'system'],
-    [PythonEnvKind.WindowsStore, 'winStore'],
+    [PythonEnvKind.MicrosoftStore, 'winStore'],
     [PythonEnvKind.Pyenv, 'pyenv'],
     [PythonEnvKind.Poetry, 'poetry'],
     [PythonEnvKind.Custom, 'customGlobal'],

--- a/src/test/pythonEnvironments/base/locatorUtils.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locatorUtils.unit.test.ts
@@ -90,7 +90,7 @@ suite('Python envs locator utils - getQueryFilter', () => {
         ([
             [PythonEnvKind.Unknown, [env3]],
             [PythonEnvKind.System, [env1, env5]],
-            [PythonEnvKind.WindowsStore, []],
+            [PythonEnvKind.MicrosoftStore, []],
             [PythonEnvKind.Pyenv, [env2, env4]],
             [PythonEnvKind.Venv, [envL1, envSL1, envSL5]],
             [PythonEnvKind.Conda, [env6, envL2, envSL3]],

--- a/src/test/pythonEnvironments/base/locators/composite/resolverUtils.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/composite/resolverUtils.unit.test.ts
@@ -101,7 +101,7 @@ suite('Resolver Utils', () => {
         });
     });
 
-    suite('Windows store', () => {
+    suite('Microsoft store', () => {
         const testLocalAppData = path.join(TEST_LAYOUT_ROOT, 'storeApps');
         const testStoreAppRoot = path.join(testLocalAppData, 'Microsoft', 'WindowsApps');
 
@@ -147,7 +147,7 @@ suite('Resolver Utils', () => {
                 searchLocation: undefined,
                 name: '',
                 location: '',
-                kind: PythonEnvKind.WindowsStore,
+                kind: PythonEnvKind.MicrosoftStore,
                 distro: { org: 'Microsoft' },
                 source: [PythonEnvSource.PathEnvVar],
                 ...createExpectedInterpreterInfo(python38path),
@@ -156,7 +156,7 @@ suite('Resolver Utils', () => {
 
             const actual = await resolveBasicEnv({
                 executablePath: python38path,
-                kind: PythonEnvKind.WindowsStore,
+                kind: PythonEnvKind.MicrosoftStore,
             });
 
             assertEnvEqual(actual, expected);
@@ -169,7 +169,7 @@ suite('Resolver Utils', () => {
                 searchLocation: undefined,
                 name: '',
                 location: '',
-                kind: PythonEnvKind.WindowsStore,
+                kind: PythonEnvKind.MicrosoftStore,
                 distro: { org: 'Microsoft' },
                 source: [PythonEnvSource.PathEnvVar],
                 ...createExpectedInterpreterInfo(python38path),
@@ -178,7 +178,7 @@ suite('Resolver Utils', () => {
 
             const actual = await resolveBasicEnv({
                 executablePath: python38path,
-                kind: PythonEnvKind.WindowsStore,
+                kind: PythonEnvKind.MicrosoftStore,
             });
 
             assertEnvEqual(actual, expected);

--- a/src/test/pythonEnvironments/base/locators/lowLevel/microsoftStoreLocator.test.ts
+++ b/src/test/pythonEnvironments/base/locators/lowLevel/microsoftStoreLocator.test.ts
@@ -11,12 +11,12 @@ import { PythonEnvKind } from '../../../../../client/pythonEnvironments/base/inf
 import { getEnvs } from '../../../../../client/pythonEnvironments/base/locatorUtils';
 import { PythonEnvsChangedEvent } from '../../../../../client/pythonEnvironments/base/watcher';
 import * as externalDeps from '../../../../../client/pythonEnvironments/common/externalDependencies';
-import { WindowsStoreLocator } from '../../../../../client/pythonEnvironments/base/locators/lowLevel/windowsStoreLocator';
+import { MicrosoftStoreLocator } from '../../../../../client/pythonEnvironments/base/locators/lowLevel/microsoftStoreLocator';
 import { TEST_TIMEOUT } from '../../../../constants';
 import { TEST_LAYOUT_ROOT } from '../../../common/commonTestConstants';
 import { traceWarn } from '../../../../../client/logging';
 
-class WindowsStoreEnvs {
+class MicrosoftStoreEnvs {
     private executables: string[] = [];
 
     private dirs: string[] = [];
@@ -42,7 +42,7 @@ class WindowsStoreEnvs {
     }
 
     public async update(version: string): Promise<void> {
-        // On update windows store removes the directory and re-adds it.
+        // On update microsoft store removes the directory and re-adds it.
         const dirName = path.join(this.storeAppRoot, `PythonSoftwareFoundation.Python.${version}_qbz5n2kfra8p0`);
         try {
             await fs.rmdir(dirName);
@@ -74,11 +74,11 @@ class WindowsStoreEnvs {
     }
 }
 
-suite('Windows Store Locator', async () => {
+suite('Microsoft Store Locator', async () => {
     const testLocalAppData = path.join(TEST_LAYOUT_ROOT, 'storeApps');
     const testStoreAppRoot = path.join(testLocalAppData, 'Microsoft', 'WindowsApps');
-    const windowsStoreEnvs = new WindowsStoreEnvs(testStoreAppRoot);
-    let locator: WindowsStoreLocator;
+    const windowsStoreEnvs = new MicrosoftStoreEnvs(testStoreAppRoot);
+    let locator: MicrosoftStoreLocator;
 
     const localAppDataOldValue = process.env.LOCALAPPDATA;
 
@@ -103,7 +103,7 @@ suite('Windows Store Locator', async () => {
     });
 
     async function setupLocator(onChanged: (e: PythonEnvsChangedEvent) => Promise<void>) {
-        locator = new WindowsStoreLocator();
+        locator = new MicrosoftStoreLocator();
         await getEnvs(locator.iterEnvs()); // Force the watchers to start.
         // Wait for watchers to get ready
         await sleep(1000);
@@ -122,7 +122,7 @@ suite('Windows Store Locator', async () => {
         let actualEvent: PythonEnvsChangedEvent;
         const deferred = createDeferred<void>();
         const expectedEvent = {
-            kind: PythonEnvKind.WindowsStore,
+            kind: PythonEnvKind.MicrosoftStore,
             type: FileChangeType.Created,
             searchLocation: Uri.file(testStoreAppRoot),
         };
@@ -143,7 +143,7 @@ suite('Windows Store Locator', async () => {
         let actualEvent: PythonEnvsChangedEvent;
         const deferred = createDeferred<void>();
         const expectedEvent = {
-            kind: PythonEnvKind.WindowsStore,
+            kind: PythonEnvKind.MicrosoftStore,
             type: FileChangeType.Deleted,
             searchLocation: Uri.file(testStoreAppRoot),
         };
@@ -167,7 +167,7 @@ suite('Windows Store Locator', async () => {
         let actualEvent: PythonEnvsChangedEvent;
         const deferred = createDeferred<void>();
         const expectedEvent = {
-            kind: PythonEnvKind.WindowsStore,
+            kind: PythonEnvKind.MicrosoftStore,
             type: FileChangeType.Changed,
             searchLocation: Uri.file(testStoreAppRoot),
         };

--- a/src/test/pythonEnvironments/base/locators/lowLevel/microsoftStoreLocator.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/lowLevel/microsoftStoreLocator.unit.test.ts
@@ -11,14 +11,14 @@ import { PythonEnvKind } from '../../../../../client/pythonEnvironments/base/inf
 import { BasicEnvInfo } from '../../../../../client/pythonEnvironments/base/locator';
 import * as externalDep from '../../../../../client/pythonEnvironments/common/externalDependencies';
 import {
-    getWindowsStorePythonExes,
-    WindowsStoreLocator,
-} from '../../../../../client/pythonEnvironments/base/locators/lowLevel/windowsStoreLocator';
+    getMicrosoftStorePythonExes,
+    MicrosoftStoreLocator,
+} from '../../../../../client/pythonEnvironments/base/locators/lowLevel/microsoftStoreLocator';
 import { getEnvs } from '../../common';
 import { TEST_LAYOUT_ROOT } from '../../../common/commonTestConstants';
 import { assertBasicEnvsEqual } from '../envTestUtils';
 
-suite('Windows Store', () => {
+suite('Microsoft Store', () => {
     suite('Utils', () => {
         let getEnvVarStub: sinon.SinonStub;
         const testLocalAppData = path.join(TEST_LAYOUT_ROOT, 'storeApps');
@@ -39,7 +39,7 @@ suite('Windows Store', () => {
                 path.join(testStoreAppRoot, 'python3.8.exe'),
             ];
 
-            const actual = await getWindowsStorePythonExes();
+            const actual = await getMicrosoftStorePythonExes();
             assert.deepEqual(actual, expected);
         });
     });
@@ -47,7 +47,7 @@ suite('Windows Store', () => {
     suite('Locator', () => {
         let stubShellExec: sinon.SinonStub;
         let getEnvVar: sinon.SinonStub;
-        let locator: WindowsStoreLocator;
+        let locator: MicrosoftStoreLocator;
         let watchLocationForPatternStub: sinon.SinonStub;
 
         const testLocalAppData = path.join(TEST_LAYOUT_ROOT, 'storeApps');
@@ -82,7 +82,7 @@ suite('Windows Store', () => {
         function createExpectedInfo(executable: string): BasicEnvInfo {
             return {
                 executablePath: executable,
-                kind: PythonEnvKind.WindowsStore,
+                kind: PythonEnvKind.MicrosoftStore,
             };
         }
 
@@ -108,7 +108,7 @@ suite('Windows Store', () => {
                 },
             });
 
-            locator = new WindowsStoreLocator();
+            locator = new MicrosoftStoreLocator();
         });
 
         teardown(async () => {

--- a/src/test/pythonEnvironments/common/environmentIdentifier.unit.test.ts
+++ b/src/test/pythonEnvironments/common/environmentIdentifier.unit.test.ts
@@ -79,7 +79,7 @@ suite('Environment Identifier', () => {
         });
     });
 
-    suite('Windows Store', () => {
+    suite('Microsoft Store', () => {
         let getEnvVar: sinon.SinonStub;
         let pathExists: sinon.SinonStub;
         const fakeLocalAppDataPath = path.join(TEST_LAYOUT_ROOT, 'storeApps');
@@ -98,13 +98,13 @@ suite('Environment Identifier', () => {
             pathExists.restore();
         });
         executable.forEach((exe) => {
-            test(`Path to local app data windows store interpreter (${exe})`, async () => {
+            test(`Path to local app data microsoft store interpreter (${exe})`, async () => {
                 getEnvVar.withArgs('LOCALAPPDATA').returns(fakeLocalAppDataPath);
                 const interpreterPath = path.join(fakeLocalAppDataPath, 'Microsoft', 'WindowsApps', exe);
                 const envType: PythonEnvKind = await identifyEnvironment(interpreterPath);
-                assert.deepEqual(envType, PythonEnvKind.WindowsStore);
+                assert.deepEqual(envType, PythonEnvKind.MicrosoftStore);
             });
-            test(`Path to local app data windows store interpreter app sub-directory (${exe})`, async () => {
+            test(`Path to local app data microsoft store interpreter app sub-directory (${exe})`, async () => {
                 getEnvVar.withArgs('LOCALAPPDATA').returns(fakeLocalAppDataPath);
                 const interpreterPath = path.join(
                     fakeLocalAppDataPath,
@@ -114,9 +114,9 @@ suite('Environment Identifier', () => {
                     exe,
                 );
                 const envType: PythonEnvKind = await identifyEnvironment(interpreterPath);
-                assert.deepEqual(envType, PythonEnvKind.WindowsStore);
+                assert.deepEqual(envType, PythonEnvKind.MicrosoftStore);
             });
-            test(`Path to program files windows store interpreter app sub-directory (${exe})`, async () => {
+            test(`Path to program files microsoft store interpreter app sub-directory (${exe})`, async () => {
                 const interpreterPath = path.join(
                     fakeProgramFilesPath,
                     'WindowsApps',
@@ -124,13 +124,13 @@ suite('Environment Identifier', () => {
                     exe,
                 );
                 const envType: PythonEnvKind = await identifyEnvironment(interpreterPath);
-                assert.deepEqual(envType, PythonEnvKind.WindowsStore);
+                assert.deepEqual(envType, PythonEnvKind.MicrosoftStore);
             });
             test(`Local app data not set (${exe})`, async () => {
                 getEnvVar.withArgs('LOCALAPPDATA').returns(undefined);
                 const interpreterPath = path.join(fakeLocalAppDataPath, 'Microsoft', 'WindowsApps', exe);
                 const envType: PythonEnvKind = await identifyEnvironment(interpreterPath);
-                assert.deepEqual(envType, PythonEnvKind.WindowsStore);
+                assert.deepEqual(envType, PythonEnvKind.MicrosoftStore);
             });
             test(`Program files app data not set (${exe})`, async () => {
                 const interpreterPath = path.join(
@@ -143,14 +143,14 @@ suite('Environment Identifier', () => {
                 pathExists.withArgs(path.join(path.dirname(interpreterPath), 'idle.exe')).resolves(true);
 
                 const envType: PythonEnvKind = await identifyEnvironment(interpreterPath);
-                assert.deepEqual(envType, PythonEnvKind.WindowsStore);
+                assert.deepEqual(envType, PythonEnvKind.MicrosoftStore);
             });
             test(`Path using forward slashes (${exe})`, async () => {
                 const interpreterPath = path
                     .join(fakeLocalAppDataPath, 'Microsoft', 'WindowsApps', exe)
                     .replace('\\', '/');
                 const envType: PythonEnvKind = await identifyEnvironment(interpreterPath);
-                assert.deepEqual(envType, PythonEnvKind.WindowsStore);
+                assert.deepEqual(envType, PythonEnvKind.MicrosoftStore);
             });
             test(`Path using long path style slashes (${exe})`, async () => {
                 const interpreterPath = path
@@ -163,7 +163,7 @@ suite('Environment Identifier', () => {
                     return Promise.resolve(false);
                 });
                 const envType: PythonEnvKind = await identifyEnvironment(`\\\\?\\${interpreterPath}`);
-                assert.deepEqual(envType, PythonEnvKind.WindowsStore);
+                assert.deepEqual(envType, PythonEnvKind.MicrosoftStore);
             });
         });
     });

--- a/src/test/pythonEnvironments/common/environmentManagers/microsoftStoreEnv.unit.test.ts
+++ b/src/test/pythonEnvironments/common/environmentManagers/microsoftStoreEnv.unit.test.ts
@@ -5,11 +5,11 @@ import * as assert from 'assert';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import * as platformApis from '../../../../client/common/utils/platform';
-import { getWindowsStorePythonExes } from '../../../../client/pythonEnvironments/base/locators/lowLevel/windowsStoreLocator';
-import { isWindowsStoreDir } from '../../../../client/pythonEnvironments/common/environmentManagers/windowsStoreEnv';
+import { getMicrosoftStorePythonExes } from '../../../../client/pythonEnvironments/base/locators/lowLevel/microsoftStoreLocator';
+import { isMicrosoftStoreDir } from '../../../../client/pythonEnvironments/common/environmentManagers/microsoftStoreEnv';
 import { TEST_LAYOUT_ROOT } from '../commonTestConstants';
 
-suite('Windows Store Env', () => {
+suite('Microsoft Store Env', () => {
     let getEnvVarStub: sinon.SinonStub;
     const testLocalAppData = path.join(TEST_LAYOUT_ROOT, 'storeApps');
     const testStoreAppRoot = path.join(testLocalAppData, 'Microsoft', 'WindowsApps');
@@ -26,16 +26,16 @@ suite('Windows Store Env', () => {
     test('Store Python Interpreters', async () => {
         const expected = [path.join(testStoreAppRoot, 'python3.7.exe'), path.join(testStoreAppRoot, 'python3.8.exe')];
 
-        const actual = await getWindowsStorePythonExes();
+        const actual = await getMicrosoftStorePythonExes();
         assert.deepEqual(actual, expected);
     });
 
-    test('isWindowsStoreDir: valid case', () => {
-        assert.deepStrictEqual(isWindowsStoreDir(testStoreAppRoot), true);
-        assert.deepStrictEqual(isWindowsStoreDir(testStoreAppRoot + path.sep), true);
+    test('isMicrosoftStoreDir: valid case', () => {
+        assert.deepStrictEqual(isMicrosoftStoreDir(testStoreAppRoot), true);
+        assert.deepStrictEqual(isMicrosoftStoreDir(testStoreAppRoot + path.sep), true);
     });
 
-    test('isWindowsStoreDir: invalid case', () => {
-        assert.deepStrictEqual(isWindowsStoreDir(__dirname), false);
+    test('isMicrosoftStoreDir: invalid case', () => {
+        assert.deepStrictEqual(isMicrosoftStoreDir(__dirname), false);
     });
 });


### PR DESCRIPTION
Simply renamed files and texts appropriately, excluding changelog.

cc/ @brettcannon 