### PR TITLE
adding extra log messages for rewrite debugging

### DIFF
--- a/src/client/testing/testController/pytest/pytestDiscoveryAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestDiscoveryAdapter.ts
@@ -10,7 +10,7 @@ import {
 import { IConfigurationService, ITestOutputChannel } from '../../../common/types';
 import { createDeferred, Deferred } from '../../../common/utils/async';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
-import { traceVerbose } from '../../../logging';
+import { traceError, traceLog, traceVerbose } from '../../../logging';
 import { DataReceivedEvent, DiscoveredTestPayload, ITestDiscoveryAdapter, ITestServer } from '../common/types';
 
 /**
@@ -80,11 +80,12 @@ export class PytestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
             resource: uri,
         };
         const execService = await executionFactory.createActivatedEnvironment(creationOptions);
-        execService
-            .exec(['-m', 'pytest', '-p', 'vscode_pytest', '--collect-only'].concat(pytestArgs), spawnOptions)
-            .catch((ex) => {
-                deferred.reject(ex as Error);
-            });
+        const discoveryArgs = ['-m', 'pytest', '-p', 'vscode_pytest', '--collect-only'].concat(pytestArgs);
+        traceLog(`Discovering pytest tests with arguments: ${discoveryArgs.join(' ')}`);
+        execService.exec(discoveryArgs, spawnOptions).catch((ex) => {
+            traceError(`Error occurred while discovering tests: ${ex}`);
+            deferred.reject(ex as Error);
+        });
         return deferred.promise;
     }
 }

--- a/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
+++ b/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
@@ -14,6 +14,7 @@ import {
     TestCommandOptions,
     TestDiscoveryCommand,
 } from '../common/types';
+import { traceInfo } from '../../../logging';
 
 /**
  * Wrapper class for unittest test discovery. This is where we call `runTestCommand`.
@@ -61,6 +62,7 @@ export class UnittestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
 
         // Send the test command to the server.
         // The server will fire an onDataReceived event once it gets a response.
+        traceInfo(`Sending discover unittest script to server.`);
         this.testServer.sendCommand(options);
 
         return deferred.promise;

--- a/src/client/testing/testController/workspaceTestAdapter.ts
+++ b/src/client/testing/testController/workspaceTestAdapter.ts
@@ -101,6 +101,7 @@ export class WorkspaceTestAdapter {
             const testCaseIds = Array.from(testCaseIdsSet);
             // ** execution factory only defined for new rewrite way
             if (executionFactory !== undefined) {
+                traceVerbose('executionFactory defined');
                 rawTestExecData = await this.executionAdapter.runTests(
                     this.workspaceUri,
                     testCaseIds,
@@ -108,7 +109,6 @@ export class WorkspaceTestAdapter {
                     executionFactory,
                     debugLauncher,
                 );
-                traceVerbose('executionFactory defined');
             } else {
                 rawTestExecData = await this.executionAdapter.runTests(this.workspaceUri, testCaseIds, debugBool);
             }
@@ -300,6 +300,7 @@ export class WorkspaceTestAdapter {
         try {
             // ** execution factory only defined for new rewrite way
             if (executionFactory !== undefined) {
+                traceVerbose('executionFactory defined');
                 rawTestData = await this.discoveryAdapter.discoverTests(this.workspaceUri, executionFactory);
             } else {
                 rawTestData = await this.discoveryAdapter.discoverTests(this.workspaceUri);


### PR DESCRIPTION
These logs print errors and other bits of information which will be helpful for debugging workflows of users where we need to get information such as args or which step in the process they got to.