### PR TITLE
Fix diagnostic to use "System32" instead of "SystemRoot"

### DIFF
--- a/src/test/application/diagnostics/checks/pythonInterpreter.unit.test.ts
+++ b/src/test/application/diagnostics/checks/pythonInterpreter.unit.test.ts
@@ -280,6 +280,7 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
             processService
                 .setup((p) => p.shellExec(typemoq.It.isAny(), typemoq.It.isAny()))
                 .returns(() => Promise.reject({ errno: -4058 }));
+            process.env.Path = 'C:\\Windows\\System32';
             const diagnostics = await diagnosticService._manualDiagnose(undefined);
             expect(diagnostics).to.be.deep.equal(
                 [new DefaultShellDiagnostic(DiagnosticCodes.DefaultShellErrorDiagnostic, undefined)],


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/16692
Follow up to https://github.com/microsoft/vscode-python/pull/20927