### PR TITLE
Add comment for call-tas-error telemetry event

### DIFF
--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -1960,7 +1960,7 @@ export interface IEventNamePropertyMapping {
 				"ABExp.queriedFeature": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The experimental feature being queried" }
 			}
 	*/
-      /* __GDPR__
+    /* __GDPR__
 			"call-tas-error" : {
 				"owner": "luabud",
 				"comment": "Logs when calls to the experiment service fails",

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -1960,4 +1960,11 @@ export interface IEventNamePropertyMapping {
 				"ABExp.queriedFeature": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The experimental feature being queried" }
 			}
 	*/
+      /* __GDPR__
+			"call-tas-error" : {
+				"owner": "luabud",
+				"comment": "Logs when calls to the experiment service fails",
+				"ABExp.queriedFeature": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth"}
+			}
+	*/
 }


### PR DESCRIPTION
This is to classify the new call-tas-error event the Python extension sends when calls to TAS fail. 