### PR TITLE
Remove Pylance auto-indent experiment code

### DIFF
--- a/src/client/activation/node/analysisOptions.ts
+++ b/src/client/activation/node/analysisOptions.ts
@@ -1,27 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ConfigurationTarget, extensions, WorkspaceConfiguration } from 'vscode';
 import { LanguageClientOptions } from 'vscode-languageclient';
-import * as semver from 'semver';
 import { IWorkspaceService } from '../../common/application/types';
-import { PYLANCE_EXTENSION_ID } from '../../common/constants';
-import { IExperimentService } from '../../common/types';
 
 import { LanguageServerAnalysisOptionsBase } from '../common/analysisOptions';
 import { ILanguageServerOutputChannel } from '../types';
-import { traceWarn } from '../../logging';
-
-const EDITOR_CONFIG_SECTION = 'editor';
-const FORMAT_ON_TYPE_CONFIG_SETTING = 'formatOnType';
 
 export class NodeLanguageServerAnalysisOptions extends LanguageServerAnalysisOptionsBase {
     // eslint-disable-next-line @typescript-eslint/no-useless-constructor
-    constructor(
-        lsOutputChannel: ILanguageServerOutputChannel,
-        workspace: IWorkspaceService,
-        private readonly experimentService: IExperimentService,
-    ) {
+    constructor(lsOutputChannel: ILanguageServerOutputChannel, workspace: IWorkspaceService) {
         super(lsOutputChannel, workspace);
     }
 
@@ -34,72 +22,6 @@ export class NodeLanguageServerAnalysisOptions extends LanguageServerAnalysisOpt
         return ({
             experimentationSupport: true,
             trustedWorkspaceSupport: true,
-            autoIndentSupport: await this.isAutoIndentEnabled(),
         } as unknown) as LanguageClientOptions;
-    }
-
-    private async isAutoIndentEnabled() {
-        let editorConfig = this.getPythonSpecificEditorSection();
-
-        // Only explicitly enable formatOnType for those who are in the experiment
-        // but have not explicitly given a value for the setting
-        if (!NodeLanguageServerAnalysisOptions.isConfigSettingSetByUser(editorConfig, FORMAT_ON_TYPE_CONFIG_SETTING)) {
-            const inExperiment = await this.isInAutoIndentExperiment();
-            if (inExperiment) {
-                await NodeLanguageServerAnalysisOptions.setPythonSpecificFormatOnType(editorConfig, true);
-
-                // Refresh our view of the config settings.
-                editorConfig = this.getPythonSpecificEditorSection();
-            }
-        }
-
-        const formatOnTypeEffectiveValue = editorConfig.get(FORMAT_ON_TYPE_CONFIG_SETTING);
-
-        return formatOnTypeEffectiveValue;
-    }
-
-    private static isConfigSettingSetByUser(configuration: WorkspaceConfiguration, setting: string): boolean {
-        const inspect = configuration.inspect(setting);
-        if (inspect === undefined) {
-            return false;
-        }
-
-        return (
-            inspect.globalValue !== undefined ||
-            inspect.workspaceValue !== undefined ||
-            inspect.workspaceFolderValue !== undefined ||
-            inspect.globalLanguageValue !== undefined ||
-            inspect.workspaceLanguageValue !== undefined ||
-            inspect.workspaceFolderLanguageValue !== undefined
-        );
-    }
-
-    private async isInAutoIndentExperiment(): Promise<boolean> {
-        if (await this.experimentService.inExperiment('pylanceAutoIndent')) {
-            return true;
-        }
-
-        const pylanceVersion = extensions.getExtension(PYLANCE_EXTENSION_ID)?.packageJSON.version as string;
-        return pylanceVersion !== undefined && semver.prerelease(pylanceVersion)?.includes('dev') === true;
-    }
-
-    private getPythonSpecificEditorSection() {
-        return this.workspace.getConfiguration(EDITOR_CONFIG_SECTION, undefined, /* languageSpecific */ true);
-    }
-
-    private static async setPythonSpecificFormatOnType(
-        editorConfig: WorkspaceConfiguration,
-        value: boolean | undefined,
-    ) {
-        try {
-            await editorConfig.update(
-                FORMAT_ON_TYPE_CONFIG_SETTING,
-                value,
-                ConfigurationTarget.Global,
-                /* overrideInLanguage */ true,
-            );
-        } catch (ex) {
-            traceWarn(`Failed to set formatOnType to ${value}`);
-        }
     }
 }

--- a/src/client/languageServer/pylanceLSExtensionManager.ts
+++ b/src/client/languageServer/pylanceLSExtensionManager.ts
@@ -49,11 +49,7 @@ export class PylanceLSExtensionManager implements IDisposable, ILanguageServerEx
         private readonly extensions: IExtensions,
         readonly applicationShell: IApplicationShell,
     ) {
-        this.analysisOptions = new NodeLanguageServerAnalysisOptions(
-            outputChannel,
-            workspaceService,
-            experimentService,
-        );
+        this.analysisOptions = new NodeLanguageServerAnalysisOptions(outputChannel, workspaceService);
         this.clientFactory = new NodeLanguageClientFactory(fileSystem, extensions);
         this.serverProxy = new NodeLanguageServerProxy(
             this.clientFactory,

--- a/src/test/activation/node/analysisOptions.unit.test.ts
+++ b/src/test/activation/node/analysisOptions.unit.test.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT License.
 import { assert, expect } from 'chai';
 import * as typemoq from 'typemoq';
-import { WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
+import { WorkspaceFolder } from 'vscode';
 import { DocumentFilter } from 'vscode-languageclient/node';
 
 import { NodeLanguageServerAnalysisOptions } from '../../../client/activation/node/analysisOptions';
 import { ILanguageServerOutputChannel } from '../../../client/activation/types';
 import { IWorkspaceService } from '../../../client/common/application/types';
 import { PYTHON, PYTHON_LANGUAGE } from '../../../client/common/constants';
-import { IExperimentService, ILogOutputChannel } from '../../../client/common/types';
+import { ILogOutputChannel } from '../../../client/common/types';
 
 suite('Pylance Language Server - Analysis Options', () => {
     class TestClass extends NodeLanguageServerAnalysisOptions {
@@ -31,19 +31,14 @@ suite('Pylance Language Server - Analysis Options', () => {
     let outputChannel: ILogOutputChannel;
     let lsOutputChannel: typemoq.IMock<ILanguageServerOutputChannel>;
     let workspace: typemoq.IMock<IWorkspaceService>;
-    let experimentService: IExperimentService;
 
     setup(() => {
         outputChannel = typemoq.Mock.ofType<ILogOutputChannel>().object;
         workspace = typemoq.Mock.ofType<IWorkspaceService>();
         workspace.setup((w) => w.isVirtualWorkspace).returns(() => false);
-        const workspaceConfig = typemoq.Mock.ofType<WorkspaceConfiguration>();
-        workspace.setup((w) => w.getConfiguration('editor', undefined, true)).returns(() => workspaceConfig.object);
-        workspaceConfig.setup((w) => w.get('formatOnType')).returns(() => true);
         lsOutputChannel = typemoq.Mock.ofType<ILanguageServerOutputChannel>();
         lsOutputChannel.setup((l) => l.channel).returns(() => outputChannel);
-        experimentService = typemoq.Mock.ofType<IExperimentService>().object;
-        analysisOptions = new TestClass(lsOutputChannel.object, workspace.object, experimentService);
+        analysisOptions = new TestClass(lsOutputChannel.object, workspace.object);
     });
 
     test('Workspace folder is undefined', () => {


### PR DESCRIPTION
Pylance's auto-indent experiment is at 100% and seems to be working fine.

Removed experiment code. It's [on by default](https://github.com/microsoft/pyrx/pull/3407) in Pylance starting with 2023.4.31. Users can still disable it using:

```json
    "[python]": {
        "editor.formatOnType": false
    }
```

Part of https://github.com/microsoft/pyrx/issues/3406.