### PR TITLE
Share telemetry from core extension.

### DIFF
--- a/src/client/browser/api.ts
+++ b/src/client/browser/api.ts
@@ -6,21 +6,17 @@
 import { BaseLanguageClient } from 'vscode-languageclient';
 import { LanguageClient } from 'vscode-languageclient/browser';
 import { PYTHON_LANGUAGE } from '../common/constants';
+import { ApiForPylance, TelemetryReporter } from '../pylanceApi';
 
 export interface IBrowserExtensionApi {
     /**
      * @deprecated Temporarily exposed for Pylance until we expose this API generally. Will be removed in an
      * iteration or two.
      */
-    pylance: {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        createClient(...args: any[]): BaseLanguageClient;
-        start(client: BaseLanguageClient): Promise<void>;
-        stop(client: BaseLanguageClient): Promise<void>;
-    };
+    pylance: ApiForPylance;
 }
 
-export function buildApi(): IBrowserExtensionApi {
+export function buildApi(reporter: TelemetryReporter): IBrowserExtensionApi {
     const api: IBrowserExtensionApi = {
         pylance: {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -28,6 +24,7 @@ export function buildApi(): IBrowserExtensionApi {
                 new LanguageClient(PYTHON_LANGUAGE, 'Python Language Server', args[0], args[1]),
             start: (client: BaseLanguageClient): Promise<void> => client.start(),
             stop: (client: BaseLanguageClient): Promise<void> => client.stop(),
+            getTelemetryReporter: () => reporter,
         },
     };
 

--- a/src/client/browser/extension.ts
+++ b/src/client/browser/extension.ts
@@ -21,10 +21,12 @@ let languageClient: LanguageClient | undefined;
 let pylanceApi: PylanceApi | undefined;
 
 export async function activate(context: vscode.ExtensionContext): Promise<IBrowserExtensionApi> {
+    const reporter = getTelemetryReporter();
+
     const pylanceExtension = vscode.extensions.getExtension<PylanceApi>(PYLANCE_EXTENSION_ID);
     if (pylanceExtension) {
         await runPylance(context, pylanceExtension);
-        return buildApi();
+        return buildApi(reporter);
     }
 
     const changeDisposable = vscode.extensions.onDidChange(async () => {
@@ -35,7 +37,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IBrows
         }
     });
 
-    return buildApi();
+    return buildApi(reporter);
 }
 
 export async function deactivate(): Promise<void> {

--- a/src/client/pylanceApi.ts
+++ b/src/client/pylanceApi.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { TelemetryEventMeasurements, TelemetryEventProperties } from '@vscode/extension-telemetry';
+import { BaseLanguageClient } from 'vscode-languageclient';
+
+export interface TelemetryReporter {
+    sendTelemetryEvent(
+        eventName: string,
+        properties?: TelemetryEventProperties,
+        measurements?: TelemetryEventMeasurements,
+    ): void;
+    sendTelemetryErrorEvent(
+        eventName: string,
+        properties?: TelemetryEventProperties,
+        measurements?: TelemetryEventMeasurements,
+    ): void;
+}
+
+export interface ApiForPylance {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    createClient(...args: any[]): BaseLanguageClient;
+    start(client: BaseLanguageClient): Promise<void>;
+    stop(client: BaseLanguageClient): Promise<void>;
+    getTelemetryReporter(): TelemetryReporter;
+}

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -76,7 +76,7 @@ export function _resetSharedProperties(): void {
 }
 
 let telemetryReporter: TelemetryReporter | undefined;
-function getTelemetryReporter() {
+export function getTelemetryReporter(): TelemetryReporter {
     if (!isTestExecution() && telemetryReporter) {
         return telemetryReporter;
     }


### PR DESCRIPTION
it turns out the new telemetry API removed a way to set extension id and version when telemetry reporter is created and it implicitly sets from extension reporter is created. the same way how LSP client is working.

since we want to keep using the same extension id and etc for our telemetry, we need the reporter created from core ext.
