### PR TITLE
Revert to using `conda activate` for fetching activated environment variables

### DIFF
--- a/src/test/interpreters/activation/service.unit.test.ts
+++ b/src/test/interpreters/activation/service.unit.test.ts
@@ -58,7 +58,7 @@ suite('Interpreters Activation - Python Environment Variables', () => {
         architecture: Architecture.x64,
     };
 
-    function initSetup(interpreter: PythonEnvironment | undefined) {
+    function initSetup() {
         helper = mock(TerminalHelper);
         platform = mock(PlatformService);
         processServiceFactory = mock(ProcessServiceFactory);
@@ -71,7 +71,6 @@ suite('Interpreters Activation - Python Environment Variables', () => {
         onDidChangeInterpreter = new EventEmitter<void>();
         when(envVarsService.onDidEnvironmentVariablesChange).thenReturn(onDidChangeEnvVariables.event);
         when(interpreterService.onDidChangeInterpreter).thenReturn(onDidChangeInterpreter.event);
-        when(interpreterService.getActiveInterpreter(anything())).thenResolve(interpreter);
         service = new EnvironmentActivationService(
             instance(helper),
             instance(platform),
@@ -90,7 +89,7 @@ suite('Interpreters Activation - Python Environment Variables', () => {
     [undefined, Uri.parse('a')].forEach((resource) =>
         [undefined, pythonInterpreter].forEach((interpreter) => {
             suite(title(resource, interpreter), () => {
-                setup(() => initSetup(interpreter));
+                setup(initSetup);
                 test('Unknown os will return empty variables', async () => {
                     when(platform.osType).thenReturn(OSType.Unknown);
                     const env = await service.getActivatedEnvironmentVariables(resource);
@@ -103,7 +102,7 @@ suite('Interpreters Activation - Python Environment Variables', () => {
 
                 osTypes.forEach((osType) => {
                     suite(osType.name, () => {
-                        setup(() => initSetup(interpreter));
+                        setup(initSetup);
                         test('getEnvironmentActivationShellCommands will be invoked', async () => {
                             when(platform.osType).thenReturn(osType.value);
                             when(


### PR DESCRIPTION
Because of https://github.com/conda/conda/issues/11814, `conda activate` is faster.

Closes https://github.com/microsoft/vscode-python/issues/19347 For https://github.com/microsoft/vscode-python/issues/19101