### PR TITLE
Ensure that `workspaceFolder` field in API points to workspace folder when available.

### DIFF
--- a/src/client/common/vscodeApis/workspaceApis.ts
+++ b/src/client/common/vscodeApis/workspaceApis.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ConfigurationScope, workspace, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
+import { ConfigurationScope, Uri, workspace, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
+
+export function getWorkspaceFolder(resource: Uri | undefined): WorkspaceFolder | undefined {
+    return resource ? workspace.getWorkspaceFolder(resource) : resource;
+}
 
 export function getWorkspaceFolders(): readonly WorkspaceFolder[] | undefined {
     return workspace.workspaceFolders;

--- a/src/client/proposedApi.ts
+++ b/src/client/proposedApi.ts
@@ -36,6 +36,7 @@ import {
 import { DeprecatedProposedAPI } from './deprecatedProposedApiTypes';
 import { IEnvironmentVariablesProvider } from './common/variables/types';
 import { IWorkspaceService } from './common/application/types';
+import { getWorkspaceFolder } from './common/vscodeApis/workspaceApis';
 
 type ActiveEnvironmentChangeEvent = {
     resource: WorkspaceFolder | undefined;
@@ -280,7 +281,7 @@ export function convertCompleteEnvInfo(env: PythonEnvInfo): ResolvedEnvironment 
                   type: convertEnvType(env.type),
                   name: env.name,
                   folderUri: Uri.file(env.location),
-                  workspaceFolder: env.searchLocation,
+                  workspaceFolder: getWorkspaceFolder(env.searchLocation)?.uri,
               }
             : undefined,
         version: version as ResolvedEnvironment['version'],


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-python/issues/20105

