### PR TITLE
Ensure dependency quick pick is not shown when user exits env creation.

### DIFF
--- a/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
+++ b/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
@@ -127,6 +127,11 @@ export class VenvCreationProvider implements CreateEnvironmentProvider {
                 [EnvironmentType.System, EnvironmentType.MicrosoftStore, EnvironmentType.Global].includes(i.envType),
         );
 
+        if (!interpreter) {
+            traceError('Virtual env creation requires an interpreter.');
+            return undefined;
+        }
+
         let addGitIgnore = true;
         let installPackages = true;
         if (options) {
@@ -138,11 +143,6 @@ export class VenvCreationProvider implements CreateEnvironmentProvider {
             installInfo = await pickPackagesToInstall(workspace);
         }
         const args = generateCommandArgs(installInfo, addGitIgnore);
-
-        if (!interpreter) {
-            traceError('Virtual env creation requires an interpreter.');
-            return undefined;
-        }
 
         if (!installInfo) {
             traceInfo('Virtual env creation exited during dependencies selection.');

--- a/src/test/pythonEnvironments/creation/provider/venvCreationProvider.unit.test.ts
+++ b/src/test/pythonEnvironments/creation/provider/venvCreationProvider.unit.test.ts
@@ -62,9 +62,14 @@ suite('venv Creation provider tests', () => {
 
     test('No workspace selected', async () => {
         pickWorkspaceFolderStub.resolves(undefined);
+        interpreterQuickPick
+            .setup((i) => i.getInterpreterViaQuickPick(typemoq.It.isAny(), typemoq.It.isAny()))
+            .verifiable(typemoq.Times.never());
 
         assert.isUndefined(await venvProvider.createEnvironment());
         assert.isTrue(pickWorkspaceFolderStub.calledOnce);
+        interpreterQuickPick.verifyAll();
+        assert.isTrue(pickPackagesToInstallStub.notCalled);
     });
 
     test('No Python selected', async () => {
@@ -76,7 +81,10 @@ suite('venv Creation provider tests', () => {
             .verifiable(typemoq.Times.once());
 
         assert.isUndefined(await venvProvider.createEnvironment());
+
+        assert.isTrue(pickWorkspaceFolderStub.calledOnce);
         interpreterQuickPick.verifyAll();
+        assert.isTrue(pickPackagesToInstallStub.notCalled);
     });
 
     test('User pressed Esc while selecting dependencies', async () => {


### PR DESCRIPTION
Fixes #20602 