### PR TITLE
Fix for telemetry JSON extraction.

### DIFF
--- a/src/client/telemetry/pylance.ts
+++ b/src/client/telemetry/pylance.ts
@@ -314,7 +314,7 @@
       "functionReturnInlayTypeHints" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
       "disableworkspacesymbol" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
       "watchforlibrarychanges" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-      "lspnotebooks" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+      "lspnotebooks" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
    }
 */
 /* __GDPR__


### PR DESCRIPTION
```
....running.
...extracting
Event Declaration Error: SyntaxError: Unexpected token } in JSON at position 1723 in file /mnt/vss/_work/1/s/src/client/telemetry/pylance.ts
Source comment:
/* __GDPR__
   "language_server/settings" : {
      "autoimportcompletions" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
      "autosearchpaths" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
      "completefunctionparens" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
      "enableextractcodeaction" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
      "hasconfigfile" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
      "hasextrapaths" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
      "indexing" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
      "openfilesonly" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
      "typecheckingmode" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
      "useimportheuristic" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
      "uselibrarycodefortypes" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
      "workspacecount" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
      "variableinlaytypehints" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
      "functionReturnInlayTypeHints" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
      "disableworkspacesymbol" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
      "watchforlibrarychanges" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
      "lspnotebooks" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
   }
*/
...writing /mnt/vss/_work/1/s/telemetry.json
##[error]Bash exited with code '1'.

```