### PR TITLE
Do not deprecate `python.terminal.activateEnvironmentInTerminal` setting along with terminal env var experiment

### DIFF
--- a/src/client/common/terminal/activator/index.ts
+++ b/src/client/common/terminal/activator/index.ts
@@ -5,8 +5,7 @@
 
 import { inject, injectable, multiInject } from 'inversify';
 import { Terminal } from 'vscode';
-import { inTerminalEnvVarExperiment } from '../../experiments/helpers';
-import { IConfigurationService, IExperimentService } from '../../types';
+import { IConfigurationService } from '../../types';
 import { ITerminalActivationHandler, ITerminalActivator, ITerminalHelper, TerminalActivationOptions } from '../types';
 import { BaseTerminalActivator } from './base';
 
@@ -18,7 +17,6 @@ export class TerminalActivator implements ITerminalActivator {
         @inject(ITerminalHelper) readonly helper: ITerminalHelper,
         @multiInject(ITerminalActivationHandler) private readonly handlers: ITerminalActivationHandler[],
         @inject(IConfigurationService) private readonly configurationService: IConfigurationService,
-        @inject(IExperimentService) private readonly experimentService: IExperimentService,
     ) {
         this.initialize();
     }
@@ -39,8 +37,7 @@ export class TerminalActivator implements ITerminalActivator {
         options?: TerminalActivationOptions,
     ): Promise<boolean> {
         const settings = this.configurationService.getSettings(options?.resource);
-        const activateEnvironment =
-            settings.terminal.activateEnvironment && !inTerminalEnvVarExperiment(this.experimentService);
+        const activateEnvironment = settings.terminal.activateEnvironment;
         if (!activateEnvironment || options?.hideFromUser) {
             return false;
         }

--- a/src/test/common/terminals/activator/index.unit.test.ts
+++ b/src/test/common/terminals/activator/index.unit.test.ts
@@ -12,12 +12,7 @@ import {
     ITerminalActivator,
     ITerminalHelper,
 } from '../../../../client/common/terminal/types';
-import {
-    IConfigurationService,
-    IExperimentService,
-    IPythonSettings,
-    ITerminalSettings,
-} from '../../../../client/common/types';
+import { IConfigurationService, IPythonSettings, ITerminalSettings } from '../../../../client/common/types';
 
 suite('Terminal Activator', () => {
     let activator: TerminalActivator;
@@ -25,14 +20,12 @@ suite('Terminal Activator', () => {
     let handler1: TypeMoq.IMock<ITerminalActivationHandler>;
     let handler2: TypeMoq.IMock<ITerminalActivationHandler>;
     let terminalSettings: TypeMoq.IMock<ITerminalSettings>;
-    let experimentService: TypeMoq.IMock<IExperimentService>;
     setup(() => {
         baseActivator = TypeMoq.Mock.ofType<ITerminalActivator>();
         terminalSettings = TypeMoq.Mock.ofType<ITerminalSettings>();
         handler1 = TypeMoq.Mock.ofType<ITerminalActivationHandler>();
         handler2 = TypeMoq.Mock.ofType<ITerminalActivationHandler>();
         const configService = TypeMoq.Mock.ofType<IConfigurationService>();
-        experimentService = TypeMoq.Mock.ofType<IExperimentService>();
         configService
             .setup((c) => c.getSettings(TypeMoq.It.isAny()))
             .returns(() => {
@@ -40,17 +33,11 @@ suite('Terminal Activator', () => {
                     terminal: terminalSettings.object,
                 } as unknown) as IPythonSettings;
             });
-        experimentService.setup((e) => e.inExperimentSync(TypeMoq.It.isAny())).returns(() => false);
         activator = new (class extends TerminalActivator {
             protected initialize() {
                 this.baseActivator = baseActivator.object;
             }
-        })(
-            TypeMoq.Mock.ofType<ITerminalHelper>().object,
-            [handler1.object, handler2.object],
-            configService.object,
-            experimentService.object,
-        );
+        })(TypeMoq.Mock.ofType<ITerminalHelper>().object, [handler1.object, handler2.object], configService.object);
     });
     async function testActivationAndHandlers(
         activationSuccessful: boolean,


### PR DESCRIPTION
I initially deprecated this setting as I thought folks only disabled it because we were sending commands which was annoying.