### PR TITLE
improve shell detector with customized terminal.integrated.defaultProfile/profiles

### DIFF
--- a/src/client/common/terminal/shellDetectors/settingsShellDetector.ts
+++ b/src/client/common/terminal/shellDetectors/settingsShellDetector.ts
@@ -28,7 +28,6 @@ export class SettingsShellDetector extends BaseShellDetector {
         super(2);
     }
     public getTerminalShellPath(): string | undefined {
-        const shellConfig = this.workspace.getConfiguration('terminal.integrated.shell');
         let osSection = '';
         switch (this.platform.osType) {
             case OSType.Windows: {
@@ -47,7 +46,15 @@ export class SettingsShellDetector extends BaseShellDetector {
                 return '';
             }
         }
-        return shellConfig.get<string>(osSection)!;
+        const legacyShell = this.workspace.getConfiguration('terminal.integrated.shell').get<string>(osSection);
+        if (legacyShell) return legacyShell;
+        const profiles = this.workspace
+            .getConfiguration('terminal.integrated.profiles')
+            .get<{ [key: string]: any }>(osSection);
+        const defaultProfile = this.workspace
+            .getConfiguration('terminal.integrated.defaultProfile')
+            .get<string>(osSection);
+        if (profiles && defaultProfile) return profiles[defaultProfile]?.path;
     }
     public identify(
         telemetryProperties: ShellIdentificationTelemetry,

--- a/src/client/common/terminal/shellDetectors/terminalNameShellDetector.ts
+++ b/src/client/common/terminal/shellDetectors/terminalNameShellDetector.ts
@@ -28,7 +28,7 @@ export class TerminalNameShellDetector extends BaseShellDetector {
         if (!terminal) {
             return;
         }
-        const shell = this.identifyShellFromShellPath(terminal.name);
+        const shell = this.identifyShellFromShellPath(terminal.name || terminal.creationOptions.name || '');
         traceVerbose(`Terminal name '${terminal.name}' identified as shell '${shell}'`);
         telemetryProperties.shellIdentificationSource =
             shell === TerminalShellType.other ? telemetryProperties.shellIdentificationSource : 'terminalName';


### PR DESCRIPTION
1. `terminal.name` can returns `''` when terminal activation callback is called and will change to correct value later. however the user can use `overrideName` to set the value of `terminal.creationOptions.name` to the shell profile name.
2. `terminal.integrated.shell` is deprecated but takes precedence over `terminal.integrated.defaultProfile`.

here are my setup on windows 11. currently detectors will all fail and fallback to `powershell.exe` in `UserEnvironmentShellDetector`.
```
  "terminal.integrated.defaultProfile.windows": "msvc-gitbash",
  "terminal.integrated.profiles.windows": {
    "msvc-gitbash": {
      "overrideName": true,
      "path": "path\\to\\script.bat"
    }
  }
```

```
@echo off
call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat" > NUL
"C:\Program Files\Git\bin\sh.exe" -i -l
```
