### PR TITLE
Fix debugger attach to process when running on WSL

### DIFF
--- a/src/client/common/process/rawProcessApis.ts
+++ b/src/client/common/process/rawProcessApis.ts
@@ -13,6 +13,8 @@ import { noop } from '../utils/misc';
 import { decodeBuffer } from './decoder';
 import { traceVerbose } from '../../logging';
 
+const PS_ERROR_SCREEN_BOGUS = /your [0-9]+x[0-9]+ screen size is bogus\. expect trouble/;
+
 function getDefaultOptions<T extends ShellOptions | SpawnOptions>(options: T, defaultEnv?: EnvironmentVariables): T {
     const defaultOptions = { ...options };
     const execOptions = defaultOptions as SpawnOptions;
@@ -136,7 +138,13 @@ export function plainExec(
         }
         const stderr: string | undefined =
             stderrBuffers.length === 0 ? undefined : decodeBuffer(stderrBuffers, encoding);
-        if (stderr && stderr.length > 0 && options.throwOnStdErr) {
+        if (
+            stderr &&
+            stderr.length > 0 &&
+            options.throwOnStdErr &&
+            // ignore this specific error silently; see this issue for context: https://github.com/microsoft/vscode/issues/75932
+            !(PS_ERROR_SCREEN_BOGUS.test(stderr) && stderr.replace(PS_ERROR_SCREEN_BOGUS, '').trim().length === 0)
+        ) {
             deferred.reject(new StdErrError(stderr));
         } else {
             let stdout = decodeBuffer(stdoutBuffers, encoding);


### PR DESCRIPTION
Possible fix for https://github.com/microsoft/vscode-python/issues/16921

Closes https://github.com/microsoft/vscode-python/issues/16921

BTW you folks should probably ask GitHub support to eject this repo from their original repository (so it stops being a fork and has its own network on GH)