### PR TITLE
Disable "snippets" expansion in Jedi LSP

### DIFF
--- a/src/client/activation/jedi/analysisOptions.ts
+++ b/src/client/activation/jedi/analysisOptions.ts
@@ -59,7 +59,7 @@ export class JediLanguageServerAnalysisOptions extends LanguageServerAnalysisOpt
             markupKindPreferred: 'markdown',
             completion: {
                 resolveEagerly: false,
-                disableSnippets: false,
+                disableSnippets: true,
             },
             diagnostics: {
                 enable: true,

--- a/src/test/activation/jedi/jediAnalysisOptions.unit.test.ts
+++ b/src/test/activation/jedi/jediAnalysisOptions.unit.test.ts
@@ -64,7 +64,7 @@ suite('Jedi LSP - analysis Options', () => {
 
         expect(result.initializationOptions.markupKindPreferred).to.deep.equal('markdown');
         expect(result.initializationOptions.completion.resolveEagerly).to.deep.equal(false);
-        expect(result.initializationOptions.completion.disableSnippets).to.deep.equal(false);
+        expect(result.initializationOptions.completion.disableSnippets).to.deep.equal(true);
         expect(result.initializationOptions.diagnostics.enable).to.deep.equal(true);
         expect(result.initializationOptions.diagnostics.didOpen).to.deep.equal(true);
         expect(result.initializationOptions.diagnostics.didSave).to.deep.equal(true);


### PR DESCRIPTION
This brings the Jedi based completion experience in line with that provided by Pylance. Completions now insert only the current symbol rather than assuming that the user wants to e.g: call that symbol.

This means for example that completing `max` will insert just `max` rather `max(arg1, arg2)`. While for this case this may be seen as less useful, it means that insertions in places where a call is not desired (such as imports and typing contexts) will not be forced to manually remove the parentheses and template arguments which might otherwise be inserted.

Users can still use the signature support UI to explore signatures and of course insertion of an opening parenthesis will still insert a closing one.

Hopefully this new configuration will be preferable to a majority of users.

I've done some light testing to check that this disables the described additional completion, however I'm not massively familiar with JediLSP so I'm not sure what other behaviours this will disable.

Fixes https://github.com/microsoft/vscode-python/issues/15858