### PR TITLE
Notify Pylance on `jupyter.runStartupCommands` config change

### DIFF
--- a/src/client/activation/common/analysisOptions.ts
+++ b/src/client/activation/common/analysisOptions.ts
@@ -42,7 +42,7 @@ export abstract class LanguageServerAnalysisOptionsBase implements ILanguageServ
             documentSelector,
             workspaceFolder,
             synchronize: {
-                configurationSection: [PYTHON_LANGUAGE, 'jupyter'],
+                configurationSection: this.getConfigSectionsToSynchronize(),
             },
             outputChannel: this.output,
             revealOutputChannelOn: RevealOutputChannelOn.Never,
@@ -56,6 +56,10 @@ export abstract class LanguageServerAnalysisOptionsBase implements ILanguageServ
 
     protected getDocumentFilters(_workspaceFolder?: WorkspaceFolder): DocumentFilter[] {
         return this.workspace.isVirtualWorkspace ? [{ language: PYTHON_LANGUAGE }] : PYTHON;
+    }
+
+    protected getConfigSectionsToSynchronize(): string[] {
+        return [PYTHON_LANGUAGE];
     }
 
     protected async getInitializationOptions(): Promise<any> {

--- a/src/client/activation/common/analysisOptions.ts
+++ b/src/client/activation/common/analysisOptions.ts
@@ -42,7 +42,7 @@ export abstract class LanguageServerAnalysisOptionsBase implements ILanguageServ
             documentSelector,
             workspaceFolder,
             synchronize: {
-                configurationSection: PYTHON_LANGUAGE,
+                configurationSection: [PYTHON_LANGUAGE, 'jupyter'],
             },
             outputChannel: this.output,
             revealOutputChannelOn: RevealOutputChannelOn.Never,

--- a/src/client/activation/node/analysisOptions.ts
+++ b/src/client/activation/node/analysisOptions.ts
@@ -26,6 +26,10 @@ export class NodeLanguageServerAnalysisOptions extends LanguageServerAnalysisOpt
         super(lsOutputChannel, workspace);
     }
 
+    protected getConfigSectionsToSynchronize(): string[] {
+        return [...super.getConfigSectionsToSynchronize(), 'jupyter'];
+    }
+
     // eslint-disable-next-line class-methods-use-this
     protected async getInitializationOptions(): Promise<LanguageClientOptions> {
         return ({

--- a/src/client/activation/node/analysisOptions.ts
+++ b/src/client/activation/node/analysisOptions.ts
@@ -27,7 +27,7 @@ export class NodeLanguageServerAnalysisOptions extends LanguageServerAnalysisOpt
     }
 
     protected getConfigSectionsToSynchronize(): string[] {
-        return [...super.getConfigSectionsToSynchronize(), 'jupyter'];
+        return [...super.getConfigSectionsToSynchronize(), 'jupyter.runStartupCommands'];
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/src/client/browser/extension.ts
+++ b/src/client/browser/extension.ts
@@ -77,7 +77,7 @@ async function runPylance(
             ],
             synchronize: {
                 // Synchronize the setting section to the server.
-                configurationSection: ['python'],
+                configurationSection: ['python', 'jupyter.runStartupCommands'],
             },
             middleware,
         };


### PR DESCRIPTION
Configure LSP to send configuration change notifications to Pylance for the `jupyter.runStartupCommands` config setting. Needed for Pylance's support of `jupyter.runStartupCommands` when LSP notebooks are enabled.

I could expand this to notify Pylance of all `jupyter.*` config changes. The downside is that config changes cause Pylance to reanalyze files, and for any other Jupyter setting that would be an unnecessary impact on the user. So I chose to limit it to this one setting for now. Let me know if you disagree.