### PR TITLE
Set conda env name to blank instead of assuming the directory name

### DIFF
--- a/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
@@ -204,6 +204,7 @@ async function resolveCondaEnv(env: BasicEnvInfo, useCache?: boolean): Promise<P
     // Environment could still be valid, resolve as a simple env.
     env.kind = PythonEnvKind.Unknown;
     const envInfo = await resolveSimpleEnv(env);
+    envInfo.name = ''; // Ensures that conda gets called with a path and not a name
     envInfo.type = PythonEnvType.Conda;
     return envInfo;
 }

--- a/src/test/pythonEnvironments/base/locators/composite/resolverUtils.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/composite/resolverUtils.unit.test.ts
@@ -298,7 +298,7 @@ suite('Resolver Utils', () => {
                     path.join(TEST_LAYOUT_ROOT, 'conda1', 'python.exe'),
                     PythonEnvKind.Unknown,
                     undefined,
-                    'conda1',
+                    '',
                     path.join(TEST_LAYOUT_ROOT, 'conda1'),
                 ),
             );
@@ -627,7 +627,7 @@ suite('Resolver Utils', () => {
                 version: parseVersion('3.8.5'),
                 arch: Architecture.x64, // Provided by registry
                 org: 'ContinuumAnalytics', // Provided by registry
-                name: 'conda3',
+                name: '',
                 source: [PythonEnvSource.WindowsRegistry],
                 type: PythonEnvType.Conda,
             });


### PR DESCRIPTION
In https://github.com/microsoft/vscode-python/issues/19166, I have wrote at length as to what the issue is and why I think this is the appropriate change. The Github issue is quite broad and not well-defined, and could cover a lot of other issues related to symlinked environments (such as auto-discovery) besides the one I am attempting to fix here.

But to summarize:

- If you select an interpreter that contains a symlink, the extension will not be able to correlate it to the list of conda environments, which only includes non-symlink paths.
- When it cannot correlate it to the list, it makes basic assumptions about the environment, including setting the name of the environment to the directory name of the environment location.
- If you set the name to something non-null/empty, then everywhere `conda` is called it will attempt to pass an environment name using `-n` instead of an environment path with `-p`. Since this environment is not recognized by `conda`, this won't work.
- The extension will always pass a path with `-p` if the name is blank or undefined. Not every conda environment has a name - names are optional - and this behavior already works in the absence of one.
- The solution proposed here is to omit a name when deriving the environment info, because this forces it to use a path in all calls instead.

We can use a blank string or `undefined`, but currently the extension's behavior when using a conda environment that lacks a name is an empty string (I believe this is because it is parsing the string output of a `conda` call). I kept that consistent here.