### PR TITLE
Add option for pyenv interpreters when creating environments with venv

### DIFF
--- a/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
+++ b/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
@@ -163,7 +163,7 @@ export class VenvCreationProvider implements CreateEnvironmentProvider {
                                     EnvironmentType.MicrosoftStore,
                                     EnvironmentType.Global,
                                     EnvironmentType.Pyenv,
-                                ].includes(i.envType),
+                                ].includes(i.envType) && i.type === undefined,  // only global intepreters
                             {
                                 skipRecommended: true,
                                 showBackButton: true,

--- a/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
+++ b/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
@@ -163,7 +163,7 @@ export class VenvCreationProvider implements CreateEnvironmentProvider {
                                     EnvironmentType.MicrosoftStore,
                                     EnvironmentType.Global,
                                     EnvironmentType.Pyenv,
-                                ].includes(i.envType) && i.type === undefined,  // only global intepreters
+                                ].includes(i.envType) && i.type === undefined, // only global intepreters
                             {
                                 skipRecommended: true,
                                 showBackButton: true,

--- a/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
+++ b/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
@@ -162,6 +162,7 @@ export class VenvCreationProvider implements CreateEnvironmentProvider {
                                     EnvironmentType.System,
                                     EnvironmentType.MicrosoftStore,
                                     EnvironmentType.Global,
+                                    EnvironmentType.Pyenv,
                                 ].includes(i.envType),
                             {
                                 skipRecommended: true,

--- a/src/client/pythonEnvironments/info/index.ts
+++ b/src/client/pythonEnvironments/info/index.ts
@@ -68,10 +68,11 @@ export type InterpreterInformation = {
  *
  * @prop companyDisplayName - the user-facing name of the distro publisher
  * @prop displayName - the user-facing name for the environment
- * @prop type - the kind of Python environment
+ * @prop envType - the kind of Python environment
  * @prop envName - the environment's name, if applicable (else `envPath` is set)
  * @prop envPath - the environment's root dir, if applicable (else `envName`)
  * @prop cachedEntry - whether or not the info came from a cache
+ * @prop type - the type of Python environment, if applicable
  */
 // Note that "cachedEntry" is specific to the caching machinery
 // and doesn't really belong here.
@@ -84,6 +85,7 @@ export type PythonEnvironment = InterpreterInformation & {
     envName?: string;
     envPath?: string;
     cachedEntry?: boolean;
+    type?: string;
 };
 
 /**

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -75,6 +75,7 @@ function convertEnvInfo(info: PythonEnvInfo): PythonEnvironment {
     }
     env.displayName = info.display;
     env.detailedDisplayName = info.detailedDisplayName;
+    env.type = info.type;
     // We do not worry about using distro.defaultDisplayName.
 
     return env;


### PR DESCRIPTION
Resolves #20881 .

Testing:

Behaves as expected when testing with Extension Development Host:

![image](https://github.com/microsoft/vscode-python/assets/30149293/d114d9ab-f2d8-4273-877b-d7dd030cfe76)
