### PR TITLE
Fix for env creation errors

### DIFF
--- a/src/client/pythonEnvironments/creation/common/commonUtils.ts
+++ b/src/client/pythonEnvironments/creation/common/commonUtils.ts
@@ -6,8 +6,10 @@ import { executeCommand } from '../../../common/vscodeApis/commandApis';
 import { showErrorMessage } from '../../../common/vscodeApis/windowApis';
 
 export async function showErrorMessageWithLogs(message: string): Promise<void> {
-    const result = await showErrorMessage(message, Common.openOutputPanel);
+    const result = await showErrorMessage(message, Common.openOutputPanel, Common.selectPythonInterpreter);
     if (result === Common.openOutputPanel) {
         await executeCommand(Commands.ViewOutput);
+    } else if (result === Common.selectPythonInterpreter) {
+        await executeCommand(Commands.Set_Interpreter);
     }
 }

--- a/src/client/pythonEnvironments/creation/provider/condaProgressAndTelemetry.ts
+++ b/src/client/pythonEnvironments/creation/provider/condaProgressAndTelemetry.ts
@@ -24,6 +24,8 @@ export class CondaProgressAndTelemetry {
 
     private condaInstalledPackagesReported = false;
 
+    private lastError: string | undefined = undefined;
+
     constructor(private readonly progress: CreateEnvironmentProgress) {}
 
     public process(output: string): void {
@@ -51,6 +53,7 @@ export class CondaProgressAndTelemetry {
                 environmentType: 'conda',
                 reason: 'other',
             });
+            this.lastError = CREATE_CONDA_FAILED_MARKER;
         } else if (!this.condaInstallingPackagesReported && output.includes(CONDA_INSTALLING_YML)) {
             this.condaInstallingPackagesReported = true;
             this.progress.report({
@@ -66,6 +69,7 @@ export class CondaProgressAndTelemetry {
                 environmentType: 'conda',
                 using: 'environment.yml',
             });
+            this.lastError = CREATE_FAILED_INSTALL_YML;
         } else if (!this.condaInstalledPackagesReported && output.includes(CREATE_CONDA_INSTALLED_YML)) {
             this.condaInstalledPackagesReported = true;
             sendTelemetryEvent(EventName.ENVIRONMENT_INSTALLED_PACKAGES, undefined, {
@@ -73,5 +77,9 @@ export class CondaProgressAndTelemetry {
                 using: 'environment.yml',
             });
         }
+    }
+
+    public getLastError(): string | undefined {
+        return this.lastError;
     }
 }

--- a/src/client/pythonEnvironments/creation/provider/condaUtils.ts
+++ b/src/client/pythonEnvironments/creation/provider/condaUtils.ts
@@ -6,9 +6,10 @@ import { Common } from '../../../browser/localize';
 import { CreateEnv } from '../../../common/utils/localize';
 import { executeCommand } from '../../../common/vscodeApis/commandApis';
 import { showErrorMessage, showQuickPick } from '../../../common/vscodeApis/windowApis';
+import { traceLog } from '../../../logging';
 import { Conda } from '../../common/environmentManagers/conda';
 
-export async function getConda(): Promise<string | undefined> {
+export async function getCondaBaseEnv(): Promise<string | undefined> {
     const conda = await Conda.getConda();
 
     if (!conda) {
@@ -18,7 +19,20 @@ export async function getConda(): Promise<string | undefined> {
         }
         return undefined;
     }
-    return conda.command;
+
+    const envs = (await conda.getEnvList()).filter((e) => e.name === 'base');
+    if (envs.length === 1) {
+        return envs[0].prefix;
+    }
+    if (envs.length > 1) {
+        traceLog(
+            'Multiple conda base envs detected: ',
+            envs.map((e) => e.prefix),
+        );
+        return undefined;
+    }
+
+    return undefined;
 }
 
 export async function pickPythonVersion(token?: CancellationToken): Promise<string | undefined> {

--- a/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
+++ b/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
@@ -78,7 +78,7 @@ async function createVenv(
 
     const deferred = createDeferred<string | undefined>();
     traceLog('Running Env creation script: ', [command, ...args]);
-    const { out, dispose } = execObservable(command, args, {
+    const { proc, out, dispose } = execObservable(command, args, {
         mergeStdOutErr: true,
         token,
         cwd: workspace.uri.fsPath,
@@ -101,7 +101,10 @@ async function createVenv(
         },
         () => {
             dispose();
-            if (!deferred.rejected) {
+            if (proc?.exitCode !== 0) {
+                traceError('Error while running venv creation script: ', progressAndTelemetry.getLastError());
+                deferred.reject(progressAndTelemetry.getLastError());
+            } else {
                 deferred.resolve(venvPath);
             }
         },

--- a/src/client/pythonEnvironments/creation/provider/venvProgressAndTelemetry.ts
+++ b/src/client/pythonEnvironments/creation/provider/venvProgressAndTelemetry.ts
@@ -33,6 +33,8 @@ export class VenvProgressAndTelemetry {
 
     private venvInstalledPackagesReported = false;
 
+    private lastError: string | undefined = undefined;
+
     constructor(private readonly progress: CreateEnvironmentProgress) {}
 
     public process(output: string): void {
@@ -60,18 +62,21 @@ export class VenvProgressAndTelemetry {
                 environmentType: 'venv',
                 reason: 'noVenv',
             });
+            this.lastError = VENV_NOT_INSTALLED_MARKER;
         } else if (!this.venvOrPipMissingReported && output.includes(PIP_NOT_INSTALLED_MARKER)) {
             this.venvOrPipMissingReported = true;
             sendTelemetryEvent(EventName.ENVIRONMENT_FAILED, undefined, {
                 environmentType: 'venv',
                 reason: 'noPip',
             });
+            this.lastError = PIP_NOT_INSTALLED_MARKER;
         } else if (!this.venvFailedReported && output.includes(CREATE_VENV_FAILED_MARKER)) {
             this.venvFailedReported = true;
             sendTelemetryEvent(EventName.ENVIRONMENT_FAILED, undefined, {
                 environmentType: 'venv',
                 reason: 'other',
             });
+            this.lastError = CREATE_VENV_FAILED_MARKER;
         } else if (!this.venvInstallingPackagesReported && output.includes(INSTALLING_REQUIREMENTS)) {
             this.venvInstallingPackagesReported = true;
             this.progress.report({
@@ -96,18 +101,21 @@ export class VenvProgressAndTelemetry {
                 environmentType: 'venv',
                 using: 'pipUpgrade',
             });
+            this.lastError = PIP_UPGRADE_FAILED_MARKER;
         } else if (!this.venvInstallingPackagesFailedReported && output.includes(INSTALL_REQUIREMENTS_FAILED_MARKER)) {
             this.venvInstallingPackagesFailedReported = true;
             sendTelemetryEvent(EventName.ENVIRONMENT_INSTALLING_PACKAGES_FAILED, undefined, {
                 environmentType: 'venv',
                 using: 'requirements.txt',
             });
+            this.lastError = INSTALL_REQUIREMENTS_FAILED_MARKER;
         } else if (!this.venvInstallingPackagesFailedReported && output.includes(INSTALL_PYPROJECT_FAILED_MARKER)) {
             this.venvInstallingPackagesFailedReported = true;
             sendTelemetryEvent(EventName.ENVIRONMENT_INSTALLING_PACKAGES_FAILED, undefined, {
                 environmentType: 'venv',
                 using: 'pyproject.toml',
             });
+            this.lastError = INSTALL_PYPROJECT_FAILED_MARKER;
         } else if (!this.venvInstalledPackagesReported && output.includes(INSTALLED_REQUIREMENTS_MARKER)) {
             this.venvInstalledPackagesReported = true;
             sendTelemetryEvent(EventName.ENVIRONMENT_INSTALLED_PACKAGES, undefined, {
@@ -121,5 +129,9 @@ export class VenvProgressAndTelemetry {
                 using: 'pyproject.toml',
             });
         }
+    }
+
+    public getLastError(): string | undefined {
+        return this.lastError;
     }
 }

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -139,7 +139,7 @@ export function sendTelemetryEvent<P extends IEventNamePropertyMapping, E extend
                         break;
                 }
             } catch (exception) {
-                console.error(`Failed to serialize ${prop} for ${eventName}`, exception);
+                console.error(`Failed to serialize ${prop} for ${String(eventName)}`, exception);
             }
         });
     }


### PR DESCRIPTION
1. We ensure that non-zero error codes are handled
2. We show error message, with got to logs, and select interpreter.
3. Uses conda base environment to find base python.

Fixes: https://github.com/microsoft/vscode-python/issues/20072
Fixes: https://github.com/microsoft/vscode-python/issues/20062