### PR TITLE
Make sure we delay start pylance server

### DIFF
--- a/src/client/browser/extension.ts
+++ b/src/client/browser/extension.ts
@@ -20,16 +20,15 @@ interface BrowserConfig {
 let languageClient: LanguageClient | undefined;
 let pylanceApi: PylanceApi | undefined;
 
-export async function activate(context: vscode.ExtensionContext): Promise<IBrowserExtensionApi> {
+export function activate(context: vscode.ExtensionContext): Promise<IBrowserExtensionApi> {
     const reporter = getTelemetryReporter();
 
+    const activationPromise = Promise.resolve(buildApi(reporter));
     const pylanceExtension = vscode.extensions.getExtension<PylanceApi>(PYLANCE_EXTENSION_ID);
     if (pylanceExtension) {
-        const promise = Promise.resolve(buildApi(reporter));
-
         // Make sure we run pylance once we activated core extension.
-        promise.then(() => runPylance(context, pylanceExtension));
-        return promise;
+        activationPromise.then(() => runPylance(context, pylanceExtension));
+        return activationPromise;
     }
 
     const changeDisposable = vscode.extensions.onDidChange(async () => {
@@ -40,7 +39,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IBrows
         }
     });
 
-    return buildApi(reporter);
+    return activationPromise;
 }
 
 export async function deactivate(): Promise<void> {

--- a/src/client/browser/extension.ts
+++ b/src/client/browser/extension.ts
@@ -25,8 +25,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<IBrows
 
     const pylanceExtension = vscode.extensions.getExtension<PylanceApi>(PYLANCE_EXTENSION_ID);
     if (pylanceExtension) {
-        await runPylance(context, pylanceExtension);
-        return buildApi(reporter);
+        const promise = Promise.resolve(buildApi(reporter));
+
+        // Make sure we run pylance once we activated core extension.
+        promise.then(() => runPylance(context, pylanceExtension));
+        return promise;
     }
 
     const changeDisposable = vscode.extensions.onDidChange(async () => {


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python/issues/20909

Activating `pylance` extension inside of `python` extension cause a dead lock since they have circular dependency. now we make sure we activate `pylance` once `python` extension is activated.

`node` already works this way. it is just browser extension that started `pylance` inside `activate` directly.