### PR TITLE
Ensure that search location is stored as a string.

### DIFF
--- a/src/client/common/persistentState.ts
+++ b/src/client/common/persistentState.ts
@@ -152,7 +152,7 @@ export class PersistentStateFactory implements IPersistentStateFactory, IExtensi
 // a simpler, alternate API
 // for components to use
 
-interface IPersistentStorage<T> {
+export interface IPersistentStorage<T> {
     get(): T;
     set(value: T): Promise<void>;
 }


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/20104

The Cause: The `workspaceFolder` field is set using an internal field `searchLocation`. `searchLocation` is what gets saved to Memento as `Uri`. when we read it back it looks like this:
![image](https://user-images.githubusercontent.com/3840081/198420406-fb4c9b87-1276-4717-8043-69d95dcdba48.png)

Interim Solution:
* Reading (broken case): Since there are already existing cases where this is broken. The surgical fix is to read bad value, extract the `scheme` and `path`, use that to re-create the URI.
* Reading/Writing (new case): Make sure that we convert Uri to string before writing and parse back the Uri when reading.

Long term solution:
Object written to memento needs to be serialized using a custom serializer that validates all values before writing and after reading.