### PR TITLE
Make sure we do not use or execute the default `python` on `PATH` if there is any other known interpreter

### DIFF
--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -51,7 +51,7 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
 
     public async create(options: ExecutionFactoryCreationOptions): Promise<IPythonExecutionService> {
         let { pythonPath } = options;
-        if (!pythonPath) {
+        if (!pythonPath || pythonPath === 'python') {
             // If python path wasn't passed in, we need to auto select it and then read it
             // from the configuration.
             const interpreterPath = this.interpreterPathExpHelper.get(options.resource);

--- a/src/client/interpreter/display/index.ts
+++ b/src/client/interpreter/display/index.ts
@@ -108,7 +108,7 @@ export class InterpreterDisplay implements IInterpreterDisplay, IExtensionSingle
         }
     }
     private onDidChangeInterpreterInformation(info: PythonEnvironment) {
-        if (!this.currentlySelectedInterpreterPath || this.currentlySelectedInterpreterPath === info.path) {
+        if (this.currentlySelectedInterpreterPath === info.path) {
             this.updateDisplay(this.currentlySelectedWorkspaceFolder).ignoreErrors();
         }
     }

--- a/src/test/common/process/pythonExecutionFactory.unit.test.ts
+++ b/src/test/common/process/pythonExecutionFactory.unit.test.ts
@@ -153,7 +153,22 @@ suite('Process - PythonExecutionFactory', () => {
                 verify(pythonSettings.pythonPath).once();
             });
 
-            test('If interpreter is explicitly set, ensure we use it', async () => {
+            test('If interpreter is explicitly set to `python`, ensure we use it', async () => {
+                const pythonSettings = mock(PythonSettings);
+                when(processFactory.create(resource)).thenResolve(processService.object);
+                when(activationHelper.getActivatedEnvironmentVariables(resource)).thenResolve({ x: '1' });
+                reset(interpreterPathExpHelper);
+                when(interpreterPathExpHelper.get(anything())).thenReturn('python');
+                when(autoSelection.autoSelectInterpreter(anything())).thenResolve();
+                when(configService.getSettings(resource)).thenReturn(instance(pythonSettings));
+
+                const service = await factory.create({ resource, pythonPath: 'python' });
+
+                expect(service).to.not.equal(undefined);
+                verify(autoSelection.autoSelectInterpreter(anything())).once();
+            });
+
+            test('Otherwise if interpreter is explicitly set, ensure we use it', async () => {
                 const pythonSettings = mock(PythonSettings);
                 when(processFactory.create(resource)).thenResolve(processService.object);
                 when(activationHelper.getActivatedEnvironmentVariables(resource)).thenResolve({ x: '1' });


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/20383

Solves bug no. 2 mentioned in the issue.