### PR TITLE
Do not use `-I` flag in case we're unable to find `encodings` module when validating python

### DIFF
--- a/src/client/pythonEnvironments/base/info/environmentInfoService.ts
+++ b/src/client/pythonEnvironments/base/info/environmentInfoService.ts
@@ -169,11 +169,16 @@ class EnvironmentInfoService implements IEnvironmentInfoService {
                     return undefined;
                 });
             } else if (reason) {
-                if (reason.message.includes('Unknown option: -I')) {
+                if (
+                    reason.message.includes('Unknown option: -I') ||
+                    reason.message.includes("ModuleNotFoundError: No module named 'encodings'")
+                ) {
                     traceWarn(reason);
-                    traceError(
-                        'Support for Python 2.7 has been dropped by the Python extension so certain features may not work, upgrade to using Python 3.',
-                    );
+                    if (reason.message.includes('Unknown option: -I')) {
+                        traceError(
+                            'Support for Python 2.7 has been dropped by the Python extension so certain features may not work, upgrade to using Python 3.',
+                        );
+                    }
                     return buildEnvironmentInfo(env, false).catch((err) => {
                         traceError(err);
                         return undefined;


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/20793