### PR TITLE
Bump VS Code engine in `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,7 @@
                 "yargs": "^15.3.1"
             },
             "engines": {
-                "vscode": "^1.74.0"
+                "vscode": "^1.75.0-20221216"
             }
         },
         "node_modules/@azure/abort-controller": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.74.0"
+        "vscode": "^1.75.0-20221216"
     },
     "keywords": [
         "python",

--- a/src/test/debuggerTest.ts
+++ b/src/test/debuggerTest.ts
@@ -2,28 +2,13 @@
 // Licensed under the MIT License.
 
 import * as path from 'path';
-import * as fs from 'fs-extra';
 import { runTests } from '@vscode/test-electron';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from './constants';
-import { EXTENSION_ROOT_DIR } from '../client/common/constants';
+import { getChannel } from './utils/vscode';
 
 const workspacePath = path.join(__dirname, '..', '..', 'src', 'testMultiRootWkspc', 'multi.code-workspace');
 process.env.IS_CI_SERVER_TEST_DEBUGGER = '1';
 process.env.VSC_PYTHON_CI_TEST = '1';
-
-function getChannel(): string {
-    if (process.env.VSC_PYTHON_CI_TEST_VSC_CHANNEL) {
-        return process.env.VSC_PYTHON_CI_TEST_VSC_CHANNEL;
-    }
-    const packageJsonPath = path.join(EXTENSION_ROOT_DIR, 'package.json');
-    if (fs.pathExistsSync(packageJsonPath)) {
-        const packageJson = fs.readJSONSync(packageJsonPath);
-        if (packageJson.engines.vscode.endsWith('insider')) {
-            return 'insiders';
-        }
-    }
-    return 'stable';
-}
 
 function start() {
     console.log('*'.repeat(100));

--- a/src/test/multiRootTest.ts
+++ b/src/test/multiRootTest.ts
@@ -1,29 +1,14 @@
 import * as path from 'path';
-import * as fs from 'fs-extra';
 import { runTests } from '@vscode/test-electron';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from './constants';
 import { initializeLogger } from './testLogger';
-import { EXTENSION_ROOT_DIR } from '../client/common/constants';
+import { getChannel } from './utils/vscode';
 
 const workspacePath = path.join(__dirname, '..', '..', 'src', 'testMultiRootWkspc', 'multi.code-workspace');
 process.env.IS_CI_SERVER_TEST_DEBUGGER = '';
 process.env.VSC_PYTHON_CI_TEST = '1';
 
 initializeLogger();
-
-function getChannel(): string {
-    if (process.env.VSC_PYTHON_CI_TEST_VSC_CHANNEL) {
-        return process.env.VSC_PYTHON_CI_TEST_VSC_CHANNEL;
-    }
-    const packageJsonPath = path.join(EXTENSION_ROOT_DIR, 'package.json');
-    if (fs.pathExistsSync(packageJsonPath)) {
-        const packageJson = fs.readJSONSync(packageJsonPath);
-        if (packageJson.engines.vscode.endsWith('insider')) {
-            return 'insiders';
-        }
-    }
-    return 'stable';
-}
 
 function start() {
     console.log('*'.repeat(100));

--- a/src/test/standardTest.ts
+++ b/src/test/standardTest.ts
@@ -3,8 +3,9 @@ import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import { downloadAndUnzipVSCode, resolveCliPathFromVSCodeExecutablePath, runTests } from '@vscode/test-electron';
-import { EXTENSION_ROOT_DIR, JUPYTER_EXTENSION_ID, PYLANCE_EXTENSION_ID } from '../client/common/constants';
+import { JUPYTER_EXTENSION_ID, PYLANCE_EXTENSION_ID } from '../client/common/constants';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from './constants';
+import { getChannel } from './utils/vscode';
 
 // If running smoke tests, we don't have access to this.
 if (process.env.TEST_FILES_SUFFIX !== 'smoke.test') {
@@ -26,20 +27,6 @@ const workspacePath = process.env.CODE_TESTS_WORKSPACE
 const extensionDevelopmentPath = process.env.CODE_EXTENSIONS_PATH
     ? process.env.CODE_EXTENSIONS_PATH
     : EXTENSION_ROOT_DIR_FOR_TESTS;
-
-function getChannel(): string {
-    if (process.env.VSC_PYTHON_CI_TEST_VSC_CHANNEL) {
-        return process.env.VSC_PYTHON_CI_TEST_VSC_CHANNEL;
-    }
-    const packageJsonPath = path.join(EXTENSION_ROOT_DIR, 'package.json');
-    if (fs.pathExistsSync(packageJsonPath)) {
-        const packageJson = fs.readJSONSync(packageJsonPath);
-        if (packageJson.engines.vscode.endsWith('insider')) {
-            return 'insiders';
-        }
-    }
-    return 'stable';
-}
 
 /**
  * Smoke tests & tests running in VSCode require Jupyter extension to be installed.

--- a/src/test/utils/vscode.ts
+++ b/src/test/utils/vscode.ts
@@ -1,0 +1,23 @@
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { EXTENSION_ROOT_DIR } from '../../client/common/constants';
+
+const insidersVersion = /^\d+\.\d+\.\d+-(insider|\d{8})$/;
+
+export function getChannel(): string {
+    if (process.env.VSC_PYTHON_CI_TEST_VSC_CHANNEL) {
+        return process.env.VSC_PYTHON_CI_TEST_VSC_CHANNEL;
+    }
+    const packageJsonPath = path.join(EXTENSION_ROOT_DIR, 'package.json');
+    if (fs.pathExistsSync(packageJsonPath)) {
+        const packageJson = fs.readJSONSync(packageJsonPath);
+        const engineVersion = packageJson.engines.vscode;
+        if (insidersVersion.test(engineVersion)) {
+            // Can't pass in the version number for an insiders build;
+            // https://github.com/microsoft/vscode-test/issues/176
+            return 'insiders';
+        }
+        return engineVersion;
+    }
+    return 'stable';
+}

--- a/src/test/utils/vscode.ts
+++ b/src/test/utils/vscode.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import { EXTENSION_ROOT_DIR } from '../../client/common/constants';
 
-const insidersVersion = /^\d+\.\d+\.\d+-(insider|\d{8})$/;
+const insidersVersion = /^\^(\d+\.\d+\.\d+)-(insider|\d{8})$/;
 
 export function getChannel(): string {
     if (process.env.VSC_PYTHON_CI_TEST_VSC_CHANNEL) {


### PR DESCRIPTION
Accidentally left out of https://github.com/microsoft/vscode-python/commit/cb124e7b408af2afa3e074e541ddf8c09b95e2ff .

As it pertains to a change made in VS Code insiders today, we are setting the engine to a specific date. This requires updating the `getChannel()` code, so took the opportunity to factor it out.