### PR TITLE
Fix `any` type issue that caused experiment bug to be missed

### DIFF
--- a/src/client/activation/node/analysisOptions.ts
+++ b/src/client/activation/node/analysisOptions.ts
@@ -63,8 +63,8 @@ export class NodeLanguageServerAnalysisOptions extends LanguageServerAnalysisOpt
             return true;
         }
 
-        const pylanceVersion = extensions.getExtension(PYLANCE_EXTENSION_ID)?.packageJSON.version;
-        return pylanceVersion && semver.prerelease(pylanceVersion)?.includes('dev') === true;
+        const pylanceVersion = extensions.getExtension(PYLANCE_EXTENSION_ID)?.packageJSON.version as string;
+        return pylanceVersion !== undefined && semver.prerelease(pylanceVersion)?.includes('dev') === true;
     }
 
     private getPythonSpecificEditorSection() {


### PR DESCRIPTION
`packageJSON` is of type `any` and everything went downhill after that. This is my first time getting bitten by something like this. Should I be using TypeScript's strict mode?

#19737