### PR TITLE
Added option to run multiple Python files in separate terminals

### DIFF
--- a/package.json
+++ b/package.json
@@ -306,6 +306,12 @@
             },
             {
                 "category": "Python",
+                "command": "python.execInNewTerminal",
+                "icon": "$(play)",
+                "title": "%python.command.python.execInNewTerminal.title%"
+            },
+            {
+                "category": "Python",
                 "command": "python.debugInTerminal",
                 "icon": "$(debug-alt)",
                 "title": "%python.command.python.debugInTerminal.title%"
@@ -1628,6 +1634,13 @@
                 },
                 {
                     "category": "Python",
+                    "command": "python.execInNewTerminal",
+                    "icon": "$(play)",
+                    "title": "%python.command.python.execInNewTerminal.title%",
+                    "when": "false && editorLangId == python"
+                },
+                {
+                    "category": "Python",
                     "command": "python.debugInTerminal",
                     "icon": "$(debug-alt)",
                     "title": "%python.command.python.debugInTerminal.title%",
@@ -1782,6 +1795,12 @@
                     "command": "python.execInTerminal-icon",
                     "group": "navigation@0",
                     "title": "%python.command.python.execInTerminalIcon.title%",
+                    "when": "resourceLangId == python && !isInDiffEditor && !virtualWorkspace && shellExecutionSupported"
+                },
+                {
+                    "command": "python.execInNewTerminal",
+                    "group": "navigation@0",
+                    "title": "%python.command.python.execInNewTerminal.title%",
                     "when": "resourceLangId == python && !isInDiffEditor && !virtualWorkspace && shellExecutionSupported"
                 },
                 {

--- a/package.nls.json
+++ b/package.nls.json
@@ -7,6 +7,7 @@
     "python.command.python.execInTerminal.title": "Run Python File in Terminal",
     "python.command.python.debugInTerminal.title": "Debug Python File",
     "python.command.python.execInTerminalIcon.title": "Run Python File",
+    "python.command.python.execInNewTerminal.title": "Run Python File in Separate Terminal",
     "python.command.python.setInterpreter.title": "Select Interpreter",
     "python.command.python.clearWorkspaceInterpreter.title": "Clear Workspace Interpreter Setting",
     "python.command.python.viewOutput.title": "Show Output",

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -44,6 +44,7 @@ export namespace Commands {
     export const Enable_SourceMap_Support = 'python.enableSourceMapSupport';
     export const Exec_In_Terminal = 'python.execInTerminal';
     export const Exec_In_Terminal_Icon = 'python.execInTerminal-icon';
+    export const Exec_In_Separate_Terminal = 'python.execInNewTerminal';
     export const Exec_Selection_In_Django_Shell = 'python.execSelectionInDjangoShell';
     export const Exec_Selection_In_Terminal = 'python.execSelectionInTerminal';
     export const GetSelectedInterpreterPath = 'python.interpreterPath';

--- a/src/client/common/terminal/types.ts
+++ b/src/client/common/terminal/types.ts
@@ -97,7 +97,7 @@ export interface ITerminalServiceFactory {
      * @returns {ITerminalService}
      * @memberof ITerminalServiceFactory
      */
-    getTerminalService(options: TerminalCreationOptions): ITerminalService;
+    getTerminalService(options: TerminalCreationOptions & { newTerminalPerFile?: boolean }): ITerminalService;
     createTerminalService(resource?: Uri, title?: string): ITerminalService;
 }
 

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -825,6 +825,12 @@ export interface IEventNamePropertyMapping {
          * @type {('command' | 'icon')}
          */
         trigger?: 'command' | 'icon';
+        /**
+         * Whether user chose to execute this Python file in a separate terminal or not.
+         *
+         * @type {boolean}
+         */
+        newTerminalPerFile?: boolean;
     };
     /**
      * Telemetry Event sent when user executes code against Django Shell.

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -29,13 +29,13 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
         @inject(IInterpreterService) protected readonly interpreterService: IInterpreterService,
     ) {}
 
-    public async executeFile(file: Uri) {
+    public async executeFile(file: Uri, options?: { newTerminalPerFile: boolean }) {
         await this.setCwdForFileExecution(file);
         const { command, args } = await this.getExecuteFileArgs(file, [
             file.fsPath.fileToCommandArgumentForPythonExt(),
         ]);
 
-        await this.getTerminalService(file).sendCommand(command, args);
+        await this.getTerminalService(file, options).sendCommand(command, args);
     }
 
     public async execute(code: string, resource?: Uri): Promise<void> {
@@ -83,10 +83,11 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
     public async getExecuteFileArgs(resource?: Uri, executeArgs: string[] = []): Promise<PythonExecInfo> {
         return this.getExecutableInfo(resource, executeArgs);
     }
-    private getTerminalService(resource?: Uri): ITerminalService {
+    private getTerminalService(resource?: Uri, options?: { newTerminalPerFile: boolean }): ITerminalService {
         return this.terminalServiceFactory.getTerminalService({
             resource,
             title: this.terminalTitle,
+            newTerminalPerFile: options?.newTerminalPerFile,
         });
     }
     private async setCwdForFileExecution(file: Uri) {

--- a/src/client/terminals/types.ts
+++ b/src/client/terminals/types.ts
@@ -8,7 +8,7 @@ export const ICodeExecutionService = Symbol('ICodeExecutionService');
 
 export interface ICodeExecutionService {
     execute(code: string, resource?: Uri): Promise<void>;
-    executeFile(file: Uri): Promise<void>;
+    executeFile(file: Uri, options?: { newTerminalPerFile: boolean }): Promise<void>;
     initializeRepl(resource?: Uri): Promise<void>;
 }
 

--- a/src/test/common/terminals/factory.unit.test.ts
+++ b/src/test/common/terminals/factory.unit.test.ts
@@ -105,7 +105,7 @@ suite('Terminal Service Factory', () => {
         expect(notSameAsThirdInstance).to.not.equal(true, 'Instances are the same');
     });
 
-    test('Ensure different terminal is returned when using different resources from the same workspace', () => {
+    test('Ensure same terminal is returned when using different resources from the same workspace', () => {
         const file1A = Uri.file('1a');
         const file2A = Uri.file('2a');
         const fileB = Uri.file('b');
@@ -129,6 +129,51 @@ suite('Terminal Service Factory', () => {
         const terminalForFile1A = factory.getTerminalService({ resource: file1A }) as SynchronousTerminalService;
         const terminalForFile2A = factory.getTerminalService({ resource: file2A }) as SynchronousTerminalService;
         const terminalForFileB = factory.getTerminalService({ resource: fileB }) as SynchronousTerminalService;
+
+        const terminalsAreSameForWorkspaceA = terminalForFile1A.terminalService === terminalForFile2A.terminalService;
+        expect(terminalsAreSameForWorkspaceA).to.equal(true, 'Instances are not the same for Workspace A');
+
+        const terminalsForWorkspaceABAreDifferent =
+            terminalForFile1A.terminalService === terminalForFileB.terminalService;
+        expect(terminalsForWorkspaceABAreDifferent).to.equal(
+            false,
+            'Instances should be different for different workspaces',
+        );
+    });
+
+    test('When `newTerminalPerFile` is true, ensure different terminal is returned when using different resources from the same workspace', () => {
+        const file1A = Uri.file('1a');
+        const file2A = Uri.file('2a');
+        const fileB = Uri.file('b');
+        const workspaceUriA = Uri.file('A');
+        const workspaceUriB = Uri.file('B');
+        const workspaceFolderA = TypeMoq.Mock.ofType<WorkspaceFolder>();
+        workspaceFolderA.setup((w) => w.uri).returns(() => workspaceUriA);
+        const workspaceFolderB = TypeMoq.Mock.ofType<WorkspaceFolder>();
+        workspaceFolderB.setup((w) => w.uri).returns(() => workspaceUriB);
+
+        workspaceService
+            .setup((w) => w.getWorkspaceFolder(TypeMoq.It.isValue(file1A)))
+            .returns(() => workspaceFolderA.object);
+        workspaceService
+            .setup((w) => w.getWorkspaceFolder(TypeMoq.It.isValue(file2A)))
+            .returns(() => workspaceFolderA.object);
+        workspaceService
+            .setup((w) => w.getWorkspaceFolder(TypeMoq.It.isValue(fileB)))
+            .returns(() => workspaceFolderB.object);
+
+        const terminalForFile1A = factory.getTerminalService({
+            resource: file1A,
+            newTerminalPerFile: true,
+        }) as SynchronousTerminalService;
+        const terminalForFile2A = factory.getTerminalService({
+            resource: file2A,
+            newTerminalPerFile: true,
+        }) as SynchronousTerminalService;
+        const terminalForFileB = factory.getTerminalService({
+            resource: fileB,
+            newTerminalPerFile: true,
+        }) as SynchronousTerminalService;
 
         const terminalsAreSameForWorkspaceA = terminalForFile1A.terminalService === terminalForFile2A.terminalService;
         expect(terminalsAreSameForWorkspaceA).to.equal(false, 'Instances are the same for Workspace A');

--- a/src/test/terminals/codeExecution/codeExecutionManager.unit.test.ts
+++ b/src/test/terminals/codeExecution/codeExecutionManager.unit.test.ts
@@ -80,6 +80,7 @@ suite('Terminal - Code Execution Manager', () => {
         expect(sorted).to.deep.equal([
             Commands.Exec_In_Terminal,
             Commands.Exec_In_Terminal_Icon,
+            Commands.Exec_In_Separate_Terminal,
             Commands.Exec_Selection_In_Django_Shell,
             Commands.Exec_Selection_In_Terminal,
         ]);

--- a/src/test/terminals/codeExecution/codeExecutionManager.unit.test.ts
+++ b/src/test/terminals/codeExecution/codeExecutionManager.unit.test.ts
@@ -81,7 +81,6 @@ suite('Terminal - Code Execution Manager', () => {
             Commands.Exec_In_Terminal,
             Commands.Exec_In_Terminal_Icon,
             Commands.Exec_In_Separate_Terminal,
-            Commands.Exec_In_Separate_Terminal,
             Commands.Exec_Selection_In_Django_Shell,
             Commands.Exec_Selection_In_Terminal,
         ]);

--- a/src/test/terminals/codeExecution/codeExecutionManager.unit.test.ts
+++ b/src/test/terminals/codeExecution/codeExecutionManager.unit.test.ts
@@ -169,7 +169,10 @@ suite('Terminal - Code Execution Manager', () => {
             .returns(() => executionService.object);
 
         await commandHandler!(fileToExecute);
-        executionService.verify(async (e) => e.executeFile(TypeMoq.It.isValue(fileToExecute), TypeMoq.It.isAny()), TypeMoq.Times.once());
+        executionService.verify(
+            async (e) => e.executeFile(TypeMoq.It.isValue(fileToExecute), TypeMoq.It.isAny()),
+            TypeMoq.Times.once(),
+        );
     });
 
     async function testExecutionOfSelectionWithoutAnyActiveDocument(commandId: string, executionSericeId: string) {

--- a/src/test/terminals/codeExecution/codeExecutionManager.unit.test.ts
+++ b/src/test/terminals/codeExecution/codeExecutionManager.unit.test.ts
@@ -78,9 +78,9 @@ suite('Terminal - Code Execution Manager', () => {
 
         const sorted = registered.sort();
         expect(sorted).to.deep.equal([
+            Commands.Exec_In_Separate_Terminal,
             Commands.Exec_In_Terminal,
             Commands.Exec_In_Terminal_Icon,
-            Commands.Exec_In_Separate_Terminal,
             Commands.Exec_Selection_In_Django_Shell,
             Commands.Exec_Selection_In_Terminal,
         ]);

--- a/src/test/terminals/codeExecution/codeExecutionManager.unit.test.ts
+++ b/src/test/terminals/codeExecution/codeExecutionManager.unit.test.ts
@@ -77,13 +77,15 @@ suite('Terminal - Code Execution Manager', () => {
         executionManager.registerCommands();
 
         const sorted = registered.sort();
-        expect(sorted).to.deep.equal([
-            Commands.Exec_In_Separate_Terminal,
-            Commands.Exec_In_Terminal,
-            Commands.Exec_In_Terminal_Icon,
-            Commands.Exec_Selection_In_Django_Shell,
-            Commands.Exec_Selection_In_Terminal,
-        ]);
+        expect(sorted).to.deep.equal(
+            [
+                Commands.Exec_In_Separate_Terminal,
+                Commands.Exec_In_Terminal,
+                Commands.Exec_In_Terminal_Icon,
+                Commands.Exec_Selection_In_Django_Shell,
+                Commands.Exec_Selection_In_Terminal,
+            ].sort(),
+        );
     });
 
     test('Ensure executeFileInterTerminal will do nothing if no file is avialble', async () => {

--- a/src/test/terminals/codeExecution/codeExecutionManager.unit.test.ts
+++ b/src/test/terminals/codeExecution/codeExecutionManager.unit.test.ts
@@ -81,6 +81,7 @@ suite('Terminal - Code Execution Manager', () => {
             Commands.Exec_In_Terminal,
             Commands.Exec_In_Terminal_Icon,
             Commands.Exec_In_Separate_Terminal,
+            Commands.Exec_In_Separate_Terminal,
             Commands.Exec_Selection_In_Django_Shell,
             Commands.Exec_Selection_In_Terminal,
         ]);
@@ -136,7 +137,10 @@ suite('Terminal - Code Execution Manager', () => {
         const fileToExecute = Uri.file('x');
         await commandHandler!(fileToExecute);
         helper.verify(async (h) => h.getFileToExecute(), TypeMoq.Times.never());
-        executionService.verify(async (e) => e.executeFile(TypeMoq.It.isValue(fileToExecute)), TypeMoq.Times.once());
+        executionService.verify(
+            async (e) => e.executeFile(TypeMoq.It.isValue(fileToExecute), TypeMoq.It.isAny()),
+            TypeMoq.Times.once(),
+        );
     });
 
     test('Ensure executeFileInterTerminal will use active file', async () => {
@@ -165,7 +169,7 @@ suite('Terminal - Code Execution Manager', () => {
             .returns(() => executionService.object);
 
         await commandHandler!(fileToExecute);
-        executionService.verify(async (e) => e.executeFile(TypeMoq.It.isValue(fileToExecute)), TypeMoq.Times.once());
+        executionService.verify(async (e) => e.executeFile(TypeMoq.It.isValue(fileToExecute), TypeMoq.It.isAny()), TypeMoq.Times.once());
     });
 
     async function testExecutionOfSelectionWithoutAnyActiveDocument(commandId: string, executionSericeId: string) {


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/21215 https://github.com/microsoft/vscode-python/issues/14094

Added the option to assign a dedicated terminal for each Python file:

![image](https://github.com/microsoft/vscode-python/assets/13199757/b01248e4-c826-4de0-b15f-cde959965e68)