### PR TITLE
fix pytest run script to add cwd to path

### DIFF
--- a/pythonFiles/vscode_pytest/run_pytest_script.py
+++ b/pythonFiles/vscode_pytest/run_pytest_script.py
@@ -21,6 +21,7 @@ if __name__ == "__main__":
     # Add the root directory to the path so that we can import the plugin.
     directory_path = pathlib.Path(__file__).parent.parent
     sys.path.append(os.fspath(directory_path))
+    sys.path.insert(0, os.getcwd())
     # Get the rest of the args to run with pytest.
     args = sys.argv[1:]
     run_test_ids_port = os.environ.get("RUN_TEST_IDS_PORT")


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python/issues/21397. The issue came from the setup of running a script that then runs pytest which is different then pytest discovery which runs pytest as a module. The run script didn't work since the script did not insert the cwd into the path like what is done when running a module. This change inserts the cwd.