### PR TITLE
Fixed a bug where pylance not working on interactive window.

### DIFF
--- a/src/client/activation/languageClientMiddleware.ts
+++ b/src/client/activation/languageClientMiddleware.ts
@@ -42,7 +42,7 @@ export class LanguageClientMiddleware extends LanguageClientMiddlewareBase {
         );
     }
 
-    private shouldCreateHidingMiddleware(jupyterDependencyManager: IJupyterExtensionDependencyManager): boolean {
+    protected shouldCreateHidingMiddleware(jupyterDependencyManager: IJupyterExtensionDependencyManager): boolean {
         return jupyterDependencyManager && jupyterDependencyManager.isJupyterExtensionInstalled;
     }
 

--- a/src/client/activation/node/languageClientMiddleware.ts
+++ b/src/client/activation/node/languageClientMiddleware.ts
@@ -44,6 +44,11 @@ export class NodeLanguageClientMiddleware extends LanguageClientMiddleware {
         }
     }
 
+    // eslint-disable-next-line class-methods-use-this
+    protected shouldCreateHidingMiddleware(_: IJupyterExtensionDependencyManager): boolean {
+        return false;
+    }
+
     protected async onExtensionChange(jupyterDependencyManager: IJupyterExtensionDependencyManager): Promise<void> {
         if (jupyterDependencyManager && jupyterDependencyManager.isJupyterExtensionInstalled) {
             await this.lspNotebooksExperiment.onJupyterInstalled();


### PR DESCRIPTION
https://github.com/microsoft/vscode-python/pull/20816/files#diff-ba59d9ca0a087381d63119a88751fdc7c0aa07e6a10e772d3aefd4c10aa36fcfL47

this should have changed to return `false` rather than deleting since it would have been always return `false`. deleting effectively made it to have the same effect as always returning `true`

follow up PR of https://github.com/microsoft/vscode-python/pull/20816