### PR TITLE
Bump extension/telemetry dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2022.21.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@vscode/extension-telemetry": "^0.7.3-preview",
+                "@vscode/extension-telemetry": "^0.7.4-preview",
                 "@vscode/jupyter-lsp-middleware": "^0.2.50",
                 "arch": "^2.1.0",
                 "diff-match-patch": "^1.0.0",
@@ -130,7 +130,7 @@
                 "yargs": "^15.3.1"
             },
             "engines": {
-                "vscode": "^1.75.0-20221216"
+                "vscode": "^1.75.0-20230104"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -1371,9 +1371,9 @@
             "dev": true
         },
         "node_modules/@vscode/extension-telemetry": {
-            "version": "0.7.3-preview",
-            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.7.3-preview.tgz",
-            "integrity": "sha512-V+TanZXj8jhCX8mwGHbRDOTJ5YSWCmngHKs7ZrRoR7sXc4vZYQX+1syp07hDX2BVnPpuBHJiovZ8GZ4zbmQvYw==",
+            "version": "0.7.4-preview",
+            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.7.4-preview.tgz",
+            "integrity": "sha512-6OkvjCc+DaC9B26t3hj7vuAxf1ONm/p4LrVvFrapa+jBCKxXXUaV1Asz6+QxYaPfd4Ws/MlnFfCvlgvv3uYRwQ==",
             "dependencies": {
                 "@microsoft/1ds-core-js": "^3.2.8",
                 "@microsoft/1ds-post-js": "^3.2.8",
@@ -1381,7 +1381,7 @@
                 "applicationinsights": "2.3.6"
             },
             "engines": {
-                "vscode": "^1.74.0"
+                "vscode": "^1.75.0"
             }
         },
         "node_modules/@vscode/jupyter-lsp-middleware": {
@@ -16697,9 +16697,9 @@
             "dev": true
         },
         "@vscode/extension-telemetry": {
-            "version": "0.7.3-preview",
-            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.7.3-preview.tgz",
-            "integrity": "sha512-V+TanZXj8jhCX8mwGHbRDOTJ5YSWCmngHKs7ZrRoR7sXc4vZYQX+1syp07hDX2BVnPpuBHJiovZ8GZ4zbmQvYw==",
+            "version": "0.7.4-preview",
+            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.7.4-preview.tgz",
+            "integrity": "sha512-6OkvjCc+DaC9B26t3hj7vuAxf1ONm/p4LrVvFrapa+jBCKxXXUaV1Asz6+QxYaPfd4Ws/MlnFfCvlgvv3uYRwQ==",
             "requires": {
                 "@microsoft/1ds-core-js": "^3.2.8",
                 "@microsoft/1ds-post-js": "^3.2.8",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.75.0-20221216"
+        "vscode": "^1.75.0-20230104"
     },
     "keywords": [
         "python",
@@ -1806,7 +1806,7 @@
     },
     "dependencies": {
         "@vscode/jupyter-lsp-middleware": "^0.2.50",
-        "@vscode/extension-telemetry": "^0.7.3-preview",
+        "@vscode/extension-telemetry": "^0.7.4-preview",
         "arch": "^2.1.0",
         "diff-match-patch": "^1.0.0",
         "fs-extra": "^10.0.1",


### PR DESCRIPTION
Corresponds to https://github.com/microsoft/vscode/commit/4acf2d9b46b75748ae687cf3b2952a0799679873 .

Closes #20456