### PR TITLE
Increase timeout of running `interpreterInfo.py` script on CI

### DIFF
--- a/src/client/proposedApi.ts
+++ b/src/client/proposedApi.ts
@@ -149,6 +149,7 @@ export function buildProposedApi(
             }
             if (e.old) {
                 if (e.new) {
+                    traceVerbose('Python API env change detected', env.id, 'update');
                     onEnvironmentsChanged.fire({ type: 'update', env: convertEnvInfoAndGetReference(e.new) });
                     reportInterpretersChanged([
                         {
@@ -157,6 +158,7 @@ export function buildProposedApi(
                         },
                     ]);
                 } else {
+                    traceVerbose('Python API env change detected', env.id, 'remove');
                     onEnvironmentsChanged.fire({ type: 'remove', env: convertEnvInfoAndGetReference(e.old) });
                     reportInterpretersChanged([
                         {
@@ -166,6 +168,7 @@ export function buildProposedApi(
                     ]);
                 }
             } else if (e.new) {
+                traceVerbose('Python API env change detected', env.id, 'add');
                 onEnvironmentsChanged.fire({ type: 'add', env: convertEnvInfoAndGetReference(e.new) });
                 reportInterpretersChanged([
                     {

--- a/src/client/pythonEnvironments/base/info/interpreter.ts
+++ b/src/client/pythonEnvironments/base/info/interpreter.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { PythonExecutableInfo, PythonVersion } from '.';
+import { isCI } from '../../../common/constants';
 import {
     interpreterInfo as getInterpreterInfoCommand,
     InterpreterInfoJson,
@@ -80,13 +81,15 @@ export async function getInterpreterInfo(
         '',
     );
 
+    // Sometimes on CI, the python process takes a long time to start up. This is a workaround for that.
+    const standardTimeout = isCI ? 30000 : 15000;
     // Try shell execing the command, followed by the arguments. This will make node kill the process if it
     // takes too long.
     // Sometimes the python path isn't valid, timeout if that's the case.
     // See these two bugs:
     // https://github.com/microsoft/vscode-python/issues/7569
     // https://github.com/microsoft/vscode-python/issues/7760
-    const result = await shellExecute(quoted, { timeout: timeout ?? 15000 });
+    const result = await shellExecute(quoted, { timeout: timeout ?? standardTimeout });
     if (result.stderr) {
         traceError(
             `Stderr when executing script with >> ${quoted} << stderr: ${result.stderr}, still attempting to parse output`,

--- a/src/client/pythonEnvironments/base/locators/composite/envsCollectionCache.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/envsCollectionCache.ts
@@ -5,7 +5,7 @@ import { Event } from 'vscode';
 import { isTestExecution } from '../../../../common/constants';
 import { traceInfo, traceVerbose } from '../../../../logging';
 import { arePathsSame, getFileInfo, pathExists } from '../../../common/externalDependencies';
-import { PythonEnvInfo, PythonEnvKind } from '../../info';
+import { PythonEnvInfo } from '../../info';
 import { areEnvsDeepEqual, areSameEnv, getEnvPath } from '../../info/env';
 import {
     BasicPythonEnvCollectionChangedEvent,

--- a/src/client/pythonEnvironments/base/locators/composite/envsCollectionCache.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/envsCollectionCache.ts
@@ -5,7 +5,7 @@ import { Event } from 'vscode';
 import { isTestExecution } from '../../../../common/constants';
 import { traceInfo, traceVerbose } from '../../../../logging';
 import { arePathsSame, getFileInfo, pathExists } from '../../../common/externalDependencies';
-import { PythonEnvInfo } from '../../info';
+import { PythonEnvInfo, PythonEnvKind } from '../../info';
 import { areEnvsDeepEqual, areSameEnv, getEnvPath } from '../../info/env';
 import {
     BasicPythonEnvCollectionChangedEvent,
@@ -126,6 +126,7 @@ export class PythonEnvInfoCache extends PythonEnvsWatcher<PythonEnvCollectionCha
             .reverse(); // Reversed so indexes do not change when deleting
         invalidIndexes.forEach((index) => {
             const env = this.envs.splice(index, 1)[0];
+            traceVerbose(`Removing invalid env from cache ${env.id}`);
             this.fire({ old: env, new: undefined });
         });
         if (envs) {


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/20292

- Increase timeout for CI
- Add verbose logging for change events fired related to envs