### PR TITLE
Onboard Python to the new localization work

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ env:
   # Use the mocha-multi-reporters and send output to both console (spec) and JUnit (mocha-junit-reporter).
   # Also enables a reporter which exits the process running the tests if it haven't already.
   MOCHA_REPORTER_JUNIT: true
-  DISABLE_TRANSLATIONS: true
 
 jobs:
   setup:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -14,7 +14,6 @@ env:
   ARTIFACT_NAME_VSIX: ms-python-insiders-vsix
   VSIX_NAME: ms-python-insiders.vsix
   TEST_RESULTS_DIRECTORY: .
-  DISABLE_TRANSLATIONS: true
   # Force a path with spaces and to test extension works in these scenarios
   # Unicode characters are causing 2.7 failures so skip that for now.
   special-working-directory: './path with spaces'

--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,5 @@ nodeLanguageServer.*/**
 dist/**
 # translation files
 *.xlf
-*.nls.*.json
-*.i18n.json
+package.nls.*.json
+l10n/

--- a/build/azure-pipeline.pre-release.yml
+++ b/build/azure-pipeline.pre-release.yml
@@ -21,8 +21,7 @@ resources:
 extends:
   template: azure-pipelines/extension/pre-release.yml@templates
   parameters:
-    locTsConfigs: $(Build.SourcesDirectory)/tsconfig.json
-    locBundleDestination: $(Build.SourcesDirectory)/out/client
+    l10nSourcePaths: ./src/client
     buildSteps:
       - task: NodeTool@0
         inputs:

--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -24,10 +24,7 @@ extends:
   template: azure-pipelines/extension/stable.yml@templates
   parameters:
     publishExtension: ${{ parameters.publishExtension }}
-
-    locTsConfigs: $(Build.SourcesDirectory)/tsconfig.json
-    locBundleDestination: $(Build.SourcesDirectory)/out/client
-
+    l10nSourcePaths: ./src/client
     buildSteps:
       - task: NodeTool@0
         inputs:

--- a/build/webpack/common.js
+++ b/build/webpack/common.js
@@ -52,16 +52,3 @@ function getListOfExistingModulesInOutDir() {
     return files.map((filePath) => `./${filePath.slice(0, -3)}`);
 }
 exports.getListOfExistingModulesInOutDir = getListOfExistingModulesInOutDir;
-function getTranlationsLoader() {
-    const loaders = [];
-    if (process.env.DISABLE_TRANSLATIONS !== 'true') {
-        loaders.push({
-            loader: 'vscode-nls-dev/lib/webpack-loader',
-            options: {
-                base: constants.ExtensionRootDir,
-            },
-        });
-    }
-    return loaders;
-}
-exports.getTranlationsLoader = getTranlationsLoader;

--- a/build/webpack/webpack.extension.config.js
+++ b/build/webpack/webpack.extension.config.js
@@ -26,7 +26,6 @@ const config = {
     },
     module: {
         rules: [
-            ...common.getTranlationsLoader(),
             {
                 test: /\.ts$/,
                 use: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
                 "vscode-languageclient": "8.0.2-next.5",
                 "vscode-languageserver": "8.0.2-next.5",
                 "vscode-languageserver-protocol": "3.17.2-next.6",
-                "vscode-nls": "^5.0.1",
                 "vscode-tas-client": "^0.1.63",
                 "which": "^2.0.2",
                 "winreg": "^1.2.4",
@@ -120,7 +119,6 @@
                 "uuid": "^8.3.2",
                 "vsce": "^2.6.6",
                 "vscode-debugadapter-testsupport": "^1.27.0",
-                "vscode-nls-dev": "^4.0.0",
                 "webpack": "^5.70.0",
                 "webpack-bundle-analyzer": "^4.5.0",
                 "webpack-cli": "^4.9.2",
@@ -5270,21 +5268,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/event-stream": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
-            "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
-            "dev": true,
-            "dependencies": {
-                "duplexer": "^0.1.1",
-                "from": "^0.1.7",
-                "map-stream": "0.0.7",
-                "pause-stream": "^0.0.11",
-                "split": "^1.0.1",
-                "stream-combiner": "^0.2.2",
-                "through": "^2.3.8"
-            }
-        },
         "node_modules/events": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -6101,12 +6084,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/from": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-            "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-            "dev": true
         },
         "node_modules/from2": {
             "version": "2.3.0",
@@ -7396,15 +7373,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
-            "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
-            "dev": true,
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/is-absolute": {
@@ -8937,12 +8905,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/map-stream": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-            "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
-            "dev": true
         },
         "node_modules/map-visit": {
             "version": "1.0.0",
@@ -10922,15 +10884,6 @@
                 "node": "*"
             }
         },
-        "node_modules/pause-stream": {
-            "version": "0.0.11",
-            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-            "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-            "dev": true,
-            "dependencies": {
-                "through": "~2.3"
-            }
-        },
         "node_modules/pbkdf2": {
             "version": "3.0.17",
             "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -12504,18 +12457,6 @@
             "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
             "dev": true
         },
-        "node_modules/split": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-            "dev": true,
-            "dependencies": {
-                "through": "2"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -12599,16 +12540,6 @@
             "dependencies": {
                 "inherits": "~2.0.1",
                 "readable-stream": "^2.0.2"
-            }
-        },
-        "node_modules/stream-combiner": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-            "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-            "dev": true,
-            "dependencies": {
-                "duplexer": "~0.1.1",
-                "through": "~2.3.4"
             }
         },
         "node_modules/stream-exhaust": {
@@ -14422,172 +14353,6 @@
             "version": "3.17.2-next.2",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2-next.2.tgz",
             "integrity": "sha512-TiAkLABgqkVWdAlC3XlOfdhdjIAdVU4YntPUm9kKGbXr+MGwpVnKz2KZMNBcvG0CFx8Hi8qliL0iq+ndPB720w=="
-        },
-        "node_modules/vscode-nls": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.1.tgz",
-            "integrity": "sha512-hHQV6iig+M21lTdItKPkJAaWrxALQb/nqpVffakO4knJOh3DrU2SXOMzUzNgo1eADPzu3qSsJY1weCzvR52q9A=="
-        },
-        "node_modules/vscode-nls-dev": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-nls-dev/-/vscode-nls-dev-4.0.0.tgz",
-            "integrity": "sha512-2JcEOy1EQKcF8JhtYfFdwAkzxFKrB2ZbHoQwKkzEFOc/RlLAPqO3laBvO2wK4k6G4XUCno/XLQjuDM33/+baRg==",
-            "dev": true,
-            "dependencies": {
-                "ansi-colors": "^4.1.1",
-                "clone": "^2.1.2",
-                "event-stream": "^3.3.4",
-                "fancy-log": "^1.3.3",
-                "glob": "^7.2.0",
-                "iconv-lite": "^0.6.3",
-                "is": "^3.3.0",
-                "source-map": "^0.6.1",
-                "typescript": "^4.5.4",
-                "vinyl": "^2.2.1",
-                "xml2js": "^0.4.23",
-                "yargs": "^17.3.0"
-            },
-            "bin": {
-                "vscl": "lib/vscl.js"
-            }
-        },
-        "node_modules/vscode-nls-dev/node_modules/ansi-colors": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/vscode-nls-dev/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/vscode-nls-dev/node_modules/cliui": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-            "dev": true,
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "wrap-ansi": "^7.0.0"
-            }
-        },
-        "node_modules/vscode-nls-dev/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/vscode-nls-dev/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/vscode-nls-dev/node_modules/get-caller-file": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true,
-            "engines": {
-                "node": "6.* || 8.* || >= 10.*"
-            }
-        },
-        "node_modules/vscode-nls-dev/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/vscode-nls-dev/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/vscode-nls-dev/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/vscode-nls-dev/node_modules/y18n": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/vscode-nls-dev/node_modules/yargs": {
-            "version": "17.4.1",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
-            "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
-            "dev": true,
-            "dependencies": {
-                "cliui": "^7.0.2",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vscode-nls-dev/node_modules/yargs-parser": {
-            "version": "21.0.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-            "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            }
         },
         "node_modules/vscode-tas-client": {
             "version": "0.1.63",
@@ -19520,21 +19285,6 @@
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
         },
-        "event-stream": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
-            "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
-            "dev": true,
-            "requires": {
-                "duplexer": "^0.1.1",
-                "from": "^0.1.7",
-                "map-stream": "0.0.7",
-                "pause-stream": "^0.0.11",
-                "split": "^1.0.1",
-                "stream-combiner": "^0.2.2",
-                "through": "^2.3.8"
-            }
-        },
         "events": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -20169,12 +19919,6 @@
             "requires": {
                 "map-cache": "^0.2.2"
             }
-        },
-        "from": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-            "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-            "dev": true
         },
         "from2": {
             "version": "2.3.0",
@@ -21181,12 +20925,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
             "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-            "dev": true
-        },
-        "is": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
-            "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
             "dev": true
         },
         "is-absolute": {
@@ -22389,12 +22127,6 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
             "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-            "dev": true
-        },
-        "map-stream": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-            "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
             "dev": true
         },
         "map-visit": {
@@ -23955,15 +23687,6 @@
             "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
             "dev": true
         },
-        "pause-stream": {
-            "version": "0.0.11",
-            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-            "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-            "dev": true,
-            "requires": {
-                "through": "~2.3"
-            }
-        },
         "pbkdf2": {
             "version": "3.0.17",
             "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -25194,15 +24917,6 @@
             "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
             "dev": true
         },
-        "split": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-            "dev": true,
-            "requires": {
-                "through": "2"
-            }
-        },
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -25268,16 +24982,6 @@
             "requires": {
                 "inherits": "~2.0.1",
                 "readable-stream": "^2.0.2"
-            }
-        },
-        "stream-combiner": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-            "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-            "dev": true,
-            "requires": {
-                "duplexer": "~0.1.1",
-                "through": "~2.3.4"
             }
         },
         "stream-exhaust": {
@@ -26712,135 +26416,6 @@
                     "version": "3.17.2-next.2",
                     "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2-next.2.tgz",
                     "integrity": "sha512-TiAkLABgqkVWdAlC3XlOfdhdjIAdVU4YntPUm9kKGbXr+MGwpVnKz2KZMNBcvG0CFx8Hi8qliL0iq+ndPB720w=="
-                }
-            }
-        },
-        "vscode-nls": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.1.tgz",
-            "integrity": "sha512-hHQV6iig+M21lTdItKPkJAaWrxALQb/nqpVffakO4knJOh3DrU2SXOMzUzNgo1eADPzu3qSsJY1weCzvR52q9A=="
-        },
-        "vscode-nls-dev": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-nls-dev/-/vscode-nls-dev-4.0.0.tgz",
-            "integrity": "sha512-2JcEOy1EQKcF8JhtYfFdwAkzxFKrB2ZbHoQwKkzEFOc/RlLAPqO3laBvO2wK4k6G4XUCno/XLQjuDM33/+baRg==",
-            "dev": true,
-            "requires": {
-                "ansi-colors": "^4.1.1",
-                "clone": "^2.1.2",
-                "event-stream": "^3.3.4",
-                "fancy-log": "^1.3.3",
-                "glob": "^7.2.0",
-                "iconv-lite": "^0.6.3",
-                "is": "^3.3.0",
-                "source-map": "^0.6.1",
-                "typescript": "^4.5.4",
-                "vinyl": "^2.2.1",
-                "xml2js": "^0.4.23",
-                "yargs": "^17.3.0"
-            },
-            "dependencies": {
-                "ansi-colors": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-                    "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-                    "dev": true
-                },
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "cliui": {
-                    "version": "7.0.4",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-                    "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-                    "dev": true,
-                    "requires": {
-                        "string-width": "^4.2.0",
-                        "strip-ansi": "^6.0.0",
-                        "wrap-ansi": "^7.0.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "get-caller-file": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-                    "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "4.2.3",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-                    "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-                    "dev": true,
-                    "requires": {
-                        "emoji-regex": "^8.0.0",
-                        "is-fullwidth-code-point": "^3.0.0",
-                        "strip-ansi": "^6.0.1"
-                    }
-                },
-                "wrap-ansi": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-                    "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.0.0",
-                        "string-width": "^4.1.0",
-                        "strip-ansi": "^6.0.0"
-                    }
-                },
-                "y18n": {
-                    "version": "5.0.8",
-                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-                    "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-                    "dev": true
-                },
-                "yargs": {
-                    "version": "17.4.1",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
-                    "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
-                    "dev": true,
-                    "requires": {
-                        "cliui": "^7.0.2",
-                        "escalade": "^3.1.1",
-                        "get-caller-file": "^2.0.5",
-                        "require-directory": "^2.1.1",
-                        "string-width": "^4.2.3",
-                        "y18n": "^5.0.5",
-                        "yargs-parser": "^21.0.0"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "21.0.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-                    "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
-                    "dev": true
                 }
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
                 "@types/stack-trace": "0.0.29",
                 "@types/tmp": "^0.0.33",
                 "@types/uuid": "^8.3.4",
-                "@types/vscode": "~1.68.0",
+                "@types/vscode": "~1.72.0",
                 "@types/which": "^2.0.1",
                 "@types/winreg": "^1.2.30",
                 "@types/xml2js": "^0.4.2",
@@ -129,7 +129,7 @@
                 "yargs": "^15.3.1"
             },
             "engines": {
-                "vscode": "^1.68.0"
+                "vscode": "^1.72.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -858,9 +858,9 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.68.1",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.1.tgz",
-            "integrity": "sha512-fXlaq13NT5yHh6yZ3c+UxXloTSk34mIvsNFYyQCeO5Po2BLFAwz7EZT4kQ43B64/aPcnAenyWy3QasrTofBOnQ==",
+            "version": "1.72.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz",
+            "integrity": "sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw==",
             "dev": true
         },
         "node_modules/@types/which": {
@@ -15786,9 +15786,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.68.1",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.1.tgz",
-            "integrity": "sha512-fXlaq13NT5yHh6yZ3c+UxXloTSk34mIvsNFYyQCeO5Po2BLFAwz7EZT4kQ43B64/aPcnAenyWy3QasrTofBOnQ==",
+            "version": "1.72.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz",
+            "integrity": "sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw==",
             "dev": true
         },
         "@types/which": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "publisher": "ms-python",
     "enabledApiProposals": [
         "quickPickSortByLabel",
-        "testObserver"
+        "testObserver",
+        "localization"
     ],
     "author": {
         "name": "Microsoft Corporation"
@@ -97,6 +98,7 @@
     ],
     "main": "./out/client/extension",
     "browser": "./dist/extension.browser.js",
+    "l10n": "./l10n",
     "contributes": {
         "walkthroughs": [
             {
@@ -1830,7 +1832,6 @@
         "vscode-languageclient": "8.0.2-next.5",
         "vscode-languageserver": "8.0.2-next.5",
         "vscode-languageserver-protocol": "3.17.2-next.6",
-        "vscode-nls": "^5.0.1",
         "vscode-tas-client": "^0.1.63",
         "winreg": "^1.2.4",
         "xml2js": "^0.4.19",
@@ -1908,7 +1909,6 @@
         "uuid": "^8.3.2",
         "vsce": "^2.6.6",
         "vscode-debugadapter-testsupport": "^1.27.0",
-        "vscode-nls-dev": "^4.0.0",
         "webpack": "^5.70.0",
         "webpack-bundle-analyzer": "^4.5.0",
         "webpack-cli": "^4.9.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.68.0"
+        "vscode": "^1.72.0"
     },
     "keywords": [
         "python",
@@ -1858,7 +1858,7 @@
         "@types/stack-trace": "0.0.29",
         "@types/tmp": "^0.0.33",
         "@types/uuid": "^8.3.4",
-        "@types/vscode": "~1.68.0",
+        "@types/vscode": "~1.72.0",
         "@types/which": "^2.0.1",
         "@types/winreg": "^1.2.30",
         "@types/xml2js": "^0.4.2",

--- a/src/client/application/diagnostics/checks/macPythonInterpreter.ts
+++ b/src/client/application/diagnostics/checks/macPythonInterpreter.ts
@@ -3,9 +3,8 @@
 
 // eslint-disable-next-line max-classes-per-file
 import { inject, injectable } from 'inversify';
-import { DiagnosticSeverity } from 'vscode';
+import { DiagnosticSeverity, l10n } from 'vscode';
 import '../../../common/extensions';
-import * as nls from 'vscode-nls';
 import { IPlatformService } from '../../../common/platform/types';
 import {
     IConfigurationService,
@@ -23,11 +22,8 @@ import { DiagnosticCommandPromptHandlerServiceId, MessageCommandPrompt } from '.
 import { DiagnosticScope, IDiagnostic, IDiagnosticCommand, IDiagnosticHandlerService } from '../types';
 import { Common } from '../../../common/utils/localize';
 
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
-
 const messages = {
-    [DiagnosticCodes.MacInterpreterSelected]: localize(
-        'DiagnosticCodes.MacInterpreterSelected',
+    [DiagnosticCodes.MacInterpreterSelected]: l10n.t(
         'The selected macOS system install of Python is not recommended, some functionality in the extension will be limited. [Install another version of Python](https://www.python.org/downloads) or select a different interpreter for the best experience. [Learn more](https://aka.ms/AA7jfor).',
     ),
 };

--- a/src/client/application/diagnostics/checks/powerShellActivation.ts
+++ b/src/client/application/diagnostics/checks/powerShellActivation.ts
@@ -3,9 +3,8 @@
 
 // eslint-disable-next-line max-classes-per-file
 import { inject, injectable } from 'inversify';
-import { DiagnosticSeverity } from 'vscode';
+import { DiagnosticSeverity, l10n } from 'vscode';
 import '../../../common/extensions';
-import * as nls from 'vscode-nls';
 import { useCommandPromptAsDefaultShell } from '../../../common/terminal/commandPrompt';
 import { IConfigurationService, ICurrentProcess, IDisposableRegistry, Resource } from '../../../common/types';
 import { Common } from '../../../common/utils/localize';
@@ -19,10 +18,7 @@ import { DiagnosticCodes } from '../constants';
 import { DiagnosticCommandPromptHandlerServiceId, MessageCommandPrompt } from '../promptHandler';
 import { DiagnosticScope, IDiagnostic, IDiagnosticHandlerService } from '../types';
 
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
-
-const PowershellActivationNotSupportedWithBatchFilesMessage = localize(
-    'powershelActivationMsg',
+const PowershellActivationNotSupportedWithBatchFilesMessage = l10n.t(
     'Activation of the selected Python environment is not supported in PowerShell. Consider changing your shell to Command Prompt.',
 );
 

--- a/src/client/application/diagnostics/checks/pythonInterpreter.ts
+++ b/src/client/application/diagnostics/checks/pythonInterpreter.ts
@@ -3,9 +3,8 @@
 
 // eslint-disable-next-line max-classes-per-file
 import { inject, injectable } from 'inversify';
-import { DiagnosticSeverity } from 'vscode';
+import { DiagnosticSeverity, l10n } from 'vscode';
 import '../../../common/extensions';
-import * as nls from 'vscode-nls';
 import * as path from 'path';
 import { IDisposableRegistry, IInterpreterPathService, Resource } from '../../../common/types';
 import { IInterpreterService } from '../../../interpreter/contracts';
@@ -30,15 +29,11 @@ import { IExtensionSingleActivationService } from '../../../activation/types';
 import { cache } from '../../../common/utils/decorators';
 import { noop } from '../../../common/utils/misc';
 
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
-
 const messages = {
-    [DiagnosticCodes.NoPythonInterpretersDiagnostic]: localize(
-        'DiagnosticCodes.NoPythonInterpretersDiagnostic',
+    [DiagnosticCodes.NoPythonInterpretersDiagnostic]: l10n.t(
         'No Python interpreter is selected. Please select a Python interpreter to enable features such as IntelliSense, linting, and debugging.',
     ),
-    [DiagnosticCodes.InvalidPythonInterpreterDiagnostic]: localize(
-        'DiagnosticCodes.NoCurrentlySelectedPythonInterpreterDiagnostic',
+    [DiagnosticCodes.InvalidPythonInterpreterDiagnostic]: l10n.t(
         'An Invalid Python interpreter is selected{0}, please try changing it to enable features such as IntelliSense, linting, and debugging.',
     ),
 };
@@ -59,7 +54,7 @@ export class InvalidPythonInterpreterDiagnostic extends BaseDiagnostic {
             // Specify folder name in case of multiroot scenarios
             const folder = workspaceService.getWorkspaceFolder(resource);
             if (folder) {
-                formatArg = ` ${localize('Common.forWorkspace', 'for workspace')} ${path.basename(folder.uri.fsPath)}`;
+                formatArg = ` ${l10n.t('for workspace')} ${path.basename(folder.uri.fsPath)}`;
             }
         }
         super(code, messages[code].format(formatArg), DiagnosticSeverity.Error, scope, resource, undefined, 'always');

--- a/src/client/browser/extension.ts
+++ b/src/client/browser/extension.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import '../../setupNls';
 import * as vscode from 'vscode';
 import TelemetryReporter from '@vscode/extension-telemetry';
 import { LanguageClientOptions } from 'vscode-languageclient';

--- a/src/client/browser/localize.ts
+++ b/src/client/browser/localize.ts
@@ -3,21 +3,20 @@
 
 'use strict';
 
+import { l10n } from 'vscode';
+
 /* eslint-disable @typescript-eslint/no-namespace */
 
 // IMPORTANT: Do not import any node fs related modules here, as they do not work in browser.
-import * as nls from 'vscode-nls';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 export namespace LanguageService {
     export const statusItem = {
-        name: localize('LanguageService.statusItem.name', 'Python IntelliSense Status'),
-        text: localize('LanguageService.statusItem.text', 'Partial Mode'),
-        detail: localize('LanguageService.statusItem.detail', 'Limited IntelliSense provided by Pylance'),
+        name: l10n.t('Python IntelliSense Status'),
+        text: l10n.t('Partial Mode'),
+        detail: l10n.t('Limited IntelliSense provided by Pylance'),
     };
 }
 
 export namespace Common {
-    export const learnMore = localize('Common.learnMore', 'Learn more');
+    export const learnMore = l10n.t('Learn more');
 }

--- a/src/client/common/experiments/service.ts
+++ b/src/client/common/experiments/service.ts
@@ -4,8 +4,8 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
+import { l10n } from 'vscode';
 import { getExperimentationService, IExperimentationService } from 'vscode-tas-client';
-import * as nls from 'vscode-nls';
 import { traceLog } from '../../logging';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
@@ -13,8 +13,6 @@ import { IApplicationEnvironment, IWorkspaceService } from '../application/types
 import { PVSC_EXTENSION_ID } from '../constants';
 import { IExperimentService, IPersistentStateFactory } from '../types';
 import { ExperimentationTelemetry } from './telemetry';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 const EXP_MEMENTO_KEY = 'VSCode.ABExp.FeatureData';
 const EXP_CONFIG_ID = 'vscode';
@@ -174,7 +172,7 @@ export class ExperimentService implements IExperimentService {
 
         if (this._optOutFrom.includes('All')) {
             // We prioritize opt out first
-            traceLog(localize('Experiments.optedOutOf', "Experiment '{0}' is inactive", 'All'));
+            traceLog(l10n.t("Experiment '{0}' is inactive", 'All'));
 
             // Since we are in the Opt Out all case, this means when checking for experiment we
             // short circuit and return. So, printing out additional experiment info might cause
@@ -183,7 +181,7 @@ export class ExperimentService implements IExperimentService {
         }
         if (this._optInto.includes('All')) {
             // Only if 'All' is not in optOut then check if it is in Opt In.
-            traceLog(localize('Experiments.inGroup', "Experiment '{0}' is active", 'All'));
+            traceLog(l10n.t("Experiment '{0}' is active", 'All'));
 
             // Similar to the opt out case. If user is opting into to all experiments we short
             // circuit the experiment checks. So, skip printing any additional details to the logs.
@@ -194,14 +192,14 @@ export class ExperimentService implements IExperimentService {
         this._optOutFrom
             .filter((exp) => exp !== 'All' && exp.toLowerCase().startsWith('python'))
             .forEach((exp) => {
-                traceLog(localize('Experiments.manuallyOptedOutOf', "Experiment '{0}' is inactive", exp));
+                traceLog(l10n.t("Experiment '{0}' is inactive", exp));
             });
 
         // Log experiments that users manually opt into, these are experiments which are added using the exp framework.
         this._optInto
             .filter((exp) => exp !== 'All' && exp.toLowerCase().startsWith('python'))
             .forEach((exp) => {
-                traceLog(localize('Experiments.manuallyOptIntoExperiments', "Experiment '{0}' is active", exp));
+                traceLog(l10n.t("Experiment '{0}' is active", exp));
             });
 
         if (!experimentsDisabled) {
@@ -214,7 +212,7 @@ export class ExperimentService implements IExperimentService {
                     !this._optOutFrom.includes(exp) &&
                     !this._optInto.includes(exp)
                 ) {
-                    traceLog(localize('Experiments.autoOptIntoExperiments', "Experiment '{0}' is active", exp));
+                    traceLog(l10n.t("Experiment '{0}' is active", exp));
                 }
             });
         }

--- a/src/client/common/installer/moduleInstaller.ts
+++ b/src/client/common/installer/moduleInstaller.ts
@@ -3,7 +3,7 @@
 
 import { injectable } from 'inversify';
 import * as path from 'path';
-import { CancellationToken, ProgressLocation, ProgressOptions } from 'vscode';
+import { CancellationToken, l10n, ProgressLocation, ProgressOptions } from 'vscode';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { traceError, traceLog } from '../../logging';
@@ -21,9 +21,6 @@ import { ExecutionInfo, IConfigurationService, IOutputChannel, Product } from '.
 import { isResource } from '../utils/misc';
 import { ProductNames } from './productNames';
 import { IModuleInstaller, InstallOptions, InterpreterUri, ModuleInstallFlags } from './types';
-import * as nls from 'vscode-nls';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 @injectable()
 export abstract class ModuleInstaller implements IModuleInstaller {
@@ -139,7 +136,7 @@ export abstract class ModuleInstaller implements IModuleInstaller {
             const options: ProgressOptions = {
                 location: ProgressLocation.Notification,
                 cancellable: true,
-                title: localize('products.installingModule', 'Installing {0}', name),
+                title: l10n.t('Installing {0}', name),
             };
             await shell.withProgress(options, async (_, token: CancellationToken) =>
                 install(wrapCancellationTokens(token, cancel)),

--- a/src/client/common/installer/productInstaller.ts
+++ b/src/client/common/installer/productInstaller.ts
@@ -253,19 +253,12 @@ export class FormatterInstaller extends BaseInstaller {
         const yesChoice = Common.bannerLabelYes;
 
         const options = [...useOptions, Common.doNotShowAgain];
-        let message = l10n.t(
-            'Formatter {0} is not installed. Install?',
-            productName,
-        );
+        let message = l10n.t('Formatter {0} is not installed. Install?', productName);
         if (this.isExecutableAModule(product, resource)) {
             options.splice(0, 0, yesChoice);
         } else {
             const executable = this.getExecutableNameFromSettings(product, resource);
-            message = l10n.t(
-                'Path to the {0} formatter is invalid ({1})',
-                productName,
-                executable,
-            );
+            message = l10n.t('Path to the {0} formatter is invalid ({1})', productName, executable);
         }
 
         const item = await this.appShell.showErrorMessage(message, ...options);
@@ -339,11 +332,7 @@ export class LinterInstaller extends BaseInstaller {
             options.splice(0, 0, install);
         } else {
             const executable = this.getExecutableNameFromSettings(product, resource);
-            message = l10n.t(
-                'Path to the {0} linter is invalid ({1})',
-                productName,
-                executable,
-            );
+            message = l10n.t('Path to the {0} linter is invalid ({1})', productName, executable);
         }
         const response = await this.appShell.showErrorMessage(message, ...options);
         if (response === install) {
@@ -398,19 +387,12 @@ export class TestFrameworkInstaller extends BaseInstaller {
         const productName = ProductNames.get(product)!;
 
         const options: string[] = [];
-        let message = l10n.t(
-            'Test framework {0} is not installed. Install?',
-            productName,
-        );
+        let message = l10n.t('Test framework {0} is not installed. Install?', productName);
         if (this.isExecutableAModule(product, resource)) {
             options.push(...[Common.bannerLabelYes, Common.bannerLabelNo]);
         } else {
             const executable = this.getExecutableNameFromSettings(product, resource);
-            message = l10n.t(
-                'Path to the {0} test framework is invalid ({1})',
-                productName,
-                executable,
-            );
+            message = l10n.t('Path to the {0} test framework is invalid ({1})', productName, executable);
         }
 
         const item = await this.appShell.showErrorMessage(message, ...options);
@@ -566,10 +548,7 @@ export class DataScienceInstaller extends BaseInstaller {
     ): Promise<InstallerResponse> {
         const productName = ProductNames.get(product)!;
         const item = await this.appShell.showErrorMessage(
-            l10n.t(
-                'Data Science library {0} is not installed. Install?',
-                productName,
-            ),
+            l10n.t('Data Science library {0} is not installed. Install?', productName),
             Common.bannerLabelYes,
             Common.bannerLabelNo,
         );

--- a/src/client/common/installer/productInstaller.ts
+++ b/src/client/common/installer/productInstaller.ts
@@ -2,9 +2,8 @@
 
 import { inject, injectable } from 'inversify';
 import * as semver from 'semver';
-import { CancellationToken, Uri } from 'vscode';
+import { CancellationToken, l10n, Uri } from 'vscode';
 import '../extensions';
-import * as nls from 'vscode-nls';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { LinterId } from '../../linters/types';
@@ -41,8 +40,6 @@ import { traceError, traceInfo } from '../../logging';
 import { isParentPath } from '../platform/fs-paths';
 
 export { Product } from '../types';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 // Products which may not be available to install from certain package registries, keyed by product name
 // Installer implementations can check this to determine a suitable installation channel for a product
@@ -252,12 +249,11 @@ export class FormatterInstaller extends BaseInstaller {
         const formatterNames = formatters.map((formatter) => ProductNames.get(formatter)!);
         const productName = ProductNames.get(product)!;
         formatterNames.splice(formatterNames.indexOf(productName), 1);
-        const useOptions = formatterNames.map((name) => localize('products.useFormatter', 'Use {0}', name));
+        const useOptions = formatterNames.map((name) => l10n.t('Use {0}', name));
         const yesChoice = Common.bannerLabelYes;
 
         const options = [...useOptions, Common.doNotShowAgain];
-        let message = localize(
-            'products.formatterNotInstalled',
+        let message = l10n.t(
             'Formatter {0} is not installed. Install?',
             productName,
         );
@@ -265,8 +261,7 @@ export class FormatterInstaller extends BaseInstaller {
             options.splice(0, 0, yesChoice);
         } else {
             const executable = this.getExecutableNameFromSettings(product, resource);
-            message = localize(
-                'products.invalidFormatterPath',
+            message = l10n.t(
                 'Path to the {0} formatter is invalid ({1})',
                 productName,
                 executable,
@@ -339,13 +334,12 @@ export class LinterInstaller extends BaseInstaller {
 
         const options = [selectLinter, doNotShowAgain];
 
-        let message = localize('Linter.notInstalled', 'Linter {0} is not installed.', productName);
+        let message = l10n.t('Linter {0} is not installed.', productName);
         if (this.isExecutableAModule(product, resource)) {
             options.splice(0, 0, install);
         } else {
             const executable = this.getExecutableNameFromSettings(product, resource);
-            message = localize(
-                'Linter.invalidPath',
+            message = l10n.t(
                 'Path to the {0} linter is invalid ({1})',
                 productName,
                 executable,
@@ -404,8 +398,7 @@ export class TestFrameworkInstaller extends BaseInstaller {
         const productName = ProductNames.get(product)!;
 
         const options: string[] = [];
-        let message = localize(
-            'TestFramework.notIstalled',
+        let message = l10n.t(
             'Test framework {0} is not installed. Install?',
             productName,
         );
@@ -413,8 +406,7 @@ export class TestFrameworkInstaller extends BaseInstaller {
             options.push(...[Common.bannerLabelYes, Common.bannerLabelNo]);
         } else {
             const executable = this.getExecutableNameFromSettings(product, resource);
-            message = localize(
-                'TestFramework.invalidPath',
+            message = l10n.t(
                 'Path to the {0} test framework is invalid ({1})',
                 productName,
                 executable,
@@ -529,8 +521,7 @@ export class DataScienceInstaller extends BaseInstaller {
         if (!installerModule) {
             this.appShell
                 .showErrorMessage(
-                    localize(
-                        'Installer.couldNotInstallLibrary',
+                    l10n.t(
                         'Could not install {0}. If pip is not available, please use the package manager of your choice to manually install this library into your Python environment.',
                         moduleName,
                     ),
@@ -575,8 +566,7 @@ export class DataScienceInstaller extends BaseInstaller {
     ): Promise<InstallerResponse> {
         const productName = ProductNames.get(product)!;
         const item = await this.appShell.showErrorMessage(
-            localize(
-                'Installer.dataScienceInstallPrompt',
+            l10n.t(
                 'Data Science library {0} is not installed. Install?',
                 productName,
             ),

--- a/src/client/common/net/fileDownloader.ts
+++ b/src/client/common/net/fileDownloader.ts
@@ -4,17 +4,14 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import * as nls from 'vscode-nls';
 import * as requestTypes from 'request';
-import { Progress } from 'vscode';
+import { l10n, Progress } from 'vscode';
 import { traceLog } from '../../logging';
 import { IApplicationShell } from '../application/types';
 import { Octicons } from '../constants';
 import { IFileSystem, WriteStream } from '../platform/types';
 import { DownloadOptions, IFileDownloader, IHttpClient } from '../types';
 import { noop } from '../utils/misc';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 @injectable()
 export class FileDownloader implements IFileDownloader {
@@ -24,7 +21,7 @@ export class FileDownloader implements IFileDownloader {
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
     ) {}
     public async downloadFile(uri: string, options: DownloadOptions): Promise<string> {
-        traceLog(localize('downloading.file', 'Downloading {0}...', uri));
+        traceLog(l10n.t('Downloading {0}...', uri));
         const tempFile = await this.fs.createTemporaryFile(options.extension);
 
         await this.downloadFileWithStatusBarProgress(uri, options.progressMessagePrefix, tempFile.filePath).then(
@@ -99,8 +96,7 @@ function formatProgressMessageWithState(progressMessagePrefix: string, state: Re
     const total = Math.round(state.size.total / 1024);
     const percentage = Math.round(100 * state.percent);
 
-    return localize(
-        'downloading.file.progress',
+    return l10n.t(
         '{0}{1} of {2} KB ({3}%)',
         progressMessagePrefix,
         received.toString(),

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -3,617 +3,373 @@
 
 'use strict';
 
-import * as nls from 'vscode-nls';
+import { l10n } from 'vscode';
 
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 /* eslint-disable @typescript-eslint/no-namespace, no-shadow */
 
 // External callers of localize use these tables to retrieve localized values.
 export namespace Diagnostics {
-    export const warnSourceMaps = localize(
-        'diagnostics.warnSourceMaps',
-        'Source map support is enabled in the Python Extension, this will adversely impact performance of the extension.',
-    );
-    export const disableSourceMaps = localize('diagnostics.disableSourceMaps', 'Disable Source Map Support');
-    export const warnBeforeEnablingSourceMaps = localize(
-        'diagnostics.warnBeforeEnablingSourceMaps',
-        'Enabling source map support in the Python Extension will adversely impact performance of the extension.',
-    );
-    export const enableSourceMapsAndReloadVSC = localize(
-        'diagnostics.enableSourceMapsAndReloadVSC',
-        'Enable and reload Window.',
-    );
-    export const lsNotSupported = localize(
-        'diagnostics.lsNotSupported',
-        'Your operating system does not meet the minimum requirements of the Python Language Server. Reverting to the alternative autocompletion provider, Jedi.',
-    );
-    export const removedPythonPathFromSettings = localize(
-        'diagnostics.removedPythonPathFromSettings',
-        'The "python.pythonPath" setting in your settings.json is no longer used by the Python extension. If you want, you can use a new setting called "python.defaultInterpreterPath" instead. Keep in mind that you need to change the value of this setting manually as the Python extension doesn\'t modify it when you change interpreters. [Learn more](https://aka.ms/AA7jfor).',
-    );
-    export const invalidPythonPathInDebuggerSettings = localize(
-        'diagnostics.invalidPythonPathInDebuggerSettings',
-        'You need to select a Python interpreter before you start debugging.\n\nTip: click on "Select Interpreter" in the status bar.',
-    );
-    export const invalidPythonPathInDebuggerLaunch = localize(
-        'diagnostics.invalidPythonPathInDebuggerLaunch',
-        'The Python path in your debug configuration is invalid.',
-    );
-    export const invalidDebuggerTypeDiagnostic = localize(
-        'diagnostics.invalidDebuggerTypeDiagnostic',
-        'Your launch.json file needs to be updated to change the "pythonExperimental" debug configurations to use the "python" debugger type, otherwise Python debugging may not work. Would you like to automatically update your launch.json file now?',
-    );
-    export const consoleTypeDiagnostic = localize(
-        'diagnostics.consoleTypeDiagnostic',
-        'Your launch.json file needs to be updated to change the console type string from "none" to "internalConsole", otherwise Python debugging may not work. Would you like to automatically update your launch.json file now?',
-    );
-    export const justMyCodeDiagnostic = localize(
-        'diagnostics.justMyCodeDiagnostic',
-        'Configuration "debugStdLib" in launch.json is no longer supported. It\'s recommended to replace it with "justMyCode", which is the exact opposite of using "debugStdLib". Would you like to automatically update your launch.json file to do that?',
-    );
-    export const yesUpdateLaunch = localize('diagnostics.yesUpdateLaunch', 'Yes, update launch.json');
-    export const invalidTestSettings = localize(
-        'diagnostics.invalidTestSettings',
-        'Your settings needs to be updated to change the setting "python.unitTest." to "python.testing.", otherwise testing Python code using the extension may not work. Would you like to automatically update your settings now?',
-    );
-    export const updateSettings = localize('diagnostics.updateSettings', 'Yes, update settings');
-    export const checkIsort5UpgradeGuide = localize(
-        'diagnostics.checkIsort5UpgradeGuide',
-        'We found outdated configuration for sorting imports in this workspace. Check the [isort upgrade guide](https://aka.ms/AA9j5x4) to update your settings.',
-    );
-    export const pylanceDefaultMessage = localize(
-        'diagnostics.pylanceDefaultMessage',
-        "The Python extension now includes Pylance to improve completions, code navigation, overall performance and much more! You can learn more about the update and learn how to change your language server [here](https://aka.ms/new-python-bundle).\n\nRead Pylance's license [here](https://marketplace.visualstudio.com/items/ms-python.vscode-pylance/license).",
-    );
+    export const warnSourceMaps = l10n.t('Source map support is enabled in the Python Extension, this will adversely impact performance of the extension.');
+    export const disableSourceMaps = l10n.t('Disable Source Map Support');
+    export const warnBeforeEnablingSourceMaps = l10n.t('Enabling source map support in the Python Extension will adversely impact performance of the extension.');
+    export const enableSourceMapsAndReloadVSC = l10n.t('Enable and reload Window.');
+    export const lsNotSupported = l10n.t('Your operating system does not meet the minimum requirements of the Python Language Server. Reverting to the alternative autocompletion provider, Jedi.');
+    export const removedPythonPathFromSettings = l10n.t('The "python.pythonPath" setting in your settings.json is no longer used by the Python extension. If you want, you can use a new setting called "python.defaultInterpreterPath" instead. Keep in mind that you need to change the value of this setting manually as the Python extension doesn\'t modify it when you change interpreters. [Learn more](https://aka.ms/AA7jfor).');
+    export const invalidPythonPathInDebuggerSettings = l10n.t('You need to select a Python interpreter before you start debugging.\n\nTip: click on "Select Interpreter" in the status bar.');
+    export const invalidPythonPathInDebuggerLaunch = l10n.t('The Python path in your debug configuration is invalid.');
+    export const invalidDebuggerTypeDiagnostic = l10n.t('Your launch.json file needs to be updated to change the "pythonExperimental" debug configurations to use the "python" debugger type, otherwise Python debugging may not work. Would you like to automatically update your launch.json file now?');
+    export const consoleTypeDiagnostic = l10n.t('Your launch.json file needs to be updated to change the console type string from "none" to "internalConsole", otherwise Python debugging may not work. Would you like to automatically update your launch.json file now?');
+    export const justMyCodeDiagnostic = l10n.t('Configuration "debugStdLib" in launch.json is no longer supported. It\'s recommended to replace it with "justMyCode", which is the exact opposite of using "debugStdLib". Would you like to automatically update your launch.json file to do that?');
+    export const yesUpdateLaunch = l10n.t('Yes, update launch.json');
+    export const invalidTestSettings = l10n.t('Your settings needs to be updated to change the setting "python.unitTest." to "python.testing.", otherwise testing Python code using the extension may not work. Would you like to automatically update your settings now?');
+    export const updateSettings = l10n.t('Yes, update settings');
+    export const checkIsort5UpgradeGuide = l10n.t('We found outdated configuration for sorting imports in this workspace. Check the [isort upgrade guide](https://aka.ms/AA9j5x4) to update your settings.');
+    export const pylanceDefaultMessage = l10n.t("The Python extension now includes Pylance to improve completions, code navigation, overall performance and much more! You can learn more about the update and learn how to change your language server [here](https://aka.ms/new-python-bundle).\n\nRead Pylance's license [here](https://marketplace.visualstudio.com/items/ms-python.vscode-pylance/license).");
 }
 
 export namespace Common {
-    export const bannerLabelYes = localize('Common.bannerLabelYes', 'Yes');
-    export const bannerLabelNo = localize('Common.bannerLabelNo', 'No');
-    export const yesPlease = localize('Common.yesPlease', 'Yes, please');
-    export const canceled = localize('Common.canceled', 'Canceled');
-    export const cancel = localize('Common.cancel', 'Cancel');
-    export const ok = localize('Common.ok', 'Ok');
-    export const error = localize('Common.error', 'Error');
-    export const gotIt = localize('Common.gotIt', 'Got it!');
-    export const install = localize('Common.install', 'Install');
-    export const loadingExtension = localize('Common.loadingPythonExtension', 'Python extension loading...');
-    export const openOutputPanel = localize('Common.openOutputPanel', 'Show output');
-    export const noIWillDoItLater = localize('Common.noIWillDoItLater', 'No, I will do it later');
-    export const notNow = localize('Common.notNow', 'Not now');
-    export const doNotShowAgain = localize('Common.doNotShowAgain', 'Do not show again');
-    export const reload = localize('Common.reload', 'Reload');
-    export const moreInfo = localize('Common.moreInfo', 'More Info');
-    export const learnMore = localize('Common.learnMore', 'Learn more');
-    export const and = localize('Common.and', 'and');
-    export const reportThisIssue = localize('Common.reportThisIssue', 'Report this issue');
-    export const recommended = localize('Common.recommended', 'Recommended');
-    export const clearAll = localize('Common.clearAll', 'Clear all');
-    export const alwaysIgnore = localize('Common.alwaysIgnore', 'Always Ignore');
-    export const ignore = localize('Common.ignore', 'Ignore');
-    export const selectPythonInterpreter = localize('Common.selectPythonInterpreter', 'Select Python Interpreter');
-    export const openLaunch = localize('Common.openLaunch', 'Open launch.json');
-    export const useCommandPrompt = localize('Common.useCommandPrompt', 'Use Command Prompt');
-    export const download = localize('Common.download', 'Download');
-    export const showLogs = localize('Common.showLogs', 'Show logs');
+    export const bannerLabelYes = l10n.t('Yes');
+    export const bannerLabelNo = l10n.t('No');
+    export const yesPlease = l10n.t('Yes, please');
+    export const canceled = l10n.t('Canceled');
+    export const cancel = l10n.t('Cancel');
+    export const ok = l10n.t('Ok');
+    export const error = l10n.t('Error');
+    export const gotIt = l10n.t('Got it!');
+    export const install = l10n.t('Install');
+    export const loadingExtension = l10n.t('Python extension loading...');
+    export const openOutputPanel = l10n.t('Show output');
+    export const noIWillDoItLater = l10n.t('No, I will do it later');
+    export const notNow = l10n.t('Not now');
+    export const doNotShowAgain = l10n.t('Do not show again');
+    export const reload = l10n.t('Reload');
+    export const moreInfo = l10n.t('More Info');
+    export const learnMore = l10n.t('Learn more');
+    export const and = l10n.t('and');
+    export const reportThisIssue = l10n.t('Report this issue');
+    export const recommended = l10n.t('Recommended');
+    export const clearAll = l10n.t('Clear all');
+    export const alwaysIgnore = l10n.t('Always Ignore');
+    export const ignore = l10n.t('Ignore');
+    export const selectPythonInterpreter = l10n.t('Select Python Interpreter');
+    export const openLaunch = l10n.t('Open launch.json');
+    export const useCommandPrompt = l10n.t('Use Command Prompt');
+    export const download = l10n.t('Download');
+    export const showLogs = l10n.t('Show logs');
 }
 
 export namespace CommonSurvey {
-    export const remindMeLaterLabel = localize('CommonSurvey.remindMeLaterLabel', 'Remind me later');
-    export const yesLabel = localize('CommonSurvey.yesLabel', 'Yes, take survey now');
-    export const noLabel = localize('CommonSurvey.noLabel', 'No, thanks');
+    export const remindMeLaterLabel = l10n.t('Remind me later');
+    export const yesLabel = l10n.t('Yes, take survey now');
+    export const noLabel = l10n.t('No, thanks');
 }
 
 export namespace AttachProcess {
-    export const attachTitle = localize('AttachProcess.attachTitle', 'Attach to process');
-    export const selectProcessPlaceholder = localize(
-        'AttachProcess.selectProcessPlaceholder',
-        'Select the process to attach to',
-    );
-    export const noProcessSelected = localize('AttachProcess.noProcessSelected', 'No process selected');
-    export const refreshList = localize('AttachProcess.refreshList', 'Refresh process list');
+    export const attachTitle = l10n.t('Attach to process');
+    export const selectProcessPlaceholder = l10n.t('Select the process to attach to');
+    export const noProcessSelected = l10n.t('No process selected');
+    export const refreshList = l10n.t('Refresh process list');
 }
 
 export namespace Pylance {
-    export const remindMeLater = localize('Pylance.remindMeLater', 'Remind me later');
+    export const remindMeLater = l10n.t('Remind me later');
 
-    export const pylanceNotInstalledMessage = localize(
-        'Pylance.pylanceNotInstalledMessage',
-        'Pylance extension is not installed.',
-    );
-    export const pylanceInstalledReloadPromptMessage = localize(
-        'Pylance.pylanceInstalledReloadPromptMessage',
-        'Pylance extension is now installed. Reload window to activate?',
-    );
+    export const pylanceNotInstalledMessage = l10n.t('Pylance extension is not installed.');
+    export const pylanceInstalledReloadPromptMessage = l10n.t('Pylance extension is now installed. Reload window to activate?');
 
-    export const pylanceRevertToJediPrompt = localize(
-        'Pylance.pylanceRevertToJediPrompt',
-        'The Pylance extension is not installed but the python.languageServer value is set to "Pylance". Would you like to install the Pylance extension to use Pylance, or revert back to Jedi?',
-    );
-    export const pylanceInstallPylance = localize('Pylance.pylanceInstallPylance', 'Install Pylance');
-    export const pylanceRevertToJedi = localize('Pylance.pylanceRevertToJedi', 'Revert to Jedi');
+    export const pylanceRevertToJediPrompt = l10n.t('The Pylance extension is not installed but the python.languageServer value is set to "Pylance". Would you like to install the Pylance extension to use Pylance, or revert back to Jedi?');
+    export const pylanceInstallPylance = l10n.t('Install Pylance');
+    export const pylanceRevertToJedi = l10n.t('Revert to Jedi');
 }
 
 export namespace TensorBoard {
-    export const enterRemoteUrl = localize('TensorBoard.enterRemoteUrl', 'Enter remote URL');
-    export const enterRemoteUrlDetail = localize(
-        'TensorBoard.enterRemoteUrlDetail',
-        'Enter a URL pointing to a remote directory containing your TensorBoard log files',
-    );
-    export const useCurrentWorkingDirectoryDetail = localize(
-        'TensorBoard.useCurrentWorkingDirectoryDetail',
-        'TensorBoard will search for tfevent files in all subdirectories of the current working directory',
-    );
-    export const useCurrentWorkingDirectory = localize(
-        'TensorBoard.useCurrentWorkingDirectory',
-        'Use current working directory',
-    );
-    export const logDirectoryPrompt = localize(
-        'TensorBoard.logDirectoryPrompt',
-        'Select a log directory to start TensorBoard with',
-    );
-    export const progressMessage = localize('TensorBoard.progressMessage', 'Starting TensorBoard session...');
-    export const nativeTensorBoardPrompt = localize(
-        'TensorBoard.nativeTensorBoardPrompt',
-        'VS Code now has integrated TensorBoard support. Would you like to launch TensorBoard?  (Tip: Launch TensorBoard anytime by opening the command palette and searching for "Launch TensorBoard".)',
-    );
-    export const selectAFolder = localize('TensorBoard.selectAFolder', 'Select a folder');
-    export const selectAFolderDetail = localize(
-        'TensorBoard.selectAFolderDetail',
-        'Select a log directory containing tfevent files',
-    );
-    export const selectAnotherFolder = localize('TensorBoard.selectAnotherFolder', 'Select another folder');
-    export const selectAnotherFolderDetail = localize(
-        'TensorBoard.selectAnotherFolderDetail',
-        'Use the file explorer to select another folder',
-    );
-    export const installPrompt = localize(
-        'TensorBoard.installPrompt',
-        'The package TensorBoard is required to launch a TensorBoard session. Would you like to install it?',
-    );
-    export const installTensorBoardAndProfilerPluginPrompt = localize(
-        'TensorBoard.installTensorBoardAndProfilerPluginPrompt',
-        'TensorBoard >= 2.4.1 and the PyTorch Profiler TensorBoard plugin >= 0.2.0 are required. Would you like to install these packages?',
-    );
-    export const installProfilerPluginPrompt = localize(
-        'TensorBoard.installProfilerPluginPrompt',
-        'We recommend installing version >= 0.2.0 of the PyTorch Profiler TensorBoard plugin. Would you like to install the package?',
-    );
-    export const upgradePrompt = localize(
-        'TensorBoard.upgradePrompt',
-        'Integrated TensorBoard support is only available for TensorBoard >= 2.4.1. Would you like to upgrade your copy of TensorBoard?',
-    );
-    export const launchNativeTensorBoardSessionCodeLens = localize(
-        'TensorBoard.launchNativeTensorBoardSessionCodeLens',
-        '▶ Launch TensorBoard Session',
-    );
-    export const launchNativeTensorBoardSessionCodeAction = localize(
-        'TensorBoard.launchNativeTensorBoardSessionCodeAction',
-        'Launch TensorBoard session',
-    );
-    export const missingSourceFile = localize(
-        'TensorBoard.missingSourceFile',
-        'We could not locate the requested source file on disk. Please manually specify the file.',
-    );
-    export const selectMissingSourceFile = localize('TensorBoard.selectMissingSourceFile', 'Choose File');
-    export const selectMissingSourceFileDescription = localize(
-        'TensorBoard.selectMissingSourceFileDescription',
-        "The source file's contents may not match the original contents in the trace.",
-    );
+    export const enterRemoteUrl = l10n.t('Enter remote URL');
+    export const enterRemoteUrlDetail = l10n.t('Enter a URL pointing to a remote directory containing your TensorBoard log files');
+    export const useCurrentWorkingDirectoryDetail = l10n.t('TensorBoard will search for tfevent files in all subdirectories of the current working directory');
+    export const useCurrentWorkingDirectory = l10n.t('Use current working directory');
+    export const logDirectoryPrompt = l10n.t('Select a log directory to start TensorBoard with');
+    export const progressMessage = l10n.t('Starting TensorBoard session...');
+    export const nativeTensorBoardPrompt = l10n.t('VS Code now has integrated TensorBoard support. Would you like to launch TensorBoard?  (Tip: Launch TensorBoard anytime by opening the command palette and searching for "Launch TensorBoard".)');
+    export const selectAFolder = l10n.t('Select a folder');
+    export const selectAFolderDetail = l10n.t('Select a log directory containing tfevent files');
+    export const selectAnotherFolder = l10n.t('Select another folder');
+    export const selectAnotherFolderDetail = l10n.t('Use the file explorer to select another folder');
+    export const installPrompt = l10n.t('The package TensorBoard is required to launch a TensorBoard session. Would you like to install it?');
+    export const installTensorBoardAndProfilerPluginPrompt = l10n.t('TensorBoard >= 2.4.1 and the PyTorch Profiler TensorBoard plugin >= 0.2.0 are required. Would you like to install these packages?');
+    export const installProfilerPluginPrompt = l10n.t('We recommend installing version >= 0.2.0 of the PyTorch Profiler TensorBoard plugin. Would you like to install the package?');
+    export const upgradePrompt = l10n.t('Integrated TensorBoard support is only available for TensorBoard >= 2.4.1. Would you like to upgrade your copy of TensorBoard?');
+    export const launchNativeTensorBoardSessionCodeLens = l10n.t('▶ Launch TensorBoard Session');
+    export const launchNativeTensorBoardSessionCodeAction = l10n.t('Launch TensorBoard session');
+    export const missingSourceFile = l10n.t('We could not locate the requested source file on disk. Please manually specify the file.');
+    export const selectMissingSourceFile = l10n.t('Choose File');
+    export const selectMissingSourceFileDescription = l10n.t("The source file's contents may not match the original contents in the trace.");
 }
 
 export namespace LanguageService {
     export const virtualWorkspaceStatusItem = {
-        detail: localize(
-            'LanguageService.virtualWorkspaceStatusItem.detail',
-            'Limited IntelliSense supported by Jedi and Pylance',
-        ),
+        detail: l10n.t('Limited IntelliSense supported by Jedi and Pylance'),
     };
     export const statusItem = {
-        name: localize('LanguageService.statusItem.name', 'Python IntelliSense Status'),
-        text: localize('LanguageService.statusItem.text', 'Partial Mode'),
-        detail: localize('LanguageService.statusItem.detail', 'Limited IntelliSense provided by Pylance'),
+        name: l10n.t('Python IntelliSense Status'),
+        text: l10n.t('Partial Mode'),
+        detail: l10n.t('Limited IntelliSense provided by Pylance'),
     };
-    export const startingPylance = localize('LanguageService.startingPylance', 'Starting Pylance language server.');
-    export const startingNone = localize(
-        'LanguageService.startingNone',
-        'Editor support is inactive since language server is set to None.',
-    );
-    export const untrustedWorkspaceMessage = localize(
-        'LanguageService.untrustedWorkspaceMessage',
-        'Only Pylance is supported in untrusted workspaces, setting language server to None.',
-    );
+    export const startingPylance = l10n.t('Starting Pylance language server.');
+    export const startingNone = l10n.t('Editor support is inactive since language server is set to None.');
+    export const untrustedWorkspaceMessage = l10n.t('Only Pylance is supported in untrusted workspaces, setting language server to None.');
 
-    export const reloadAfterLanguageServerChange = localize(
-        'LanguageService.reloadAfterLanguageServerChange',
-        'Please reload the window switching between language servers.',
-    );
+    export const reloadAfterLanguageServerChange = l10n.t('Please reload the window switching between language servers.');
 
-    export const lsFailedToStart = localize(
-        'LanguageService.lsFailedToStart',
-        'We encountered an issue starting the language server. Reverting to Jedi language engine. Check the Python output panel for details.',
-    );
-    export const lsFailedToDownload = localize(
-        'LanguageService.lsFailedToDownload',
-        'We encountered an issue downloading the language server. Reverting to Jedi language engine. Check the Python output panel for details.',
-    );
-    export const lsFailedToExtract = localize(
-        'LanguageService.lsFailedToExtract',
-        'We encountered an issue extracting the language server. Reverting to Jedi language engine. Check the Python output panel for details.',
-    );
-    export const downloadFailedOutputMessage = localize(
-        'LanguageService.downloadFailedOutputMessage',
-        'Language server download failed.',
-    );
-    export const extractionFailedOutputMessage = localize(
-        'LanguageService.extractionFailedOutputMessage',
-        'Language server extraction failed.',
-    );
-    export const extractionCompletedOutputMessage = localize(
-        'LanguageService.extractionCompletedOutputMessage',
-        'Language server download complete.',
-    );
-    export const extractionDoneOutputMessage = localize('LanguageService.extractionDoneOutputMessage', 'done.');
-    export const reloadVSCodeIfSeachPathHasChanged = localize(
-        'LanguageService.reloadVSCodeIfSeachPathHasChanged',
-        'Search paths have changed for this Python interpreter. Please reload the extension to ensure that the IntelliSense works correctly.',
-    );
+    export const lsFailedToStart = l10n.t('We encountered an issue starting the language server. Reverting to Jedi language engine. Check the Python output panel for details.');
+    export const lsFailedToDownload = l10n.t('We encountered an issue downloading the language server. Reverting to Jedi language engine. Check the Python output panel for details.');
+    export const lsFailedToExtract = l10n.t('We encountered an issue extracting the language server. Reverting to Jedi language engine. Check the Python output panel for details.');
+    export const downloadFailedOutputMessage = l10n.t('Language server download failed.');
+    export const extractionFailedOutputMessage = l10n.t('Language server extraction failed.');
+    export const extractionCompletedOutputMessage = l10n.t('Language server download complete.');
+    export const extractionDoneOutputMessage = l10n.t('done.');
+    export const reloadVSCodeIfSeachPathHasChanged = l10n.t('Search paths have changed for this Python interpreter. Please reload the extension to ensure that the IntelliSense works correctly.');
 }
 export namespace Interpreters {
-    export const installingPython = localize('Interpreters.installingPython', 'Installing Python into Environment...');
-    export const discovering = localize('Interpreters.DiscoveringInterpreters', 'Discovering Python Interpreters');
-    export const refreshing = localize('Interpreters.RefreshingInterpreters', 'Refreshing Python Interpreters');
-    export const condaInheritEnvMessage = localize(
-        'Interpreters.condaInheritEnvMessage',
-        'We noticed you\'re using a conda environment. If you are experiencing issues with this environment in the integrated terminal, we recommend that you let the Python extension change "terminal.integrated.inheritEnv" to false in your user settings.',
-    );
-    export const environmentPromptMessage = localize(
-        'Interpreters.environmentPromptMessage',
-        'We noticed a new environment has been created. Do you want to select it for the workspace folder?',
-    );
-    export const entireWorkspace = localize('Interpreters.entireWorkspace', 'Select at workspace level');
-    export const clearAtWorkspace = localize('Interpreters.clearAtWorkspace', 'Clear at workspace level');
-    export const selectInterpreterTip = localize(
-        'Interpreters.selectInterpreterTip',
-        'Tip: you can change the Python interpreter used by the Python extension by clicking on the Python version in the status bar',
-    );
-    export const installPythonTerminalMessage = localize(
-        'Interpreters.installPythonTerminalMessage',
-        '💡 Please try installing the python package using your package manager. Alternatively you can also download it from https://www.python.org/downloads',
-    );
+    export const installingPython = l10n.t('Installing Python into Environment...');
+    export const discovering = l10n.t('Discovering Python Interpreters');
+    export const refreshing = l10n.t('Refreshing Python Interpreters');
+    export const condaInheritEnvMessage = l10n.t('We noticed you\'re using a conda environment. If you are experiencing issues with this environment in the integrated terminal, we recommend that you let the Python extension change "terminal.integrated.inheritEnv" to false in your user settings.');
+    export const environmentPromptMessage = l10n.t('We noticed a new environment has been created. Do you want to select it for the workspace folder?');
+    export const entireWorkspace = l10n.t('Select at workspace level');
+    export const clearAtWorkspace = l10n.t('Clear at workspace level');
+    export const selectInterpreterTip = l10n.t('Tip: you can change the Python interpreter used by the Python extension by clicking on the Python version in the status bar');
+    export const installPythonTerminalMessage = l10n.t('💡 Please try installing the python package using your package manager. Alternatively you can also download it from https://www.python.org/downloads');
 }
 
 export namespace InterpreterQuickPickList {
-    export const noPythonInstalled = localize(
-        'InterpreterQuickPickList.noPythonInstalled',
-        'Python is not installed, please download and install it',
-    );
-    export const clickForInstructions = localize(
-        'InterpreterQuickPickList.clickForInstructions',
-        'Click for instructions...',
-    );
-    export const globalGroupName = localize('InterpreterQuickPickList.globalGroupName', 'Global');
-    export const workspaceGroupName = localize('InterpreterQuickPickList.workspaceGroupName', 'Workspace');
+    export const noPythonInstalled = l10n.t('Python is not installed, please download and install it');
+    export const clickForInstructions = l10n.t('Click for instructions...');
+    export const globalGroupName = l10n.t('Global');
+    export const workspaceGroupName = l10n.t('Workspace');
     export const enterPath = {
-        label: localize('InterpreterQuickPickList.enterPath.label', 'Enter interpreter path...'),
-        placeholder: localize('InterpreterQuickPickList.enterPath.placeholder', 'Enter path to a Python interpreter.'),
+        label: l10n.t('Enter interpreter path...'),
+        placeholder: l10n.t('Enter path to a Python interpreter.'),
     };
     export const defaultInterpreterPath = {
-        label: localize(
-            'InterpreterQuickPickList.defaultInterpreterPath.label',
-            'Use Python from `python.defaultInterpreterPath` setting',
-        ),
+        label: l10n.t('Use Python from `python.defaultInterpreterPath` setting'),
     };
     export const browsePath = {
-        label: localize('InterpreterQuickPickList.browsePath.label', 'Find...'),
-        detail: localize(
-            'InterpreterQuickPickList.browsePath.detail',
-            'Browse your file system to find a Python interpreter.',
-        ),
-        openButtonLabel: localize('python.command.python.setInterpreter.title', 'Select Interpreter'),
-        title: localize('InterpreterQuickPickList.browsePath.title', 'Select Python interpreter'),
+        label: l10n.t('Find...'),
+        detail: l10n.t('Browse your file system to find a Python interpreter.'),
+        openButtonLabel: l10n.t('Select Interpreter'),
+        title: l10n.t('Select Python interpreter'),
     };
-    export const refreshInterpreterList = localize(
-        'InterpreterQuickPickList.refreshInterpreterList',
-        'Refresh Interpreter list',
-    );
-    export const refreshingInterpreterList = localize(
-        'InterpreterQuickPickList.refreshingInterpreterList',
-        'Refreshing Interpreter list...',
-    );
+    export const refreshInterpreterList = l10n.t('Refresh Interpreter list');
+    export const refreshingInterpreterList = l10n.t('Refreshing Interpreter list...');
 }
 
 export namespace OutputChannelNames {
-    export const languageServer = localize('OutputChannelNames.languageServer', 'Python Language Server');
-    export const python = localize('OutputChannelNames.python', 'Python');
-    export const pythonTest = localize('OutputChannelNames.pythonTest', 'Python Test Log');
+    export const languageServer = l10n.t('Python Language Server');
+    export const python = l10n.t('Python');
+    export const pythonTest = l10n.t('Python Test Log');
 }
 
 export namespace Logging {
-    export const currentWorkingDirectory = localize('Logging.CurrentWorkingDirectory', 'cwd:');
+    export const currentWorkingDirectory = l10n.t('cwd:');
 }
 
 export namespace Linters {
-    export const selectLinter = localize('Linter.selectLinter', 'Select Linter');
+    export const selectLinter = l10n.t('Select Linter');
 }
 
 export namespace Installer {
-    export const noCondaOrPipInstaller = localize(
-        'Installer.noCondaOrPipInstaller',
-        'There is no Conda or Pip installer available in the selected environment.',
-    );
-    export const noPipInstaller = localize(
-        'Installer.noPipInstaller',
-        'There is no Pip installer available in the selected environment.',
-    );
-    export const searchForHelp = localize('Installer.searchForHelp', 'Search for help');
+    export const noCondaOrPipInstaller = l10n.t('There is no Conda or Pip installer available in the selected environment.');
+    export const noPipInstaller = l10n.t('There is no Pip installer available in the selected environment.');
+    export const searchForHelp = l10n.t('Search for help');
 }
 
 export namespace ExtensionSurveyBanner {
-    export const bannerMessage = localize(
-        'ExtensionSurveyBanner.bannerMessage',
-        'Can you please take 2 minutes to tell us how the Python extension is working for you?',
-    );
-    export const bannerLabelYes = localize('ExtensionSurveyBanner.bannerLabelYes', 'Yes, take survey now');
-    export const bannerLabelNo = localize('ExtensionSurveyBanner.bannerLabelNo', 'No, thanks');
-    export const maybeLater = localize('ExtensionSurveyBanner.maybeLater', 'Maybe later');
+    export const bannerMessage = l10n.t('Can you please take 2 minutes to tell us how the Python extension is working for you?');
+    export const bannerLabelYes = l10n.t('Yes, take survey now');
+    export const bannerLabelNo = l10n.t('No, thanks');
+    export const maybeLater = l10n.t('Maybe later');
 }
 export namespace DebugConfigStrings {
     export const selectConfiguration = {
-        title: localize('debug.selectConfigurationTitle', 'Select a debug configuration'),
-        placeholder: localize('debug.selectConfigurationPlaceholder', 'Debug Configuration'),
+        title: l10n.t('Select a debug configuration'),
+        placeholder: l10n.t('Debug Configuration'),
     };
     export const launchJsonCompletions = {
-        label: localize('debug.launchJsonConfigurationsCompletionLabel', 'Python'),
-        description: localize(
-            'debug.launchJsonConfigurationsCompletionDescription',
-            'Select a Python debug configuration',
-        ),
+        label: l10n.t('Python'),
+        description: l10n.t('Select a Python debug configuration'),
     };
 
     export namespace file {
         export const snippet = {
-            name: localize('python.snippet.launch.standard.label', 'Python: Current File'),
+            name: l10n.t('Python: Current File'),
         };
 
         export const selectConfiguration = {
-            label: localize('debug.debugFileConfigurationLabel', 'Python File'),
-            description: localize('debug.debugFileConfigurationDescription', 'Debug the currently active Python file'),
+            label: l10n.t('Python File'),
+            description: l10n.t('Debug the currently active Python file'),
         };
     }
     export namespace module {
         export const snippet = {
-            name: localize('python.snippet.launch.module.label', 'Python: Module'),
-            default: localize('python.snippet.launch.module.default', 'enter-your-module-name'),
+            name: l10n.t('Python: Module'),
+            default: l10n.t('enter-your-module-name'),
         };
 
         export const selectConfiguration = {
-            label: localize('debug.debugModuleConfigurationLabel', 'Module'),
-            description: localize(
-                'debug.debugModuleConfigurationDescription',
-                "Debug a Python module by invoking it with '-m'",
-            ),
+            label: l10n.t('Module'),
+            description: l10n.t("Debug a Python module by invoking it with '-m'"),
         };
         export const enterModule = {
-            title: localize('debug.moduleEnterModuleTitle', 'Debug Module'),
-            prompt: localize('debug.moduleEnterModulePrompt', 'Enter a Python module/package name'),
-            default: localize('debug.moduleEnterModuleDefault', 'enter-your-module-name'),
-            invalid: localize('debug.moduleEnterModuleInvalidNameError', 'Enter a valid module name'),
+            title: l10n.t('Debug Module'),
+            prompt: l10n.t('Enter a Python module/package name'),
+            default: l10n.t('enter-your-module-name'),
+            invalid: l10n.t('Enter a valid module name'),
         };
     }
     export namespace attach {
         export const snippet = {
-            name: localize('python.snippet.launch.attach.label', 'Python: Remote Attach'),
+            name: l10n.t('Python: Remote Attach'),
         };
 
         export const selectConfiguration = {
-            label: localize('debug.remoteAttachConfigurationLabel', 'Remote Attach'),
-            description: localize('debug.remoteAttachConfigurationDescription', 'Attach to a remote debug server'),
+            label: l10n.t('Remote Attach'),
+            description: l10n.t('Attach to a remote debug server'),
         };
         export const enterRemoteHost = {
-            title: localize('debug.attachRemoteHostTitle', 'Remote Debugging'),
-            prompt: localize('debug.attachRemoteHostPrompt', 'Enter a valid host name or IP address'),
-            invalid: localize('debug.attachRemoteHostValidationError', 'Enter a valid host name or IP address'),
+            title: l10n.t('Remote Debugging'),
+            prompt: l10n.t('Enter a valid host name or IP address'),
+            invalid: l10n.t('Enter a valid host name or IP address'),
         };
         export const enterRemotePort = {
-            title: localize('debug.attachRemotePortTitle', 'Remote Debugging'),
-            prompt: localize(
-                'debug.attachRemotePortPrompt',
-                'Enter the port number that the debug server is listening on',
-            ),
-            invalid: localize('debug.attachRemotePortValidationError', 'Enter a valid port number'),
+            title: l10n.t('Remote Debugging'),
+            prompt: l10n.t('Enter the port number that the debug server is listening on'),
+            invalid: l10n.t('Enter a valid port number'),
         };
     }
     export namespace attachPid {
         export const snippet = {
-            name: localize('python.snippet.launch.attachpid.label', 'Python: Attach using Process Id'),
+            name: l10n.t('Python: Attach using Process Id'),
         };
 
         export const selectConfiguration = {
-            label: localize('debug.attachPidConfigurationLabel', 'Attach using Process ID'),
-            description: localize('debug.attachPidConfigurationDescription', 'Attach to a local process'),
+            label: l10n.t('Attach using Process ID'),
+            description: l10n.t('Attach to a local process'),
         };
     }
     export namespace django {
         export const snippet = {
-            name: localize('python.snippet.launch.django.label', 'Python: Django'),
+            name: l10n.t('Python: Django'),
         };
 
         export const selectConfiguration = {
-            label: localize('debug.debugDjangoConfigurationLabel', 'Django'),
-            description: localize(
-                'debug.debugDjangoConfigurationDescription',
-                'Launch and debug a Django web application',
-            ),
+            label: l10n.t('Django'),
+            description: l10n.t('Launch and debug a Django web application'),
         };
         export const enterManagePyPath = {
-            title: localize('debug.djangoEnterManagePyPathTitle', 'Debug Django'),
-            prompt: localize(
-                'debug.djangoEnterManagePyPathPrompt',
-                "Enter the path to manage.py ('${workspaceFolderToken}' points to the root of the current workspace folder)",
-            ),
-            invalid: localize('debug.djangoEnterManagePyPathInvalidFilePathError', 'Enter a valid Python file path'),
+            title: l10n.t('Debug Django'),
+            prompt: l10n.t("Enter the path to manage.py ('${workspaceFolderToken}' points to the root of the current workspace folder)"),
+            invalid: l10n.t('Enter a valid Python file path'),
         };
     }
     export namespace fastapi {
         export const snippet = {
-            name: localize('python.snippet.launch.fastapi.label', 'Python: FastAPI'),
+            name: l10n.t('Python: FastAPI'),
         };
 
         export const selectConfiguration = {
-            label: localize('debug.debugFastAPIConfigurationLabel', 'FastAPI'),
-            description: localize(
-                'debug.debugFastAPIConfigurationDescription',
-                'Launch and debug a FastAPI web application',
-            ),
+            label: l10n.t('FastAPI'),
+            description: l10n.t('Launch and debug a FastAPI web application'),
         };
         export const enterAppPathOrNamePath = {
-            title: localize('debug.fastapiEnterAppPathOrNamePathTitle', 'Debug FastAPI'),
-            prompt: localize(
-                'debug.fastapiEnterAppPathOrNamePathPrompt',
-                "Enter the path to the application, e.g. 'main.py' or 'main'",
-            ),
-            invalid: localize('debug.fastapiEnterAppPathOrNamePathInvalidNameError', 'Enter a valid name'),
+            title: l10n.t('Debug FastAPI'),
+            prompt: l10n.t("Enter the path to the application, e.g. 'main.py' or 'main'"),
+            invalid: l10n.t('Enter a valid name'),
         };
     }
     export namespace flask {
         export const snippet = {
-            name: localize('python.snippet.launch.flask.label', 'Python: Flask'),
+            name: l10n.t('Python: Flask'),
         };
 
         export const selectConfiguration = {
-            label: localize('debug.debugFlaskConfigurationLabel', 'Flask'),
-            description: localize(
-                'debug.debugFlaskConfigurationDescription',
-                'Launch and debug a Flask web application',
-            ),
+            label: l10n.t('Flask'),
+            description: l10n.t('Launch and debug a Flask web application'),
         };
         export const enterAppPathOrNamePath = {
-            title: localize('debug.flaskEnterAppPathOrNamePathTitle', 'Debug Flask'),
-            prompt: localize('debug.flaskEnterAppPathOrNamePathPrompt', 'Python: Flask'),
-            invalid: localize('debug.flaskEnterAppPathOrNamePathInvalidNameError', 'Enter a valid name'),
+            title: l10n.t('Debug Flask'),
+            prompt: l10n.t('Python: Flask'),
+            invalid: l10n.t('Enter a valid name'),
         };
     }
     export namespace pyramid {
         export const snippet = {
-            name: localize('python.snippet.launch.pyramid.label', 'Python: Pyramid Application'),
+            name: l10n.t('Python: Pyramid Application'),
         };
 
         export const selectConfiguration = {
-            label: localize('debug.debugPyramidConfigurationLabel', 'Pyramid'),
-            description: localize(
-                'debug.debugPyramidConfigurationDescription',
-                'Launch and debug a Pyramid web application',
-            ),
+            label: l10n.t('Pyramid'),
+            description: l10n.t('Launch and debug a Pyramid web application'),
         };
         export const enterDevelopmentIniPath = {
-            title: localize('debug.pyramidEnterDevelopmentIniPathTitle', 'Debug Pyramid'),
-            invalid: localize('debug.pyramidEnterDevelopmentIniPathInvalidFilePathError', 'Enter a valid file path'),
+            title: l10n.t('Debug Pyramid'),
+            invalid: l10n.t('Enter a valid file path'),
         };
     }
 }
 
 export namespace Testing {
-    export const configureTests = localize('Testing.configureTests', 'Configure Test Framework');
-    export const testNotConfigured = localize('Testing.testNotConfigured', 'No test framework configured.');
-    export const cancelUnittestDiscovery = localize(
-        'Testing.cancelUnittestDiscovery',
-        'Canceled unittest test discovery',
-    );
-    export const errorUnittestDiscovery = localize('Testing.errorUnittestDiscovery', 'Unittest test discovery error');
-    export const seePythonOutput = localize('Testing.seePythonOutput', '(see Output > Python)');
-    export const cancelUnittestExecution = localize(
-        'Testing.cancelUnittestExecution',
-        'Canceled unittest test execution',
-    );
-    export const errorUnittestExecution = localize('Testing.errorUnittestExecution', 'Unittest test execution error');
+    export const configureTests = l10n.t('Configure Test Framework');
+    export const testNotConfigured = l10n.t('No test framework configured.');
+    export const cancelUnittestDiscovery = l10n.t('Canceled unittest test discovery');
+    export const errorUnittestDiscovery = l10n.t('Unittest test discovery error');
+    export const seePythonOutput = l10n.t('(see Output > Python)');
+    export const cancelUnittestExecution = l10n.t('Canceled unittest test execution');
+    export const errorUnittestExecution = l10n.t('Unittest test execution error');
 }
 
 export namespace OutdatedDebugger {
-    export const outdatedDebuggerMessage = localize(
-        'OutdatedDebugger.updateDebuggerMessage',
-        'We noticed you are attaching to ptvsd (Python debugger), which was deprecated on May 1st, 2020. Please switch to [debugpy](https://aka.ms/migrateToDebugpy).',
-    );
+    export const outdatedDebuggerMessage = l10n.t('We noticed you are attaching to ptvsd (Python debugger), which was deprecated on May 1st, 2020. Please switch to [debugpy](https://aka.ms/migrateToDebugpy).');
 }
 
 export namespace Python27Support {
-    export const jediMessage = localize(
-        'Python27Support.jediMessage',
-        'IntelliSense with Jedi for Python 2.7 is no longer supported. [Learn more](https://aka.ms/python-27-support).',
-    );
+    export const jediMessage = l10n.t('IntelliSense with Jedi for Python 2.7 is no longer supported. [Learn more](https://aka.ms/python-27-support).');
 }
 
 export namespace SwitchToDefaultLS {
-    export const bannerMessage = localize(
-        'SwitchToDefaultLS.bannerMessage',
-        "The Microsoft Python Language Server has reached end of life. Your language server has been set to the default for Python in VS Code, Pylance.\n\nIf you'd like to change your language server, you can learn about how to do so [here](https://devblogs.microsoft.com/python/python-in-visual-studio-code-may-2021-release/#configuring-your-language-server).\n\nRead Pylance's license [here](https://marketplace.visualstudio.com/items/ms-python.vscode-pylance/license).",
-    );
+    export const bannerMessage = l10n.t("The Microsoft Python Language Server has reached end of life. Your language server has been set to the default for Python in VS Code, Pylance.\n\nIf you'd like to change your language server, you can learn about how to do so [here](https://devblogs.microsoft.com/python/python-in-visual-studio-code-may-2021-release/#configuring-your-language-server).\n\nRead Pylance's license [here](https://marketplace.visualstudio.com/items/ms-python.vscode-pylance/license).");
 }
 
 export namespace CreateEnv {
-    export const informEnvCreation = localize(
-        'createEnv.informEnvCreation',
-        'We have selected the following environment:',
-    );
-    export const statusTitle = localize('createEnv.statusTitle', 'Creating environment');
-    export const statusStarting = localize('createEnv.statusStarting', 'Starting...');
+    export const informEnvCreation = l10n.t('We have selected the following environment:');
+    export const statusTitle = l10n.t('Creating environment');
+    export const statusStarting = l10n.t('Starting...');
 
-    export const hasVirtualEnv = localize('createEnv.hasVirtualEnv', 'Workspace folder contains a virtual environment');
+    export const hasVirtualEnv = l10n.t('Workspace folder contains a virtual environment');
 
-    export const noWorkspace = localize(
-        'createEnv.noWorkspace',
-        'Please open a directory when creating an environment using venv.',
-    );
+    export const noWorkspace = l10n.t('Please open a directory when creating an environment using venv.');
 
-    export const pickWorkspacePlaceholder = localize(
-        'createEnv.workspaceQuickPick.placeholder',
-        'Select a workspace to create environment',
-    );
+    export const pickWorkspacePlaceholder = l10n.t('Select a workspace to create environment');
 
-    export const providersQuickPickPlaceholder = localize(
-        'createEnv.providersQuickPick.placeholder',
-        'Select an environment type',
-    );
+    export const providersQuickPickPlaceholder = l10n.t('Select an environment type');
 
     export namespace Venv {
-        export const creating = localize('createEnv.venv.creating', 'Creating venv...');
-        export const created = localize('createEnv.venv.created', 'Environment created...');
-        export const installingPackages = localize('createEnv.venv.installingPackages', 'Installing packages...');
-        export const errorCreatingEnvironment = localize(
-            'createEnv.venv.errorCreatingEnvironment',
-            'Error while creating virtual environment.',
-        );
-        export const selectPythonQuickPickTitle = localize(
-            'createEnv.venv.basePython.title',
-            'Select a python to use for environment creation',
-        );
-        export const providerDescription = localize(
-            'createEnv.venv.description',
-            'Creates a `.venv` virtual environment in the current workspace',
-        );
-        export const error = localize('createEnv.venv.error', 'Creating virtual environment failed with error.');
+        export const creating = l10n.t('Creating venv...');
+        export const created = l10n.t('Environment created...');
+        export const installingPackages = l10n.t('Installing packages...');
+        export const errorCreatingEnvironment = l10n.t('Error while creating virtual environment.');
+        export const selectPythonQuickPickTitle = l10n.t('Select a python to use for environment creation');
+        export const providerDescription = l10n.t('Creates a `.venv` virtual environment in the current workspace');
+        export const error = l10n.t('Creating virtual environment failed with error.');
     }
 
     export namespace Conda {
-        export const condaMissing = localize(
-            'createEnv.conda.missing',
-            'Please install `conda` to create conda environments.',
-        );
-        export const created = localize('createEnv.conda.created', 'Environment created...');
-        export const installingPackages = localize('createEnv.conda.installingPackages', 'Installing packages...');
-        export const errorCreatingEnvironment = localize(
-            'createEnv.conda.errorCreatingEnvironment',
-            'Error while creating conda environment.',
-        );
-        export const selectPythonQuickPickPlaceholder = localize(
-            'createEnv.conda.pythonSelection.placeholder',
-            'Please select the version of Python to install in the environment',
-        );
-        export const creating = localize('createEnv.conda.creating', 'Creating conda environment...');
-        export const providerDescription = localize(
-            'createEnv.conda.description',
-            'Creates a `.conda` Conda environment in the current workspace',
-        );
+        export const condaMissing = l10n.t('Please install `conda` to create conda environments.');
+        export const created = l10n.t('Environment created...');
+        export const installingPackages = l10n.t('Installing packages...');
+        export const errorCreatingEnvironment = l10n.t('Error while creating conda environment.');
+        export const selectPythonQuickPickPlaceholder = l10n.t('Please select the version of Python to install in the environment');
+        export const creating = l10n.t('Creating conda environment...');
+        export const providerDescription = l10n.t('Creates a `.conda` Conda environment in the current workspace');
     }
 }

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -5,27 +5,48 @@
 
 import { l10n } from 'vscode';
 
-
 /* eslint-disable @typescript-eslint/no-namespace, no-shadow */
 
 // External callers of localize use these tables to retrieve localized values.
 export namespace Diagnostics {
-    export const warnSourceMaps = l10n.t('Source map support is enabled in the Python Extension, this will adversely impact performance of the extension.');
+    export const warnSourceMaps = l10n.t(
+        'Source map support is enabled in the Python Extension, this will adversely impact performance of the extension.',
+    );
     export const disableSourceMaps = l10n.t('Disable Source Map Support');
-    export const warnBeforeEnablingSourceMaps = l10n.t('Enabling source map support in the Python Extension will adversely impact performance of the extension.');
+    export const warnBeforeEnablingSourceMaps = l10n.t(
+        'Enabling source map support in the Python Extension will adversely impact performance of the extension.',
+    );
     export const enableSourceMapsAndReloadVSC = l10n.t('Enable and reload Window.');
-    export const lsNotSupported = l10n.t('Your operating system does not meet the minimum requirements of the Python Language Server. Reverting to the alternative autocompletion provider, Jedi.');
-    export const removedPythonPathFromSettings = l10n.t('The "python.pythonPath" setting in your settings.json is no longer used by the Python extension. If you want, you can use a new setting called "python.defaultInterpreterPath" instead. Keep in mind that you need to change the value of this setting manually as the Python extension doesn\'t modify it when you change interpreters. [Learn more](https://aka.ms/AA7jfor).');
-    export const invalidPythonPathInDebuggerSettings = l10n.t('You need to select a Python interpreter before you start debugging.\n\nTip: click on "Select Interpreter" in the status bar.');
+    export const lsNotSupported = l10n.t(
+        'Your operating system does not meet the minimum requirements of the Python Language Server. Reverting to the alternative autocompletion provider, Jedi.',
+    );
+    export const removedPythonPathFromSettings = l10n.t(
+        'The "python.pythonPath" setting in your settings.json is no longer used by the Python extension. If you want, you can use a new setting called "python.defaultInterpreterPath" instead. Keep in mind that you need to change the value of this setting manually as the Python extension doesn\'t modify it when you change interpreters. [Learn more](https://aka.ms/AA7jfor).',
+    );
+    export const invalidPythonPathInDebuggerSettings = l10n.t(
+        'You need to select a Python interpreter before you start debugging.\n\nTip: click on "Select Interpreter" in the status bar.',
+    );
     export const invalidPythonPathInDebuggerLaunch = l10n.t('The Python path in your debug configuration is invalid.');
-    export const invalidDebuggerTypeDiagnostic = l10n.t('Your launch.json file needs to be updated to change the "pythonExperimental" debug configurations to use the "python" debugger type, otherwise Python debugging may not work. Would you like to automatically update your launch.json file now?');
-    export const consoleTypeDiagnostic = l10n.t('Your launch.json file needs to be updated to change the console type string from "none" to "internalConsole", otherwise Python debugging may not work. Would you like to automatically update your launch.json file now?');
-    export const justMyCodeDiagnostic = l10n.t('Configuration "debugStdLib" in launch.json is no longer supported. It\'s recommended to replace it with "justMyCode", which is the exact opposite of using "debugStdLib". Would you like to automatically update your launch.json file to do that?');
+    export const invalidDebuggerTypeDiagnostic = l10n.t(
+        'Your launch.json file needs to be updated to change the "pythonExperimental" debug configurations to use the "python" debugger type, otherwise Python debugging may not work. Would you like to automatically update your launch.json file now?',
+    );
+    export const consoleTypeDiagnostic = l10n.t(
+        'Your launch.json file needs to be updated to change the console type string from "none" to "internalConsole", otherwise Python debugging may not work. Would you like to automatically update your launch.json file now?',
+    );
+    export const justMyCodeDiagnostic = l10n.t(
+        'Configuration "debugStdLib" in launch.json is no longer supported. It\'s recommended to replace it with "justMyCode", which is the exact opposite of using "debugStdLib". Would you like to automatically update your launch.json file to do that?',
+    );
     export const yesUpdateLaunch = l10n.t('Yes, update launch.json');
-    export const invalidTestSettings = l10n.t('Your settings needs to be updated to change the setting "python.unitTest." to "python.testing.", otherwise testing Python code using the extension may not work. Would you like to automatically update your settings now?');
+    export const invalidTestSettings = l10n.t(
+        'Your settings needs to be updated to change the setting "python.unitTest." to "python.testing.", otherwise testing Python code using the extension may not work. Would you like to automatically update your settings now?',
+    );
     export const updateSettings = l10n.t('Yes, update settings');
-    export const checkIsort5UpgradeGuide = l10n.t('We found outdated configuration for sorting imports in this workspace. Check the [isort upgrade guide](https://aka.ms/AA9j5x4) to update your settings.');
-    export const pylanceDefaultMessage = l10n.t("The Python extension now includes Pylance to improve completions, code navigation, overall performance and much more! You can learn more about the update and learn how to change your language server [here](https://aka.ms/new-python-bundle).\n\nRead Pylance's license [here](https://marketplace.visualstudio.com/items/ms-python.vscode-pylance/license).");
+    export const checkIsort5UpgradeGuide = l10n.t(
+        'We found outdated configuration for sorting imports in this workspace. Check the [isort upgrade guide](https://aka.ms/AA9j5x4) to update your settings.',
+    );
+    export const pylanceDefaultMessage = l10n.t(
+        "The Python extension now includes Pylance to improve completions, code navigation, overall performance and much more! You can learn more about the update and learn how to change your language server [here](https://aka.ms/new-python-bundle).\n\nRead Pylance's license [here](https://marketplace.visualstudio.com/items/ms-python.vscode-pylance/license).",
+    );
 }
 
 export namespace Common {
@@ -76,34 +97,56 @@ export namespace Pylance {
     export const remindMeLater = l10n.t('Remind me later');
 
     export const pylanceNotInstalledMessage = l10n.t('Pylance extension is not installed.');
-    export const pylanceInstalledReloadPromptMessage = l10n.t('Pylance extension is now installed. Reload window to activate?');
+    export const pylanceInstalledReloadPromptMessage = l10n.t(
+        'Pylance extension is now installed. Reload window to activate?',
+    );
 
-    export const pylanceRevertToJediPrompt = l10n.t('The Pylance extension is not installed but the python.languageServer value is set to "Pylance". Would you like to install the Pylance extension to use Pylance, or revert back to Jedi?');
+    export const pylanceRevertToJediPrompt = l10n.t(
+        'The Pylance extension is not installed but the python.languageServer value is set to "Pylance". Would you like to install the Pylance extension to use Pylance, or revert back to Jedi?',
+    );
     export const pylanceInstallPylance = l10n.t('Install Pylance');
     export const pylanceRevertToJedi = l10n.t('Revert to Jedi');
 }
 
 export namespace TensorBoard {
     export const enterRemoteUrl = l10n.t('Enter remote URL');
-    export const enterRemoteUrlDetail = l10n.t('Enter a URL pointing to a remote directory containing your TensorBoard log files');
-    export const useCurrentWorkingDirectoryDetail = l10n.t('TensorBoard will search for tfevent files in all subdirectories of the current working directory');
+    export const enterRemoteUrlDetail = l10n.t(
+        'Enter a URL pointing to a remote directory containing your TensorBoard log files',
+    );
+    export const useCurrentWorkingDirectoryDetail = l10n.t(
+        'TensorBoard will search for tfevent files in all subdirectories of the current working directory',
+    );
     export const useCurrentWorkingDirectory = l10n.t('Use current working directory');
     export const logDirectoryPrompt = l10n.t('Select a log directory to start TensorBoard with');
     export const progressMessage = l10n.t('Starting TensorBoard session...');
-    export const nativeTensorBoardPrompt = l10n.t('VS Code now has integrated TensorBoard support. Would you like to launch TensorBoard?  (Tip: Launch TensorBoard anytime by opening the command palette and searching for "Launch TensorBoard".)');
+    export const nativeTensorBoardPrompt = l10n.t(
+        'VS Code now has integrated TensorBoard support. Would you like to launch TensorBoard?  (Tip: Launch TensorBoard anytime by opening the command palette and searching for "Launch TensorBoard".)',
+    );
     export const selectAFolder = l10n.t('Select a folder');
     export const selectAFolderDetail = l10n.t('Select a log directory containing tfevent files');
     export const selectAnotherFolder = l10n.t('Select another folder');
     export const selectAnotherFolderDetail = l10n.t('Use the file explorer to select another folder');
-    export const installPrompt = l10n.t('The package TensorBoard is required to launch a TensorBoard session. Would you like to install it?');
-    export const installTensorBoardAndProfilerPluginPrompt = l10n.t('TensorBoard >= 2.4.1 and the PyTorch Profiler TensorBoard plugin >= 0.2.0 are required. Would you like to install these packages?');
-    export const installProfilerPluginPrompt = l10n.t('We recommend installing version >= 0.2.0 of the PyTorch Profiler TensorBoard plugin. Would you like to install the package?');
-    export const upgradePrompt = l10n.t('Integrated TensorBoard support is only available for TensorBoard >= 2.4.1. Would you like to upgrade your copy of TensorBoard?');
+    export const installPrompt = l10n.t(
+        'The package TensorBoard is required to launch a TensorBoard session. Would you like to install it?',
+    );
+    export const installTensorBoardAndProfilerPluginPrompt = l10n.t(
+        'TensorBoard >= 2.4.1 and the PyTorch Profiler TensorBoard plugin >= 0.2.0 are required. Would you like to install these packages?',
+    );
+    export const installProfilerPluginPrompt = l10n.t(
+        'We recommend installing version >= 0.2.0 of the PyTorch Profiler TensorBoard plugin. Would you like to install the package?',
+    );
+    export const upgradePrompt = l10n.t(
+        'Integrated TensorBoard support is only available for TensorBoard >= 2.4.1. Would you like to upgrade your copy of TensorBoard?',
+    );
     export const launchNativeTensorBoardSessionCodeLens = l10n.t('▶ Launch TensorBoard Session');
     export const launchNativeTensorBoardSessionCodeAction = l10n.t('Launch TensorBoard session');
-    export const missingSourceFile = l10n.t('We could not locate the requested source file on disk. Please manually specify the file.');
+    export const missingSourceFile = l10n.t(
+        'We could not locate the requested source file on disk. Please manually specify the file.',
+    );
     export const selectMissingSourceFile = l10n.t('Choose File');
-    export const selectMissingSourceFileDescription = l10n.t("The source file's contents may not match the original contents in the trace.");
+    export const selectMissingSourceFileDescription = l10n.t(
+        "The source file's contents may not match the original contents in the trace.",
+    );
 }
 
 export namespace LanguageService {
@@ -117,29 +160,49 @@ export namespace LanguageService {
     };
     export const startingPylance = l10n.t('Starting Pylance language server.');
     export const startingNone = l10n.t('Editor support is inactive since language server is set to None.');
-    export const untrustedWorkspaceMessage = l10n.t('Only Pylance is supported in untrusted workspaces, setting language server to None.');
+    export const untrustedWorkspaceMessage = l10n.t(
+        'Only Pylance is supported in untrusted workspaces, setting language server to None.',
+    );
 
-    export const reloadAfterLanguageServerChange = l10n.t('Please reload the window switching between language servers.');
+    export const reloadAfterLanguageServerChange = l10n.t(
+        'Please reload the window switching between language servers.',
+    );
 
-    export const lsFailedToStart = l10n.t('We encountered an issue starting the language server. Reverting to Jedi language engine. Check the Python output panel for details.');
-    export const lsFailedToDownload = l10n.t('We encountered an issue downloading the language server. Reverting to Jedi language engine. Check the Python output panel for details.');
-    export const lsFailedToExtract = l10n.t('We encountered an issue extracting the language server. Reverting to Jedi language engine. Check the Python output panel for details.');
+    export const lsFailedToStart = l10n.t(
+        'We encountered an issue starting the language server. Reverting to Jedi language engine. Check the Python output panel for details.',
+    );
+    export const lsFailedToDownload = l10n.t(
+        'We encountered an issue downloading the language server. Reverting to Jedi language engine. Check the Python output panel for details.',
+    );
+    export const lsFailedToExtract = l10n.t(
+        'We encountered an issue extracting the language server. Reverting to Jedi language engine. Check the Python output panel for details.',
+    );
     export const downloadFailedOutputMessage = l10n.t('Language server download failed.');
     export const extractionFailedOutputMessage = l10n.t('Language server extraction failed.');
     export const extractionCompletedOutputMessage = l10n.t('Language server download complete.');
     export const extractionDoneOutputMessage = l10n.t('done.');
-    export const reloadVSCodeIfSeachPathHasChanged = l10n.t('Search paths have changed for this Python interpreter. Please reload the extension to ensure that the IntelliSense works correctly.');
+    export const reloadVSCodeIfSeachPathHasChanged = l10n.t(
+        'Search paths have changed for this Python interpreter. Please reload the extension to ensure that the IntelliSense works correctly.',
+    );
 }
 export namespace Interpreters {
     export const installingPython = l10n.t('Installing Python into Environment...');
     export const discovering = l10n.t('Discovering Python Interpreters');
     export const refreshing = l10n.t('Refreshing Python Interpreters');
-    export const condaInheritEnvMessage = l10n.t('We noticed you\'re using a conda environment. If you are experiencing issues with this environment in the integrated terminal, we recommend that you let the Python extension change "terminal.integrated.inheritEnv" to false in your user settings.');
-    export const environmentPromptMessage = l10n.t('We noticed a new environment has been created. Do you want to select it for the workspace folder?');
+    export const condaInheritEnvMessage = l10n.t(
+        'We noticed you\'re using a conda environment. If you are experiencing issues with this environment in the integrated terminal, we recommend that you let the Python extension change "terminal.integrated.inheritEnv" to false in your user settings.',
+    );
+    export const environmentPromptMessage = l10n.t(
+        'We noticed a new environment has been created. Do you want to select it for the workspace folder?',
+    );
     export const entireWorkspace = l10n.t('Select at workspace level');
     export const clearAtWorkspace = l10n.t('Clear at workspace level');
-    export const selectInterpreterTip = l10n.t('Tip: you can change the Python interpreter used by the Python extension by clicking on the Python version in the status bar');
-    export const installPythonTerminalMessage = l10n.t('💡 Please try installing the python package using your package manager. Alternatively you can also download it from https://www.python.org/downloads');
+    export const selectInterpreterTip = l10n.t(
+        'Tip: you can change the Python interpreter used by the Python extension by clicking on the Python version in the status bar',
+    );
+    export const installPythonTerminalMessage = l10n.t(
+        '💡 Please try installing the python package using your package manager. Alternatively you can also download it from https://www.python.org/downloads',
+    );
 }
 
 export namespace InterpreterQuickPickList {
@@ -179,13 +242,17 @@ export namespace Linters {
 }
 
 export namespace Installer {
-    export const noCondaOrPipInstaller = l10n.t('There is no Conda or Pip installer available in the selected environment.');
+    export const noCondaOrPipInstaller = l10n.t(
+        'There is no Conda or Pip installer available in the selected environment.',
+    );
     export const noPipInstaller = l10n.t('There is no Pip installer available in the selected environment.');
     export const searchForHelp = l10n.t('Search for help');
 }
 
 export namespace ExtensionSurveyBanner {
-    export const bannerMessage = l10n.t('Can you please take 2 minutes to tell us how the Python extension is working for you?');
+    export const bannerMessage = l10n.t(
+        'Can you please take 2 minutes to tell us how the Python extension is working for you?',
+    );
     export const bannerLabelYes = l10n.t('Yes, take survey now');
     export const bannerLabelNo = l10n.t('No, thanks');
     export const maybeLater = l10n.t('Maybe later');
@@ -268,7 +335,9 @@ export namespace DebugConfigStrings {
         };
         export const enterManagePyPath = {
             title: l10n.t('Debug Django'),
-            prompt: l10n.t("Enter the path to manage.py ('${workspaceFolderToken}' points to the root of the current workspace folder)"),
+            prompt: l10n.t(
+                "Enter the path to manage.py ('${workspaceFolderToken}' points to the root of the current workspace folder)",
+            ),
             invalid: l10n.t('Enter a valid Python file path'),
         };
     }
@@ -329,15 +398,21 @@ export namespace Testing {
 }
 
 export namespace OutdatedDebugger {
-    export const outdatedDebuggerMessage = l10n.t('We noticed you are attaching to ptvsd (Python debugger), which was deprecated on May 1st, 2020. Please switch to [debugpy](https://aka.ms/migrateToDebugpy).');
+    export const outdatedDebuggerMessage = l10n.t(
+        'We noticed you are attaching to ptvsd (Python debugger), which was deprecated on May 1st, 2020. Please switch to [debugpy](https://aka.ms/migrateToDebugpy).',
+    );
 }
 
 export namespace Python27Support {
-    export const jediMessage = l10n.t('IntelliSense with Jedi for Python 2.7 is no longer supported. [Learn more](https://aka.ms/python-27-support).');
+    export const jediMessage = l10n.t(
+        'IntelliSense with Jedi for Python 2.7 is no longer supported. [Learn more](https://aka.ms/python-27-support).',
+    );
 }
 
 export namespace SwitchToDefaultLS {
-    export const bannerMessage = l10n.t("The Microsoft Python Language Server has reached end of life. Your language server has been set to the default for Python in VS Code, Pylance.\n\nIf you'd like to change your language server, you can learn about how to do so [here](https://devblogs.microsoft.com/python/python-in-visual-studio-code-may-2021-release/#configuring-your-language-server).\n\nRead Pylance's license [here](https://marketplace.visualstudio.com/items/ms-python.vscode-pylance/license).");
+    export const bannerMessage = l10n.t(
+        "The Microsoft Python Language Server has reached end of life. Your language server has been set to the default for Python in VS Code, Pylance.\n\nIf you'd like to change your language server, you can learn about how to do so [here](https://devblogs.microsoft.com/python/python-in-visual-studio-code-may-2021-release/#configuring-your-language-server).\n\nRead Pylance's license [here](https://marketplace.visualstudio.com/items/ms-python.vscode-pylance/license).",
+    );
 }
 
 export namespace CreateEnv {
@@ -368,7 +443,9 @@ export namespace CreateEnv {
         export const created = l10n.t('Environment created...');
         export const installingPackages = l10n.t('Installing packages...');
         export const errorCreatingEnvironment = l10n.t('Error while creating conda environment.');
-        export const selectPythonQuickPickPlaceholder = l10n.t('Please select the version of Python to install in the environment');
+        export const selectPythonQuickPickPlaceholder = l10n.t(
+            'Please select the version of Python to install in the environment',
+        );
         export const creating = l10n.t('Creating conda environment...');
         export const providerDescription = l10n.t('Creates a `.conda` Conda environment in the current workspace');
     }

--- a/src/client/debugger/extension/adapter/factory.ts
+++ b/src/client/debugger/extension/adapter/factory.ts
@@ -10,6 +10,7 @@ import {
     DebugAdapterExecutable,
     DebugAdapterServer,
     DebugSession,
+    l10n,
     WorkspaceFolder,
 } from 'vscode';
 import { IApplicationShell } from '../../../common/application/types';
@@ -21,9 +22,6 @@ import { sendTelemetryEvent } from '../../../telemetry';
 import { EventName } from '../../../telemetry/constants';
 import { AttachRequestArguments, LaunchRequestArguments } from '../../types';
 import { IDebugAdapterDescriptorFactory } from '../types';
-import * as nls from 'vscode-nls';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 @injectable()
 export class DebugAdapterDescriptorFactory implements IDebugAdapterDescriptorFactory {
@@ -162,7 +160,7 @@ export class DebugAdapterDescriptorFactory implements IDebugAdapterDescriptorFac
      */
     private async notifySelectInterpreter() {
         await this.appShell.showErrorMessage(
-            localize('interpreterError', 'Please install Python or select a Python Interpreter to use the debugger.'),
+            l10n.t('Please install Python or select a Python Interpreter to use the debugger.'),
         );
     }
 }

--- a/src/client/debugger/extension/attachQuickPick/provider.ts
+++ b/src/client/debugger/extension/attachQuickPick/provider.ts
@@ -69,12 +69,7 @@ export class AttachProcessProvider implements IAttachProcessProvider {
         } else if (this.platformService.isWindows) {
             processCmd = WmicProcessParser.wmicCommand;
         } else {
-            throw new Error(
-                l10n.t(
-                    "Operating system '{0}' not supported.",
-                    this.platformService.osType,
-                ),
-            );
+            throw new Error(l10n.t("Operating system '{0}' not supported.", this.platformService.osType));
         }
 
         const processService = await this.processServiceFactory.create();

--- a/src/client/debugger/extension/attachQuickPick/provider.ts
+++ b/src/client/debugger/extension/attachQuickPick/provider.ts
@@ -4,14 +4,12 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import * as nls from 'vscode-nls';
+import { l10n } from 'vscode';
 import { IPlatformService } from '../../../common/platform/types';
 import { IProcessServiceFactory } from '../../../common/process/types';
 import { PsProcessParser } from './psProcessParser';
 import { IAttachItem, IAttachProcessProvider, ProcessListCommand } from './types';
 import { WmicProcessParser } from './wmicProcessParser';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 @injectable()
 export class AttachProcessProvider implements IAttachProcessProvider {
@@ -72,8 +70,7 @@ export class AttachProcessProvider implements IAttachProcessProvider {
             processCmd = WmicProcessParser.wmicCommand;
         } else {
             throw new Error(
-                localize(
-                    'AttachProcess.unsupportedOS',
+                l10n.t(
                     "Operating system '{0}' not supported.",
                     this.platformService.osType,
                 ),

--- a/src/client/debugger/extension/banner.ts
+++ b/src/client/debugger/extension/banner.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { Disposable, env, UIKind } from 'vscode';
+import { Disposable, env, l10n, UIKind } from 'vscode';
 import { IApplicationShell, IDebugService } from '../../common/application/types';
 import '../../common/extensions';
 import { IBrowserService, IDisposableRegistry, IPersistentStateFactory, IRandom } from '../../common/types';
@@ -13,9 +13,6 @@ import { IServiceContainer } from '../../ioc/types';
 import { traceError } from '../../logging';
 import { DebuggerTypeName } from '../constants';
 import { IDebuggerBanner } from './types';
-import * as nls from 'vscode-nls';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 const SAMPLE_SIZE_PER_HUNDRED = 10;
 
@@ -78,10 +75,7 @@ export class DebuggerBanner implements IDebuggerBanner {
 
     public async show(): Promise<void> {
         const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
-        const msg = localize(
-            'debuggerSurveyText',
-            'Can you please take 2 minutes to tell us how the debugger is working for you?',
-        );
+        const msg = l10n.t('Can you please take 2 minutes to tell us how the debugger is working for you?');
         const yes = CommonSurvey.yesLabel;
         const no = CommonSurvey.noLabel;
         const later = CommonSurvey.remindMeLaterLabel;

--- a/src/client/debugger/extension/configuration/providers/pyramidLaunch.ts
+++ b/src/client/debugger/extension/configuration/providers/pyramidLaunch.ts
@@ -5,7 +5,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs-extra';
-import { WorkspaceFolder } from 'vscode';
+import { l10n, WorkspaceFolder } from 'vscode';
 import { DebugConfigStrings } from '../../../../common/utils/localize';
 import { MultiStepInput } from '../../../../common/utils/multiStepInput';
 import { sendTelemetryEvent } from '../../../../telemetry';
@@ -13,10 +13,7 @@ import { EventName } from '../../../../telemetry/constants';
 import { DebuggerTypeName } from '../../../constants';
 import { LaunchRequestArguments } from '../../../types';
 import { DebugConfigurationState, DebugConfigurationType } from '../../types';
-import * as nls from 'vscode-nls';
 import { resolveVariables } from '../utils/common';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 const workspaceFolderToken = '${workspaceFolder}';
 
@@ -43,8 +40,7 @@ export async function buildPyramidLaunchConfiguration(
         const selectedIniPath = await input.showInputBox({
             title: DebugConfigStrings.pyramid.enterDevelopmentIniPath.title,
             value: defaultIni,
-            prompt: localize(
-                'debug.pyramidEnterDevelopmentIniPathPrompt',
+            prompt: l10n.t(
                 'Enter the path to development.ini ({0} points to the root of the current workspace folder)',
                 workspaceFolderToken,
             ),

--- a/src/client/debugger/extension/hooks/childProcessAttachService.ts
+++ b/src/client/debugger/extension/hooks/childProcessAttachService.ts
@@ -35,9 +35,7 @@ export class ChildProcessAttachService implements IChildProcessAttachService {
         const launched = await this.debugService.startDebugging(folder, debugConfig, parentSession);
         if (!launched) {
             this.appShell
-                .showErrorMessage(
-                    l10n.t('Failed to launch debugger for child process {0}', processId),
-                )
+                .showErrorMessage(l10n.t('Failed to launch debugger for child process {0}', processId))
                 .then(noop, noop);
         }
     }

--- a/src/client/debugger/extension/hooks/childProcessAttachService.ts
+++ b/src/client/debugger/extension/hooks/childProcessAttachService.ts
@@ -4,16 +4,13 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { DebugConfiguration, DebugSession, WorkspaceFolder } from 'vscode';
+import { DebugConfiguration, DebugSession, l10n, WorkspaceFolder } from 'vscode';
 import { IApplicationShell, IDebugService, IWorkspaceService } from '../../../common/application/types';
 import { noop } from '../../../common/utils/misc';
 import { captureTelemetry } from '../../../telemetry';
 import { EventName } from '../../../telemetry/constants';
 import { AttachRequestArguments } from '../../types';
 import { IChildProcessAttachService } from './types';
-import * as nls from 'vscode-nls';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 /**
  * This class is responsible for attaching the debugger to any
@@ -39,7 +36,7 @@ export class ChildProcessAttachService implements IChildProcessAttachService {
         if (!launched) {
             this.appShell
                 .showErrorMessage(
-                    localize('debuggerError', 'Failed to launch debugger for child process {0}', processId),
+                    l10n.t('Failed to launch debugger for child process {0}', processId),
                 )
                 .then(noop, noop);
         }

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -28,7 +28,6 @@ initializeFileLogging(logDispose);
 //===============================================
 // loading starts here
 
-import '../setupNls';
 import { ProgressLocation, ProgressOptions, window } from 'vscode';
 import { buildApi } from './api';
 import { IApplicationShell, IWorkspaceService } from './common/application/types';

--- a/src/client/formatters/blackFormatter.ts
+++ b/src/client/formatters/blackFormatter.ts
@@ -37,9 +37,7 @@ export class BlackFormatter extends BaseFormatter {
             const shell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
             // Black does not support partial formatting on purpose.
             shell
-                .showErrorMessage(
-                    vscode.l10n.t('Black does not support the "Format Selection" command'),
-                )
+                .showErrorMessage(vscode.l10n.t('Black does not support the "Format Selection" command'))
                 .then(noop, noop);
             return [];
         }

--- a/src/client/formatters/blackFormatter.ts
+++ b/src/client/formatters/blackFormatter.ts
@@ -5,7 +5,6 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as nls from 'vscode-nls';
 import { IApplicationShell } from '../common/application/types';
 import { Product } from '../common/installer/productInstaller';
 import { IConfigurationService } from '../common/types';
@@ -15,8 +14,6 @@ import { IServiceContainer } from '../ioc/types';
 import { sendTelemetryWhenDone } from '../telemetry';
 import { EventName } from '../telemetry/constants';
 import { BaseFormatter } from './baseFormatter';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 export class BlackFormatter extends BaseFormatter {
     constructor(serviceContainer: IServiceContainer) {
@@ -41,7 +38,7 @@ export class BlackFormatter extends BaseFormatter {
             // Black does not support partial formatting on purpose.
             shell
                 .showErrorMessage(
-                    localize('formatSelectionError', 'Black does not support the "Format Selection" command'),
+                    vscode.l10n.t('Black does not support the "Format Selection" command'),
                 )
                 .then(noop, noop);
             return [];

--- a/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -6,8 +6,7 @@
 import { inject, injectable } from 'inversify';
 import { cloneDeep } from 'lodash';
 import * as path from 'path';
-import { QuickPick, QuickPickItem, QuickPickItemKind, ThemeIcon } from 'vscode';
-import * as nls from 'vscode-nls';
+import { l10n, QuickPick, QuickPickItem, QuickPickItemKind, ThemeIcon } from 'vscode';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../../../../common/application/types';
 import { Commands, Octicons, ThemeIcons } from '../../../../common/constants';
 import { isParentPath } from '../../../../common/platform/fs-paths';
@@ -37,7 +36,6 @@ import {
 } from '../../types';
 import { BaseInterpreterSelectorCommand } from './base';
 
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 const untildify = require('untildify');
 
 export type InterpreterStateArgs = { path?: string; workspace: Resource };
@@ -143,8 +141,7 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand implem
             params?.placeholder === null
                 ? undefined
                 : params?.placeholder ??
-                  localize(
-                      'InterpreterQuickPickList.quickPickListPlaceholder',
+                  l10n.t(
                       'Selected Interpreter: {0}',
                       currentInterpreterPathDisplay,
                   );

--- a/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -140,11 +140,7 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand implem
         const placeholder =
             params?.placeholder === null
                 ? undefined
-                : params?.placeholder ??
-                  l10n.t(
-                      'Selected Interpreter: {0}',
-                      currentInterpreterPathDisplay,
-                  );
+                : params?.placeholder ?? l10n.t('Selected Interpreter: {0}', currentInterpreterPathDisplay);
         const title =
             params?.title === null ? undefined : params?.title ?? InterpreterQuickPickList.browsePath.openButtonLabel;
         const selection = await input.showQuickPick<QuickPickType, IQuickPickParameters<QuickPickType>>({

--- a/src/client/interpreter/configuration/pythonPathUpdaterService.ts
+++ b/src/client/interpreter/configuration/pythonPathUpdaterService.ts
@@ -1,7 +1,6 @@
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import { ConfigurationTarget, Uri, window } from 'vscode';
-import * as nls from 'vscode-nls';
+import { ConfigurationTarget, l10n, Uri, window } from 'vscode';
 import { StopWatch } from '../../common/utils/stopWatch';
 import { SystemVariables } from '../../common/variables/systemVariables';
 import { traceError } from '../../logging';
@@ -10,8 +9,6 @@ import { EventName } from '../../telemetry/constants';
 import { PythonInterpreterTelemetry } from '../../telemetry/types';
 import { IComponentAdapter } from '../contracts';
 import { IPythonPathUpdaterServiceFactory, IPythonPathUpdaterServiceManager } from './types';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 @injectable()
 export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManager {
@@ -37,7 +34,7 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
             const reason = err as Error;
             const message = reason && typeof reason.message === 'string' ? (reason.message as string) : '';
             window.showErrorMessage(
-                localize('setInterpreterError', 'Failed to set interpreter path. Error: {0}', message),
+                l10n.t('Failed to set interpreter path. Error: {0}', message),
             );
             traceError(reason);
         }

--- a/src/client/interpreter/configuration/pythonPathUpdaterService.ts
+++ b/src/client/interpreter/configuration/pythonPathUpdaterService.ts
@@ -33,9 +33,7 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
             failed = true;
             const reason = err as Error;
             const message = reason && typeof reason.message === 'string' ? (reason.message as string) : '';
-            window.showErrorMessage(
-                l10n.t('Failed to set interpreter path. Error: {0}', message),
-            );
+            window.showErrorMessage(l10n.t('Failed to set interpreter path. Error: {0}', message));
             traceError(reason);
         }
         // do not wait for this to complete

--- a/src/client/interpreter/display/index.ts
+++ b/src/client/interpreter/display/index.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from 'inversify';
 import {
     Disposable,
+    l10n,
     LanguageStatusItem,
     LanguageStatusSeverity,
     StatusBarAlignment,
@@ -23,9 +24,6 @@ import {
     IInterpreterService,
     IInterpreterStatusbarVisibilityFilter,
 } from '../contracts';
-import * as nls from 'vscode-nls';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 /**
  * Based on https://github.com/microsoft/vscode-python/issues/18040#issuecomment-992567670.
@@ -126,8 +124,7 @@ export class InterpreterDisplay implements IInterpreterDisplay, IExtensionSingle
                 this.statusBar.tooltip = this.pathUtils.getDisplayName(interpreter.path, workspaceFolder?.fsPath);
                 if (this.currentlySelectedInterpreterPath !== interpreter.path) {
                     traceLog(
-                        localize(
-                            'Interpreters.sttausBarPythonInterpreterPath',
+                        l10n.t(
                             'Python interpreter path: {0}',
                             this.pathUtils.getDisplayName(interpreter.path, workspaceFolder?.fsPath),
                         ),
@@ -151,8 +148,7 @@ export class InterpreterDisplay implements IInterpreterDisplay, IExtensionSingle
                 this.languageStatus.detail = this.pathUtils.getDisplayName(interpreter.path, workspaceFolder?.fsPath);
                 if (this.currentlySelectedInterpreterPath !== interpreter.path) {
                     traceLog(
-                        localize(
-                            'Interpreters.pythonInterpreterPath',
+                        l10n.t(
                             'Python interpreter path: {0}',
                             this.pathUtils.getDisplayName(interpreter.path, workspaceFolder?.fsPath),
                         ),

--- a/src/client/languageServer/watcher.ts
+++ b/src/client/languageServer/watcher.ts
@@ -3,8 +3,7 @@
 
 import * as path from 'path';
 import { inject, injectable } from 'inversify';
-import { ConfigurationChangeEvent, Uri, WorkspaceFoldersChangeEvent } from 'vscode';
-import * as nls from 'vscode-nls';
+import { ConfigurationChangeEvent, l10n, Uri, WorkspaceFoldersChangeEvent } from 'vscode';
 import { LanguageServerChangeHandler } from '../activation/common/languageServerChangeHandler';
 import { IExtensionActivationService, ILanguageServerOutputChannel, LanguageServerType } from '../activation/types';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../common/application/types';
@@ -29,8 +28,6 @@ import { NoneLSExtensionManager } from './noneLSExtensionManager';
 import { PylanceLSExtensionManager } from './pylanceLSExtensionManager';
 import { ILanguageServerExtensionManager, ILanguageServerWatcher } from './types';
 import { LspNotebooksExperiment } from '../activation/node/lspNotebooksExperiment';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 @injectable()
 /**
@@ -380,7 +377,7 @@ function logStartup(languageServerType: LanguageServerType, resource: Uri): void
 
     switch (languageServerType) {
         case LanguageServerType.Jedi:
-            outputLine = localize('LanguageService.startingJedi', 'Starting Jedi language server for {0}.', basename);
+            outputLine = l10n.t('Starting Jedi language server for {0}.', basename);
             break;
         case LanguageServerType.Node:
             outputLine = LanguageService.startingPylance;

--- a/src/client/linters/errorHandlers/standard.ts
+++ b/src/client/linters/errorHandlers/standard.ts
@@ -1,5 +1,4 @@
-import { Uri } from 'vscode';
-import * as nls from 'vscode-nls';
+import { l10n, Uri } from 'vscode';
 import { IApplicationShell } from '../../common/application/types';
 import { STANDARD_OUTPUT_CHANNEL } from '../../common/constants';
 import { ExecutionInfo, IOutputChannel } from '../../common/types';
@@ -7,7 +6,6 @@ import { traceError, traceLog } from '../../logging';
 import { ILinterManager, LinterId } from '../types';
 import { BaseErrorHandler } from './baseErrorHandler';
 
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 export class StandardErrorHandler extends BaseErrorHandler {
     public async handleError(error: Error, resource: Uri, execInfo: ExecutionInfo): Promise<boolean> {
         if (
@@ -29,7 +27,7 @@ export class StandardErrorHandler extends BaseErrorHandler {
     }
 
     private async displayLinterError(linterId: LinterId) {
-        const message = localize('linterError', "There was an error in running the linter '{0}'", linterId);
+        const message = l10n.t("There was an error in running the linter '{0}'", linterId);
         const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
         const outputChannel = this.serviceContainer.get<IOutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
         const action = await appShell.showErrorMessage(message, 'View Errors');

--- a/src/client/linters/linterCommands.ts
+++ b/src/client/linters/linterCommands.ts
@@ -3,8 +3,7 @@
 
 'use strict';
 
-import { DiagnosticCollection, Disposable, QuickPickOptions, Uri } from 'vscode';
-import * as nls from 'vscode-nls';
+import { DiagnosticCollection, Disposable, l10n, QuickPickOptions, Uri } from 'vscode';
 import { IApplicationShell, ICommandManager, IDocumentManager } from '../common/application/types';
 import { Commands } from '../common/constants';
 import { IDisposable } from '../common/types';
@@ -13,8 +12,6 @@ import { IServiceContainer } from '../ioc/types';
 import { sendTelemetryEvent } from '../telemetry';
 import { EventName } from '../telemetry/constants';
 import { ILinterManager, ILintingEngine, LinterId } from './types';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 export class LinterCommands implements IDisposable {
     private disposables: Disposable[] = [];
@@ -74,8 +71,7 @@ export class LinterCommands implements IDisposable {
                 const index = linters.findIndex((x) => x.id === selection);
                 if (activeLinters.length > 1) {
                     const response = await this.appShell.showWarningMessage(
-                        localize(
-                            'Linter.replaceWithSelectedLinter',
+                        l10n.t(
                             "Multiple linters are enabled in settings. Replace with '{0}'?",
                             selection,
                         ),

--- a/src/client/linters/linterCommands.ts
+++ b/src/client/linters/linterCommands.ts
@@ -71,10 +71,7 @@ export class LinterCommands implements IDisposable {
                 const index = linters.findIndex((x) => x.id === selection);
                 if (activeLinters.length > 1) {
                     const response = await this.appShell.showWarningMessage(
-                        l10n.t(
-                            "Multiple linters are enabled in settings. Replace with '{0}'?",
-                            selection,
-                        ),
+                        l10n.t("Multiple linters are enabled in settings. Replace with '{0}'?", selection),
                         Common.bannerLabelYes,
                         Common.bannerLabelNo,
                     );

--- a/src/client/providers/importSortProvider.ts
+++ b/src/client/providers/importSortProvider.ts
@@ -1,8 +1,7 @@
 import { inject, injectable } from 'inversify';
 import { EOL } from 'os';
 import * as path from 'path';
-import { CancellationToken, CancellationTokenSource, TextDocument, Uri, WorkspaceEdit } from 'vscode';
-import * as nls from 'vscode-nls';
+import { CancellationToken, CancellationTokenSource, l10n, TextDocument, Uri, WorkspaceEdit } from 'vscode';
 import { IApplicationShell, ICommandManager, IDocumentManager } from '../common/application/types';
 import { Commands, PYTHON_LANGUAGE } from '../common/constants';
 import * as internalScripts from '../common/process/internal/scripts';
@@ -23,8 +22,6 @@ import { traceError } from '../logging';
 import { captureTelemetry } from '../telemetry';
 import { EventName } from '../telemetry/constants';
 import { ISortImportsEditingProvider } from './types';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 const doNotDisplayPromptStateKey = 'ISORT5_UPGRADE_WARNING_KEY';
 
@@ -128,7 +125,7 @@ export class SortImportsEditingProvider implements ISortImportsEditingProvider {
             const activeEditor = this.documentManager.activeTextEditor;
             if (!activeEditor || activeEditor.document.languageId !== PYTHON_LANGUAGE) {
                 this.shell
-                    .showErrorMessage(localize('sortImportError', 'Please open a Python file to sort the imports.'))
+                    .showErrorMessage(l10n.t('Please open a Python file to sort the imports.'))
                     .then(noop, noop);
                 return;
             }

--- a/src/client/providers/importSortProvider.ts
+++ b/src/client/providers/importSortProvider.ts
@@ -124,9 +124,7 @@ export class SortImportsEditingProvider implements ISortImportsEditingProvider {
         if (!uri) {
             const activeEditor = this.documentManager.activeTextEditor;
             if (!activeEditor || activeEditor.document.languageId !== PYTHON_LANGUAGE) {
-                this.shell
-                    .showErrorMessage(l10n.t('Please open a Python file to sort the imports.'))
-                    .then(noop, noop);
+                this.shell.showErrorMessage(l10n.t('Please open a Python file to sort the imports.')).then(noop, noop);
                 return;
             }
             uri = activeEditor.document.uri;

--- a/src/client/tensorBoard/tensorBoardSession.ts
+++ b/src/client/tensorBoard/tensorBoardSession.ts
@@ -9,6 +9,7 @@ import {
     env,
     Event,
     EventEmitter,
+    l10n,
     Position,
     Progress,
     ProgressLocation,
@@ -23,7 +24,6 @@ import {
     window,
     workspace,
 } from 'vscode';
-import * as nls from 'vscode-nls';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../common/application/types';
 import { createPromiseFromCancellation } from '../common/cancellation';
 import { tensorboardLauncher } from '../common/process/internal/scripts';
@@ -47,8 +47,6 @@ import { TensorBoardPromptSelection, TensorBoardSessionStartResult } from './con
 import { IMultiStepInputFactory } from '../common/utils/multiStepInput';
 import { ModuleInstallFlags } from '../common/installer/types';
 import { traceError, traceInfo } from '../logging';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 enum Messages {
     JumpToSource = 'jump_to_source',
@@ -357,7 +355,7 @@ export class TensorBoardSession {
         const item = await this.applicationShell.showQuickPick(items, {
             canPickMany: false,
             ignoreFocusOut: false,
-            placeHolder: logDir ? localize('TensorBoard.currentDirectory', 'Current: {0}', logDir) : undefined,
+            placeHolder: logDir ? l10n.t('Current: {0}', logDir) : undefined,
         });
         switch (item?.label) {
             case useCurrentWorkingDirectory:

--- a/src/client/tensorBoard/tensorBoardSessionProvider.ts
+++ b/src/client/tensorBoard/tensorBoardSessionProvider.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import { ViewColumn } from 'vscode';
-import * as nls from 'vscode-nls';
+import { l10n, ViewColumn } from 'vscode';
 import { IExtensionSingleActivationService } from '../activation/types';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../common/application/types';
 import { Commands } from '../common/constants';
@@ -17,8 +16,6 @@ import { sendTelemetryEvent } from '../telemetry';
 import { EventName } from '../telemetry/constants';
 import { TensorBoardEntrypoint, TensorBoardEntrypointTrigger } from './constants';
 import { TensorBoardSession } from './tensorBoardSession';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 const PREFERRED_VIEWGROUP = 'PythonTensorBoardWebviewPreferredViewGroup';
 
@@ -111,8 +108,7 @@ export class TensorBoardSessionProvider implements IExtensionSingleActivationSer
         } catch (e) {
             traceError(`Encountered error while starting new TensorBoard session: ${e}`);
             await this.applicationShell.showErrorMessage(
-                localize(
-                    'TensorBoard.failedToStartSessionError',
+                l10n.t(
                     'We failed to start a TensorBoard session due to the following error: {0}',
                     (e as Error).message,
                 ),

--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -87,15 +87,11 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
             return undefined;
         }
         if (activeEditor.document.isUntitled) {
-            this.applicationShell.showErrorMessage(
-                l10n.t('The active file needs to be saved before it can be run'),
-            );
+            this.applicationShell.showErrorMessage(l10n.t('The active file needs to be saved before it can be run'));
             return undefined;
         }
         if (activeEditor.document.languageId !== PYTHON_LANGUAGE) {
-            this.applicationShell.showErrorMessage(
-                l10n.t('The active file is not a Python source file)'),
-            );
+            this.applicationShell.showErrorMessage(l10n.t('The active file is not a Python source file)'));
             return undefined;
         }
         if (activeEditor.document.isDirty) {

--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -3,9 +3,8 @@
 import '../../common/extensions';
 
 import { inject, injectable } from 'inversify';
-import { Position, Range, TextEditor, Uri } from 'vscode';
+import { l10n, Position, Range, TextEditor, Uri } from 'vscode';
 
-import * as nls from 'vscode-nls';
 import { IApplicationShell, IDocumentManager } from '../../common/application/types';
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import * as internalScripts from '../../common/process/internal/scripts';
@@ -15,8 +14,6 @@ import { IInterpreterService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { ICodeExecutionHelper } from '../types';
 import { traceError } from '../../logging';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 @injectable()
 export class CodeExecutionHelper implements ICodeExecutionHelper {
@@ -86,18 +83,18 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
     public async getFileToExecute(): Promise<Uri | undefined> {
         const activeEditor = this.documentManager.activeTextEditor;
         if (!activeEditor) {
-            this.applicationShell.showErrorMessage(localize('documentError.Empty', 'No open file to run in terminal'));
+            this.applicationShell.showErrorMessage(l10n.t('No open file to run in terminal'));
             return undefined;
         }
         if (activeEditor.document.isUntitled) {
             this.applicationShell.showErrorMessage(
-                localize('documentError.NoSaved', 'The active file needs to be saved before it can be run'),
+                l10n.t('The active file needs to be saved before it can be run'),
             );
             return undefined;
         }
         if (activeEditor.document.languageId !== PYTHON_LANGUAGE) {
             this.applicationShell.showErrorMessage(
-                localize('documentError.NotPythonFile', 'The active file is not a Python source file)'),
+                l10n.t('The active file is not a Python source file)'),
             );
             return undefined;
         }

--- a/src/client/testing/common/debugLauncher.ts
+++ b/src/client/testing/common/debugLauncher.ts
@@ -1,7 +1,7 @@
 import { inject, injectable, named } from 'inversify';
 
 import * as path from 'path';
-import { DebugConfiguration, Uri, WorkspaceFolder } from 'vscode';
+import { DebugConfiguration, l10n, Uri, WorkspaceFolder } from 'vscode';
 import { IApplicationShell, IDebugService, IWorkspaceService } from '../../common/application/types';
 import { EXTENSION_ROOT_DIR } from '../../common/constants';
 import * as internalScripts from '../../common/process/internal/scripts';
@@ -13,9 +13,6 @@ import { IServiceContainer } from '../../ioc/types';
 import { traceError } from '../../logging';
 import { TestProvider } from '../types';
 import { ITestDebugLauncher, LaunchOptions } from './types';
-import * as nls from 'vscode-nls';
-
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 @injectable()
 export class DebugLauncher implements ITestDebugLauncher {
@@ -64,7 +61,7 @@ export class DebugLauncher implements ITestDebugLauncher {
             traceError('could not get debug config', exc);
             const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
             await appShell.showErrorMessage(
-                localize('readDebugError', 'Could not load unit test config from launch.json as it is missing a field'),
+                l10n.t('Could not load unit test config from launch.json as it is missing a field'),
             );
             return [];
         }

--- a/src/setupNls.ts
+++ b/src/setupNls.ts
@@ -1,8 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-
-import * as nls from 'vscode-nls';
-
-nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone });

--- a/types/vscode.proposed.localization.d.ts
+++ b/types/vscode.proposed.localization.d.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+    export namespace l10n {
+        /**
+         * A string that can be pulled out of a localization bundle if it exists.
+         */
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        export function t(message: string, ...args: any[]): string;
+        /**
+         * A string that can be pulled out of a localization bundle if it exists.
+         */
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        export function t(options: { message: string; args?: any[]; comment: string[] }): string;
+        /**
+         * The bundle of localized strings that have been loaded for the extension.
+         */
+        export const bundle: { [key: string]: string } | undefined;
+        /**
+         * The URI of the localization bundle that has been loaded for the extension.
+         */
+        export const uri: Uri | undefined;
+    }
+}


### PR DESCRIPTION
Following https://github.com/microsoft/vscode-engineering/wiki/Extensions-Localization

This onboards vscode-python to the new localization API which enables localization for the web.

It's a large PR ... but pretty boring since it's just replacing one syntax with another.