### PR TITLE
Revert "Default to `--no-cov` when debugging pytest"

### DIFF
--- a/src/client/testing/testController/pytest/runner.ts
+++ b/src/client/testing/testController/pytest/runner.ts
@@ -95,10 +95,6 @@ export class PytestRunner implements ITestsRunner {
                 testArgs.push('--capture', 'no');
             }
 
-            if (options.debug && !testArgs.some((a) => a.startsWith('--no-cov'))) {
-                testArgs.push('--no-cov');
-            }
-
             // Positional arguments control the tests to be run.
             const rawData = idToRawData.get(testNode.id);
             if (!rawData) {


### PR DESCRIPTION
Reverts microsoft/vscode-python#21048

Closes https://github.com/microsoft/vscode-python/issues/21146
Related https://github.com/microsoft/vscode-python/issues/19985