### PR TITLE
Add snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,12 @@
     "main": "./out/client/extension",
     "browser": "./dist/extension.browser.js",
     "contributes": {
+        "snippets": [
+            {
+                "language": "python",
+                "path": "./snippets/snippets.json"
+            }
+        ],
         "walkthroughs": [
             {
                 "id": "pythonWelcome",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -48,6 +48,28 @@
             "\t$0"
         ]
     },
+    "tr": {
+        "description": "[tr]y",
+        "prefix": "tr",
+        "body": [
+            "try",
+            "\t${1:print()}",
+            "except:",
+            "\t$0"
+        ]
+    },
+    "trf": {
+        "description": "[tr]y [f]inally",
+        "prefix": "trf",
+        "body": [
+            "try",
+            "\t${1:print()}",
+            "except:",
+            "\t${2:print()}",
+            "finally:",
+            "\t$0"
+        ]
+    },
     "ma": {
         "description": "[ma]in",
         "prefix": "ma",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -55,5 +55,19 @@
             "def main():",
             "\t$0"
         ]
+    },
+    "fr": {
+        "description": "[fr]om",
+        "prefix": "fr",
+        "body": [
+            "from ${1:module} import ${2:items}"
+        ]
+    },
+    "im": {
+        "description": "[im]port",
+        "prefix": "im",
+        "body": [
+            "import ${1:module}"
+        ]
     }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,0 +1,59 @@
+{
+    "shebang": {
+        "description": "[sh]hebang",
+        "prefix": "sh",
+        "body": [
+            "#!/usr/bin/env ${1|python3,python|}"
+        ]
+    },
+    "if": {
+        "description": "[if]",
+        "prefix": "if",
+        "body": [
+            "if ${1:condition}:",
+            "\t$0"
+        ]
+    },
+    "ife": {
+        "description": "[if] [e]lse",
+        "prefix": "ife",
+        "body": [
+            "if ${1:condition}:",
+            "\tprint()",
+            "else:",
+            "\t$0"
+        ]
+    },
+    "wh": {
+        "description": "[wh]ile",
+        "prefix": "wh",
+        "body": [
+            "while ${1:condition}:",
+            "\t$0"
+        ]
+    },
+    "fo": {
+        "description": "[fo]r",
+        "prefix": "fo",
+        "body": [
+            "for ${1:variable} in ${2:list}:",
+            "\t$0"
+        ]
+    },
+    "de": {
+        "description": "[de]f",
+        "prefix": "de",
+        "body": [
+            "def ${1:function_name}(${2:parameters}):",
+            "\t$0"
+        ]
+    },
+    "ma": {
+        "description": "[ma]in",
+        "prefix": "ma",
+        "body": [
+            "def main():",
+            "\t$0"
+        ]
+    }
+}

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -19,7 +19,7 @@
         "prefix": "ife",
         "body": [
             "if ${1:condition}:",
-            "\tprint()",
+            "\t${2:print()}",
             "else:",
             "\t$0"
         ]

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -127,5 +127,14 @@
         "body": [
             "import ${1:module}"
         ]
+    },
+    "@dataclass": {
+        "description": "[@dataclass]",
+        "prefix": "@dataclass",
+        "body": [
+            "@dataclass(init=${1|True,False|}, eq=${2|True,False|}, order=${3|True,False|})",
+            "class ${4:name}:",
+            "\t$0"
+        ]
     }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -32,11 +32,31 @@
             "\t$0"
         ]
     },
+    "whe": {
+        "description": "[wh]ile [e]lse",
+        "prefix": "whe",
+        "body": [
+            "while ${1:condition}:",
+            "\t${2:print()}",
+            "else:",
+            "\t$0"
+        ]
+    },
     "fo": {
         "description": "[fo]r",
         "prefix": "fo",
         "body": [
             "for ${1:variable} in ${2:list}:",
+            "\t$0"
+        ]
+    },
+    "foe": {
+        "description": "[fo]r [e]lse",
+        "prefix": "foe",
+        "body": [
+            "for ${1:variable} in ${2:list}:",
+            "\t${3:print()}",
+            "else:",
             "\t$0"
         ]
     },

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -68,6 +68,14 @@
             "\t$0"
         ]
     },
+    "cl": {
+        "description": "[cl]ass",
+        "prefix": "cl",
+        "body": [
+            "class ${1:name}:",
+            "\t$0"
+        ]
+    },
     "tr": {
         "description": "[tr]y",
         "prefix": "tr",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -90,6 +90,14 @@
             "\t$0"
         ]
     },
+    "wi": {
+        "description": "[wi]th",
+        "prefix": "wi",
+        "body": [
+            "with open(\"${1:path/to/file}\", \"${2|r,w|}\") as ${3:file}:",
+            "\t$0"
+        ]
+    },
     "ma": {
         "description": "[ma]in",
         "prefix": "ma",


### PR DESCRIPTION
All snippets are named using the following convention:

- if snippet is not for decorator, then:
  - first two letters from the first word used **and** one letter from a second word (if it exists) as a snippet prefix
- else
  - decorator name used as a snippet prefix