### PR TITLE
Show `Python: Report issue` command in palette regardless of whether a Python file is opened

### DIFF
--- a/package.json
+++ b/package.json
@@ -1620,7 +1620,7 @@
                     "category": "Python",
                     "command": "python.reportIssue",
                     "title": "%python.command.python.reportIssue.title%",
-                    "when": "!virtualWorkspace && shellExecutionSupported && editorLangId == python"
+                    "when": "!virtualWorkspace && shellExecutionSupported"
                 },
                 {
                     "category": "Test",


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/20723