### PR TITLE
Only remove assignees if issue doesn't have a needs or TPI label

### DIFF
--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -39,6 +39,20 @@ jobs:
                 issue_number: context.issue.number,
                 labels: ['triage-needed']
               })
+              const currentAssignees = await github.rest.issues
+                .get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                })
+                .then((result) => result.data.assignees.map((a) => a.login));
+              const assigneesToRemove = currentAssignees.filter(a => !knownTriagers.includes(a));
+              github.rest.issues.removeAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                assignees: assigneesToRemove,
+              });
             } else {
               console.log('This issue already has a "needs __", "iteration-plan", "release-plan", or the "testplan-item" label, do not add the "triage-needed" label.')
             }
@@ -53,17 +67,3 @@ jobs:
                 })
               }
             }
-            const currentAssignees = await github.rest.issues
-              .get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-              })
-              .then((result) => result.data.assignees.map((a) => a.login));
-            const assigneesToRemove = currentAssignees.filter(a => !knownTriagers.includes(a));
-            github.rest.issues.removeAssignees({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              assignees: assigneesToRemove,
-            });


### PR DESCRIPTION
We only need to remove assignees for the triage flow, in other cases if an issue is created with the appropriate labels, it's fine to leave assignees (could be an external contributor or a random TPI).