### PR TITLE
Enables successfull running of python file even when parentheses are present in the path

### DIFF
--- a/src/client/common/extensions.ts
+++ b/src/client/common/extensions.ts
@@ -73,7 +73,9 @@ String.prototype.toCommandArgumentForPythonExt = function (this: string): string
     if (!this) {
         return this;
     }
-    return (this.indexOf(' ') >= 0 || this.indexOf('&') >= 0) && !this.startsWith('"') && !this.endsWith('"')
+    return (this.indexOf(' ') >= 0 || this.indexOf('&') >= 0 || this.indexOf('(') >= 0 || this.indexOf(')') >= 0) &&
+        !this.startsWith('"') &&
+        !this.endsWith('"')
         ? `"${this}"`
         : this.toString();
 };


### PR DESCRIPTION
Issue #20360  . Adding some more conditions for '(' and ')' seemed to be the cleanest solution to me.