### PR TITLE
Stop installing pre-release version of black when using poetry or pipenv environments

### DIFF
--- a/src/client/common/installer/pipEnvInstaller.ts
+++ b/src/client/common/installer/pipEnvInstaller.ts
@@ -62,9 +62,6 @@ export class PipEnvInstaller extends ModuleInstaller {
             flags & ModuleInstallFlags.updateDependencies ||
             flags & ModuleInstallFlags.upgrade;
         const args = [update ? 'update' : 'install', moduleName, '--dev'];
-        if (moduleName === 'black') {
-            args.push('--pre');
-        }
         return {
             args: args,
             execPath: pipenvName,

--- a/src/client/common/installer/poetryInstaller.ts
+++ b/src/client/common/installer/poetryInstaller.ts
@@ -71,9 +71,6 @@ export class PoetryInstaller extends ModuleInstaller {
     protected async getExecutionInfo(moduleName: string, resource?: InterpreterUri): Promise<ExecutionInfo> {
         const execPath = this.configurationService.getSettings(isResource(resource) ? resource : undefined).poetryPath;
         const args = ['add', '--group', 'dev', moduleName];
-        if (moduleName === 'black') {
-            args.push('--allow-prereleases');
-        }
         return {
             args,
             execPath,

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -641,9 +641,6 @@ suite('Module Installer', () => {
                                                 moduleName,
                                                 '--dev',
                                             ];
-                                            if (moduleName === 'black') {
-                                                expectedArgs.push('--pre');
-                                            }
                                             await installModuleAndVerifyCommand(
                                                 pipenvName,
                                                 expectedArgs,

--- a/src/test/common/installer/poetryInstaller.unit.test.ts
+++ b/src/test/common/installer/poetryInstaller.unit.test.ts
@@ -115,7 +115,7 @@ suite('Module Installer - Poetry', () => {
         const info = await poetryInstaller.getExecutionInfo('black', uri);
 
         assert.deepEqual(info, {
-            args: ['add', '--group', 'dev', 'black', '--allow-prereleases'],
+            args: ['add', '--group', 'dev', 'black'],
             execPath: 'poetry path',
         });
     });


### PR DESCRIPTION
Release version is now available on pypi, so this should no longer be needed.

Closes https://github.com/microsoft/vscode-python/issues/10696