### PR TITLE
Ensure interpreter quickpick is initialized synchronously

### DIFF
--- a/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -150,7 +150,7 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand {
             items: suggestions,
             sortByLabel: !preserveOrderWhenFiltering,
             keepScrollPosition: true,
-            activeItem: await this.getActiveItem(state.workspace, suggestions),
+            activeItem: this.getActiveItem(state.workspace, suggestions), // Use a promise here to ensure quickpick is initialized synchronously.
             matchOnDetail: true,
             matchOnDescription: true,
             title: InterpreterQuickPickList.browsePath.openButtonLabel,

--- a/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
+++ b/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
@@ -243,7 +243,6 @@ suite('Set Interpreter Command', () => {
             const expectedParameters: IQuickPickParameters<QuickPickItem> = {
                 placeholder: `Selected Interpreter: ${currentPythonPath}`,
                 items: suggestions,
-                activeItem: recommended,
                 matchOnDetail: true,
                 matchOnDescription: true,
                 title: InterpreterQuickPickList.browsePath.openButtonLabel,
@@ -266,6 +265,9 @@ suite('Set Interpreter Command', () => {
             delete actualParameters!.initialize;
             delete actualParameters!.customButtonSetups;
             delete actualParameters!.onChangeItem;
+            const activeItem = await actualParameters!.activeItem;
+            assert.deepStrictEqual(activeItem, recommended);
+            delete actualParameters!.activeItem;
             assert.deepStrictEqual(actualParameters, expectedParameters, 'Params not equal');
         });
 
@@ -280,7 +282,6 @@ suite('Set Interpreter Command', () => {
             const expectedParameters: IQuickPickParameters<QuickPickItem> = {
                 placeholder: `Selected Interpreter: ${currentPythonPath}`,
                 items: suggestions, // Verify suggestions
-                activeItem: noPythonInstalled, // Verify active item
                 matchOnDetail: true,
                 matchOnDescription: true,
                 title: InterpreterQuickPickList.browsePath.openButtonLabel,
@@ -307,6 +308,9 @@ suite('Set Interpreter Command', () => {
             delete actualParameters!.initialize;
             delete actualParameters!.customButtonSetups;
             delete actualParameters!.onChangeItem;
+            const activeItem = await actualParameters!.activeItem;
+            assert.deepStrictEqual(activeItem, noPythonInstalled);
+            delete actualParameters!.activeItem;
             assert.deepStrictEqual(actualParameters, expectedParameters, 'Params not equal');
         });
 
@@ -524,7 +528,6 @@ suite('Set Interpreter Command', () => {
             const expectedParameters: IQuickPickParameters<QuickPickItem> = {
                 placeholder: `Selected Interpreter: ${currentPythonPath}`,
                 items: suggestions,
-                activeItem: recommended,
                 matchOnDetail: true,
                 matchOnDescription: true,
                 title: InterpreterQuickPickList.browsePath.openButtonLabel,
@@ -548,6 +551,9 @@ suite('Set Interpreter Command', () => {
             delete actualParameters!.initialize;
             delete actualParameters!.customButtonSetups;
             delete actualParameters!.onChangeItem;
+            const activeItem = await actualParameters!.activeItem;
+            assert.deepStrictEqual(activeItem, recommended);
+            delete actualParameters!.activeItem;
 
             assert.deepStrictEqual(actualParameters, expectedParameters, 'Params not equal');
         });


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/19101

Before the change item events start coming in, we have to ensure quickpick is ready to receive those events.