### PR TITLE
Add testing for unittest execution python logic

### DIFF
--- a/pythonFiles/tests/unittestadapter/test_execution.py
+++ b/pythonFiles/tests/unittestadapter/test_execution.py
@@ -1,0 +1,71 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from typing import List
+
+import pytest
+
+from pythonFiles.unittestadapter.execution import parse_execution_cli_args, run_tests
+
+TEST_DATA_FOLDER_PATH = 'pythonFiles/tests/unittestadapter/.data'
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        (
+            ['--port', '111', '--uuid', 'fake-uuid', '--testids', 'test_file.test_class.test_method'],
+            (111, "fake-uuid", ["test_file.test_class.test_method"]),
+        ),
+        (
+            ['--port', '111', '--uuid', 'fake-uuid', '--testids', ''],
+            (111, "fake-uuid", [""]),
+        ),
+        (
+            ['--port', '111', '--uuid', 'fake-uuid', '--testids', 'test_file.test_class.test_method', '-v', '-s'],
+            (111, "fake-uuid", ["test_file.test_class.test_method"]),
+        ),
+    ],
+)
+def test_parse_execution_cli_args(args: List[str], expected: List[str]) -> None:
+    """The parse_execution_cli_args function should return values for the port, uuid, and testids arguments
+    when passed as command-line options, and ignore unrecognized arguments.
+    """
+    actual = parse_execution_cli_args(args)
+    assert actual == expected
+
+
+
+def test_no_ids_run() -> None:
+    """This test runs on an empty array of test_ids, therefore it should return
+    an empty dict for the result.
+    """
+    start_dir = TEST_DATA_FOLDER_PATH
+    testids = []
+    pattern = 'discovery_simple*'
+    actual = run_tests(start_dir, testids, pattern, None, 'fake-uuid')
+    assert actual
+    assert all(item in actual for item in ("cwd", "status", "result"))
+    assert actual["status"] == "success"
+    assert actual["cwd"] == '/Users/eleanorboyd/vscode-python/pythonFiles/tests/unittestadapter/.data'
+    assert len(actual["result"]) == 0
+
+def test_single_ids_run() -> None:
+    """This test runs on a single test_id, therefore it should return
+    a dict with a single key-value pair for the result. 
+    
+    This single test passes so the outcome should be 'success'.
+    """
+    start_dir = TEST_DATA_FOLDER_PATH
+    id = 'discovery_simple.DiscoverySimple.test_one'
+    testids = [id]
+    pattern = 'discovery_simple*'
+    top_level_dir = None
+    uuid = 'fake-uuid'
+    actual = run_tests(start_dir, testids, pattern, top_level_dir, uuid)
+    assert actual
+    assert all(item in actual for item in ("cwd", "status", "result"))
+    assert actual["status"] == "success"
+    assert actual["cwd"] == '/Users/eleanorboyd/vscode-python/pythonFiles/tests/unittestadapter/.data'
+    assert len(actual["result"]) == 1
+    assert actual["result"][id]
+    assert actual["result"][id]['outcome'] == 'success'

--- a/pythonFiles/tests/unittestadapter/test_execution.py
+++ b/pythonFiles/tests/unittestadapter/test_execution.py
@@ -6,21 +6,38 @@ from typing import List
 import pytest
 from unittestadapter.execution import parse_execution_cli_args, run_tests
 
-TEST_DATA_FOLDER_PATH = 'pythonFiles/tests/unittestadapter/.data'
+TEST_DATA_FOLDER_PATH = "pythonFiles/tests/unittestadapter/.data"
+
 
 @pytest.mark.parametrize(
     "args, expected",
     [
         (
-            ['--port', '111', '--uuid', 'fake-uuid', '--testids', 'test_file.test_class.test_method'],
+            [
+                "--port",
+                "111",
+                "--uuid",
+                "fake-uuid",
+                "--testids",
+                "test_file.test_class.test_method",
+            ],
             (111, "fake-uuid", ["test_file.test_class.test_method"]),
         ),
         (
-            ['--port', '111', '--uuid', 'fake-uuid', '--testids', ''],
+            ["--port", "111", "--uuid", "fake-uuid", "--testids", ""],
             (111, "fake-uuid", [""]),
         ),
         (
-            ['--port', '111', '--uuid', 'fake-uuid', '--testids', 'test_file.test_class.test_method', '-v', '-s'],
+            [
+                "--port",
+                "111",
+                "--uuid",
+                "fake-uuid",
+                "--testids",
+                "test_file.test_class.test_method",
+                "-v",
+                "-s",
+            ],
             (111, "fake-uuid", ["test_file.test_class.test_method"]),
         ),
     ],
@@ -33,38 +50,61 @@ def test_parse_execution_cli_args(args: List[str], expected: List[str]) -> None:
     assert actual == expected
 
 
-
 def test_no_ids_run() -> None:
     """This test runs on an empty array of test_ids, therefore it should return
     an empty dict for the result.
     """
     start_dir = TEST_DATA_FOLDER_PATH
     testids = []
-    pattern = 'discovery_simple*'
-    actual = run_tests(start_dir, testids, pattern, None, 'fake-uuid')
+    pattern = "discovery_simple*"
+    actual = run_tests(start_dir, testids, pattern, None, "fake-uuid")
     assert actual
-    assert all(item in actual for item in ("cwd", "status", "result"))
+    assert all(item in actual for item in ("cwd", "status"))
     assert actual["status"] == "success"
-    assert actual["cwd"] == '/Users/eleanorboyd/vscode-python/pythonFiles/tests/unittestadapter/.data'
-    assert len(actual["result"]) == 0
+    assert (
+        actual["cwd"]
+        == "/Users/eleanorboyd/vscode-python/pythonFiles/tests/unittestadapter/.data"
+    )
+    if "result" in actual:
+        assert len(actual["result"]) == 0
+    else:
+        raise AssertionError("actual['result'] is None")
+
 
 def test_single_ids_run() -> None:
     """This test runs on a single test_id, therefore it should return
-    a dict with a single key-value pair for the result. 
-    
+    a dict with a single key-value pair for the result.
+
     This single test passes so the outcome should be 'success'.
     """
     start_dir = TEST_DATA_FOLDER_PATH
-    id = 'discovery_simple.DiscoverySimple.test_one'
+    id = "discovery_simple.DiscoverySimple.test_one"
     testids = [id]
-    pattern = 'discovery_simple*'
+    pattern = "discovery_simple*"
     top_level_dir = None
-    uuid = 'fake-uuid'
+    uuid = "fake-uuid"
     actual = run_tests(start_dir, testids, pattern, top_level_dir, uuid)
     assert actual
-    assert all(item in actual for item in ("cwd", "status", "result"))
+    assert all(item in actual for item in ("cwd", "status"))
     assert actual["status"] == "success"
-    assert actual["cwd"] == '/Users/eleanorboyd/vscode-python/pythonFiles/tests/unittestadapter/.data'
-    assert len(actual["result"]) == 1
-    assert actual["result"][id]
-    assert actual["result"][id]['outcome'] == 'success'
+    assert (
+        actual["cwd"]
+        == "/Users/eleanorboyd/vscode-python/pythonFiles/tests/unittestadapter/.data"
+    )
+    if "result" in actual:
+        result = actual["result"]
+        assert len(result) == 1
+        if id in result:
+            id_result = result[id]
+            assert id_result is not None
+            if "outcome" in id_result and id_result["outcome"] == "success":
+                # success
+                pass
+            else:
+                raise AssertionError(
+                    "actual['result'][{}]['outcome'] is not 'success'".format(id)
+                )
+        else:
+            raise AssertionError("id not in actual['result']")
+    else:
+        raise AssertionError("actual['result'] is not present")

--- a/pythonFiles/tests/unittestadapter/test_execution.py
+++ b/pythonFiles/tests/unittestadapter/test_execution.py
@@ -76,13 +76,8 @@ def test_single_ids_run() -> None:
 
     This single test passes so the outcome should be 'success'.
     """
-    start_dir: str = os.fspath(TEST_DATA_PATH)
     id = "discovery_simple.DiscoverySimple.test_one"
-    testids = [id]
-    pattern = "discovery_simple*"
-    top_level_dir = None
-    uuid = "fake-uuid"
-    actual = run_tests(start_dir, testids, pattern, top_level_dir, uuid)
+    actual = run_tests(os.fspath(TEST_DATA_PATH), [id], "discovery_simple*", None, "fake-uuid")
     assert actual
     assert all(item in actual for item in ("cwd", "status"))
     assert actual["status"] == "success"

--- a/pythonFiles/tests/unittestadapter/test_execution.py
+++ b/pythonFiles/tests/unittestadapter/test_execution.py
@@ -1,12 +1,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import os
+import pathlib
 from typing import List
 
 import pytest
 from unittestadapter.execution import parse_execution_cli_args, run_tests
 
-TEST_DATA_FOLDER_PATH = "pythonFiles/tests/unittestadapter/.data"
+TEST_DATA_PATH = pathlib.Path(__file__).parent / ".data"
 
 
 @pytest.mark.parametrize(
@@ -54,17 +56,14 @@ def test_no_ids_run() -> None:
     """This test runs on an empty array of test_ids, therefore it should return
     an empty dict for the result.
     """
-    start_dir = TEST_DATA_FOLDER_PATH
+    start_dir: str = os.fspath(TEST_DATA_PATH)
     testids = []
     pattern = "discovery_simple*"
     actual = run_tests(start_dir, testids, pattern, None, "fake-uuid")
     assert actual
     assert all(item in actual for item in ("cwd", "status"))
     assert actual["status"] == "success"
-    assert (
-        actual["cwd"]
-        == "/Users/eleanorboyd/vscode-python/pythonFiles/tests/unittestadapter/.data"
-    )
+    assert actual["cwd"] == os.fspath(TEST_DATA_PATH)
     if "result" in actual:
         assert len(actual["result"]) == 0
     else:
@@ -77,7 +76,7 @@ def test_single_ids_run() -> None:
 
     This single test passes so the outcome should be 'success'.
     """
-    start_dir = TEST_DATA_FOLDER_PATH
+    start_dir: str = os.fspath(TEST_DATA_PATH)
     id = "discovery_simple.DiscoverySimple.test_one"
     testids = [id]
     pattern = "discovery_simple*"
@@ -87,10 +86,7 @@ def test_single_ids_run() -> None:
     assert actual
     assert all(item in actual for item in ("cwd", "status"))
     assert actual["status"] == "success"
-    assert (
-        actual["cwd"]
-        == "/Users/eleanorboyd/vscode-python/pythonFiles/tests/unittestadapter/.data"
-    )
+    assert actual["cwd"] == os.fspath(TEST_DATA_PATH)
     if "result" in actual:
         result = actual["result"]
         assert len(result) == 1

--- a/pythonFiles/tests/unittestadapter/test_execution.py
+++ b/pythonFiles/tests/unittestadapter/test_execution.py
@@ -77,7 +77,9 @@ def test_single_ids_run() -> None:
     This single test passes so the outcome should be 'success'.
     """
     id = "discovery_simple.DiscoverySimple.test_one"
-    actual = run_tests(os.fspath(TEST_DATA_PATH), [id], "discovery_simple*", None, "fake-uuid")
+    actual = run_tests(
+        os.fspath(TEST_DATA_PATH), [id], "discovery_simple*", None, "fake-uuid"
+    )
     assert actual
     assert all(item in actual for item in ("cwd", "status"))
     assert actual["status"] == "success"

--- a/pythonFiles/tests/unittestadapter/test_execution.py
+++ b/pythonFiles/tests/unittestadapter/test_execution.py
@@ -87,20 +87,11 @@ def test_single_ids_run() -> None:
     assert all(item in actual for item in ("cwd", "status"))
     assert actual["status"] == "success"
     assert actual["cwd"] == os.fspath(TEST_DATA_PATH)
-    if "result" in actual:
-        result = actual["result"]
-        assert len(result) == 1
-        if id in result:
-            id_result = result[id]
-            assert id_result is not None
-            if "outcome" in id_result and id_result["outcome"] == "success":
-                # success
-                pass
-            else:
-                raise AssertionError(
-                    "actual['result'][{}]['outcome'] is not 'success'".format(id)
-                )
-        else:
-            raise AssertionError("id not in actual['result']")
-    else:
-        raise AssertionError("actual['result'] is not present")
+    assert "result" in actual
+    result = actual["result"]
+    assert len(result) == 1
+    assert id in result
+    id_result = result[id]
+    assert id_result is not None
+    assert "outcome" in id_result
+    assert id_result["outcome"] == "success"

--- a/pythonFiles/tests/unittestadapter/test_execution.py
+++ b/pythonFiles/tests/unittestadapter/test_execution.py
@@ -4,8 +4,7 @@
 from typing import List
 
 import pytest
-
-from pythonFiles.unittestadapter.execution import parse_execution_cli_args, run_tests
+from unittestadapter.execution import parse_execution_cli_args, run_tests
 
 TEST_DATA_FOLDER_PATH = 'pythonFiles/tests/unittestadapter/.data'
 

--- a/pythonFiles/unittestadapter/execution.py
+++ b/pythonFiles/unittestadapter/execution.py
@@ -206,11 +206,11 @@ def run_tests(
 
     if error is not None:
         payload["error"] = error
+    else:
+        status = TestExecutionStatus.success
 
     payload["status"] = status
-
-    # print(f"payload: \n{json.dumps(payload, indent=4)}")
-
+    
     return payload
 
 

--- a/pythonFiles/unittestadapter/execution.py
+++ b/pythonFiles/unittestadapter/execution.py
@@ -210,7 +210,7 @@ def run_tests(
         status = TestExecutionStatus.success
 
     payload["status"] = status
-    
+
     return payload
 
 


### PR DESCRIPTION
these tests cover:
- parsing execution args for unittest
- test run with no test_ids attached
- test run with single test_id and test is a success.