### PR TITLE
Catch exceptions when changing `formatOnType` setting

### DIFF
--- a/src/client/activation/node/analysisOptions.ts
+++ b/src/client/activation/node/analysisOptions.ts
@@ -11,6 +11,7 @@ import { IExperimentService } from '../../common/types';
 import { LanguageServerAnalysisOptionsBase } from '../common/analysisOptions';
 import { ILanguageServerOutputChannel } from '../types';
 import { LspNotebooksExperiment } from './lspNotebooksExperiment';
+import { traceWarn } from '../../logging';
 
 const EDITOR_CONFIG_SECTION = 'editor';
 const FORMAT_ON_TYPE_CONFIG_SETTING = 'formatOnType';
@@ -79,11 +80,15 @@ export class NodeLanguageServerAnalysisOptions extends LanguageServerAnalysisOpt
         editorConfig: WorkspaceConfiguration,
         value: boolean | undefined,
     ) {
-        await editorConfig.update(
-            FORMAT_ON_TYPE_CONFIG_SETTING,
-            value,
-            ConfigurationTarget.Global,
-            /* overrideInLanguage */ true,
-        );
+        try {
+            await editorConfig.update(
+                FORMAT_ON_TYPE_CONFIG_SETTING,
+                value,
+                ConfigurationTarget.Global,
+                /* overrideInLanguage */ true,
+            );
+        } catch (ex) {
+            traceWarn(`Failed to set formatOnType to ${value}`);
+        }
     }
 }


### PR DESCRIPTION
For https://github.com/microsoft/pylance-release/issues/3685

Based on telemetry, some users in the auto-indent experiment are hitting exceptions when we try to set the `editor.formatOnType` config setting because their `settings.json` is dirty.

Catch exceptions from `WorkspaceConfiguration.update` and log that the settings change failed. This means that `formatOnType` will be left unchanged and will be out of sync with the user's experiment configuration (ex. users in the treatment group should have `formatOnType` enabled).

Next time we start Pylance we'll try again and hopefully succeed. After that point, assuming the user doesn't remove the `formatOnType` setting from their `settings.json` we won't need to touch it again so the dirty state of their `settings.json` won't matter.