### PR TITLE
add pythonTestAdapter to experiment enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -462,13 +462,15 @@
                             "All",
                             "pythonSurveyNotification",
                             "pythonPromptNewToolsExt",
-                            "pythonTerminalEnvVarActivation"
+                            "pythonTerminalEnvVarActivation",
+                            "pythonTestAdapter"
                         ],
                         "enumDescriptions": [
                             "%python.experiments.All.description%",
                             "%python.experiments.pythonSurveyNotification.description%",
                             "%python.experiments.pythonPromptNewToolsExt.description%",
-                            "%python.experiments.pythonTerminalEnvVarActivation.description%"
+                            "%python.experiments.pythonTerminalEnvVarActivation.description%",
+                            "%python.experiments.pythonTestAdapter.description%"
                         ]
                     },
                     "scope": "machine",
@@ -483,13 +485,15 @@
                             "All",
                             "pythonSurveyNotification",
                             "pythonPromptNewToolsExt",
-                            "pythonTerminalEnvVarActivation"
+                            "pythonTerminalEnvVarActivation",
+                            "pythonTestAdapter"
                         ],
                         "enumDescriptions": [
                             "%python.experiments.All.description%",
                             "%python.experiments.pythonSurveyNotification.description%",
                             "%python.experiments.pythonPromptNewToolsExt.description%",
-                            "%python.experiments.pythonTerminalEnvVarActivation.description%"
+                            "%python.experiments.pythonTerminalEnvVarActivation.description%",
+                            "%python.experiments.pythonTestAdapter.description%"
                         ]
                     },
                     "scope": "machine",

--- a/package.nls.json
+++ b/package.nls.json
@@ -43,6 +43,7 @@
     "python.experiments.pythonSurveyNotification.description": "Denotes the Python Survey Notification experiment.",
     "python.experiments.pythonPromptNewToolsExt.description": "Denotes the Python Prompt New Tools Extension experiment.",
     "python.experiments.pythonTerminalEnvVarActivation.description": "Enables use of environment variables to activate terminals instead of sending activation commands.",
+    "python.experiments.pythonTestAdapter.description": "Denotes the Python Test Adapter experiment.",
     "python.formatting.autopep8Args.description": "Arguments passed in. Each argument is a separate item in the array.",
     "python.formatting.autopep8Path.description": "Path to autopep8, you can use a custom version of autopep8 by modifying this setting to include the full path.",
     "python.formatting.blackArgs.description": "Arguments passed in. Each argument is a separate item in the array.",


### PR DESCRIPTION
allow people to opt in and out of the pythonTestAdapter rewrite via the setting `python.experiment.optInto` or `python.experiment.optOutfrom`