### PR TITLE
Point to Python v3.11 instead of Python v3.10 when opening windows store

### DIFF
--- a/src/client/interpreter/configuration/interpreterSelector/commands/installPython/index.ts
+++ b/src/client/interpreter/configuration/interpreterSelector/commands/installPython/index.ts
@@ -34,7 +34,7 @@ export class InstallPythonCommand implements IExtensionSingleActivationService {
             if (version.major > 8) {
                 // OS is not Windows 8, ms-windows-store URIs are available:
                 // https://docs.microsoft.com/en-us/windows/uwp/launch-resume/launch-store-app
-                this.browserService.launch('ms-windows-store://pdp/?ProductId=9PJPW5LDXLZ5');
+                this.browserService.launch('ms-windows-store://pdp/?ProductId=9NRWMJP3717K');
                 return;
             }
         }


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/20736