### PR TITLE
Fix UUID unittest

### DIFF
--- a/src/client/testing/testController/common/server.ts
+++ b/src/client/testing/testController/common/server.ts
@@ -87,7 +87,7 @@ export class PythonTestServer implements ITestServer, Disposable {
     }
 
     async sendCommand(options: TestCommandOptions): Promise<void> {
-        const uuid = this.createUUID(options.cwd);
+        const { uuid } = options;
         const spawnOptions: SpawnOptions = {
             token: options.token,
             cwd: options.cwd,

--- a/src/client/testing/testController/common/types.ts
+++ b/src/client/testing/testController/common/types.ts
@@ -146,6 +146,7 @@ export type TestCommandOptions = {
     workspaceFolder: Uri;
     cwd: string;
     command: TestDiscoveryCommand | TestExecutionCommand;
+    uuid: string;
     token?: CancellationToken;
     outChannel?: OutputChannel;
     debugBool?: boolean;

--- a/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
+++ b/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
@@ -43,13 +43,15 @@ export class UnittestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
         const command = buildDiscoveryCommand(unittestArgs);
 
         this.cwd = uri.fsPath;
+        const uuid = this.testServer.createUUID(uri.fsPath);
 
         const options: TestCommandOptions = {
             workspaceFolder: uri,
             command,
             cwd: this.cwd,
+            uuid,
         };
-        const uuid = this.testServer.createUUID(uri.fsPath);
+
         this.promiseMap.set(uuid, deferred);
 
         // Send the test command to the server.

--- a/src/client/testing/testController/unittest/testExecutionAdapter.ts
+++ b/src/client/testing/testController/unittest/testExecutionAdapter.ts
@@ -43,15 +43,17 @@ export class UnittestTestExecutionAdapter implements ITestExecutionAdapter {
 
         const command = buildExecutionCommand(unittestArgs);
         this.cwd = uri.fsPath;
+        const uuid = this.testServer.createUUID(uri.fsPath);
 
         const options: TestCommandOptions = {
             workspaceFolder: uri,
             command,
             cwd: this.cwd,
+            uuid,
             debugBool,
             testIds,
         };
-        const uuid = this.testServer.createUUID(uri.fsPath);
+
         this.promiseMap.set(uuid, deferred);
 
         // send test command to server

--- a/src/test/testing/testController/server.unit.test.ts
+++ b/src/test/testing/testController/server.unit.test.ts
@@ -53,6 +53,7 @@ suite('Python Test Server', () => {
             command: { script: 'myscript', args: ['-foo', 'foo'] },
             workspaceFolder: Uri.file('/foo/bar'),
             cwd: '/foo/bar',
+            uuid: fakeUuid,
         };
 
         server = new PythonTestServer(stubExecutionFactory, debugLauncher);
@@ -75,6 +76,7 @@ suite('Python Test Server', () => {
             command: { script: 'myscript', args: ['-foo', 'foo'] },
             workspaceFolder: Uri.file('/foo/bar'),
             cwd: '/foo/bar',
+            uuid: fakeUuid,
             outChannel,
         };
 
@@ -101,6 +103,7 @@ suite('Python Test Server', () => {
             command: { script: 'myscript', args: ['-foo', 'foo'] },
             workspaceFolder: Uri.file('/foo/bar'),
             cwd: '/foo/bar',
+            uuid: fakeUuid,
         };
 
         server = new PythonTestServer(stubExecutionFactory, debugLauncher);
@@ -122,6 +125,7 @@ suite('Python Test Server', () => {
             command: { script: 'myscript', args: ['-foo', 'foo'] },
             workspaceFolder: Uri.file('/foo/bar'),
             cwd: '/foo/bar',
+            uuid: fakeUuid,
         };
 
         let response;
@@ -163,6 +167,7 @@ suite('Python Test Server', () => {
             command: { script: 'myscript', args: ['-foo', 'foo'] },
             workspaceFolder: Uri.file('/foo/bar'),
             cwd: '/foo/bar',
+            uuid: fakeUuid,
         };
 
         let response;
@@ -205,6 +210,7 @@ suite('Python Test Server', () => {
             command: { script: 'myscript', args: ['-foo', 'foo'] },
             workspaceFolder: Uri.file('/foo/bar'),
             cwd: '/foo/bar',
+            uuid: '987654321',
         };
 
         let response;
@@ -246,6 +252,7 @@ suite('Python Test Server', () => {
             command: { script: 'myscript', args: ['-foo', 'foo'] },
             workspaceFolder: Uri.file('/foo/bar'),
             cwd: '/foo/bar',
+            uuid: fakeUuid,
         };
 
         let response;

--- a/src/test/testing/testController/server.unit.test.ts
+++ b/src/test/testing/testController/server.unit.test.ts
@@ -48,7 +48,7 @@ suite('Python Test Server', () => {
         server.dispose();
     });
 
-    test('sendCommand should add the port and uuid to the command being sent', async () => {
+    test('sendCommand should add the port to the command being sent', async () => {
         const options = {
             command: { script: 'myscript', args: ['-foo', 'foo'] },
             workspaceFolder: Uri.file('/foo/bar'),
@@ -119,48 +119,6 @@ suite('Python Test Server', () => {
         assert.deepStrictEqual(eventData!.errors, ['Failed to execute']);
     });
 
-    test('If the server receives data, it should fire an event if it is a known uuid', async () => {
-        const deferred = createDeferred();
-        const options = {
-            command: { script: 'myscript', args: ['-foo', 'foo'] },
-            workspaceFolder: Uri.file('/foo/bar'),
-            cwd: '/foo/bar',
-            uuid: fakeUuid,
-        };
-
-        let response;
-
-        server = new PythonTestServer(stubExecutionFactory, debugLauncher);
-        await server.serverReady();
-
-        server.onDataReceived(({ data }) => {
-            response = data;
-            deferred.resolve();
-        });
-
-        await server.sendCommand(options);
-
-        // Send data back.
-        const port = server.getPort();
-        const requestOptions = {
-            hostname: 'localhost',
-            method: 'POST',
-            port,
-            headers: { 'Request-uuid': fakeUuid },
-        };
-
-        const request = http.request(requestOptions, (res) => {
-            res.setEncoding('utf8');
-        });
-
-        const postData = JSON.stringify({ status: 'success', uuid: fakeUuid });
-        request.write(postData);
-        request.end();
-
-        await deferred.promise;
-
-        assert.deepStrictEqual(response, postData);
-    });
     test('If the server receives malformed data, it should display a log message, and not fire an event', async () => {
         const deferred = createDeferred();
         const options = {
@@ -202,101 +160,5 @@ suite('Python Test Server', () => {
 
         sinon.assert.calledOnce(traceLogStub);
         assert.deepStrictEqual(response, '');
-    });
-
-    test('If the server receives data, it should not fire an event if it is an unknown uuid', async () => {
-        const deferred = createDeferred();
-        const options = {
-            command: { script: 'myscript', args: ['-foo', 'foo'] },
-            workspaceFolder: Uri.file('/foo/bar'),
-            cwd: '/foo/bar',
-            uuid: '987654321',
-        };
-
-        let response;
-
-        server = new PythonTestServer(stubExecutionFactory, debugLauncher);
-        await server.serverReady();
-
-        server.onDataReceived(({ data }) => {
-            response = data;
-            deferred.resolve();
-        });
-
-        await server.sendCommand(options);
-
-        // Send data back.
-        const port = server.getPort();
-        const requestOptions = {
-            hostname: 'localhost',
-            method: 'POST',
-            port,
-            headers: { 'Request-uuid': fakeUuid },
-        };
-        // request.hasHeader()
-        const request = http.request(requestOptions, (res) => {
-            res.setEncoding('utf8');
-        });
-        const postData = JSON.stringify({ status: 'success', uuid: fakeUuid, payload: 'foo' });
-        request.write(postData);
-        request.end();
-
-        await deferred.promise;
-
-        assert.deepStrictEqual(response, postData);
-    });
-
-    test('If the server receives data, it should not fire an event if there is no uuid', async () => {
-        const deferred = createDeferred();
-        const options = {
-            command: { script: 'myscript', args: ['-foo', 'foo'] },
-            workspaceFolder: Uri.file('/foo/bar'),
-            cwd: '/foo/bar',
-            uuid: fakeUuid,
-        };
-
-        let response;
-
-        server = new PythonTestServer(stubExecutionFactory, debugLauncher);
-        await server.serverReady();
-
-        server.onDataReceived(({ data }) => {
-            response = data;
-            deferred.resolve();
-        });
-
-        await server.sendCommand(options);
-
-        // Send data back.
-        const port = server.getPort();
-        const requestOptions = {
-            hostname: 'localhost',
-            method: 'POST',
-            port,
-            headers: { 'Request-uuid': 'some-other-uuid' },
-        };
-        const requestOptions2 = {
-            hostname: 'localhost',
-            method: 'POST',
-            port,
-            headers: { 'Request-uuid': fakeUuid },
-        };
-        const requestOne = http.request(requestOptions, (res) => {
-            res.setEncoding('utf8');
-        });
-        const postDataOne = JSON.stringify({ status: 'success', uuid: 'some-other-uuid', payload: 'foo' });
-        requestOne.write(postDataOne);
-        requestOne.end();
-
-        const requestTwo = http.request(requestOptions2, (res) => {
-            res.setEncoding('utf8');
-        });
-        const postDataTwo = JSON.stringify({ status: 'success', uuid: fakeUuid, payload: 'foo' });
-        requestTwo.write(postDataTwo);
-        requestTwo.end();
-
-        await deferred.promise;
-
-        assert.deepStrictEqual(response, postDataTwo);
     });
 });

--- a/src/test/testing/testController/unittest/testDiscoveryAdapter.unit.test.ts
+++ b/src/test/testing/testController/unittest/testDiscoveryAdapter.unit.test.ts
@@ -44,6 +44,7 @@ suite('Unittest test discovery adapter', () => {
             workspaceFolder: uri,
             cwd: uri.fsPath,
             command: { script, args: ['--udiscovery', '-v', '-s', '.', '-p', 'test*'] },
+            uuid: '123456789',
         });
     });
 


### PR DESCRIPTION
UUID is now handled by the adapter therefore is added to options sent to the server from the adapter.

Since the UUID is no longer being added by the server, the server tests should no longer test if the server is correctly handling the UUID. This logic is now passed to the adapter and therefore tests related to processing non-existent UUID and UUID not currently active is the adapters role.