### PR TITLE
Prevent auto-indent inExperiment method from returning undefined

### DIFF
--- a/src/client/activation/node/analysisOptions.ts
+++ b/src/client/activation/node/analysisOptions.ts
@@ -64,7 +64,7 @@ export class NodeLanguageServerAnalysisOptions extends LanguageServerAnalysisOpt
         }
 
         const pylanceVersion = extensions.getExtension(PYLANCE_EXTENSION_ID)?.packageJSON.version;
-        return pylanceVersion && semver.prerelease(pylanceVersion)?.includes('dev');
+        return pylanceVersion && semver.prerelease(pylanceVersion)?.includes('dev') === true;
     }
 
     private getPythonSpecificEditorSection() {


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode-python/issues/19737

Pylance versions without semver prerelease tags were not handled correctly in the auto-indent experiment code I added yesterday.

Fixed `inExperiment` to not return undefined in this case.