### PR TITLE
Cherry pick fixes and update `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "python",
-    "version": "2022.18.0-rc",
+    "version": "2022.18.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "python",
-            "version": "2022.18.0-rc",
+            "version": "2022.18.0",
             "license": "MIT",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.6.2",
@@ -131,7 +131,7 @@
                 "yargs": "^15.3.1"
             },
             "engines": {
-                "vscode": "^1.68.0"
+                "vscode": "^1.73.0-insider"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "python",
     "displayName": "Python",
     "description": "IntelliSense (Pylance), Linting, Debugging (multi-threaded, remote), Jupyter Notebooks, code formatting, refactoring, unit tests, and more.",
-    "version": "2022.18.0-rc",
+    "version": "2022.18.0",
     "featureFlags": {
         "usingNewInterpreterStorage": true
     },
@@ -40,7 +40,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.68.0"
+        "vscode": "^1.73.0-insider"
     },
     "keywords": [
         "python",

--- a/src/test/debuggerTest.ts
+++ b/src/test/debuggerTest.ts
@@ -2,13 +2,29 @@
 // Licensed under the MIT License.
 
 import * as path from 'path';
+import * as fs from 'fs-extra';
 import { runTests } from '@vscode/test-electron';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from './constants';
+import { EXTENSION_ROOT_DIR } from '../client/common/constants';
 
 const workspacePath = path.join(__dirname, '..', '..', 'src', 'testMultiRootWkspc', 'multi.code-workspace');
 process.env.IS_CI_SERVER_TEST_DEBUGGER = '1';
 process.env.VSC_PYTHON_CI_TEST = '1';
-const channel = process.env.VSC_PYTHON_CI_TEST_VSC_CHANNEL || 'stable';
+
+function getChannel(): string {
+    if (process.env.VSC_PYTHON_CI_TEST_VSC_CHANNEL) {
+        return process.env.VSC_PYTHON_CI_TEST_VSC_CHANNEL;
+    }
+
+    const packageJsonPath = path.join(EXTENSION_ROOT_DIR, 'package.json');
+    if (fs.pathExistsSync(packageJsonPath)) {
+        const packageJson = fs.readJSONSync(packageJsonPath);
+        if (packageJson.engines.vscode.endsWith('insider')) {
+            return 'insiders';
+        }
+    }
+    return 'stable';
+}
 
 function start() {
     console.log('*'.repeat(100));
@@ -17,7 +33,7 @@ function start() {
         extensionDevelopmentPath: EXTENSION_ROOT_DIR_FOR_TESTS,
         extensionTestsPath: path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'out', 'test', 'index'),
         launchArgs: [workspacePath],
-        version: channel,
+        version: getChannel(),
         extensionTestsEnv: { ...process.env, UITEST_DISABLE_INSIDERS: '1' },
     }).catch((ex) => {
         console.error('End Debugger tests (with errors)', ex);


### PR DESCRIPTION
- Update engine to upcoming VS Code version. (#20058)
- Update `package.json` to remove `-rc`.