### PR TITLE
Fix workspaceFolderToken -> workspaceFolder

### DIFF
--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -350,7 +350,7 @@ export namespace DebugConfigStrings {
         export const enterManagePyPath = {
             title: l10n.t('Debug Django'),
             prompt: l10n.t(
-                "Enter the path to manage.py ('${workspaceFolderToken}' points to the root of the current workspace folder)",
+                "Enter the path to manage.py ('${workspaceFolder}' points to the root of the current workspace folder)",
             ),
             invalid: l10n.t('Enter a valid Python file path'),
         };


### PR DESCRIPTION
The UI string is currently using the internal variable name (workspaceFolderToken) instead of the one actually used in the file (workspaceFolder). This PR fixes that.