### PR TITLE
Don't set `formatOnType` for auto-indent experiment if it's already set

### DIFF
--- a/src/client/activation/node/analysisOptions.ts
+++ b/src/client/activation/node/analysisOptions.ts
@@ -43,20 +43,38 @@ export class NodeLanguageServerAnalysisOptions extends LanguageServerAnalysisOpt
     }
 
     private async isAutoIndentEnabled() {
-        const editorConfig = this.getPythonSpecificEditorSection();
-        const formatOnTypeInspect = editorConfig.inspect(FORMAT_ON_TYPE_CONFIG_SETTING);
-        const formatOnTypeSetForPython = formatOnTypeInspect?.globalLanguageValue !== undefined;
+        let editorConfig = this.getPythonSpecificEditorSection();
 
-        const inExperiment = await this.isInAutoIndentExperiment();
-        // only explicitly enable formatOnType for those who are in the experiment
-        // but have not explicitly given a value for the setting
-        if (!formatOnTypeSetForPython && inExperiment) {
-            await NodeLanguageServerAnalysisOptions.setPythonSpecificFormatOnType(editorConfig, true);
+        if (!NodeLanguageServerAnalysisOptions.isConfigSettingSetByUser(editorConfig, FORMAT_ON_TYPE_CONFIG_SETTING)) {
+            const inExperiment = await this.isInAutoIndentExperiment();
+
+            // only explicitly enable formatOnType for those who are in the experiment
+            // but have not explicitly given a value for the setting
+            if (inExperiment) {
+                await NodeLanguageServerAnalysisOptions.setPythonSpecificFormatOnType(editorConfig, true);
+                editorConfig = this.getPythonSpecificEditorSection();
+            }
         }
 
-        const formatOnTypeEffectiveValue = this.getPythonSpecificEditorSection().get(FORMAT_ON_TYPE_CONFIG_SETTING);
+        const formatOnTypeEffectiveValue = editorConfig.get(FORMAT_ON_TYPE_CONFIG_SETTING);
 
         return formatOnTypeEffectiveValue;
+    }
+
+    private static isConfigSettingSetByUser(configuration: WorkspaceConfiguration, setting: string): boolean {
+        const inspect = configuration.inspect(setting);
+        if (inspect === undefined) {
+            return false;
+        }
+
+        return (
+            inspect.globalValue !== undefined ||
+            inspect.workspaceValue !== undefined ||
+            inspect.workspaceFolderValue !== undefined ||
+            inspect.globalLanguageValue !== undefined ||
+            inspect.workspaceLanguageValue !== undefined ||
+            inspect.workspaceFolderLanguageValue !== undefined
+        );
     }
 
     private async isInAutoIndentExperiment(): Promise<boolean> {

--- a/src/client/activation/node/analysisOptions.ts
+++ b/src/client/activation/node/analysisOptions.ts
@@ -45,13 +45,14 @@ export class NodeLanguageServerAnalysisOptions extends LanguageServerAnalysisOpt
     private async isAutoIndentEnabled() {
         let editorConfig = this.getPythonSpecificEditorSection();
 
+        // Only explicitly enable formatOnType for those who are in the experiment
+        // but have not explicitly given a value for the setting
         if (!NodeLanguageServerAnalysisOptions.isConfigSettingSetByUser(editorConfig, FORMAT_ON_TYPE_CONFIG_SETTING)) {
             const inExperiment = await this.isInAutoIndentExperiment();
-
-            // only explicitly enable formatOnType for those who are in the experiment
-            // but have not explicitly given a value for the setting
             if (inExperiment) {
                 await NodeLanguageServerAnalysisOptions.setPythonSpecificFormatOnType(editorConfig, true);
+
+                // Refresh our view of the config settings.
                 editorConfig = this.getPythonSpecificEditorSection();
             }
         }


### PR DESCRIPTION
Fix #20673

This code adds the following to the user's settings.json:

```json
  "[python]": {
    "editor.formatOnType": true
  },
```

Previously we only skipped this if the user had already globally set `formatOnType` for `[python]`.

With this change, we skip it if the user has set `formatOnType` anywhere that impacts the current workspace.