### PR TITLE
Ensure picker returns array only if multi-select is enabled

### DIFF
--- a/src/client/common/vscodeApis/windowApis.ts
+++ b/src/client/common/vscodeApis/windowApis.ts
@@ -112,7 +112,12 @@ export async function showQuickPickWithBack<T extends QuickPickItem>(
         }),
         quickPick.onDidAccept(() => {
             if (!deferred.completed) {
-                deferred.resolve(quickPick.selectedItems.map((item) => item));
+                if (quickPick.canSelectMany) {
+                    deferred.resolve(quickPick.selectedItems.map((item) => item));
+                } else {
+                    deferred.resolve(quickPick.selectedItems[0]);
+                }
+
                 quickPick.hide();
             }
         }),

--- a/src/test/pythonEnvironments/creation/provider/condaUtils.unit.test.ts
+++ b/src/test/pythonEnvironments/creation/provider/condaUtils.unit.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { assert } from 'chai';
+import * as sinon from 'sinon';
+import { CancellationTokenSource } from 'vscode';
+import * as windowApis from '../../../../client/common/vscodeApis/windowApis';
+import { pickPythonVersion } from '../../../../client/pythonEnvironments/creation/provider/condaUtils';
+
+suite('Conda Utils test', () => {
+    let showQuickPickWithBackStub: sinon.SinonStub;
+
+    setup(() => {
+        showQuickPickWithBackStub = sinon.stub(windowApis, 'showQuickPickWithBack');
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('No version selected or user pressed escape', async () => {
+        showQuickPickWithBackStub.resolves(undefined);
+
+        const actual = await pickPythonVersion();
+        assert.isUndefined(actual);
+    });
+
+    test('User selected a version', async () => {
+        showQuickPickWithBackStub.resolves({ label: 'Python', description: '3.10' });
+
+        const actual = await pickPythonVersion();
+        assert.equal(actual, '3.10');
+    });
+
+    test('With cancellation', async () => {
+        const source = new CancellationTokenSource();
+
+        showQuickPickWithBackStub.callsFake(() => {
+            source.cancel();
+        });
+
+        const actual = await pickPythonVersion(source.token);
+        assert.isUndefined(actual);
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-python/issues/20768