### PR TITLE
Remove VS Code engine version suffix

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.75.0-20230104"
+        "vscode": "^1.75.0"
     },
     "keywords": [
         "python",


### PR DESCRIPTION
This is an attempt to fix our telemetry issues 