### PR TITLE
Add support for 'back' to all create env UI.

### DIFF
--- a/pythonFiles/create_venv.py
+++ b/pythonFiles/create_venv.py
@@ -154,13 +154,13 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     if pip_installed:
         upgrade_pip(venv_path)
 
-    if args.requirements:
-        print(f"VENV_INSTALLING_REQUIREMENTS: {args.requirements}")
-        install_requirements(venv_path, args.requirements)
-
     if args.toml:
         print(f"VENV_INSTALLING_PYPROJECT: {args.toml}")
         install_toml(venv_path, args.extras)
+
+    if args.requirements:
+        print(f"VENV_INSTALLING_REQUIREMENTS: {args.requirements}")
+        install_requirements(venv_path, args.requirements)
 
 
 if __name__ == "__main__":

--- a/src/client/common/utils/async.ts
+++ b/src/client/common/utils/async.ts
@@ -27,7 +27,7 @@ export interface Deferred<T> {
     readonly rejected: boolean;
     readonly completed: boolean;
     resolve(value?: T | PromiseLike<T>): void;
-    reject(reason?: string | Error | Record<string, unknown>): void;
+    reject(reason?: string | Error | Record<string, unknown> | unknown): void;
 }
 
 class DeferredImpl<T> implements Deferred<T> {

--- a/src/client/common/vscodeApis/windowApis.ts
+++ b/src/client/common/vscodeApis/windowApis.ts
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable max-classes-per-file */
 
 import {
     CancellationToken,
@@ -7,19 +9,26 @@ import {
     MessageOptions,
     Progress,
     ProgressOptions,
+    QuickPick,
+    QuickInputButtons,
     QuickPickItem,
     QuickPickOptions,
     TextEditor,
     window,
+    Disposable,
 } from 'vscode';
+import { createDeferred, Deferred } from '../utils/async';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 export function showQuickPick<T extends QuickPickItem>(
     items: readonly T[] | Thenable<readonly T[]>,
     options?: QuickPickOptions,
     token?: CancellationToken,
 ): Thenable<T | undefined> {
     return window.showQuickPick(items, options, token);
+}
+
+export function createQuickPick<T extends QuickPickItem>(): QuickPick<T> {
+    return window.createQuickPick<T>();
 }
 
 export function showErrorMessage<T extends string>(message: string, ...items: T[]): Thenable<T | undefined>;
@@ -66,4 +75,123 @@ export function withProgress<R>(
 export function getActiveTextEditor(): TextEditor | undefined {
     const { activeTextEditor } = window;
     return activeTextEditor;
+}
+
+export enum MultiStepAction {
+    Back = 'Back',
+    Cancel = 'Cancel',
+    Continue = 'Continue',
+}
+
+export async function showQuickPickWithBack<T extends QuickPickItem>(
+    items: readonly T[],
+    options?: QuickPickOptions,
+    token?: CancellationToken,
+): Promise<T | T[] | undefined> {
+    const quickPick: QuickPick<T> = window.createQuickPick<T>();
+    const disposables: Disposable[] = [quickPick];
+
+    quickPick.items = items;
+    quickPick.buttons = [QuickInputButtons.Back];
+    quickPick.canSelectMany = options?.canPickMany ?? false;
+    quickPick.ignoreFocusOut = options?.ignoreFocusOut ?? false;
+    quickPick.matchOnDescription = options?.matchOnDescription ?? false;
+    quickPick.matchOnDetail = options?.matchOnDetail ?? false;
+    quickPick.placeholder = options?.placeHolder;
+    quickPick.title = options?.title;
+
+    const deferred = createDeferred<T | T[] | undefined>();
+
+    disposables.push(
+        quickPick,
+        quickPick.onDidTriggerButton((item) => {
+            if (item === QuickInputButtons.Back) {
+                deferred.reject(MultiStepAction.Back);
+                quickPick.hide();
+            }
+        }),
+        quickPick.onDidAccept(() => {
+            if (!deferred.completed) {
+                deferred.resolve(quickPick.selectedItems.map((item) => item));
+                quickPick.hide();
+            }
+        }),
+        quickPick.onDidHide(() => {
+            if (!deferred.completed) {
+                deferred.resolve(undefined);
+            }
+        }),
+    );
+    if (token) {
+        disposables.push(
+            token.onCancellationRequested(() => {
+                quickPick.hide();
+            }),
+        );
+    }
+    quickPick.show();
+
+    try {
+        return await deferred.promise;
+    } finally {
+        disposables.forEach((d) => d.dispose());
+    }
+}
+
+export class MultiStepNode {
+    constructor(
+        public previous: MultiStepNode | undefined,
+        public readonly current: (context?: MultiStepAction) => Promise<MultiStepAction>,
+        public next: MultiStepNode | undefined,
+    ) {}
+
+    public static async run(step: MultiStepNode, context?: MultiStepAction): Promise<MultiStepAction> {
+        let nextStep: MultiStepNode | undefined = step;
+        let flowAction = await nextStep.current(context);
+        while (nextStep !== undefined) {
+            if (flowAction === MultiStepAction.Cancel) {
+                return flowAction;
+            }
+            if (flowAction === MultiStepAction.Back) {
+                nextStep = nextStep?.previous;
+            }
+            if (flowAction === MultiStepAction.Continue) {
+                nextStep = nextStep?.next;
+            }
+
+            if (nextStep) {
+                flowAction = await nextStep?.current(flowAction);
+            }
+        }
+
+        return flowAction;
+    }
+}
+
+export function createStepBackEndNode<T>(deferred?: Deferred<T>): MultiStepNode {
+    return new MultiStepNode(
+        undefined,
+        async () => {
+            if (deferred) {
+                // This is to ensure we don't leave behind any pending promises.
+                deferred.reject(MultiStepAction.Back);
+            }
+            return Promise.resolve(MultiStepAction.Back);
+        },
+        undefined,
+    );
+}
+
+export function createStepForwardEndNode<T>(deferred?: Deferred<T>, result?: T): MultiStepNode {
+    return new MultiStepNode(
+        undefined,
+        async () => {
+            if (deferred) {
+                // This is to ensure we don't leave behind any pending promises.
+                deferred.resolve(result);
+            }
+            return Promise.resolve(MultiStepAction.Back);
+        },
+        undefined,
+    );
 }

--- a/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -6,7 +6,15 @@
 import { inject, injectable } from 'inversify';
 import { cloneDeep } from 'lodash';
 import * as path from 'path';
-import { l10n, QuickPick, QuickPickItem, QuickPickItemKind, ThemeIcon } from 'vscode';
+import {
+    l10n,
+    QuickInputButton,
+    QuickInputButtons,
+    QuickPick,
+    QuickPickItem,
+    QuickPickItemKind,
+    ThemeIcon,
+} from 'vscode';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../../../../common/application/types';
 import { Commands, Octicons, ThemeIcons } from '../../../../common/constants';
 import { isParentPath } from '../../../../common/platform/fs-paths';
@@ -20,6 +28,7 @@ import {
     InputFlowAction,
     InputStep,
     IQuickPickParameters,
+    QuickInputButtonSetup,
 } from '../../../../common/utils/multiStepInput';
 import { SystemVariables } from '../../../../common/variables/systemVariables';
 import { TriggerRefreshOptions } from '../../../../pythonEnvironments/base/locator';
@@ -145,6 +154,23 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand implem
                 : params?.placeholder ?? l10n.t('Selected Interpreter: {0}', currentInterpreterPathDisplay);
         const title =
             params?.title === null ? undefined : params?.title ?? InterpreterQuickPickList.browsePath.openButtonLabel;
+        const buttons: QuickInputButtonSetup[] = [
+            {
+                button: this.refreshButton,
+                callback: (quickpickInput) => {
+                    this.refreshCallback(quickpickInput, { isButton: true, showBackButton: params?.showBackButton });
+                },
+            },
+        ];
+        if (params?.showBackButton) {
+            buttons.push({
+                button: QuickInputButtons.Back,
+                callback: () => {
+                    // Do nothing. This is handled as a promise rejection in the quickpick.
+                },
+            });
+        }
+
         const selection = await input.showQuickPick<QuickPickType, IQuickPickParameters<QuickPickType>>({
             placeholder,
             items: suggestions,
@@ -154,23 +180,19 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand implem
             matchOnDetail: true,
             matchOnDescription: true,
             title,
-            customButtonSetups: [
-                {
-                    button: this.refreshButton,
-                    callback: (quickpickInput) => {
-                        this.refreshCallback(quickpickInput, { isButton: true });
-                    },
-                },
-            ],
+            customButtonSetups: buttons,
             initialize: (quickPick) => {
                 // Note discovery is no longer guranteed to be auto-triggered on extension load, so trigger it when
                 // user interacts with the interpreter picker but only once per session. Users can rely on the
                 // refresh button if they want to trigger it more than once. However if no envs were found previously,
                 // always trigger a refresh.
                 if (this.interpreterService.getInterpreters().length === 0) {
-                    this.refreshCallback(quickPick);
+                    this.refreshCallback(quickPick, { showBackButton: params?.showBackButton });
                 } else {
-                    this.refreshCallback(quickPick, { ifNotTriggerredAlready: true });
+                    this.refreshCallback(quickPick, {
+                        ifNotTriggerredAlready: true,
+                        showBackButton: params?.showBackButton,
+                    });
                 }
             },
             onChangeItem: {
@@ -436,19 +458,16 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand implem
         }
     }
 
-    private refreshCallback(input: QuickPick<QuickPickItem>, options?: TriggerRefreshOptions & { isButton?: boolean }) {
-        if (options?.isButton) {
-            input.buttons = [
-                {
-                    iconPath: new ThemeIcon(ThemeIcons.SpinningLoader),
-                    tooltip: InterpreterQuickPickList.refreshingInterpreterList,
-                },
-            ];
-        }
+    private refreshCallback(
+        input: QuickPick<QuickPickItem>,
+        options?: TriggerRefreshOptions & { isButton?: boolean; showBackButton?: boolean },
+    ) {
+        input.buttons = this.getButtons(options);
+
         this.interpreterService
             .triggerRefresh(undefined, options)
             .finally(() => {
-                input.buttons = [this.refreshButton];
+                input.buttons = this.getButtons({ isButton: false, showBackButton: options?.showBackButton });
             })
             .ignoreErrors();
         if (this.interpreterService.refreshPromise) {
@@ -457,6 +476,22 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand implem
                 input.busy = false;
             });
         }
+    }
+
+    private getButtons(options?: { isButton?: boolean; showBackButton?: boolean }): QuickInputButton[] {
+        const buttons: QuickInputButton[] = [];
+        if (options?.showBackButton) {
+            buttons.push(QuickInputButtons.Back);
+        }
+        if (options?.isButton) {
+            buttons.push({
+                iconPath: new ThemeIcon(ThemeIcons.SpinningLoader),
+                tooltip: InterpreterQuickPickList.refreshingInterpreterList,
+            });
+        } else {
+            buttons.push(this.refreshButton);
+        }
+        return buttons;
     }
 
     @captureTelemetry(EventName.SELECT_INTERPRETER_ENTER_BUTTON)

--- a/src/client/interpreter/configuration/types.ts
+++ b/src/client/interpreter/configuration/types.ts
@@ -79,6 +79,11 @@ export interface InterpreterQuickPickParams {
      * Specify `true` to skip showing recommended python interpreter.
      */
     skipRecommended?: boolean;
+
+    /**
+     * Specify `true` to show back button.
+     */
+    showBackButton?: boolean;
 }
 
 export const IInterpreterQuickPick = Symbol('IInterpreterQuickPick');

--- a/src/client/pythonEnvironments/creation/createEnvironment.ts
+++ b/src/client/pythonEnvironments/creation/createEnvironment.ts
@@ -169,7 +169,11 @@ export async function handleCreateEnvironmentCommand(
     const action = await MultiStepNode.run(envTypeStep);
     if (options?.showBackButton) {
         if (action === MultiStepAction.Back || action === MultiStepAction.Cancel) {
-            throw action;
+            result = {
+                path: result?.path,
+                uri: result?.uri,
+                action: action === MultiStepAction.Back ? 'Back' : 'Cancel',
+            };
         }
     }
 

--- a/src/client/pythonEnvironments/creation/createEnvironment.ts
+++ b/src/client/pythonEnvironments/creation/createEnvironment.ts
@@ -1,10 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License
 
-import { Event, EventEmitter, QuickPickItem } from 'vscode';
+import { Event, EventEmitter, QuickInputButtons, QuickPickItem } from 'vscode';
 import { CreateEnv } from '../../common/utils/localize';
-import { showQuickPick } from '../../common/vscodeApis/windowApis';
-import { traceError } from '../../logging';
+import {
+    MultiStepAction,
+    MultiStepNode,
+    showQuickPick,
+    showQuickPickWithBack,
+} from '../../common/vscodeApis/windowApis';
+import { traceError, traceVerbose } from '../../logging';
 import { CreateEnvironmentOptions, CreateEnvironmentProvider, CreateEnvironmentResult } from './types';
 
 const onCreateEnvironmentStartedEvent = new EventEmitter<void>();
@@ -49,6 +54,14 @@ async function createEnvironment(
     try {
         fireStartedEvent();
         result = await provider.createEnvironment(options);
+    } catch (ex) {
+        if (ex === QuickInputButtons.Back) {
+            traceVerbose('Create Env: User clicked back button during environment creation');
+            if (!options.showBackButton) {
+                return undefined;
+            }
+        }
+        throw ex;
     } finally {
         fireExitedEvent(result);
     }
@@ -61,22 +74,37 @@ interface CreateEnvironmentProviderQuickPickItem extends QuickPickItem {
 
 async function showCreateEnvironmentQuickPick(
     providers: readonly CreateEnvironmentProvider[],
+    options?: CreateEnvironmentOptions,
 ): Promise<CreateEnvironmentProvider | undefined> {
     const items: CreateEnvironmentProviderQuickPickItem[] = providers.map((p) => ({
         label: p.name,
         description: p.description,
         id: p.id,
     }));
-    const selected = await showQuickPick(items, {
-        placeHolder: CreateEnv.providersQuickPickPlaceholder,
-        matchOnDescription: true,
-        ignoreFocusOut: true,
-    });
 
-    if (selected) {
-        const selections = providers.filter((p) => p.id === selected.id);
-        if (selections.length > 0) {
-            return selections[0];
+    let selectedItem: CreateEnvironmentProviderQuickPickItem | CreateEnvironmentProviderQuickPickItem[] | undefined;
+
+    if (options?.showBackButton) {
+        selectedItem = await showQuickPickWithBack(items, {
+            placeHolder: CreateEnv.providersQuickPickPlaceholder,
+            matchOnDescription: true,
+            ignoreFocusOut: true,
+        });
+    } else {
+        selectedItem = await showQuickPick(items, {
+            placeHolder: CreateEnv.providersQuickPickPlaceholder,
+            matchOnDescription: true,
+            ignoreFocusOut: true,
+        });
+    }
+
+    if (selectedItem) {
+        const selected = Array.isArray(selectedItem) ? selectedItem[0] : selectedItem;
+        if (selected) {
+            const selections = providers.filter((p) => p.id === selected.id);
+            if (selections.length > 0) {
+                return selections[0];
+            }
         }
     }
     return undefined;
@@ -86,16 +114,64 @@ export async function handleCreateEnvironmentCommand(
     providers: readonly CreateEnvironmentProvider[],
     options?: CreateEnvironmentOptions,
 ): Promise<CreateEnvironmentResult | undefined> {
-    if (providers.length === 1) {
-        return createEnvironment(providers[0], options);
-    }
-    if (providers.length > 1) {
-        const provider = await showCreateEnvironmentQuickPick(providers);
-        if (provider) {
-            return createEnvironment(provider, options);
+    let selectedProvider: CreateEnvironmentProvider | undefined;
+    const envTypeStep = new MultiStepNode(
+        undefined,
+        async (context?: MultiStepAction) => {
+            if (providers.length > 0) {
+                try {
+                    selectedProvider = await showCreateEnvironmentQuickPick(providers, options);
+                } catch (ex) {
+                    if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+                        return ex;
+                    }
+                    throw ex;
+                }
+                if (!selectedProvider) {
+                    return MultiStepAction.Cancel;
+                }
+            } else {
+                traceError('No Environment Creation providers were registered.');
+                if (context === MultiStepAction.Back) {
+                    // There are no providers to select, so just step back.
+                    return MultiStepAction.Back;
+                }
+            }
+            return MultiStepAction.Continue;
+        },
+        undefined,
+    );
+
+    let result: CreateEnvironmentResult | undefined;
+    const createStep = new MultiStepNode(
+        envTypeStep,
+        async (context?: MultiStepAction) => {
+            if (context === MultiStepAction.Back) {
+                // This step is to trigger creation, which can go into other extension.
+                return MultiStepAction.Back;
+            }
+            if (selectedProvider) {
+                try {
+                    result = await createEnvironment(selectedProvider, options);
+                } catch (ex) {
+                    if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+                        return ex;
+                    }
+                    throw ex;
+                }
+            }
+            return MultiStepAction.Continue;
+        },
+        undefined,
+    );
+    envTypeStep.next = createStep;
+
+    const action = await MultiStepNode.run(envTypeStep);
+    if (options?.showBackButton) {
+        if (action === MultiStepAction.Back || action === MultiStepAction.Cancel) {
+            throw action;
         }
-    } else {
-        traceError('No Environment Creation providers were registered.');
     }
-    return undefined;
+
+    return result;
 }

--- a/src/client/pythonEnvironments/creation/provider/condaUtils.ts
+++ b/src/client/pythonEnvironments/creation/provider/condaUtils.ts
@@ -3,11 +3,14 @@
 
 import { CancellationToken, QuickPickItem, Uri } from 'vscode';
 import { Common } from '../../../browser/localize';
+import { Octicons } from '../../../common/constants';
 import { CreateEnv } from '../../../common/utils/localize';
 import { executeCommand } from '../../../common/vscodeApis/commandApis';
-import { showErrorMessage, showQuickPick } from '../../../common/vscodeApis/windowApis';
+import { showErrorMessage, showQuickPickWithBack } from '../../../common/vscodeApis/windowApis';
 import { traceLog } from '../../../logging';
 import { Conda } from '../../common/environmentManagers/conda';
+
+const RECOMMENDED_CONDA_PYTHON = '3.10';
 
 export async function getCondaBaseEnv(): Promise<string | undefined> {
     const conda = await Conda.getConda();
@@ -36,16 +39,21 @@ export async function getCondaBaseEnv(): Promise<string | undefined> {
 }
 
 export async function pickPythonVersion(token?: CancellationToken): Promise<string | undefined> {
-    const items: QuickPickItem[] = ['3.10', '3.9', '3.8', '3.7'].map((v) => ({
-        label: `Python`,
+    const items: QuickPickItem[] = ['3.10', '3.11', '3.9', '3.8', '3.7'].map((v) => ({
+        label: v === RECOMMENDED_CONDA_PYTHON ? `${Octicons.Star} Python` : 'Python',
         description: v,
     }));
-    const version = await showQuickPick(
+    const selection = await showQuickPickWithBack(
         items,
         {
             placeHolder: CreateEnv.Conda.selectPythonQuickPickPlaceholder,
         },
         token,
     );
-    return version?.description;
+
+    if (selection) {
+        return (selection as QuickPickItem).description;
+    }
+
+    return undefined;
 }

--- a/src/client/pythonEnvironments/creation/types.ts
+++ b/src/client/pythonEnvironments/creation/types.ts
@@ -8,6 +8,7 @@ export interface CreateEnvironmentProgress extends Progress<{ message?: string; 
 export interface CreateEnvironmentOptions {
     installPackages?: boolean;
     ignoreSourceControl?: boolean;
+    showBackButton?: boolean;
 }
 
 export interface CreateEnvironmentResult {

--- a/src/client/pythonEnvironments/creation/types.ts
+++ b/src/client/pythonEnvironments/creation/types.ts
@@ -14,6 +14,7 @@ export interface CreateEnvironmentOptions {
 export interface CreateEnvironmentResult {
     path: string | undefined;
     uri: Uri | undefined;
+    action?: 'Back' | 'Cancel';
 }
 
 export interface CreateEnvironmentProvider {

--- a/src/test/pythonEnvironments/creation/createEnvironment.unit.test.ts
+++ b/src/test/pythonEnvironments/creation/createEnvironment.unit.test.ts
@@ -211,4 +211,56 @@ suite('Create Environments Tests', () => {
         assert.isTrue(startedEventTriggered);
         assert.isTrue(exitedEventTriggered);
     });
+
+    test('User clicked Back', async () => {
+        const provider1 = typemoq.Mock.ofType<CreateEnvironmentProvider>();
+        provider1.setup((p) => p.name).returns(() => 'test1');
+        provider1.setup((p) => p.id).returns(() => 'test-id1');
+        provider1.setup((p) => p.description).returns(() => 'test-description1');
+        provider1.setup((p) => p.createEnvironment(typemoq.It.isAny())).returns(() => Promise.resolve(undefined));
+
+        const provider2 = typemoq.Mock.ofType<CreateEnvironmentProvider>();
+        provider2.setup((p) => p.name).returns(() => 'test2');
+        provider2.setup((p) => p.id).returns(() => 'test-id2');
+        provider2.setup((p) => p.description).returns(() => 'test-description2');
+        provider2.setup((p) => p.createEnvironment(typemoq.It.isAny())).returns(() => Promise.resolve(undefined));
+
+        showQuickPickWithBackStub.returns(Promise.reject(windowApis.MultiStepAction.Back));
+
+        provider1.setup((p) => (p as any).then).returns(() => undefined);
+        provider2.setup((p) => (p as any).then).returns(() => undefined);
+        const result = await handleCreateEnvironmentCommand([provider1.object, provider2.object], {
+            showBackButton: true,
+        });
+
+        assert.deepStrictEqual(result, { path: undefined, uri: undefined, action: 'Back' });
+        assert.isTrue(showQuickPickStub.notCalled);
+        assert.isTrue(showQuickPickWithBackStub.calledOnce);
+    });
+
+    test('User pressed Escape', async () => {
+        const provider1 = typemoq.Mock.ofType<CreateEnvironmentProvider>();
+        provider1.setup((p) => p.name).returns(() => 'test1');
+        provider1.setup((p) => p.id).returns(() => 'test-id1');
+        provider1.setup((p) => p.description).returns(() => 'test-description1');
+        provider1.setup((p) => p.createEnvironment(typemoq.It.isAny())).returns(() => Promise.resolve(undefined));
+
+        const provider2 = typemoq.Mock.ofType<CreateEnvironmentProvider>();
+        provider2.setup((p) => p.name).returns(() => 'test2');
+        provider2.setup((p) => p.id).returns(() => 'test-id2');
+        provider2.setup((p) => p.description).returns(() => 'test-description2');
+        provider2.setup((p) => p.createEnvironment(typemoq.It.isAny())).returns(() => Promise.resolve(undefined));
+
+        showQuickPickWithBackStub.returns(Promise.reject(windowApis.MultiStepAction.Cancel));
+
+        provider1.setup((p) => (p as any).then).returns(() => undefined);
+        provider2.setup((p) => (p as any).then).returns(() => undefined);
+        const result = await handleCreateEnvironmentCommand([provider1.object, provider2.object], {
+            showBackButton: true,
+        });
+
+        assert.deepStrictEqual(result, { path: undefined, uri: undefined, action: 'Cancel' });
+        assert.isTrue(showQuickPickStub.notCalled);
+        assert.isTrue(showQuickPickWithBackStub.calledOnce);
+    });
 });

--- a/src/test/pythonEnvironments/creation/createEnvironment.unit.test.ts
+++ b/src/test/pythonEnvironments/creation/createEnvironment.unit.test.ts
@@ -16,12 +16,14 @@ chaiUse(chaiAsPromised);
 
 suite('Create Environments Tests', () => {
     let showQuickPickStub: sinon.SinonStub;
+    let showQuickPickWithBackStub: sinon.SinonStub;
     const disposables: IDisposableRegistry = [];
     let startedEventTriggered = false;
     let exitedEventTriggered = false;
 
     setup(() => {
         showQuickPickStub = sinon.stub(windowApis, 'showQuickPick');
+        showQuickPickWithBackStub = sinon.stub(windowApis, 'showQuickPickWithBack');
         startedEventTriggered = false;
         exitedEventTriggered = false;
         disposables.push(
@@ -55,6 +57,25 @@ suite('Create Environments Tests', () => {
 
         assert.isTrue(startedEventTriggered);
         assert.isTrue(exitedEventTriggered);
+        assert.isTrue(showQuickPickWithBackStub.notCalled);
+        provider.verifyAll();
+    });
+
+    test('Successful environment creation with Back', async () => {
+        const provider = typemoq.Mock.ofType<CreateEnvironmentProvider>();
+        provider.setup((p) => p.name).returns(() => 'test');
+        provider.setup((p) => p.id).returns(() => 'test-id');
+        provider.setup((p) => p.description).returns(() => 'test-description');
+        provider.setup((p) => p.createEnvironment(typemoq.It.isAny())).returns(() => Promise.resolve(undefined));
+        provider.setup((p) => (p as any).then).returns(() => undefined);
+
+        showQuickPickWithBackStub.resolves(provider.object);
+
+        await handleCreateEnvironmentCommand([provider.object], { showBackButton: true });
+
+        assert.isTrue(startedEventTriggered);
+        assert.isTrue(exitedEventTriggered);
+        assert.isTrue(showQuickPickStub.notCalled);
         provider.verifyAll();
     });
 
@@ -63,10 +84,27 @@ suite('Create Environments Tests', () => {
         provider.setup((p) => p.name).returns(() => 'test');
         provider.setup((p) => p.id).returns(() => 'test-id');
         provider.setup((p) => p.description).returns(() => 'test-description');
-        provider.setup((p) => p.createEnvironment(typemoq.It.isAny())).returns(() => Promise.reject());
+        provider.setup((p) => p.createEnvironment(typemoq.It.isAny())).returns(() => Promise.reject(new Error('test')));
         provider.setup((p) => (p as any).then).returns(() => undefined);
 
+        showQuickPickStub.resolves(provider.object);
         await assert.isRejected(handleCreateEnvironmentCommand([provider.object]));
+
+        assert.isTrue(startedEventTriggered);
+        assert.isTrue(exitedEventTriggered);
+        provider.verifyAll();
+    });
+
+    test('Environment creation error with Back', async () => {
+        const provider = typemoq.Mock.ofType<CreateEnvironmentProvider>();
+        provider.setup((p) => p.name).returns(() => 'test');
+        provider.setup((p) => p.id).returns(() => 'test-id');
+        provider.setup((p) => p.description).returns(() => 'test-description');
+        provider.setup((p) => p.createEnvironment(typemoq.It.isAny())).returns(() => Promise.reject(new Error('test')));
+        provider.setup((p) => (p as any).then).returns(() => undefined);
+
+        showQuickPickWithBackStub.resolves(provider.object);
+        await assert.isRejected(handleCreateEnvironmentCommand([provider.object], { showBackButton: true }));
 
         assert.isTrue(startedEventTriggered);
         assert.isTrue(exitedEventTriggered);
@@ -77,6 +115,7 @@ suite('Create Environments Tests', () => {
         await handleCreateEnvironmentCommand([]);
 
         assert.isTrue(showQuickPickStub.notCalled);
+        assert.isTrue(showQuickPickWithBackStub.notCalled);
         assert.isFalse(startedEventTriggered);
         assert.isFalse(exitedEventTriggered);
     });
@@ -89,9 +128,11 @@ suite('Create Environments Tests', () => {
         provider.setup((p) => p.createEnvironment(typemoq.It.isAny())).returns(() => Promise.resolve(undefined));
         provider.setup((p) => (p as any).then).returns(() => undefined);
 
+        showQuickPickStub.resolves(provider.object);
         await handleCreateEnvironmentCommand([provider.object]);
 
-        assert.isTrue(showQuickPickStub.notCalled);
+        assert.isTrue(showQuickPickStub.calledOnce);
+        assert.isTrue(showQuickPickWithBackStub.notCalled);
         assert.isTrue(startedEventTriggered);
         assert.isTrue(exitedEventTriggered);
     });
@@ -120,6 +161,53 @@ suite('Create Environments Tests', () => {
         await handleCreateEnvironmentCommand([provider1.object, provider2.object]);
 
         assert.isTrue(showQuickPickStub.calledOnce);
+        assert.isTrue(showQuickPickWithBackStub.notCalled);
+        assert.isTrue(startedEventTriggered);
+        assert.isTrue(exitedEventTriggered);
+    });
+
+    test('Single environment creation provider registered with Back', async () => {
+        const provider = typemoq.Mock.ofType<CreateEnvironmentProvider>();
+        provider.setup((p) => p.name).returns(() => 'test');
+        provider.setup((p) => p.id).returns(() => 'test-id');
+        provider.setup((p) => p.description).returns(() => 'test-description');
+        provider.setup((p) => p.createEnvironment(typemoq.It.isAny())).returns(() => Promise.resolve(undefined));
+        provider.setup((p) => (p as any).then).returns(() => undefined);
+
+        showQuickPickWithBackStub.resolves(provider.object);
+        await handleCreateEnvironmentCommand([provider.object], { showBackButton: true });
+
+        assert.isTrue(showQuickPickStub.notCalled);
+        assert.isTrue(showQuickPickWithBackStub.calledOnce);
+        assert.isTrue(startedEventTriggered);
+        assert.isTrue(exitedEventTriggered);
+    });
+
+    test('Multiple environment creation providers registered with Back', async () => {
+        const provider1 = typemoq.Mock.ofType<CreateEnvironmentProvider>();
+        provider1.setup((p) => p.name).returns(() => 'test1');
+        provider1.setup((p) => p.id).returns(() => 'test-id1');
+        provider1.setup((p) => p.description).returns(() => 'test-description1');
+        provider1.setup((p) => p.createEnvironment(typemoq.It.isAny())).returns(() => Promise.resolve(undefined));
+
+        const provider2 = typemoq.Mock.ofType<CreateEnvironmentProvider>();
+        provider2.setup((p) => p.name).returns(() => 'test2');
+        provider2.setup((p) => p.id).returns(() => 'test-id2');
+        provider2.setup((p) => p.description).returns(() => 'test-description2');
+        provider2.setup((p) => p.createEnvironment(typemoq.It.isAny())).returns(() => Promise.resolve(undefined));
+
+        showQuickPickWithBackStub.resolves({
+            id: 'test-id2',
+            label: 'test2',
+            description: 'test-description2',
+        });
+
+        provider1.setup((p) => (p as any).then).returns(() => undefined);
+        provider2.setup((p) => (p as any).then).returns(() => undefined);
+        await handleCreateEnvironmentCommand([provider1.object, provider2.object], { showBackButton: true });
+
+        assert.isTrue(showQuickPickStub.notCalled);
+        assert.isTrue(showQuickPickWithBackStub.calledOnce);
         assert.isTrue(startedEventTriggered);
         assert.isTrue(exitedEventTriggered);
     });

--- a/src/test/pythonEnvironments/creation/provider/condaCreationProvider.unit.test.ts
+++ b/src/test/pythonEnvironments/creation/provider/condaCreationProvider.unit.test.ts
@@ -64,7 +64,7 @@ suite('Conda Creation provider tests', () => {
         getCondaBaseEnvStub.resolves('/usr/bin/conda');
         pickWorkspaceFolderStub.resolves(undefined);
 
-        assert.isUndefined(await condaProvider.createEnvironment());
+        await assert.isRejected(condaProvider.createEnvironment());
     });
 
     test('No python version picked selected', async () => {

--- a/src/test/pythonEnvironments/creation/provider/venvCreationProvider.unit.test.ts
+++ b/src/test/pythonEnvironments/creation/provider/venvCreationProvider.unit.test.ts
@@ -66,7 +66,7 @@ suite('venv Creation provider tests', () => {
             .setup((i) => i.getInterpreterViaQuickPick(typemoq.It.isAny(), typemoq.It.isAny()))
             .verifiable(typemoq.Times.never());
 
-        assert.isUndefined(await venvProvider.createEnvironment());
+        await assert.isRejected(venvProvider.createEnvironment());
         assert.isTrue(pickWorkspaceFolderStub.calledOnce);
         interpreterQuickPick.verifyAll();
         assert.isTrue(pickPackagesToInstallStub.notCalled);
@@ -80,7 +80,7 @@ suite('venv Creation provider tests', () => {
             .returns(() => Promise.resolve(undefined))
             .verifiable(typemoq.Times.once());
 
-        assert.isUndefined(await venvProvider.createEnvironment());
+        await assert.isRejected(venvProvider.createEnvironment());
 
         assert.isTrue(pickWorkspaceFolderStub.calledOnce);
         interpreterQuickPick.verifyAll();
@@ -97,11 +97,11 @@ suite('venv Creation provider tests', () => {
 
         pickPackagesToInstallStub.resolves(undefined);
 
-        assert.isUndefined(await venvProvider.createEnvironment());
+        await assert.isRejected(venvProvider.createEnvironment());
         assert.isTrue(pickPackagesToInstallStub.calledOnce);
     });
 
-    test('Create venv with python selected by user', async () => {
+    test('Create venv with python selected by user no packages selected', async () => {
         pickWorkspaceFolderStub.resolves(workspace1);
 
         interpreterQuickPick
@@ -109,10 +109,7 @@ suite('venv Creation provider tests', () => {
             .returns(() => Promise.resolve('/usr/bin/python'))
             .verifiable(typemoq.Times.once());
 
-        pickPackagesToInstallStub.resolves({
-            installType: 'none',
-            installList: [],
-        });
+        pickPackagesToInstallStub.resolves([]);
 
         const deferred = createDeferred();
         let _next: undefined | ((value: Output<string>) => void);
@@ -172,10 +169,7 @@ suite('venv Creation provider tests', () => {
             .returns(() => Promise.resolve('/usr/bin/python'))
             .verifiable(typemoq.Times.once());
 
-        pickPackagesToInstallStub.resolves({
-            installType: 'none',
-            installList: [],
-        });
+        pickPackagesToInstallStub.resolves([]);
 
         const deferred = createDeferred();
         let _error: undefined | ((error: unknown) => void);
@@ -229,10 +223,7 @@ suite('venv Creation provider tests', () => {
             .returns(() => Promise.resolve('/usr/bin/python'))
             .verifiable(typemoq.Times.once());
 
-        pickPackagesToInstallStub.resolves({
-            installType: 'none',
-            installList: [],
-        });
+        pickPackagesToInstallStub.resolves([]);
 
         const deferred = createDeferred();
         let _next: undefined | ((value: Output<string>) => void);

--- a/src/test/pythonEnvironments/creation/provider/venvUtils.unit.test.ts
+++ b/src/test/pythonEnvironments/creation/provider/venvUtils.unit.test.ts
@@ -40,10 +40,7 @@ suite('Venv Utils test', () => {
 
         const actual = await pickPackagesToInstall(workspace1);
         assert.isTrue(showQuickPickStub.notCalled);
-        assert.deepStrictEqual(actual, {
-            installType: 'none',
-            installList: [],
-        });
+        assert.deepStrictEqual(actual, []);
     });
 
     test('Toml found with no build system', async () => {
@@ -53,10 +50,7 @@ suite('Venv Utils test', () => {
 
         const actual = await pickPackagesToInstall(workspace1);
         assert.isTrue(showQuickPickStub.notCalled);
-        assert.deepStrictEqual(actual, {
-            installType: 'none',
-            installList: [],
-        });
+        assert.deepStrictEqual(actual, []);
     });
 
     test('Toml found with no optional deps', async () => {
@@ -68,11 +62,12 @@ suite('Venv Utils test', () => {
 
         const actual = await pickPackagesToInstall(workspace1);
         assert.isTrue(showQuickPickStub.notCalled);
-        assert.deepStrictEqual(actual, {
-            installType: 'toml',
-            installList: [],
-            source: path.join(workspace1.uri.fsPath, 'pyproject.toml'),
-        });
+        assert.deepStrictEqual(actual, [
+            {
+                installType: 'toml',
+                source: path.join(workspace1.uri.fsPath, 'pyproject.toml'),
+            },
+        ]);
     });
 
     test('Toml found with deps, but user presses escape', async () => {
@@ -120,11 +115,12 @@ suite('Venv Utils test', () => {
                 undefined,
             ),
         );
-        assert.deepStrictEqual(actual, {
-            installType: 'toml',
-            installList: [],
-            source: path.join(workspace1.uri.fsPath, 'pyproject.toml'),
-        });
+        assert.deepStrictEqual(actual, [
+            {
+                installType: 'toml',
+                source: path.join(workspace1.uri.fsPath, 'pyproject.toml'),
+            },
+        ]);
     });
 
     test('Toml found with dependencies and user selects One', async () => {
@@ -148,11 +144,13 @@ suite('Venv Utils test', () => {
                 undefined,
             ),
         );
-        assert.deepStrictEqual(actual, {
-            installType: 'toml',
-            installList: ['doc'],
-            source: path.join(workspace1.uri.fsPath, 'pyproject.toml'),
-        });
+        assert.deepStrictEqual(actual, [
+            {
+                installType: 'toml',
+                installItem: 'doc',
+                source: path.join(workspace1.uri.fsPath, 'pyproject.toml'),
+            },
+        ]);
     });
 
     test('Toml found with dependencies and user selects Few', async () => {
@@ -176,11 +174,18 @@ suite('Venv Utils test', () => {
                 undefined,
             ),
         );
-        assert.deepStrictEqual(actual, {
-            installType: 'toml',
-            installList: ['test', 'cov'],
-            source: path.join(workspace1.uri.fsPath, 'pyproject.toml'),
-        });
+        assert.deepStrictEqual(actual, [
+            {
+                installType: 'toml',
+                installItem: 'test',
+                source: path.join(workspace1.uri.fsPath, 'pyproject.toml'),
+            },
+            {
+                installType: 'toml',
+                installItem: 'cov',
+                source: path.join(workspace1.uri.fsPath, 'pyproject.toml'),
+            },
+        ]);
     });
 
     test('Requirements found, but user presses escape', async () => {
@@ -245,10 +250,7 @@ suite('Venv Utils test', () => {
                 undefined,
             ),
         );
-        assert.deepStrictEqual(actual, {
-            installType: 'requirements',
-            installList: [],
-        });
+        assert.deepStrictEqual(actual, []);
         assert.isTrue(readFileStub.notCalled);
     });
 
@@ -281,10 +283,12 @@ suite('Venv Utils test', () => {
                 undefined,
             ),
         );
-        assert.deepStrictEqual(actual, {
-            installType: 'requirements',
-            installList: [path.join(workspace1.uri.fsPath, 'requirements.txt')],
-        });
+        assert.deepStrictEqual(actual, [
+            {
+                installType: 'requirements',
+                installItem: path.join(workspace1.uri.fsPath, 'requirements.txt'),
+            },
+        ]);
         assert.isTrue(readFileStub.notCalled);
     });
 
@@ -317,13 +321,16 @@ suite('Venv Utils test', () => {
                 undefined,
             ),
         );
-        assert.deepStrictEqual(actual, {
-            installType: 'requirements',
-            installList: [
-                path.join(workspace1.uri.fsPath, 'dev-requirements.txt'),
-                path.join(workspace1.uri.fsPath, 'test-requirements.txt'),
-            ],
-        });
+        assert.deepStrictEqual(actual, [
+            {
+                installType: 'requirements',
+                installItem: path.join(workspace1.uri.fsPath, 'dev-requirements.txt'),
+            },
+            {
+                installType: 'requirements',
+                installItem: path.join(workspace1.uri.fsPath, 'test-requirements.txt'),
+            },
+        ]);
         assert.isTrue(readFileStub.notCalled);
     });
 });


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/20274


### Usage

This change allows callers of the Create Environment command to handle `Back` and `Cancel`:
``` typescript
let result: CreateEnvironmentResult | undefined;
try {
    const result = await commands.executeCommand("python.createEnvironment", {showBackButton: true});
} catch(e) {
   // error while creating environment
}

if (result?.action === 'Back') {
    // user clicked Back
}

if (result?.action === 'Cancel') {
    // user pressed escape or Cancel
}
```
I decided to go with `result?.action` because we don't have a npm package for python extension API so catching particular exception might be error prone with `ex instanceof <error>`. We will provide a proper interface via `api.environments` for create environment, and contribution to create environment. Until that point this command will provide the stop gap.

### Notes

1. I did not use the multi-step input that is used in the rest of the extension because, the existing implementation does not have context. Consider the following scenario: venv -> workspace select -> python select -> packages. Assume that there is only one workspace, and we don't show the workspace selection UI, that decision is done inside the workspace step. So, if there is only 1 workspace it is a short circuit to next step. User is on python selection and clicks `back`, workspace selection short circuits to next step which is python selection. So, from user perspective, back does not work. This can be fixed by sending context that the reason control moved to previous step was because user clicked on back.
2. This makes a change to old multi step API to rethrow the exception, if user hits `back` and the current step has no steps to go back to.