### PR TITLE
Show busy indicator when quickpick is loading

### DIFF
--- a/src/client/common/utils/multiStepInput.ts
+++ b/src/client/common/utils/multiStepInput.ts
@@ -57,7 +57,7 @@ export interface IQuickPickParameters<T extends QuickPickItem, E = any> {
     /**
      * A method called only after quickpick has been created and all handlers are registered.
      */
-    initialize?: () => void;
+    initialize?: (quickPick: QuickPick<T>) => void;
     onChangeItem?: {
         callback: (event: E, quickPick: QuickPick<T>) => void;
         event: Event<E>;
@@ -152,7 +152,7 @@ export class MultiStepInput<S> implements IMultiStepInput<S> {
         }
         // Quickpick should be initialized synchronously and on changed item handlers are registered synchronously.
         if (initialize) {
-            initialize();
+            initialize(input);
         }
         if (activeItem) {
             input.activeItems = [await activeItem];

--- a/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
+++ b/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
@@ -80,7 +80,6 @@ suite('Set Interpreter Command', () => {
         workspace = TypeMoq.Mock.ofType<IWorkspaceService>();
         interpreterService = mock<IInterpreterService>();
         when(interpreterService.refreshPromise).thenReturn(undefined);
-        when(interpreterService.triggerRefresh()).thenResolve();
         when(interpreterService.triggerRefresh(anything(), anything())).thenResolve();
         workspace.setup((w) => w.rootPath).returns(() => 'rootPath');
 
@@ -694,7 +693,7 @@ suite('Set Interpreter Command', () => {
 
             await refreshButtons![0].callback!({} as QuickPick<QuickPickItem>); // Invoke callback, meaning that the refresh button is clicked.
 
-            verify(interpreterService.triggerRefresh()).once();
+            verify(interpreterService.triggerRefresh(anything(), anything())).once();
         });
 
         test('Events to update quickpick updates the quickpick accordingly', async () => {


### PR DESCRIPTION
Even if no interpreters change, show while the list is likely to change.

![image](https://user-images.githubusercontent.com/13199757/196564377-384775b8-6442-4534-8dc6-faa1904fdd3d.png)
