### PR TITLE
Fix isort pyi organize imports

### DIFF
--- a/pythonFiles/sortImports.py
+++ b/pythonFiles/sortImports.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import io
 import os
 import os.path
 import sys

--- a/src/client/common/process/internal/scripts/index.ts
+++ b/src/client/common/process/internal/scripts/index.ts
@@ -65,6 +65,11 @@ export function interpreterInfo(): [string[], (out: string) => InterpreterInfoJs
 export function sortImports(filename: string, sortArgs?: string[]): [string[], (out: string) => string] {
     const script = path.join(SCRIPTS_DIR, 'sortImports.py');
     const args = [script, filename, '--diff'];
+
+    if (path.extname(filename) === '.pyi') {
+        args.push(...['--ext-format', 'pyi']);
+    }
+
     if (sortArgs) {
         args.push(...sortArgs);
     }


### PR DESCRIPTION
Partially address #14702 like this [issue](https://github.com/microsoft/vscode-python/issues/13341#issuecomment-735985592)
Fix modeled on the pull request #14736.
Would the use of a regex to match for `tmp` files as described [here](https://github.com/microsoft/vscode-python/pull/14736#discussion_r524728158) address this issue altogether?