### PR TITLE
Fix ability to recognize extensions which access environment API

### DIFF
--- a/src/client/proposedApi.ts
+++ b/src/client/proposedApi.ts
@@ -125,20 +125,16 @@ export function buildProposedApi(
     const extensions = serviceContainer.get<IExtensions>(IExtensions);
     const envVarsProvider = serviceContainer.get<IEnvironmentVariablesProvider>(IEnvironmentVariablesProvider);
     function sendApiTelemetry(apiName: string, args?: unknown) {
-        setTimeout(() =>
-            extensions
-                .determineExtensionFromCallStack()
-                .then((info) => {
-                    sendTelemetryEvent(EventName.PYTHON_ENVIRONMENTS_API, undefined, {
-                        apiName,
-                        extensionId: info.extensionId,
-                    });
-                    traceVerbose(
-                        `Extension ${info.extensionId} accessed ${apiName} with args: ${JSON.stringify(args)}`,
-                    );
-                })
-                .ignoreErrors(),
-        );
+        extensions
+            .determineExtensionFromCallStack()
+            .then((info) => {
+                sendTelemetryEvent(EventName.PYTHON_ENVIRONMENTS_API, undefined, {
+                    apiName,
+                    extensionId: info.extensionId,
+                });
+                traceVerbose(`Extension ${info.extensionId} accessed ${apiName} with args: ${JSON.stringify(args)}`);
+            })
+            .ignoreErrors();
     }
     disposables.push(
         discoveryApi.onChanged((e) => {

--- a/src/test/proposedApi.unit.test.ts
+++ b/src/test/proposedApi.unit.test.ts
@@ -99,6 +99,8 @@ suite('Proposed Extension API', () => {
     });
 
     teardown(() => {
+        // Verify each API method sends telemetry regarding who called the API.
+        extensions.verifyAll();
         sinon.restore();
     });
 


### PR DESCRIPTION
Follow up from https://github.com/microsoft/vscode-python/pull/20222.

Apparently `setTimeout` changed the stack in such a way that we were unable to recognize which extension called the API:
```
[DEBUG 2023-2-2 16:21:9.641]: Extension unknown accessed getActiveEnvironmentPath with args: undefined
```
Reverting the change.