### PR TITLE
Use new logging API for python extension logger and LS logger

### DIFF
--- a/src/client/activation/common/analysisOptions.ts
+++ b/src/client/activation/common/analysisOptions.ts
@@ -5,7 +5,7 @@ import { DocumentFilter, LanguageClientOptions, RevealOutputChannelOn } from 'vs
 import { IWorkspaceService } from '../../common/application/types';
 
 import { PYTHON, PYTHON_LANGUAGE } from '../../common/constants';
-import { IOutputChannel, Resource } from '../../common/types';
+import { ILogOutputChannel, Resource } from '../../common/types';
 import { debounceSync } from '../../common/utils/decorators';
 import { IEnvironmentVariablesProvider } from '../../common/variables/types';
 import { traceDecoratorError } from '../../logging';
@@ -14,7 +14,7 @@ import { ILanguageServerAnalysisOptions, ILanguageServerOutputChannel } from '..
 
 export abstract class LanguageServerAnalysisOptionsBase implements ILanguageServerAnalysisOptions {
     protected readonly didChange = new EventEmitter<void>();
-    private readonly output: IOutputChannel;
+    private readonly output: ILogOutputChannel;
 
     protected constructor(
         lsOutputChannel: ILanguageServerOutputChannel,

--- a/src/client/activation/common/outputChannel.ts
+++ b/src/client/activation/common/outputChannel.ts
@@ -6,13 +6,13 @@
 import { inject, injectable } from 'inversify';
 import { IApplicationShell, ICommandManager } from '../../common/application/types';
 import '../../common/extensions';
-import { IDisposableRegistry, IOutputChannel } from '../../common/types';
+import { IDisposableRegistry, ILogOutputChannel } from '../../common/types';
 import { OutputChannelNames } from '../../common/utils/localize';
 import { ILanguageServerOutputChannel } from '../types';
 
 @injectable()
 export class LanguageServerOutputChannel implements ILanguageServerOutputChannel {
-    public output: IOutputChannel | undefined;
+    public output: ILogOutputChannel | undefined;
 
     private registered = false;
 
@@ -22,7 +22,7 @@ export class LanguageServerOutputChannel implements ILanguageServerOutputChannel
         @inject(IDisposableRegistry) private readonly disposable: IDisposableRegistry,
     ) {}
 
-    public get channel(): IOutputChannel {
+    public get channel(): ILogOutputChannel {
         if (!this.output) {
             this.output = this.appShell.createOutputChannel(OutputChannelNames.languageServer);
             this.disposable.push(this.output);

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -5,7 +5,7 @@
 
 import { Event } from 'vscode';
 import { LanguageClient, LanguageClientOptions } from 'vscode-languageclient/node';
-import type { IDisposable, IOutputChannel, Resource } from '../common/types';
+import type { IDisposable, ILogOutputChannel, Resource } from '../common/types';
 import { PythonEnvironment } from '../pythonEnvironments/info';
 
 export const IExtensionActivationManager = Symbol('IExtensionActivationManager');
@@ -110,10 +110,10 @@ export interface ILanguageServerOutputChannel {
     /**
      * Creates output channel if necessary and returns it
      *
-     * @type {IOutputChannel}
+     * @type {ILogOutputChannel}
      * @memberof ILanguageServerOutputChannel
      */
-    readonly channel: IOutputChannel;
+    readonly channel: ILogOutputChannel;
 }
 
 export const IExtensionSingleActivationService = Symbol('IExtensionSingleActivationService');

--- a/src/client/common/application/applicationShell.ts
+++ b/src/client/common/application/applicationShell.ts
@@ -14,10 +14,10 @@ import {
     InputBoxOptions,
     languages,
     LanguageStatusItem,
+    LogOutputChannel,
     MessageItem,
     MessageOptions,
     OpenDialogOptions,
-    OutputChannel,
     Progress,
     ProgressOptions,
     QuickPick,
@@ -166,8 +166,8 @@ export class ApplicationShell implements IApplicationShell {
     public createTreeView<T>(viewId: string, options: TreeViewOptions<T>): TreeView<T> {
         return window.createTreeView<T>(viewId, options);
     }
-    public createOutputChannel(name: string): OutputChannel {
-        return window.createOutputChannel(name);
+    public createOutputChannel(name: string): LogOutputChannel {
+        return window.createOutputChannel(name, { log: true });
     }
     public createLanguageStatusItem(id: string, selector: DocumentSelector): LanguageStatusItem {
         return languages.createLanguageStatusItem(id, selector);

--- a/src/client/common/application/types.ts
+++ b/src/client/common/application/types.ts
@@ -25,10 +25,10 @@ import {
     InputBox,
     InputBoxOptions,
     LanguageStatusItem,
+    LogOutputChannel,
     MessageItem,
     MessageOptions,
     OpenDialogOptions,
-    OutputChannel,
     Progress,
     ProgressOptions,
     QuickPick,
@@ -429,7 +429,7 @@ export interface IApplicationShell {
      *
      * @param name Human-readable string which will be used to represent the channel in the UI.
      */
-    createOutputChannel(name: string): OutputChannel;
+    createOutputChannel(name: string): LogOutputChannel;
     createLanguageStatusItem(id: string, selector: DocumentSelector): LanguageStatusItem;
 }
 

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -93,8 +93,6 @@ export namespace ThemeIcons {
 
 export const DEFAULT_INTERPRETER_SETTING = 'python';
 
-export const STANDARD_OUTPUT_CHANNEL = 'STANDARD_OUTPUT_CHANNEL';
-
 export const isCI = process.env.TRAVIS === 'true' || process.env.TF_BUILD !== undefined;
 
 export function isTestExecution(): boolean {

--- a/src/client/common/installer/moduleInstaller.ts
+++ b/src/client/common/installer/moduleInstaller.ts
@@ -12,12 +12,11 @@ import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { IApplicationShell } from '../application/types';
 import { wrapCancellationTokens } from '../cancellation';
-import { STANDARD_OUTPUT_CHANNEL } from '../constants';
 import { IFileSystem } from '../platform/types';
 import * as internalPython from '../process/internal/python';
 import { IProcessServiceFactory } from '../process/types';
 import { ITerminalServiceFactory, TerminalCreationOptions } from '../terminal/types';
-import { ExecutionInfo, IConfigurationService, IOutputChannel, Product } from '../types';
+import { ExecutionInfo, IConfigurationService, ILogOutputChannel, Product } from '../types';
 import { isResource } from '../utils/misc';
 import { ProductNames } from './productNames';
 import { IModuleInstaller, InstallOptions, InterpreterUri, ModuleInstallFlags } from './types';
@@ -152,7 +151,7 @@ export abstract class ModuleInstaller implements IModuleInstaller {
         const options = {
             name: 'VS Code Python',
         };
-        const outputChannel = this.serviceContainer.get<IOutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
+        const outputChannel = this.serviceContainer.get<ILogOutputChannel>(ILogOutputChannel);
         const command = `"${execPath.replace(/\\/g, '/')}" ${args.join(' ')}`;
 
         traceLog(`[Elevated] ${command}`);

--- a/src/client/common/process/rawProcessApis.ts
+++ b/src/client/common/process/rawProcessApis.ts
@@ -121,7 +121,10 @@ export function plainExec(
     }
 
     const stdoutBuffers: Buffer[] = [];
-    on(proc.stdout, 'data', (data: Buffer) => stdoutBuffers.push(data));
+    on(proc.stdout, 'data', (data: Buffer) => {
+        stdoutBuffers.push(data);
+        options.outputChannel?.append(data.toString());
+    });
     const stderrBuffers: Buffer[] = [];
     on(proc.stderr, 'data', (data: Buffer) => {
         if (options.mergeStdOutErr) {
@@ -130,6 +133,7 @@ export function plainExec(
         } else {
             stderrBuffers.push(data);
         }
+        options.outputChannel?.append(data.toString());
     });
 
     proc.once('close', () => {

--- a/src/client/common/process/types.ts
+++ b/src/client/common/process/types.ts
@@ -3,7 +3,7 @@
 
 import { ChildProcess, ExecOptions, SpawnOptions as ChildProcessSpawnOptions } from 'child_process';
 import { Observable } from 'rxjs/Observable';
-import { CancellationToken, Uri } from 'vscode';
+import { CancellationToken, OutputChannel, Uri } from 'vscode';
 import { PythonExecInfo } from '../../pythonEnvironments/exec';
 import { InterpreterInformation, PythonEnvironment } from '../../pythonEnvironments/info';
 import { ExecutionInfo, IDisposable } from '../types';
@@ -24,6 +24,7 @@ export type SpawnOptions = ChildProcessSpawnOptions & {
     mergeStdOutErr?: boolean;
     throwOnStdErr?: boolean;
     extraVariables?: NodeJS.ProcessEnv;
+    outputChannel?: OutputChannel;
 };
 
 export type ShellOptions = ExecOptions & { throwOnStdErr?: boolean };

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -18,6 +18,7 @@ import {
     LogOutputChannel,
     Uri,
     WorkspaceEdit,
+    OutputChannel,
 } from 'vscode';
 import { LanguageServerType } from '../activation/types';
 import type { InstallOptions, InterpreterUri, ModuleInstallFlags } from './installer/types';
@@ -29,8 +30,10 @@ export interface IDisposable {
     dispose(): void | undefined | Promise<void>;
 }
 
-export const IOutputChannel = Symbol('IOutputChannel');
-export interface IOutputChannel extends LogOutputChannel {}
+export const ILogOutputChannel = Symbol('ILogOutputChannel');
+export interface ILogOutputChannel extends LogOutputChannel {}
+export const ITestOutputChannel = Symbol('ITestOutputChannel');
+export interface ITestOutputChannel extends OutputChannel {}
 export const IDocumentSymbolProvider = Symbol('IDocumentSymbolProvider');
 export interface IDocumentSymbolProvider extends DocumentSymbolProvider {}
 export const IsWindows = Symbol('IS_WINDOWS');

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -15,7 +15,7 @@ import {
     Extension,
     ExtensionContext,
     Memento,
-    OutputChannel,
+    LogOutputChannel,
     Uri,
     WorkspaceEdit,
 } from 'vscode';
@@ -30,7 +30,7 @@ export interface IDisposable {
 }
 
 export const IOutputChannel = Symbol('IOutputChannel');
-export interface IOutputChannel extends OutputChannel {}
+export interface IOutputChannel extends LogOutputChannel {}
 export const IDocumentSymbolProvider = Symbol('IDocumentSymbolProvider');
 export interface IDocumentSymbolProvider extends DocumentSymbolProvider {}
 export const IsWindows = Symbol('IS_WINDOWS');

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -3,21 +3,14 @@
 
 'use strict';
 
-import {
-    debug,
-    DebugConfigurationProvider,
-    DebugConfigurationProviderTriggerKind,
-    languages,
-    OutputChannel,
-    window,
-} from 'vscode';
+import { debug, DebugConfigurationProvider, DebugConfigurationProviderTriggerKind, languages, window } from 'vscode';
 
 import { registerTypes as activationRegisterTypes } from './activation/serviceRegistry';
 import { IExtensionActivationManager } from './activation/types';
 import { registerTypes as appRegisterTypes } from './application/serviceRegistry';
 import { IApplicationDiagnostics } from './application/types';
 import { IApplicationEnvironment, ICommandManager, IWorkspaceService } from './common/application/types';
-import { Commands, PYTHON, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL, UseProposedApi } from './common/constants';
+import { Commands, PYTHON, PYTHON_LANGUAGE, UseProposedApi } from './common/constants';
 import { registerTypes as installerRegisterTypes } from './common/installer/serviceRegistry';
 import { IFileSystem } from './common/platform/types';
 import {
@@ -25,7 +18,7 @@ import {
     IDisposableRegistry,
     IExtensions,
     IInterpreterPathService,
-    IOutputChannel,
+    ILogOutputChannel,
     IPathUtils,
 } from './common/types';
 import { noop } from './common/utils/misc';
@@ -173,7 +166,7 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
             const dispatcher = new DebugSessionEventDispatcher(handlers, DebugService.instance, disposables);
             dispatcher.registerEventHandlers();
 
-            const outputChannel = serviceManager.get<OutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
+            const outputChannel = serviceManager.get<ILogOutputChannel>(ILogOutputChannel);
             disposables.push(cmdManager.registerCommand(Commands.ViewOutput, () => outputChannel.show()));
             cmdManager.executeCommand('setContext', 'python.vscode.channel', applicationEnv.channel).then(noop, noop);
 

--- a/src/client/extensionInit.ts
+++ b/src/client/extensionInit.ts
@@ -4,9 +4,8 @@
 'use strict';
 
 import { Container } from 'inversify';
-import { Disposable, LogOutputChannel, Memento, window } from 'vscode';
+import { Disposable, Memento, window } from 'vscode';
 import { instance, mock } from 'ts-mockito';
-import { STANDARD_OUTPUT_CHANNEL } from './common/constants';
 import { registerTypes as platformRegisterTypes } from './common/platform/serviceRegistry';
 import { registerTypes as processRegisterTypes } from './common/process/serviceRegistry';
 import { registerTypes as commonRegisterTypes } from './common/serviceRegistry';
@@ -16,7 +15,8 @@ import {
     IDisposableRegistry,
     IExtensionContext,
     IMemento,
-    IOutputChannel,
+    ILogOutputChannel,
+    ITestOutputChannel,
     WORKSPACE_MEMENTO,
 } from './common/types';
 import { registerTypes as variableRegisterTypes } from './common/variables/serviceRegistry';
@@ -26,7 +26,6 @@ import { ServiceContainer } from './ioc/container';
 import { ServiceManager } from './ioc/serviceManager';
 import { IServiceContainer, IServiceManager } from './ioc/types';
 import * as pythonEnvironments from './pythonEnvironments';
-import { TEST_OUTPUT_CHANNEL } from './testing/constants';
 import { IDiscoveryAPI } from './pythonEnvironments/base/locator';
 import { registerLogger } from './logging';
 import { OutputChannelLogger } from './logging/outputChannelLogger';
@@ -62,16 +61,12 @@ export function initializeGlobals(
     const unitTestOutChannel =
         workspaceService.isVirtualWorkspace || !workspaceService.isTrusted
             ? // Do not create any test related output UI when using virtual workspaces.
-              instance(mock<IOutputChannel>())
-            : window.createOutputChannel(OutputChannelNames.pythonTest, { log: true });
+              instance(mock<ITestOutputChannel>())
+            : window.createOutputChannel(OutputChannelNames.pythonTest);
     disposables.push(unitTestOutChannel);
 
-    serviceManager.addSingletonInstance<LogOutputChannel>(
-        IOutputChannel,
-        standardOutputChannel,
-        STANDARD_OUTPUT_CHANNEL,
-    );
-    serviceManager.addSingletonInstance<LogOutputChannel>(IOutputChannel, unitTestOutChannel, TEST_OUTPUT_CHANNEL);
+    serviceManager.addSingletonInstance<ILogOutputChannel>(ILogOutputChannel, standardOutputChannel);
+    serviceManager.addSingletonInstance<ITestOutputChannel>(ITestOutputChannel, unitTestOutChannel);
 
     return {
         context,

--- a/src/client/linters/errorHandlers/standard.ts
+++ b/src/client/linters/errorHandlers/standard.ts
@@ -1,7 +1,6 @@
 import { l10n, Uri } from 'vscode';
 import { IApplicationShell } from '../../common/application/types';
-import { STANDARD_OUTPUT_CHANNEL } from '../../common/constants';
-import { ExecutionInfo, IOutputChannel } from '../../common/types';
+import { ExecutionInfo, ILogOutputChannel } from '../../common/types';
 import { traceError, traceLog } from '../../logging';
 import { ILinterManager, LinterId } from '../types';
 import { BaseErrorHandler } from './baseErrorHandler';
@@ -29,7 +28,7 @@ export class StandardErrorHandler extends BaseErrorHandler {
     private async displayLinterError(linterId: LinterId) {
         const message = l10n.t("There was an error in running the linter '{0}'", linterId);
         const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
-        const outputChannel = this.serviceContainer.get<IOutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
+        const outputChannel = this.serviceContainer.get<ILogOutputChannel>(ILogOutputChannel);
         const action = await appShell.showErrorMessage(message, 'View Errors');
         if (action === 'View Errors') {
             outputChannel.show();

--- a/src/client/logging/outputChannelLogger.ts
+++ b/src/client/logging/outputChannelLogger.ts
@@ -2,34 +2,29 @@
 // Licensed under the MIT License.
 
 import * as util from 'util';
-import { OutputChannel } from 'vscode';
+import { LogOutputChannel } from 'vscode';
 import { Arguments, ILogging } from './types';
-import { getTimeForLogging } from './util';
-
-function formatMessage(level?: string, ...data: Arguments): string {
-    return level ? `[${level.toUpperCase()} ${getTimeForLogging()}]: ${util.format(...data)}` : util.format(...data);
-}
 
 export class OutputChannelLogger implements ILogging {
-    constructor(private readonly channel: OutputChannel) {}
+    constructor(private readonly channel: LogOutputChannel) {}
 
     public traceLog(...data: Arguments): void {
         this.channel.appendLine(util.format(...data));
     }
 
     public traceError(...data: Arguments): void {
-        this.channel.appendLine(formatMessage('error', ...data));
+        this.channel.error(util.format(...data));
     }
 
     public traceWarn(...data: Arguments): void {
-        this.channel.appendLine(formatMessage('warn', ...data));
+        this.channel.warn(util.format(...data));
     }
 
     public traceInfo(...data: Arguments): void {
-        this.channel.appendLine(formatMessage('info', ...data));
+        this.channel.info(util.format(...data));
     }
 
     public traceVerbose(...data: Arguments): void {
-        this.channel.appendLine(formatMessage('debug', ...data));
+        this.channel.debug(util.format(...data));
     }
 }

--- a/src/client/testing/constants.ts
+++ b/src/client/testing/constants.ts
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-export const TEST_OUTPUT_CHANNEL = 'TEST_OUTPUT_CHANNEL';

--- a/src/client/testing/testController/common/server.ts
+++ b/src/client/testing/testController/common/server.ts
@@ -99,6 +99,7 @@ export class PythonTestServer implements ITestServer, Disposable {
             token: options.token,
             cwd: options.cwd,
             throwOnStdErr: true,
+            outputChannel: options.outChannel,
         };
 
         // Create the Python environment in which to execute the command.

--- a/src/client/testing/testController/controller.ts
+++ b/src/client/testing/testController/controller.ts
@@ -20,7 +20,7 @@ import { IExtensionSingleActivationService } from '../../activation/types';
 import { ICommandManager, IWorkspaceService } from '../../common/application/types';
 import * as constants from '../../common/constants';
 import { IPythonExecutionFactory } from '../../common/process/types';
-import { IConfigurationService, IDisposableRegistry, Resource } from '../../common/types';
+import { IConfigurationService, IDisposableRegistry, ITestOutputChannel, Resource } from '../../common/types';
 import { DelayedTrigger, IDelayedTrigger } from '../../common/utils/delayTrigger';
 import { noop } from '../../common/utils/misc';
 import { IInterpreterService } from '../../interpreter/contracts';
@@ -92,6 +92,7 @@ export class PythonTestController implements ITestController, IExtensionSingleAc
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
         @inject(IPythonExecutionFactory) private readonly pythonExecFactory: IPythonExecutionFactory,
         @inject(ITestDebugLauncher) private readonly debugLauncher: ITestDebugLauncher,
+        @inject(ITestOutputChannel) private readonly testOutputChannel: ITestOutputChannel,
     ) {
         this.refreshCancellation = new CancellationTokenSource();
 
@@ -158,12 +159,28 @@ export class PythonTestController implements ITestController, IExtensionSingleAc
             let executionAdapter: ITestExecutionAdapter;
             let testProvider: TestProvider;
             if (settings.testing.unittestEnabled) {
-                discoveryAdapter = new UnittestTestDiscoveryAdapter(this.pythonTestServer, this.configSettings);
-                executionAdapter = new UnittestTestExecutionAdapter(this.pythonTestServer, this.configSettings);
+                discoveryAdapter = new UnittestTestDiscoveryAdapter(
+                    this.pythonTestServer,
+                    this.configSettings,
+                    this.testOutputChannel,
+                );
+                executionAdapter = new UnittestTestExecutionAdapter(
+                    this.pythonTestServer,
+                    this.configSettings,
+                    this.testOutputChannel,
+                );
                 testProvider = UNITTEST_PROVIDER;
             } else {
-                discoveryAdapter = new PytestTestDiscoveryAdapter(this.pythonTestServer, this.configSettings);
-                executionAdapter = new PytestTestExecutionAdapter(this.pythonTestServer, this.configSettings);
+                discoveryAdapter = new PytestTestDiscoveryAdapter(
+                    this.pythonTestServer,
+                    this.configSettings,
+                    this.testOutputChannel,
+                );
+                executionAdapter = new PytestTestExecutionAdapter(
+                    this.pythonTestServer,
+                    this.configSettings,
+                    this.testOutputChannel,
+                );
                 testProvider = PYTEST_PROVIDER;
             }
 

--- a/src/client/testing/testController/pytest/pytestDiscoveryAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestDiscoveryAdapter.ts
@@ -7,7 +7,7 @@ import {
     IPythonExecutionFactory,
     SpawnOptions,
 } from '../../../common/process/types';
-import { IConfigurationService } from '../../../common/types';
+import { IConfigurationService, ITestOutputChannel } from '../../../common/types';
 import { createDeferred, Deferred } from '../../../common/utils/async';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
 import { traceVerbose } from '../../../logging';
@@ -21,7 +21,11 @@ export class PytestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
 
     private deferred: Deferred<DiscoveredTestPayload> | undefined;
 
-    constructor(public testServer: ITestServer, public configSettings: IConfigurationService) {
+    constructor(
+        public testServer: ITestServer,
+        public configSettings: IConfigurationService,
+        private readonly outputChannel: ITestOutputChannel,
+    ) {
         testServer.onDataReceived(this.onDataReceivedHandler, this);
     }
 
@@ -68,6 +72,7 @@ export class PytestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
                 TEST_UUID: uuid.toString(),
                 TEST_PORT: this.testServer.getPort().toString(),
             },
+            outputChannel: this.outputChannel,
         };
 
         // Create the Python environment in which to execute the command.

--- a/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Uri } from 'vscode';
-import { IConfigurationService } from '../../../common/types';
+import { IConfigurationService, ITestOutputChannel } from '../../../common/types';
 import { createDeferred, Deferred } from '../../../common/utils/async';
 import { traceVerbose } from '../../../logging';
 import { DataReceivedEvent, ExecutionTestPayload, ITestExecutionAdapter, ITestServer } from '../common/types';
@@ -16,7 +16,11 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
 
     private deferred: Deferred<ExecutionTestPayload> | undefined;
 
-    constructor(public testServer: ITestServer, public configSettings: IConfigurationService) {
+    constructor(
+        public testServer: ITestServer,
+        public configSettings: IConfigurationService,
+        private readonly outputChannel: ITestOutputChannel,
+    ) {
         testServer.onDataReceived(this.onDataReceivedHandler, this);
     }
 
@@ -31,6 +35,8 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
     // ** Old version of discover tests.
     async runTests(uri: Uri, testIds: string[], debugBool?: boolean): Promise<ExecutionTestPayload> {
         traceVerbose(uri, testIds, debugBool);
+        // TODO:Remove this line after enabling runs
+        this.outputChannel.appendLine('Running tests.');
         this.deferred = createDeferred<ExecutionTestPayload>();
         return this.deferred.promise;
     }
@@ -62,6 +68,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
 //                 TEST_UUID: uuid.toString(),
 //                 TEST_PORT: this.testServer.getPort().toString(),
 //             },
+//             outputChannel: this.outputChannel,
 //         };
 
 //         // Create the Python environment in which to execute the command.

--- a/src/client/testing/testController/pytest/runner.ts
+++ b/src/client/testing/testController/pytest/runner.ts
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { inject, injectable, named } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { Disposable, TestItem, TestRun, TestRunProfileKind } from 'vscode';
-import { IOutputChannel } from '../../../common/types';
+import { ITestOutputChannel } from '../../../common/types';
 import { PYTEST_PROVIDER } from '../../common/constants';
 import { ITestDebugLauncher, ITestRunner, LaunchOptions, Options } from '../../common/types';
-import { TEST_OUTPUT_CHANNEL } from '../../constants';
 import { filterArguments, getOptionValues } from '../common/argumentsHelper';
 import { createTemporaryFile } from '../common/externalDependencies';
 import { updateResultFromJunitXml } from '../common/resultsHelper';
@@ -32,7 +31,7 @@ export class PytestRunner implements ITestsRunner {
     constructor(
         @inject(ITestRunner) private readonly runner: ITestRunner,
         @inject(ITestDebugLauncher) private readonly debugLauncher: ITestDebugLauncher,
-        @inject(IOutputChannel) @named(TEST_OUTPUT_CHANNEL) private readonly outputChannel: IOutputChannel,
+        @inject(ITestOutputChannel) private readonly outputChannel: ITestOutputChannel,
     ) {}
 
     public async runTests(

--- a/src/client/testing/testController/unittest/runner.ts
+++ b/src/client/testing/testController/unittest/runner.ts
@@ -1,16 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { injectable, inject, named } from 'inversify';
+import { injectable, inject } from 'inversify';
 import { Location, TestController, TestItem, TestMessage, TestRun, TestRunProfileKind } from 'vscode';
 import * as internalScripts from '../../../common/process/internal/scripts';
 import { splitLines } from '../../../common/stringUtils';
-import { IOutputChannel } from '../../../common/types';
+import { ITestOutputChannel } from '../../../common/types';
 import { noop } from '../../../common/utils/misc';
 import { traceError, traceInfo } from '../../../logging';
 import { UNITTEST_PROVIDER } from '../../common/constants';
 import { ITestRunner, ITestDebugLauncher, IUnitTestSocketServer, LaunchOptions, Options } from '../../common/types';
-import { TEST_OUTPUT_CHANNEL } from '../../constants';
 import { clearAllChildren, getTestCaseNodes } from '../common/testItemUtilities';
 import { ITestRun, ITestsRunner, TestData, TestRunInstanceOptions, TestRunOptions } from '../common/types';
 import { fixLogLines } from '../common/utils';
@@ -33,7 +32,7 @@ export class UnittestRunner implements ITestsRunner {
     constructor(
         @inject(ITestRunner) private readonly runner: ITestRunner,
         @inject(ITestDebugLauncher) private readonly debugLauncher: ITestDebugLauncher,
-        @inject(IOutputChannel) @named(TEST_OUTPUT_CHANNEL) private readonly outputChannel: IOutputChannel,
+        @inject(ITestOutputChannel) private readonly outputChannel: ITestOutputChannel,
         @inject(IUnitTestSocketServer) private readonly server: IUnitTestSocketServer,
     ) {}
 

--- a/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
+++ b/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
@@ -3,7 +3,7 @@
 
 import * as path from 'path';
 import { Uri } from 'vscode';
-import { IConfigurationService } from '../../../common/types';
+import { IConfigurationService, ITestOutputChannel } from '../../../common/types';
 import { createDeferred, Deferred } from '../../../common/utils/async';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
 import {
@@ -23,7 +23,11 @@ export class UnittestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
 
     private cwd: string | undefined;
 
-    constructor(public testServer: ITestServer, public configSettings: IConfigurationService) {
+    constructor(
+        public testServer: ITestServer,
+        public configSettings: IConfigurationService,
+        private readonly outputChannel: ITestOutputChannel,
+    ) {
         testServer.onDataReceived(this.onDataReceivedHandler, this);
     }
 
@@ -50,6 +54,7 @@ export class UnittestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
             command,
             cwd: this.cwd,
             uuid,
+            outChannel: this.outputChannel,
         };
 
         this.promiseMap.set(uuid, deferred);

--- a/src/client/testing/testController/unittest/testExecutionAdapter.ts
+++ b/src/client/testing/testController/unittest/testExecutionAdapter.ts
@@ -3,7 +3,7 @@
 
 import * as path from 'path';
 import { Uri } from 'vscode';
-import { IConfigurationService } from '../../../common/types';
+import { IConfigurationService, ITestOutputChannel } from '../../../common/types';
 import { createDeferred, Deferred } from '../../../common/utils/async';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
 import {
@@ -24,7 +24,11 @@ export class UnittestTestExecutionAdapter implements ITestExecutionAdapter {
 
     private cwd: string | undefined;
 
-    constructor(public testServer: ITestServer, public configSettings: IConfigurationService) {
+    constructor(
+        public testServer: ITestServer,
+        public configSettings: IConfigurationService,
+        private readonly outputChannel: ITestOutputChannel,
+    ) {
         testServer.onDataReceived(this.onDataReceivedHandler, this);
     }
 
@@ -51,6 +55,7 @@ export class UnittestTestExecutionAdapter implements ITestExecutionAdapter {
             uuid,
             debugBool,
             testIds,
+            outChannel: this.outputChannel,
         };
 
         const deferred = createDeferred<ExecutionTestPayload>();

--- a/src/test/activation/node/analysisOptions.unit.test.ts
+++ b/src/test/activation/node/analysisOptions.unit.test.ts
@@ -9,7 +9,7 @@ import { NodeLanguageServerAnalysisOptions } from '../../../client/activation/no
 import { ILanguageServerOutputChannel } from '../../../client/activation/types';
 import { IWorkspaceService } from '../../../client/common/application/types';
 import { PYTHON, PYTHON_LANGUAGE } from '../../../client/common/constants';
-import { IExperimentService, IOutputChannel } from '../../../client/common/types';
+import { IExperimentService, ILogOutputChannel } from '../../../client/common/types';
 
 suite('Pylance Language Server - Analysis Options', () => {
     class TestClass extends NodeLanguageServerAnalysisOptions {
@@ -28,13 +28,13 @@ suite('Pylance Language Server - Analysis Options', () => {
     }
 
     let analysisOptions: TestClass;
-    let outputChannel: IOutputChannel;
+    let outputChannel: ILogOutputChannel;
     let lsOutputChannel: typemoq.IMock<ILanguageServerOutputChannel>;
     let workspace: typemoq.IMock<IWorkspaceService>;
     let experimentService: IExperimentService;
 
     setup(() => {
-        outputChannel = typemoq.Mock.ofType<IOutputChannel>().object;
+        outputChannel = typemoq.Mock.ofType<ILogOutputChannel>().object;
         workspace = typemoq.Mock.ofType<IWorkspaceService>();
         workspace.setup((w) => w.isVirtualWorkspace).returns(() => false);
         const workspaceConfig = typemoq.Mock.ofType<WorkspaceConfiguration>();

--- a/src/test/activation/outputChannel.unit.test.ts
+++ b/src/test/activation/outputChannel.unit.test.ts
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 import * as TypeMoq from 'typemoq';
 import { LanguageServerOutputChannel } from '../../client/activation/common/outputChannel';
 import { IApplicationShell, ICommandManager } from '../../client/common/application/types';
-import { IOutputChannel } from '../../client/common/types';
+import { ILogOutputChannel } from '../../client/common/types';
 import { sleep } from '../../client/common/utils/async';
 import { OutputChannelNames } from '../../client/common/utils/localize';
 
@@ -15,10 +15,10 @@ suite('Language Server Output Channel', () => {
     let appShell: TypeMoq.IMock<IApplicationShell>;
     let languageServerOutputChannel: LanguageServerOutputChannel;
     let commandManager: TypeMoq.IMock<ICommandManager>;
-    let output: TypeMoq.IMock<IOutputChannel>;
+    let output: TypeMoq.IMock<ILogOutputChannel>;
     setup(() => {
         appShell = TypeMoq.Mock.ofType<IApplicationShell>();
-        output = TypeMoq.Mock.ofType<IOutputChannel>();
+        output = TypeMoq.Mock.ofType<ILogOutputChannel>();
         commandManager = TypeMoq.Mock.ofType<ICommandManager>();
         languageServerOutputChannel = new LanguageServerOutputChannel(appShell.object, commandManager.object, []);
     });

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -13,7 +13,6 @@ import { anything, instance, mock, when } from 'ts-mockito';
 import * as TypeMoq from 'typemoq';
 import { CancellationTokenSource, Disposable, ProgressLocation, Uri, WorkspaceConfiguration } from 'vscode';
 import { IApplicationShell, IWorkspaceService } from '../../../client/common/application/types';
-import { STANDARD_OUTPUT_CHANNEL } from '../../../client/common/constants';
 import { CondaInstaller } from '../../../client/common/installer/condaInstaller';
 import { ModuleInstaller } from '../../../client/common/installer/moduleInstaller';
 import { PipEnvInstaller, pipenvName } from '../../../client/common/installer/pipEnvInstaller';
@@ -32,7 +31,7 @@ import {
     IConfigurationService,
     IDisposableRegistry,
     IInstaller,
-    IOutputChannel,
+    ILogOutputChannel,
     IPythonSettings,
     Product,
 } from '../../../client/common/types';
@@ -89,7 +88,7 @@ suite('Module Installer', () => {
             return super.elevatedInstall(execPath, args);
         }
     }
-    let outputChannel: TypeMoq.IMock<IOutputChannel>;
+    let outputChannel: TypeMoq.IMock<ILogOutputChannel>;
 
     let appShell: TypeMoq.IMock<IApplicationShell>;
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
@@ -104,9 +103,9 @@ suite('Module Installer', () => {
             traceLogStub = sinon.stub(logging, 'traceLog');
 
             serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
-            outputChannel = TypeMoq.Mock.ofType<IOutputChannel>();
+            outputChannel = TypeMoq.Mock.ofType<ILogOutputChannel>();
             serviceContainer
-                .setup((c) => c.get(TypeMoq.It.isValue(IOutputChannel), TypeMoq.It.isValue(STANDARD_OUTPUT_CHANNEL)))
+                .setup((c) => c.get(TypeMoq.It.isValue(ILogOutputChannel)))
                 .returns(() => outputChannel.object);
             appShell = TypeMoq.Mock.ofType<IApplicationShell>();
             serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(IApplicationShell))).returns(() => appShell.object);

--- a/src/test/format/formatter.unit.test.ts
+++ b/src/test/format/formatter.unit.test.ts
@@ -13,7 +13,6 @@ import { IApplicationShell, IWorkspaceService } from '../../client/common/applic
 import { WorkspaceService } from '../../client/common/application/workspace';
 import { PythonSettings } from '../../client/common/configSettings';
 import { ConfigurationService } from '../../client/common/configuration/service';
-import { STANDARD_OUTPUT_CHANNEL } from '../../client/common/constants';
 import { PythonToolExecutionService } from '../../client/common/process/pythonToolService';
 import { IPythonToolExecutionService } from '../../client/common/process/types';
 import {
@@ -21,7 +20,7 @@ import {
     IConfigurationService,
     IDisposableRegistry,
     IFormattingSettings,
-    IOutputChannel,
+    ILogOutputChannel,
     IPythonSettings,
 } from '../../client/common/types';
 import { AutoPep8Formatter } from '../../client/formatters/autoPep8Formatter';
@@ -37,7 +36,7 @@ import { MockOutputChannel } from '../mockClasses';
 
 suite('Formatting - Test Arguments', () => {
     let container: IServiceContainer;
-    let outputChannel: IOutputChannel;
+    let outputChannel: ILogOutputChannel;
     let workspace: IWorkspaceService;
     let settings: IPythonSettings;
     const workspaceUri = Uri.file(__dirname);
@@ -85,9 +84,7 @@ suite('Formatting - Test Arguments', () => {
 
         when(configService.getSettings(anything())).thenReturn(instance(settings));
         when(workspace.getWorkspaceFolder(anything())).thenReturn({ name: '', index: 0, uri: workspaceUri });
-        when(container.get<IOutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL)).thenReturn(
-            instance(outputChannel),
-        );
+        when(container.get<ILogOutputChannel>(ILogOutputChannel)).thenReturn(instance(outputChannel));
         when(container.get<IApplicationShell>(IApplicationShell)).thenReturn(instance(appShell));
         when(container.get<IFormatterHelper>(IFormatterHelper)).thenReturn(formatterHelper);
         when(container.get<IWorkspaceService>(IWorkspaceService)).thenReturn(instance(workspace));

--- a/src/test/linters/common.ts
+++ b/src/test/linters/common.ts
@@ -18,7 +18,7 @@ import {
     IConfigurationService,
     IInstaller,
     IMypyCategorySeverity,
-    IOutputChannel,
+    ILogOutputChannel,
     IPycodestyleCategorySeverity,
     IPylintCategorySeverity,
     IPythonSettings,
@@ -243,7 +243,7 @@ export class BaseTestFixture {
     public lintingSettings: LintingSettings;
 
     // data
-    public outputChannel: TypeMoq.IMock<IOutputChannel>;
+    public outputChannel: TypeMoq.IMock<ILogOutputChannel>;
 
     // artifacts
     public output: string;
@@ -309,10 +309,10 @@ export class BaseTestFixture {
 
         // data
 
-        this.outputChannel = TypeMoq.Mock.ofType<IOutputChannel>(undefined, TypeMoq.MockBehavior.Strict);
+        this.outputChannel = TypeMoq.Mock.ofType<ILogOutputChannel>(undefined, TypeMoq.MockBehavior.Strict);
 
         this.serviceContainer
-            .setup((c) => c.get(TypeMoq.It.isValue(IOutputChannel), TypeMoq.It.isAny()))
+            .setup((c) => c.get(TypeMoq.It.isValue(ILogOutputChannel)))
             .returns(() => this.outputChannel.object);
         this.initData();
 

--- a/src/test/linters/lintengine.test.ts
+++ b/src/test/linters/lintengine.test.ts
@@ -4,12 +4,12 @@
 'use strict';
 
 import * as TypeMoq from 'typemoq';
-import { OutputChannel, TextDocument, Uri } from 'vscode';
+import { TextDocument, Uri } from 'vscode';
 import { IDocumentManager, IWorkspaceService } from '../../client/common/application/types';
-import { PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL } from '../../client/common/constants';
+import { PYTHON_LANGUAGE } from '../../client/common/constants';
 import '../../client/common/extensions';
 import { IFileSystem } from '../../client/common/platform/types';
-import { IConfigurationService, ILintingSettings, IOutputChannel, IPythonSettings } from '../../client/common/types';
+import { IConfigurationService, ILintingSettings, ILogOutputChannel, IPythonSettings } from '../../client/common/types';
 import { IInterpreterService } from '../../client/interpreter/contracts';
 import { IServiceContainer } from '../../client/ioc/types';
 import { LintingEngine } from '../../client/linters/lintingEngine';
@@ -54,10 +54,8 @@ suite('Linting - LintingEngine', () => {
             .setup((c) => c.get(TypeMoq.It.isValue(IConfigurationService), TypeMoq.It.isAny()))
             .returns(() => configService.object);
 
-        const outputChannel = TypeMoq.Mock.ofType<OutputChannel>();
-        serviceContainer
-            .setup((c) => c.get(TypeMoq.It.isValue(IOutputChannel), TypeMoq.It.isValue(STANDARD_OUTPUT_CHANNEL)))
-            .returns(() => outputChannel.object);
+        const outputChannel = TypeMoq.Mock.ofType<ILogOutputChannel>();
+        serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(ILogOutputChannel))).returns(() => outputChannel.object);
 
         lintManager = TypeMoq.Mock.ofType<ILinterManager>();
         lintManager.setup((x) => x.isLintingEnabled(TypeMoq.It.isAny())).returns(async () => true);

--- a/src/test/mockClasses.ts
+++ b/src/test/mockClasses.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as util from 'util';
 import {
     Flake8CategorySeverity,
     ILintingSettings,
@@ -7,13 +8,32 @@ import {
     IPylintCategorySeverity,
 } from '../client/common/types';
 
-export class MockOutputChannel implements vscode.OutputChannel {
+export class MockOutputChannel implements vscode.LogOutputChannel {
     public name: string;
     public output: string;
     public isShown!: boolean;
+    private _eventEmitter = new vscode.EventEmitter<vscode.LogLevel>();
+    public onDidChangeLogLevel: vscode.Event<vscode.LogLevel> = this._eventEmitter.event;
     constructor(name: string) {
         this.name = name;
         this.output = '';
+        this.logLevel = vscode.LogLevel.Debug;
+    }
+    public logLevel: vscode.LogLevel;
+    trace(message: string, ...args: any[]): void {
+        this.appendLine(util.format(message, ...args));
+    }
+    debug(message: string, ...args: any[]): void {
+        this.appendLine(util.format(message, ...args));
+    }
+    info(message: string, ...args: any[]): void {
+        this.appendLine(util.format(message, ...args));
+    }
+    warn(message: string, ...args: any[]): void {
+        this.appendLine(util.format(message, ...args));
+    }
+    error(error: string | Error, ...args: any[]): void {
+        this.appendLine(util.format(error, ...args));
     }
     public append(value: string) {
         this.output += value;

--- a/src/test/mocks/vsc/index.ts
+++ b/src/test/mocks/vsc/index.ts
@@ -411,3 +411,35 @@ export class InlayHint {
         public kind?: vscode.InlayHintKind,
     ) {}
 }
+
+export enum LogLevel {
+    /**
+     * No messages are logged with this level.
+     */
+    Off = 0,
+
+    /**
+     * All messages are logged with this level.
+     */
+    Trace = 1,
+
+    /**
+     * Messages with debug and higher log level are logged with this level.
+     */
+    Debug = 2,
+
+    /**
+     * Messages with info and higher log level are logged with this level.
+     */
+    Info = 3,
+
+    /**
+     * Messages with warning and higher log level are logged with this level.
+     */
+    Warning = 4,
+
+    /**
+     * Only error messages are logged with this level.
+     */
+    Error = 5,
+}

--- a/src/test/serviceRegistry.ts
+++ b/src/test/serviceRegistry.ts
@@ -4,8 +4,7 @@
 import { Container } from 'inversify';
 import { anything, instance, mock, when } from 'ts-mockito';
 import * as TypeMoq from 'typemoq';
-import { Disposable, Memento, OutputChannel } from 'vscode';
-import { STANDARD_OUTPUT_CHANNEL } from '../client/common/constants';
+import { Disposable, Memento } from 'vscode';
 import { IS_WINDOWS } from '../client/common/platform/constants';
 import { FileSystem } from '../client/common/platform/fileSystem';
 import { PathUtils } from '../client/common/platform/pathUtils';
@@ -28,10 +27,11 @@ import {
     ICurrentProcess,
     IDisposableRegistry,
     IMemento,
-    IOutputChannel,
+    ILogOutputChannel,
     IPathUtils,
     IsWindows,
     WORKSPACE_MEMENTO,
+    ITestOutputChannel,
 } from '../client/common/types';
 import { registerTypes as variableRegisterTypes } from '../client/common/variables/serviceRegistry';
 import { registerTypes as formattersRegisterTypes } from '../client/formatters/serviceRegistry';
@@ -48,7 +48,6 @@ import { ServiceContainer } from '../client/ioc/container';
 import { ServiceManager } from '../client/ioc/serviceManager';
 import { IServiceContainer, IServiceManager } from '../client/ioc/types';
 import { registerTypes as lintersRegisterTypes } from '../client/linters/serviceRegistry';
-import { TEST_OUTPUT_CHANNEL } from '../client/testing/constants';
 import { registerTypes as unittestsRegisterTypes } from '../client/testing/serviceRegistry';
 import { LegacyFileSystem } from './legacyFileSystem';
 import { MockOutputChannel } from './mockClasses';
@@ -83,14 +82,10 @@ export class IocContainer {
 
         const stdOutputChannel = new MockOutputChannel('Python');
         this.disposables.push(stdOutputChannel);
-        this.serviceManager.addSingletonInstance<OutputChannel>(
-            IOutputChannel,
-            stdOutputChannel,
-            STANDARD_OUTPUT_CHANNEL,
-        );
+        this.serviceManager.addSingletonInstance<ILogOutputChannel>(ILogOutputChannel, stdOutputChannel);
         const testOutputChannel = new MockOutputChannel('Python Test - UnitTests');
         this.disposables.push(testOutputChannel);
-        this.serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, testOutputChannel, TEST_OUTPUT_CHANNEL);
+        this.serviceManager.addSingletonInstance<ITestOutputChannel>(ITestOutputChannel, testOutputChannel);
 
         this.serviceManager.addSingleton<IInterpreterAutoSelectionService>(
             IInterpreterAutoSelectionService,

--- a/src/test/testing/common/managers/testConfigurationManager.unit.test.ts
+++ b/src/test/testing/common/managers/testConfigurationManager.unit.test.ts
@@ -5,13 +5,12 @@
 
 import * as TypeMoq from 'typemoq';
 import { OutputChannel, Uri } from 'vscode';
-import { IInstaller, IOutputChannel, Product } from '../../../../client/common/types';
+import { IInstaller, ITestOutputChannel, Product } from '../../../../client/common/types';
 import { getNamesAndValues } from '../../../../client/common/utils/enum';
 import { IServiceContainer } from '../../../../client/ioc/types';
 import { UNIT_TEST_PRODUCTS } from '../../../../client/testing/common/constants';
 import { TestConfigurationManager } from '../../../../client/testing/common/testConfigurationManager';
 import { ITestConfigSettingsService, UnitTestProduct } from '../../../../client/testing/common/types';
-import { TEST_OUTPUT_CHANNEL } from '../../../../client/testing/constants';
 
 class MockTestConfigurationManager extends TestConfigurationManager {
     // The workspace arg is ignored.
@@ -42,7 +41,7 @@ suite('Unit Test Configuration Manager (unit)', () => {
                 const installer = TypeMoq.Mock.ofType<IInstaller>().object;
                 const serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
                 serviceContainer
-                    .setup((s) => s.get(TypeMoq.It.isValue(IOutputChannel), TypeMoq.It.isValue(TEST_OUTPUT_CHANNEL)))
+                    .setup((s) => s.get(TypeMoq.It.isValue(ITestOutputChannel)))
                     .returns(() => outputChannel);
                 serviceContainer
                     .setup((s) => s.get(TypeMoq.It.isValue(ITestConfigSettingsService)))

--- a/src/test/testing/configuration.unit.test.ts
+++ b/src/test/testing/configuration.unit.test.ts
@@ -7,7 +7,13 @@ import { expect } from 'chai';
 import * as typeMoq from 'typemoq';
 import { OutputChannel, Uri, WorkspaceConfiguration } from 'vscode';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../../client/common/application/types';
-import { IConfigurationService, IInstaller, IOutputChannel, IPythonSettings, Product } from '../../client/common/types';
+import {
+    IConfigurationService,
+    IInstaller,
+    ITestOutputChannel,
+    IPythonSettings,
+    Product,
+} from '../../client/common/types';
 import { getNamesAndValues } from '../../client/common/utils/enum';
 import { IServiceContainer } from '../../client/ioc/types';
 import { UNIT_TEST_PRODUCTS } from '../../client/testing/common/constants';
@@ -18,7 +24,6 @@ import {
     ITestConfigurationManagerFactory,
     ITestsHelper,
 } from '../../client/testing/common/types';
-import { TEST_OUTPUT_CHANNEL } from '../../client/testing/constants';
 import { ITestingSettings } from '../../client/testing/configuration/types';
 import { NONE_SELECTED, UnitTestConfigurationService } from '../../client/testing/configuration';
 
@@ -56,7 +61,7 @@ suite('Unit Tests - ConfigurationService', () => {
                 configurationService.setup((c) => c.getSettings(workspaceUri)).returns(() => pythonSettings.object);
 
                 serviceContainer
-                    .setup((c) => c.get(typeMoq.It.isValue(IOutputChannel), typeMoq.It.isValue(TEST_OUTPUT_CHANNEL)))
+                    .setup((c) => c.get(typeMoq.It.isValue(ITestOutputChannel)))
                     .returns(() => outputChannel.object);
                 serviceContainer.setup((c) => c.get(typeMoq.It.isValue(IInstaller))).returns(() => installer.object);
                 serviceContainer

--- a/src/test/testing/configurationFactory.unit.test.ts
+++ b/src/test/testing/configurationFactory.unit.test.ts
@@ -7,11 +7,10 @@ import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as typeMoq from 'typemoq';
 import { OutputChannel, Uri } from 'vscode';
-import { IInstaller, IOutputChannel, Product } from '../../client/common/types';
+import { IInstaller, ITestOutputChannel, Product } from '../../client/common/types';
 import { IServiceContainer } from '../../client/ioc/types';
 import { ITestConfigSettingsService, ITestConfigurationManagerFactory } from '../../client/testing/common/types';
 import { TestConfigurationManagerFactory } from '../../client/testing/configurationFactory';
-import { TEST_OUTPUT_CHANNEL } from '../../client/testing/constants';
 import * as pytest from '../../client/testing/configuration/pytest/testConfigurationManager';
 import * as unittest from '../../client/testing/configuration/unittest/testConfigurationManager';
 
@@ -26,7 +25,7 @@ suite('Unit Tests - ConfigurationManagerFactory', () => {
         const testConfigService = typeMoq.Mock.ofType<ITestConfigSettingsService>();
 
         serviceContainer
-            .setup((c) => c.get(typeMoq.It.isValue(IOutputChannel), typeMoq.It.isValue(TEST_OUTPUT_CHANNEL)))
+            .setup((c) => c.get(typeMoq.It.isValue(ITestOutputChannel)))
             .returns(() => outputChannel.object);
         serviceContainer.setup((c) => c.get(typeMoq.It.isValue(IInstaller))).returns(() => installer.object);
         serviceContainer

--- a/src/test/testing/testController/unittest/testDiscoveryAdapter.unit.test.ts
+++ b/src/test/testing/testController/unittest/testDiscoveryAdapter.unit.test.ts
@@ -3,14 +3,16 @@
 
 import * as assert from 'assert';
 import * as path from 'path';
+import * as typemoq from 'typemoq';
 import { Uri } from 'vscode';
-import { IConfigurationService } from '../../../../client/common/types';
+import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
 import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
 import { ITestServer, TestCommandOptions } from '../../../../client/testing/testController/common/types';
 import { UnittestTestDiscoveryAdapter } from '../../../../client/testing/testController/unittest/testDiscoveryAdapter';
 
 suite('Unittest test discovery adapter', () => {
     let stubConfigSettings: IConfigurationService;
+    let outputChannel: typemoq.IMock<ITestOutputChannel>;
 
     setup(() => {
         stubConfigSettings = ({
@@ -18,6 +20,7 @@ suite('Unittest test discovery adapter', () => {
                 testing: { unittestArgs: ['-v', '-s', '.', '-p', 'test*'] },
             }),
         } as unknown) as IConfigurationService;
+        outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
     });
 
     test('discoverTests should send the discovery command to the test server', async () => {
@@ -37,7 +40,7 @@ suite('Unittest test discovery adapter', () => {
         const uri = Uri.file('/foo/bar');
         const script = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'unittestadapter', 'discovery.py');
 
-        const adapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings);
+        const adapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
         adapter.discoverTests(uri);
 
         assert.deepStrictEqual(options, {
@@ -62,7 +65,7 @@ suite('Unittest test discovery adapter', () => {
         const uri = Uri.file('/foo/bar');
         const data = { status: 'success' };
         const uuid = '123456789';
-        const adapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings);
+        const adapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
         const promise = adapter.discoverTests(uri);
 
         adapter.onDataReceivedHandler({ uuid, data: JSON.stringify(data) });
@@ -87,7 +90,7 @@ suite('Unittest test discovery adapter', () => {
 
         const uri = Uri.file('/foo/bar');
 
-        const adapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings);
+        const adapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
         const promise = adapter.discoverTests(uri);
 
         const data = { status: 'success' };

--- a/src/test/testing/testController/unittest/testDiscoveryAdapter.unit.test.ts
+++ b/src/test/testing/testController/unittest/testDiscoveryAdapter.unit.test.ts
@@ -28,6 +28,7 @@ suite('Unittest test discovery adapter', () => {
 
         const stubTestServer = ({
             sendCommand(opt: TestCommandOptions): Promise<void> {
+                delete opt.outChannel;
                 options = opt;
                 return Promise.resolve();
             },

--- a/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
+++ b/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
@@ -3,14 +3,16 @@
 
 import * as assert from 'assert';
 import * as path from 'path';
+import * as typemoq from 'typemoq';
 import { Uri } from 'vscode';
-import { IConfigurationService } from '../../../../client/common/types';
+import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
 import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
 import { ITestServer, TestCommandOptions } from '../../../../client/testing/testController/common/types';
 import { UnittestTestExecutionAdapter } from '../../../../client/testing/testController/unittest/testExecutionAdapter';
 
 suite('Unittest test execution adapter', () => {
     let stubConfigSettings: IConfigurationService;
+    let outputChannel: typemoq.IMock<ITestOutputChannel>;
 
     setup(() => {
         stubConfigSettings = ({
@@ -18,6 +20,7 @@ suite('Unittest test execution adapter', () => {
                 testing: { unittestArgs: ['-v', '-s', '.', '-p', 'test*'] },
             }),
         } as unknown) as IConfigurationService;
+        outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
     });
 
     test('runTests should send the run command to the test server', async () => {
@@ -37,7 +40,7 @@ suite('Unittest test execution adapter', () => {
         const uri = Uri.file('/foo/bar');
         const script = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'unittestadapter', 'execution.py');
 
-        const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings);
+        const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
         adapter.runTests(uri, [], false);
 
         const expectedOptions: TestCommandOptions = {
@@ -66,7 +69,7 @@ suite('Unittest test execution adapter', () => {
         const data = { status: 'success' };
         const uuid = '123456789';
 
-        const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings);
+        const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
 
         // triggers runTests flow which will run onDataReceivedHandler and the
         // promise resolves into the parsed data.
@@ -93,7 +96,7 @@ suite('Unittest test execution adapter', () => {
 
         const uri = Uri.file('/foo/bar');
 
-        const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings);
+        const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
 
         // triggers runTests flow which will run onDataReceivedHandler and the
         // promise resolves into the parsed data.

--- a/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
+++ b/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
@@ -28,6 +28,7 @@ suite('Unittest test execution adapter', () => {
 
         const stubTestServer = ({
             sendCommand(opt: TestCommandOptions): Promise<void> {
+                delete opt.outChannel;
                 options = opt;
                 return Promise.resolve();
             },

--- a/src/test/testing/testController/workspaceTestAdapter.unit.test.ts
+++ b/src/test/testing/testController/workspaceTestAdapter.unit.test.ts
@@ -3,9 +3,10 @@
 
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import * as typemoq from 'typemoq';
 
 import { TestController, TestItem, Uri } from 'vscode';
-import { IConfigurationService } from '../../../client/common/types';
+import { IConfigurationService, ITestOutputChannel } from '../../../client/common/types';
 import { UnittestTestDiscoveryAdapter } from '../../../client/testing/testController/unittest/testDiscoveryAdapter';
 import { UnittestTestExecutionAdapter } from '../../../client/testing/testController/unittest/testExecutionAdapter'; // 7/7
 import { WorkspaceTestAdapter } from '../../../client/testing/testController/workspaceTestAdapter';
@@ -20,6 +21,7 @@ suite('Workspace test adapter', () => {
 
         let discoverTestsStub: sinon.SinonStub;
         let sendTelemetryStub: sinon.SinonStub;
+        let outputChannel: typemoq.IMock<ITestOutputChannel>;
 
         let telemetryEvent: { eventName: EventName; properties: Record<string, unknown> }[] = [];
 
@@ -97,6 +99,7 @@ suite('Workspace test adapter', () => {
 
             discoverTestsStub = sandbox.stub(UnittestTestDiscoveryAdapter.prototype, 'discoverTests');
             sendTelemetryStub = sandbox.stub(Telemetry, 'sendTelemetryEvent').callsFake(mockSendTelemetryEvent);
+            outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
         });
 
         teardown(() => {
@@ -109,8 +112,16 @@ suite('Workspace test adapter', () => {
         test("When discovering tests, the workspace test adapter should call the test discovery adapter's discoverTest method", async () => {
             discoverTestsStub.resolves();
 
-            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings);
-            const testExecutionAdapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings); // 7/7
+            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
+                stubTestServer,
+                stubConfigSettings,
+                outputChannel.object,
+            );
+            const testExecutionAdapter = new UnittestTestExecutionAdapter(
+                stubTestServer,
+                stubConfigSettings,
+                outputChannel.object,
+            );
             const workspaceTestAdapter = new WorkspaceTestAdapter(
                 'unittest',
                 testDiscoveryAdapter,
@@ -134,8 +145,16 @@ suite('Workspace test adapter', () => {
                     }),
             );
 
-            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings);
-            const testExecutionAdapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings); // 7/7
+            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
+                stubTestServer,
+                stubConfigSettings,
+                outputChannel.object,
+            );
+            const testExecutionAdapter = new UnittestTestExecutionAdapter(
+                stubTestServer,
+                stubConfigSettings,
+                outputChannel.object,
+            );
             const workspaceTestAdapter = new WorkspaceTestAdapter(
                 'unittest',
                 testDiscoveryAdapter,
@@ -155,8 +174,16 @@ suite('Workspace test adapter', () => {
         test('If discovery succeeds, send a telemetry event with the "failed" key set to false', async () => {
             discoverTestsStub.resolves({ status: 'success' });
 
-            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings);
-            const testExecutionAdapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings);
+            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
+                stubTestServer,
+                stubConfigSettings,
+                outputChannel.object,
+            );
+            const testExecutionAdapter = new UnittestTestExecutionAdapter(
+                stubTestServer,
+                stubConfigSettings,
+                outputChannel.object,
+            );
 
             const workspaceTestAdapter = new WorkspaceTestAdapter(
                 'unittest',
@@ -177,8 +204,16 @@ suite('Workspace test adapter', () => {
         test('If discovery failed, send a telemetry event with the "failed" key set to true, and add an error node to the test controller', async () => {
             discoverTestsStub.rejects(new Error('foo'));
 
-            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings);
-            const testExecutionAdapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings);
+            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
+                stubTestServer,
+                stubConfigSettings,
+                outputChannel.object,
+            );
+            const testExecutionAdapter = new UnittestTestExecutionAdapter(
+                stubTestServer,
+                stubConfigSettings,
+                outputChannel.object,
+            );
 
             const workspaceTestAdapter = new WorkspaceTestAdapter(
                 'unittest',

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -112,6 +112,7 @@ mockedVSCode.FileSystemError = vscodeMocks.vscMockExtHostedTypes.FileSystemError
 mockedVSCode.LanguageStatusSeverity = vscodeMocks.LanguageStatusSeverity;
 mockedVSCode.QuickPickItemKind = vscodeMocks.QuickPickItemKind;
 mockedVSCode.InlayHint = vscodeMocks.InlayHint;
+mockedVSCode.LogLevel = vscodeMocks.LogLevel;
 (mockedVSCode as any).NotebookCellKind = vscodeMocks.vscMockExtHostedTypes.NotebookCellKind;
 (mockedVSCode as any).CellOutputKind = vscodeMocks.vscMockExtHostedTypes.CellOutputKind;
 (mockedVSCode as any).NotebookCellRunState = vscodeMocks.vscMockExtHostedTypes.NotebookCellRunState;


### PR DESCRIPTION
In this PR:
1. Changes the python extension logging to use LogOutputChannel
2. Changes the language server logger with LogOutputChannel
3. Test output channel uses OutputChannel as it needs to show test output and not really logging. Also, using logging test output makes it pretty much unreadable.
4. Simplifies logging channel and output channel registration.

We need to do this now to make it easier for new test work to integrate with output logging.

For #20844

This still doesn't get rid of the log level setting. 