### PR TITLE
Added support for Django unittests

### DIFF
--- a/pythonFiles/testing_tools/unittest_discovery.py
+++ b/pythonFiles/testing_tools/unittest_discovery.py
@@ -4,11 +4,14 @@ import sys
 import traceback
 import unittest
 
+from ..unittestadapter.utils import config_django_env
+
 start_dir = sys.argv[1]
 pattern = sys.argv[2]
 top_level_dir = sys.argv[3] if len(sys.argv) >= 4 else None
 sys.path.insert(0, os.getcwd())
 
+config_django_env(start_dir)
 
 def get_sourceline(obj):
     try:

--- a/pythonFiles/unittestadapter/utils.py
+++ b/pythonFiles/unittestadapter/utils.py
@@ -226,3 +226,26 @@ def parse_unittest_args(args: List[str]) -> Tuple[str, str, Union[str, None]]:
         parsed_args.pattern,
         parsed_args.top_level_directory,
     )
+
+def config_django_env(start_dir) -> None:
+    """This will try to set DJANGO_SETTINGS_MODULE and call django.setup in order to make it possible to locate/run django unittests"""
+    from pathlib import Path
+    from ast import literal_eval
+    if Path(start_dir + "/manage.py").is_file():
+        with open(start_dir + "/manage.py", "r") as management_file:
+            contents = management_file.readlines()
+            if any(True for line in contents if line.strip().replace('"""', '') == "Django\'s command-line utility for administrative tasks."):
+                print("django management file found!")
+                for line in contents:
+                    if line.strip().startswith("os.environ.setdefault"):
+                        try:
+                            literal_eval(line.strip())
+                        except:
+                            pass
+                        else:
+                            eval(line.strip()) # this is the not recommended part!!!
+                            try:
+                                import django
+                                django.setup()
+                            except ModuleNotFoundError:
+                                pass

--- a/pythonFiles/unittestadapter/utils.py
+++ b/pythonFiles/unittestadapter/utils.py
@@ -239,7 +239,7 @@ def config_django_env(start_dir) -> None:
                 for line in contents:
                     if line.strip().startswith("os.environ.setdefault"):
                         try:
-                            literal_eval(line.strip())
+                            literal_eval(line.strip().replace('os.environ.setdefault("DJANGO_SETTINGS_MODULE",', "", 1))
                         except:
                             pass
                         else:

--- a/pythonFiles/visualstudio_py_testlauncher.py
+++ b/pythonFiles/visualstudio_py_testlauncher.py
@@ -214,6 +214,22 @@ def signal_handler(signal, frame):
     raise ExitCommand()
 
 
+def config_django_env(start_dir):
+    from pathlib import Path
+    if Path(start_dir + "/manage.py").is_file():
+        with open(start_dir + "/manage.py", "r") as management_file:
+            contents = management_file.readlines()
+            if any(True for line in contents if line.strip().replace('"""', '') == "Django\'s command-line utility for administrative tasks."):
+                print("django management file found!")
+                for line in contents:
+                    if line.strip().startswith("os.environ.setdefault"):
+                        eval(line.strip()) # this is the not recommended part!!!
+                        try:
+                            import django
+                            django.setup()
+                        except ModuleNotFoundError:
+                            pass
+
 def main():
     import os
     import sys
@@ -377,6 +393,9 @@ def main():
             runner = unittest.TextTestRunner(
                 verbosity=opts.uvInt, resultclass=VsTestResult
             )
+        
+        config_django_env(opts.ut or opts.us)
+
         result = runner.run(tests)
         if _channel is not None:
             _channel.close()

--- a/pythonFiles/visualstudio_py_testlauncher.py
+++ b/pythonFiles/visualstudio_py_testlauncher.py
@@ -25,6 +25,8 @@ import sys
 import traceback
 import unittest
 
+from .unittestadapter.utils import config_django_env
+
 try:
     import thread
 except:
@@ -213,23 +215,6 @@ class ExitCommand(Exception):
 def signal_handler(signal, frame):
     raise ExitCommand()
 
-
-def config_django_env(start_dir):
-    from pathlib import Path
-    if Path(start_dir + "/manage.py").is_file():
-        with open(start_dir + "/manage.py", "r") as management_file:
-            contents = management_file.readlines()
-            if any(True for line in contents if line.strip().replace('"""', '') == "Django\'s command-line utility for administrative tasks."):
-                print("django management file found!")
-                for line in contents:
-                    if line.strip().startswith("os.environ.setdefault"):
-                        eval(line.strip()) # this is the not recommended part!!!
-                        try:
-                            import django
-                            django.setup()
-                        except ModuleNotFoundError:
-                            pass
-
 def main():
     import os
     import sys
@@ -393,7 +378,7 @@ def main():
             runner = unittest.TextTestRunner(
                 verbosity=opts.uvInt, resultclass=VsTestResult
             )
-        
+
         config_django_env(opts.ut or opts.us)
 
         result = runner.run(tests)


### PR DESCRIPTION
it would check to see if there is a `manage.py` in the root folder and then checks inside that file to see if it is generated by django and also checks if `ast.literal_eval` has no exception due to execution of the line which would set `DJANGO_SETTINGS_MODULE` and then call `django.setup` to load all django apps and prepare to run the tests.