### PR TITLE
Ensure any labels or assignees do not carry over when transferring issues to `vscode-python`

### DIFF
--- a/.github/workflows/getLabels.js
+++ b/.github/workflows/getLabels.js
@@ -1,0 +1,18 @@
+/**
+ * To run this file:
+ * * npm install @octokit/rest
+ * * node .github/workflows/getLabels.js
+ */
+
+ const { Octokit } = require('@octokit/rest');
+ const octokit = new Octokit();
+ octokit.rest.issues
+     .listLabelsForRepo({
+         owner: 'microsoft',
+         repo: 'vscode-python',
+     })
+     .then((result) => {
+         const labels = result.data.map((label) => label.name);
+         console.log(JSON.stringify(labels));
+     });
+ 

--- a/.github/workflows/getLabels.js
+++ b/.github/workflows/getLabels.js
@@ -4,15 +4,14 @@
  * * node .github/workflows/getLabels.js
  */
 
- const { Octokit } = require('@octokit/rest');
- const octokit = new Octokit();
- octokit.rest.issues
-     .listLabelsForRepo({
-         owner: 'microsoft',
-         repo: 'vscode-python',
-     })
-     .then((result) => {
-         const labels = result.data.map((label) => label.name);
-         console.log(JSON.stringify(labels));
-     });
- 
+const { Octokit } = require('@octokit/rest');
+const github = new Octokit();
+github.rest.issues
+    .listLabelsForRepo({
+        owner: 'microsoft',
+        repo: 'vscode-python',
+    })
+    .then((result) => {
+        const labels = result.data.map((label) => label.name);
+        console.log(JSON.stringify(labels));
+    });

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   # From https://github.com/marketplace/actions/github-script#apply-a-label-to-an-issue.
   add-classify-label:
-    name: "Add 'triage-needed' and remove unrecognizable labels and assignees"
+    name: "Add 'triage-needed' and remove unrecognizable labels & assignees"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -4,6 +4,11 @@ on:
   issues:
     types: [opened, reopened]
 
+env:
+  # To update the list of labels, see `getLabels.js`.
+  REPO_LABELS: '["area-data science","area-debugging","area-diagnostics","area-editor-*","area-environments","area-formatting","area-intellisense","area-internal","area-linting","area-terminal","area-testing","author-verification-requested","bug","community ask","debt","dependencies","documentation","experimenting","feature-request","good first issue","help wanted","important","info-needed","invalid-testplan-item","investigating","iteration-candidate","iteration-plan","iteration-plan-draft","javascript","linux"]'
+  TRIAGERS: '["karrtikr","karthiknadig","paulacamargo25"]'
+
 permissions:
   issues: write
 
@@ -11,10 +16,6 @@ jobs:
   # From https://github.com/marketplace/actions/github-script#apply-a-label-to-an-issue.
   add-classify-label:
     name: "Add 'triage-needed' and remove unrecognizable labels and assignees"
-    env:
-      # To update the list of labels, see `getLabels.js`.
-      REPO_LABELS: '["area-data science","area-debugging","area-diagnostics","area-editor-*","area-environments","area-formatting","area-intellisense","area-internal","area-linting","area-terminal","area-testing","author-verification-requested","bug","community ask","debt","dependencies","documentation","experimenting","feature-request","good first issue","help wanted","important","info-needed","invalid-testplan-item","investigating","iteration-candidate","iteration-plan","iteration-plan-draft","javascript","linux"]'
-      TRIAGERS: '["karrtikr","karthiknadig","paulacamargo25"]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -7,7 +7,7 @@ on:
 env:
   # To update the list of labels, see `getLabels.js`.
   REPO_LABELS: '["area-data science","area-debugging","area-diagnostics","area-editor-*","area-environments","area-formatting","area-intellisense","area-internal","area-linting","area-terminal","area-testing","author-verification-requested","bug","community ask","debt","dependencies","documentation","experimenting","feature-request","good first issue","help wanted","important","info-needed","invalid-testplan-item","investigating","iteration-candidate","iteration-plan","iteration-plan-draft","javascript","linux"]'
-  TRIAGERS: '["karrtikr","karthiknadig","paulacamargo25"]'
+  TRIAGERS: '["karrtikr","karthiknadig","paulacamargo25","eleanorjboyd"]'
 
 permissions:
   issues: write

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -67,4 +67,3 @@ jobs:
               issue_number: context.issue.number,
               assignees: assigneesToRemove,
             });
-            

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -10,7 +10,11 @@ permissions:
 jobs:
   # From https://github.com/marketplace/actions/github-script#apply-a-label-to-an-issue.
   add-classify-label:
-    name: "Add 'triage-needed'"
+    name: "Add 'triage-needed' and remove unrecognizable labels and assignees"
+    env:
+      # To update the list of labels, see `getLabels.js`.
+      REPO_LABELS: '["area-data science","area-debugging","area-diagnostics","area-editor-*","area-environments","area-formatting","area-intellisense","area-internal","area-linting","area-terminal","area-testing","author-verification-requested","bug","community ask","debt","dependencies","documentation","experimenting","feature-request","good first issue","help wanted","important","info-needed","invalid-testplan-item","investigating","iteration-candidate","iteration-plan","iteration-plan-draft","javascript","linux"]'
+      TRIAGERS: '["karrtikr","karthiknadig","paulacamargo25"]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6
@@ -37,3 +41,29 @@ jobs:
             } else {
               console.log('This issue already has a "needs __", "iteration-plan", "release-plan", or the "testplan-item" label, do not add the "triage-needed" label.')
             }
+            const knownLabels = ${{ env.REPO_LABELS }}
+            const knownTriagers = ${{ env.TRIAGERS }}
+            for( const label of labels) {
+              if (!knownLabels.includes(label)) {
+                await github.rest.issues.deleteLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                })
+              }
+            }
+            const currentAssignees = await github.rest.issues
+              .get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              })
+              .then((result) => result.data.assignees.map((a) => a.login));
+            const assigneesToRemove = currentAssignees.filter(a => !knownTriagers.includes(a));
+            github.rest.issues.removeAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: assigneesToRemove,
+            });
+            


### PR DESCRIPTION
Deletes any unrecognized labels or assignees not belonging to triage flow.