### PR TITLE
remove unneeded multiroot code

### DIFF
--- a/src/client/testing/testController/controller.ts
+++ b/src/client/testing/testController/controller.ts
@@ -254,8 +254,6 @@ export class PythonTestController implements ITestController, IExtensionSingleAc
                     testAdapter.discoverTests(
                         this.testController,
                         this.refreshCancellation.token,
-                        this.testAdapters.size > 1,
-                        this.workspaceService.workspaceFile?.fsPath,
                         this.pythonExecFactory,
                     );
                 } else {
@@ -274,8 +272,7 @@ export class PythonTestController implements ITestController, IExtensionSingleAc
                     testAdapter.discoverTests(
                         this.testController,
                         this.refreshCancellation.token,
-                        this.testAdapters.size > 1,
-                        this.workspaceService.workspaceFile?.fsPath,
+                        this.pythonExecFactory,
                     );
                 } else {
                     // else use OLD test discovery mechanism

--- a/src/client/testing/testController/workspaceTestAdapter.ts
+++ b/src/client/testing/testController/workspaceTestAdapter.ts
@@ -367,39 +367,6 @@ export class WorkspaceTestAdapter {
             // then parse and insert test data.
             testController.items.delete(`DiscoveryError:${workspacePath}`);
 
-            // Wrap the data under a root node named after the test provider.
-            const wrappedTests = rawTestData.tests;
-
-            // If we are in a multiroot workspace scenario, wrap the current folder's test result in a tree under the overall root + the current folder name.
-            let rootPath = workspacePath;
-            let childrenRootPath = rootPath;
-            let childrenRootName = path.basename(rootPath);
-
-            if (isMultiroot) {
-                rootPath = workspaceFilePath!;
-                childrenRootPath = workspacePath;
-                childrenRootName = path.basename(workspacePath);
-            }
-
-            const children = [
-                {
-                    path: childrenRootPath,
-                    name: childrenRootName,
-                    type_: 'folder' as DiscoveredTestType,
-                    id_: childrenRootPath,
-                    children: wrappedTests ? [wrappedTests] : [],
-                },
-            ];
-
-            // Update the raw test data with the wrapped data.
-            rawTestData.tests = {
-                path: rootPath,
-                name: this.testProvider,
-                type_: 'folder',
-                id_: rootPath,
-                children,
-            };
-
             if (rawTestData.tests) {
                 // If the test root for this folder exists: Workspace refresh, update its children.
                 // Otherwise, it is a freshly discovered workspace, and we need to create a new test root and populate the test tree.

--- a/src/client/testing/testController/workspaceTestAdapter.ts
+++ b/src/client/testing/testController/workspaceTestAdapter.ts
@@ -29,13 +29,7 @@ import {
     getTestCaseNodes,
     RunTestTag,
 } from './common/testItemUtilities';
-import {
-    DiscoveredTestItem,
-    DiscoveredTestNode,
-    DiscoveredTestType,
-    ITestDiscoveryAdapter,
-    ITestExecutionAdapter,
-} from './common/types';
+import { DiscoveredTestItem, DiscoveredTestNode, ITestDiscoveryAdapter, ITestExecutionAdapter } from './common/types';
 import { fixLogLines } from './common/utils';
 import { IPythonExecutionFactory } from '../../common/process/types';
 import { ITestDebugLauncher } from '../common/types';
@@ -288,8 +282,6 @@ export class WorkspaceTestAdapter {
     public async discoverTests(
         testController: TestController,
         token?: CancellationToken,
-        isMultiroot?: boolean,
-        workspaceFilePath?: string,
         executionFactory?: IPythonExecutionFactory,
     ): Promise<void> {
         sendTelemetryEvent(EventName.UNITTEST_DISCOVERING, undefined, { tool: this.testProvider });


### PR DESCRIPTION
removed extra steps to wrap data since this creates duplicate folders in the controller and only keeps the most recent instead of all the roots from different workspaces.