### PR TITLE
Update Pylance settings telemetry properties

### DIFF
--- a/src/client/telemetry/pylance.ts
+++ b/src/client/telemetry/pylance.ts
@@ -301,20 +301,23 @@
       "autoimportcompletions" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
       "autosearchpaths" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
       "completefunctionparens" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+      "disableworkspacesymbol" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
       "enableextractcodeaction" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+      "formatontype" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+      "functionReturnInlayTypeHints" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
       "hasconfigfile" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
       "hasextrapaths" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+      "importformat" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
       "indexing" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+      "lspinteractivewindows" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+      "lspnotebooks" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
       "openfilesonly" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
       "typecheckingmode" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
       "useimportheuristic" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
       "uselibrarycodefortypes" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-      "workspacecount" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
       "variableinlaytypehints" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-      "functionReturnInlayTypeHints" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-      "disableworkspacesymbol" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
       "watchforlibrarychanges" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-      "lspnotebooks" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+      "workspacecount" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
    }
 */
 /* __GDPR__


### PR DESCRIPTION
Added new `formatOnType` property, plus older `importFormat` and `lspInteractiveWindows` properties which were missing.
Fixed list alphabetization for easier maintenance.