### PR TITLE
Ensure we don't use the same interpreter for equally named project on different hosts

### DIFF
--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -9,7 +9,7 @@ import { IApplicationDiagnostics } from '../application/types';
 import { IActiveResourceService, IDocumentManager, IWorkspaceService } from '../common/application/types';
 import { PYTHON_LANGUAGE } from '../common/constants';
 import { IFileSystem } from '../common/platform/types';
-import { IDisposable, Resource } from '../common/types';
+import { IDisposable, IInterpreterPathService, Resource } from '../common/types';
 import { Deferred } from '../common/utils/async';
 import { IInterpreterAutoSelectionService } from '../interpreter/autoSelection/types';
 import { traceDecoratorError } from '../logging';
@@ -36,6 +36,7 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IFileSystem) private readonly fileSystem: IFileSystem,
         @inject(IActiveResourceService) private readonly activeResourceService: IActiveResourceService,
+        @inject(IInterpreterPathService) private readonly interpreterPathService: IInterpreterPathService,
     ) {}
 
     private filterServices() {
@@ -91,6 +92,7 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         if (this.workspaceService.isTrusted) {
             // Do not interact with interpreters in a untrusted workspace.
             await this.autoSelection.autoSelectInterpreter(resource);
+            await this.interpreterPathService.copyOldInterpreterStorageValuesToNew(resource);
         }
         await sendActivationTelemetry(this.fileSystem, this.workspaceService, resource);
         await Promise.all(this.activationServices.map((item) => item.activate(resource)));

--- a/src/client/common/interpreterPathService.ts
+++ b/src/client/common/interpreterPathService.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs-extra';
 import { inject, injectable } from 'inversify';
 import { ConfigurationChangeEvent, ConfigurationTarget, Event, EventEmitter, Uri } from 'vscode';
 import { traceError } from '../logging';
-import { IWorkspaceService } from './application/types';
+import { IApplicationEnvironment, IWorkspaceService } from './application/types';
 import { PythonSettings } from './configSettings';
 import { isTestExecution } from './constants';
 import { FileSystemPaths } from './platform/fs-paths';
@@ -24,6 +24,9 @@ import {
 } from './types';
 import { SystemVariables } from './variables/systemVariables';
 
+export const remoteWorkspaceKeysForWhichTheCopyIsDone_Key = 'remoteWorkspaceKeysForWhichTheCopyIsDone_Key';
+export const remoteWorkspaceFolderKeysForWhichTheCopyIsDone_Key = 'remoteWorkspaceFolderKeysForWhichTheCopyIsDone_Key';
+export const isRemoteGlobalSettingCopiedKey = 'isRemoteGlobalSettingCopiedKey';
 export const defaultInterpreterPathSetting: keyof IPythonSettings = 'defaultInterpreterPath';
 const CI_PYTHON_PATH = getCIPythonPath();
 
@@ -44,6 +47,7 @@ export class InterpreterPathService implements IInterpreterPathService {
         @inject(IPersistentStateFactory) private readonly persistentStateFactory: IPersistentStateFactory,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IDisposableRegistry) disposables: IDisposable[],
+        @inject(IApplicationEnvironment) private readonly appEnvironment: IApplicationEnvironment,
     ) {
         disposables.push(this.workspaceService.onDidChangeConfiguration(this.onDidChangeConfiguration.bind(this)));
         this.fileSystemPaths = FileSystemPaths.withDefaults();
@@ -55,17 +59,17 @@ export class InterpreterPathService implements IInterpreterPathService {
         }
     }
 
-    public inspect(resource: Resource): InspectInterpreterSettingType {
+    public inspect(resource: Resource, useOldKey = false): InspectInterpreterSettingType {
         resource = PythonSettings.getSettingsUriAndTarget(resource, this.workspaceService).uri;
         let workspaceFolderSetting: IPersistentState<string | undefined> | undefined;
         let workspaceSetting: IPersistentState<string | undefined> | undefined;
         if (resource) {
             workspaceFolderSetting = this.persistentStateFactory.createGlobalPersistentState<string | undefined>(
-                this.getSettingKey(resource, ConfigurationTarget.WorkspaceFolder),
+                this.getSettingKey(resource, ConfigurationTarget.WorkspaceFolder, useOldKey),
                 undefined,
             );
             workspaceSetting = this.persistentStateFactory.createGlobalPersistentState<string | undefined>(
-                this.getSettingKey(resource, ConfigurationTarget.Workspace),
+                this.getSettingKey(resource, ConfigurationTarget.Workspace, useOldKey),
                 undefined,
             );
         }
@@ -125,6 +129,7 @@ export class InterpreterPathService implements IInterpreterPathService {
     public getSettingKey(
         resource: Uri,
         configTarget: ConfigurationTarget.Workspace | ConfigurationTarget.WorkspaceFolder,
+        useOldKey = false,
     ): string {
         let settingKey: string;
         const folderKey = this.workspaceService.getWorkspaceFolderIdentifier(resource);
@@ -138,6 +143,71 @@ export class InterpreterPathService implements IInterpreterPathService {
                 : // Only a single folder is opened, use fsPath of the folder as key
                   `WORKSPACE_FOLDER_INTERPRETER_PATH_${folderKey}`;
         }
+        if (!useOldKey && this.appEnvironment.remoteName) {
+            return `${this.appEnvironment.remoteName}_${settingKey}`;
+        }
         return settingKey;
+    }
+
+    public async copyOldInterpreterStorageValuesToNew(resource: Resource): Promise<void> {
+        resource = PythonSettings.getSettingsUriAndTarget(resource, this.workspaceService).uri;
+        const oldSettings = this.inspect(resource, true);
+        await Promise.all([
+            this._copyWorkspaceFolderValueToNewStorage(resource, oldSettings.workspaceFolderValue),
+            this._copyWorkspaceValueToNewStorage(resource, oldSettings.workspaceValue),
+            this._moveGlobalSettingValueToNewStorage(oldSettings.globalValue),
+        ]);
+    }
+
+    public async _copyWorkspaceFolderValueToNewStorage(resource: Resource, value: string | undefined): Promise<void> {
+        // Copy workspace folder setting into the new storage if it hasn't been copied already
+        const workspaceFolderKey = this.workspaceService.getWorkspaceFolderIdentifier(resource, '');
+        if (workspaceFolderKey === '') {
+            // No workspace folder is opened, simply return.
+            return;
+        }
+        const flaggedWorkspaceFolderKeysStorage = this.persistentStateFactory.createGlobalPersistentState<string[]>(
+            remoteWorkspaceFolderKeysForWhichTheCopyIsDone_Key,
+            [],
+        );
+        const flaggedWorkspaceFolderKeys = flaggedWorkspaceFolderKeysStorage.value;
+        const shouldUpdateWorkspaceFolderSetting = !flaggedWorkspaceFolderKeys.includes(workspaceFolderKey);
+        if (shouldUpdateWorkspaceFolderSetting) {
+            await this.update(resource, ConfigurationTarget.WorkspaceFolder, value);
+            await flaggedWorkspaceFolderKeysStorage.updateValue([workspaceFolderKey, ...flaggedWorkspaceFolderKeys]);
+        }
+    }
+
+    public async _copyWorkspaceValueToNewStorage(resource: Resource, value: string | undefined): Promise<void> {
+        // Copy workspace setting into the new storage if it hasn't been copied already
+        const workspaceKey = this.workspaceService.workspaceFile
+            ? this.fileSystemPaths.normCase(this.workspaceService.workspaceFile.fsPath)
+            : undefined;
+        if (!workspaceKey) {
+            return;
+        }
+        const flaggedWorkspaceKeysStorage = this.persistentStateFactory.createGlobalPersistentState<string[]>(
+            remoteWorkspaceKeysForWhichTheCopyIsDone_Key,
+            [],
+        );
+        const flaggedWorkspaceKeys = flaggedWorkspaceKeysStorage.value;
+        const shouldUpdateWorkspaceSetting = !flaggedWorkspaceKeys.includes(workspaceKey);
+        if (shouldUpdateWorkspaceSetting) {
+            await this.update(resource, ConfigurationTarget.Workspace, value);
+            await flaggedWorkspaceKeysStorage.updateValue([workspaceKey, ...flaggedWorkspaceKeys]);
+        }
+    }
+
+    public async _moveGlobalSettingValueToNewStorage(value: string | undefined) {
+        // Move global setting into the new storage if it hasn't been moved already
+        const isGlobalSettingCopiedStorage = this.persistentStateFactory.createGlobalPersistentState<boolean>(
+            isRemoteGlobalSettingCopiedKey,
+            false,
+        );
+        const shouldUpdateGlobalSetting = !isGlobalSettingCopiedStorage.value;
+        if (shouldUpdateGlobalSetting) {
+            await this.update(undefined, ConfigurationTarget.Global, value);
+            await isGlobalSettingCopiedStorage.updateValue(true);
+        }
     }
 }

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -479,6 +479,7 @@ export interface IInterpreterPathService {
     get(resource: Resource): string;
     inspect(resource: Resource): InspectInterpreterSettingType;
     update(resource: Resource, configTarget: ConfigurationTarget, value: string | undefined): Promise<void>;
+    copyOldInterpreterStorageValuesToNew(resource: Resource): Promise<void>;
 }
 
 export type DefaultLSType = LanguageServerType.Jedi | LanguageServerType.Node;

--- a/src/test/activation/activationManager.unit.test.ts
+++ b/src/test/activation/activationManager.unit.test.ts
@@ -46,6 +46,9 @@ suite('Activation Manager', () => {
         let fileSystem: IFileSystem;
         setup(() => {
             interpreterPathService = typemoq.Mock.ofType<IInterpreterPathService>();
+            interpreterPathService
+                .setup((i) => i.copyOldInterpreterStorageValuesToNew(typemoq.It.isAny()))
+                .returns(() => Promise.resolve());
             workspaceService = mock(WorkspaceService);
             activeResourceService = mock(ActiveResourceService);
             appDiagnostics = typemoq.Mock.ofType<IApplicationDiagnostics>();
@@ -66,6 +69,7 @@ suite('Activation Manager', () => {
                 instance(workspaceService),
                 instance(fileSystem),
                 instance(activeResourceService),
+                interpreterPathService.object,
             );
 
             sinon.stub(EnvFileTelemetry, 'sendActivationTelemetry').resolves();
@@ -97,6 +101,7 @@ suite('Activation Manager', () => {
                 instance(workspaceService),
                 instance(fileSystem),
                 instance(activeResourceService),
+                interpreterPathService.object,
             );
             await managerTest.activateWorkspace(resource);
 
@@ -126,6 +131,7 @@ suite('Activation Manager', () => {
                 instance(workspaceService),
                 instance(fileSystem),
                 instance(activeResourceService),
+                interpreterPathService.object,
             );
             await managerTest.activateWorkspace(resource);
 

--- a/src/test/common/configSettings/configSettings.unit.test.ts
+++ b/src/test/common/configSettings/configSettings.unit.test.ts
@@ -11,6 +11,7 @@ import * as TypeMoq from 'typemoq';
 import untildify = require('untildify');
 import { WorkspaceConfiguration } from 'vscode';
 import { LanguageServerType } from '../../../client/activation/types';
+import { IApplicationEnvironment } from '../../../client/common/application/types';
 import { WorkspaceService } from '../../../client/common/application/workspace';
 import { PythonSettings } from '../../../client/common/configSettings';
 import { InterpreterPathService } from '../../../client/common/interpreterPathService';
@@ -54,14 +55,18 @@ suite('Python Settings', async () => {
             undefined,
             new MockAutoSelectionService(),
             workspaceService,
-            new InterpreterPathService(persistentStateFactory, workspaceService, []),
+            new InterpreterPathService(persistentStateFactory, workspaceService, [], {
+                remoteName: undefined,
+            } as IApplicationEnvironment),
             undefined,
         );
         settings = new CustomPythonSettings(
             undefined,
             new MockAutoSelectionService(),
             workspaceService,
-            new InterpreterPathService(persistentStateFactory, workspaceService, []),
+            new InterpreterPathService(persistentStateFactory, workspaceService, [], {
+                remoteName: undefined,
+            } as IApplicationEnvironment),
             undefined,
         );
         expected.defaultInterpreterPath = 'python';

--- a/src/test/common/interpreterPathService.unit.test.ts
+++ b/src/test/common/interpreterPathService.unit.test.ts
@@ -14,7 +14,7 @@ import {
     Uri,
     WorkspaceConfiguration,
 } from 'vscode';
-import { IWorkspaceService } from '../../client/common/application/types';
+import { IApplicationEnvironment, IWorkspaceService } from '../../client/common/application/types';
 import { defaultInterpreterPathSetting, InterpreterPathService } from '../../client/common/interpreterPathService';
 import { FileSystemPaths } from '../../client/common/platform/fs-paths';
 import { InterpreterConfigurationScope, IPersistentState, IPersistentStateFactory } from '../../client/common/types';
@@ -24,6 +24,7 @@ suite('Interpreter Path Service', async () => {
     let interpreterPathService: InterpreterPathService;
     let persistentStateFactory: TypeMoq.IMock<IPersistentStateFactory>;
     let workspaceService: TypeMoq.IMock<IWorkspaceService>;
+    let appEnvironment: TypeMoq.IMock<IApplicationEnvironment>;
     const resource = Uri.parse('a');
     const resourceOutsideOfWorkspace = Uri.parse('b');
     const interpreterPath = 'path/to/interpreter';
@@ -31,6 +32,8 @@ suite('Interpreter Path Service', async () => {
     setup(() => {
         const event = TypeMoq.Mock.ofType<Event<ConfigurationChangeEvent>>();
         workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
+        appEnvironment = TypeMoq.Mock.ofType<IApplicationEnvironment>();
+        appEnvironment.setup((a) => a.remoteName).returns(() => undefined);
         workspaceService
             .setup((w) => w.getWorkspaceFolder(resource))
             .returns(() => ({
@@ -41,7 +44,12 @@ suite('Interpreter Path Service', async () => {
         workspaceService.setup((w) => w.getWorkspaceFolder(resourceOutsideOfWorkspace)).returns(() => undefined);
         persistentStateFactory = TypeMoq.Mock.ofType<IPersistentStateFactory>();
         workspaceService.setup((w) => w.onDidChangeConfiguration).returns(() => event.object);
-        interpreterPathService = new InterpreterPathService(persistentStateFactory.object, workspaceService.object, []);
+        interpreterPathService = new InterpreterPathService(
+            persistentStateFactory.object,
+            workspaceService.object,
+            [],
+            appEnvironment.object,
+        );
     });
 
     teardown(() => {

--- a/src/test/extensionSettings.ts
+++ b/src/test/extensionSettings.ts
@@ -6,6 +6,7 @@
 'use strict';
 
 import { Event, Uri } from 'vscode';
+import { IApplicationEnvironment } from '../client/common/application/types';
 import { WorkspaceService } from '../client/common/application/workspace';
 import { InterpreterPathService } from '../client/common/interpreterPathService';
 import { PersistentStateFactory } from '../client/common/persistentState';
@@ -44,7 +45,9 @@ export function getExtensionSettings(resource: Uri | undefined): IPythonSettings
         resource,
         new AutoSelectionService(),
         workspaceService,
-        new InterpreterPathService(persistentStateFactory, workspaceService, []),
+        new InterpreterPathService(persistentStateFactory, workspaceService, [], {
+            remoteName: undefined,
+        } as IApplicationEnvironment),
         undefined,
     );
 }


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/19859

Include remote name in path keys for fetch interpreter setting value