### PR TITLE
Move testid server

### DIFF
--- a/pythonFiles/vscode_pytest/run_pytest_script.py
+++ b/pythonFiles/vscode_pytest/run_pytest_script.py
@@ -21,6 +21,7 @@ if __name__ == "__main__":
     # Add the root directory to the path so that we can import the plugin.
     directory_path = pathlib.Path(__file__).parent.parent
     sys.path.append(os.fspath(directory_path))
+    sys.path.insert(0, os.getcwd())
     # Get the rest of the args to run with pytest.
     args = sys.argv[1:]
     run_test_ids_port = os.environ.get("RUN_TEST_IDS_PORT")

--- a/src/client/testing/common/socketServer.ts
+++ b/src/client/testing/common/socketServer.ts
@@ -123,7 +123,7 @@ export class UnitTestSocketServer extends EventEmitter implements IUnitTestSocke
             if ((socket as any).id) {
                 destroyedSocketId = (socket as any).id;
             }
-            this.log('socket disconnected', destroyedSocketId.toString());
+            this.log('socket disconnected', destroyedSocketId?.toString());
             if (socket && socket.destroy) {
                 socket.destroy();
             }

--- a/src/client/testing/testController/common/resultResolver.ts
+++ b/src/client/testing/testController/common/resultResolver.ts
@@ -1,0 +1,320 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {
+    CancellationToken,
+    Position,
+    TestController,
+    TestItem,
+    Uri,
+    Range,
+    TestMessage,
+    Location,
+    TestRun,
+} from 'vscode';
+import * as util from 'util';
+import * as path from 'path';
+import {
+    DiscoveredTestItem,
+    DiscoveredTestNode,
+    DiscoveredTestPayload,
+    ExecutionTestPayload,
+    ITestResultResolver,
+} from './types';
+import { TestProvider } from '../../types';
+import { traceError } from '../../../logging';
+import { Testing } from '../../../common/utils/localize';
+import {
+    DebugTestTag,
+    ErrorTestItemOptions,
+    RunTestTag,
+    clearAllChildren,
+    createErrorTestItem,
+    getTestCaseNodes,
+} from './testItemUtilities';
+import { sendTelemetryEvent } from '../../../telemetry';
+import { EventName } from '../../../telemetry/constants';
+import { splitLines } from '../../../common/stringUtils';
+import { fixLogLines } from './utils';
+
+export class PythonResultResolver implements ITestResultResolver {
+    testController: TestController;
+
+    testProvider: TestProvider;
+
+    public runIdToTestItem: Map<string, TestItem>;
+
+    public runIdToVSid: Map<string, string>;
+
+    public vsIdToRunId: Map<string, string>;
+
+    constructor(testController: TestController, testProvider: TestProvider, private workspaceUri: Uri) {
+        this.testController = testController;
+        this.testProvider = testProvider;
+
+        this.runIdToTestItem = new Map<string, TestItem>();
+        this.runIdToVSid = new Map<string, string>();
+        this.vsIdToRunId = new Map<string, string>();
+    }
+
+    public resolveDiscovery(payload: DiscoveredTestPayload, token?: CancellationToken): Promise<void> {
+        const workspacePath = this.workspaceUri.fsPath;
+
+        const rawTestData = payload;
+        if (!rawTestData) {
+            // No test data is available
+            return Promise.resolve();
+        }
+
+        // Check if there were any errors in the discovery process.
+        if (rawTestData.status === 'error') {
+            const testingErrorConst =
+                this.testProvider === 'pytest' ? Testing.errorPytestDiscovery : Testing.errorUnittestDiscovery;
+            const { errors } = rawTestData;
+            traceError(testingErrorConst, '\r\n', errors!.join('\r\n\r\n'));
+
+            let errorNode = this.testController.items.get(`DiscoveryError:${workspacePath}`);
+            const message = util.format(
+                `${testingErrorConst} ${Testing.seePythonOutput}\r\n`,
+                errors!.join('\r\n\r\n'),
+            );
+
+            if (errorNode === undefined) {
+                const options = buildErrorNodeOptions(this.workspaceUri, message, this.testProvider);
+                errorNode = createErrorTestItem(this.testController, options);
+                this.testController.items.add(errorNode);
+            }
+            errorNode.error = message;
+        } else {
+            // Remove the error node if necessary,
+            // then parse and insert test data.
+            this.testController.items.delete(`DiscoveryError:${workspacePath}`);
+
+            if (rawTestData.tests) {
+                // If the test root for this folder exists: Workspace refresh, update its children.
+                // Otherwise, it is a freshly discovered workspace, and we need to create a new test root and populate the test tree.
+                populateTestTree(this.testController, rawTestData.tests, undefined, this, token);
+            } else {
+                // Delete everything from the test controller.
+                this.testController.items.replace([]);
+            }
+        }
+
+        sendTelemetryEvent(EventName.UNITTEST_DISCOVERY_DONE, undefined, {
+            tool: this.testProvider,
+            failed: false,
+        });
+        return Promise.resolve();
+    }
+
+    public resolveExecution(payload: ExecutionTestPayload, runInstance: TestRun): Promise<void> {
+        const rawTestExecData = payload;
+        if (rawTestExecData !== undefined && rawTestExecData.result !== undefined) {
+            // Map which holds the subtest information for each test item.
+            const subTestStats: Map<string, { passed: number; failed: number }> = new Map();
+
+            // iterate through payload and update the UI accordingly.
+            for (const keyTemp of Object.keys(rawTestExecData.result)) {
+                const testCases: TestItem[] = [];
+
+                // grab leaf level test items
+                this.testController.items.forEach((i) => {
+                    const tempArr: TestItem[] = getTestCaseNodes(i);
+                    testCases.push(...tempArr);
+                });
+
+                if (
+                    rawTestExecData.result[keyTemp].outcome === 'failure' ||
+                    rawTestExecData.result[keyTemp].outcome === 'passed-unexpected'
+                ) {
+                    const rawTraceback = rawTestExecData.result[keyTemp].traceback ?? '';
+                    const traceback = splitLines(rawTraceback, {
+                        trim: false,
+                        removeEmptyEntries: true,
+                    }).join('\r\n');
+
+                    const text = `${rawTestExecData.result[keyTemp].test} failed: ${
+                        rawTestExecData.result[keyTemp].message ?? rawTestExecData.result[keyTemp].outcome
+                    }\r\n${traceback}\r\n`;
+                    const message = new TestMessage(text);
+
+                    // note that keyTemp is a runId for unittest library...
+                    const grabVSid = this.runIdToVSid.get(keyTemp);
+                    // search through freshly built array of testItem to find the failed test and update UI.
+                    testCases.forEach((indiItem) => {
+                        if (indiItem.id === grabVSid) {
+                            if (indiItem.uri && indiItem.range) {
+                                message.location = new Location(indiItem.uri, indiItem.range);
+                                runInstance.failed(indiItem, message);
+                                runInstance.appendOutput(fixLogLines(text));
+                            }
+                        }
+                    });
+                } else if (
+                    rawTestExecData.result[keyTemp].outcome === 'success' ||
+                    rawTestExecData.result[keyTemp].outcome === 'expected-failure'
+                ) {
+                    const grabTestItem = this.runIdToTestItem.get(keyTemp);
+                    const grabVSid = this.runIdToVSid.get(keyTemp);
+                    if (grabTestItem !== undefined) {
+                        testCases.forEach((indiItem) => {
+                            if (indiItem.id === grabVSid) {
+                                if (indiItem.uri && indiItem.range) {
+                                    runInstance.passed(grabTestItem);
+                                    runInstance.appendOutput('Passed here');
+                                }
+                            }
+                        });
+                    }
+                } else if (rawTestExecData.result[keyTemp].outcome === 'skipped') {
+                    const grabTestItem = this.runIdToTestItem.get(keyTemp);
+                    const grabVSid = this.runIdToVSid.get(keyTemp);
+                    if (grabTestItem !== undefined) {
+                        testCases.forEach((indiItem) => {
+                            if (indiItem.id === grabVSid) {
+                                if (indiItem.uri && indiItem.range) {
+                                    runInstance.skipped(grabTestItem);
+                                    runInstance.appendOutput('Skipped here');
+                                }
+                            }
+                        });
+                    }
+                } else if (rawTestExecData.result[keyTemp].outcome === 'subtest-failure') {
+                    // split on " " since the subtest ID has the parent test ID in the first part of the ID.
+                    const parentTestCaseId = keyTemp.split(' ')[0];
+                    const parentTestItem = this.runIdToTestItem.get(parentTestCaseId);
+                    const data = rawTestExecData.result[keyTemp];
+                    // find the subtest's parent test item
+                    if (parentTestItem) {
+                        const subtestStats = subTestStats.get(parentTestCaseId);
+                        if (subtestStats) {
+                            subtestStats.failed += 1;
+                        } else {
+                            subTestStats.set(parentTestCaseId, { failed: 1, passed: 0 });
+                            runInstance.appendOutput(fixLogLines(`${parentTestCaseId} [subtests]:\r\n`));
+                            // clear since subtest items don't persist between runs
+                            clearAllChildren(parentTestItem);
+                        }
+                        const subtestId = keyTemp;
+                        const subTestItem = this.testController?.createTestItem(subtestId, subtestId);
+                        runInstance.appendOutput(fixLogLines(`${subtestId} Failed\r\n`));
+                        // create a new test item for the subtest
+                        if (subTestItem) {
+                            const traceback = data.traceback ?? '';
+                            const text = `${data.subtest} Failed: ${data.message ?? data.outcome}\r\n${traceback}\r\n`;
+                            runInstance.appendOutput(fixLogLines(text));
+                            parentTestItem.children.add(subTestItem);
+                            runInstance.started(subTestItem);
+                            const message = new TestMessage(rawTestExecData?.result[keyTemp].message ?? '');
+                            if (parentTestItem.uri && parentTestItem.range) {
+                                message.location = new Location(parentTestItem.uri, parentTestItem.range);
+                            }
+                            runInstance.failed(subTestItem, message);
+                        } else {
+                            throw new Error('Unable to create new child node for subtest');
+                        }
+                    } else {
+                        throw new Error('Parent test item not found');
+                    }
+                } else if (rawTestExecData.result[keyTemp].outcome === 'subtest-success') {
+                    // split on " " since the subtest ID has the parent test ID in the first part of the ID.
+                    const parentTestCaseId = keyTemp.split(' ')[0];
+                    const parentTestItem = this.runIdToTestItem.get(parentTestCaseId);
+
+                    // find the subtest's parent test item
+                    if (parentTestItem) {
+                        const subtestStats = subTestStats.get(parentTestCaseId);
+                        if (subtestStats) {
+                            subtestStats.passed += 1;
+                        } else {
+                            subTestStats.set(parentTestCaseId, { failed: 0, passed: 1 });
+                            runInstance.appendOutput(fixLogLines(`${parentTestCaseId} [subtests]:\r\n`));
+                            // clear since subtest items don't persist between runs
+                            clearAllChildren(parentTestItem);
+                        }
+                        const subtestId = keyTemp;
+                        const subTestItem = this.testController?.createTestItem(subtestId, subtestId);
+                        // create a new test item for the subtest
+                        if (subTestItem) {
+                            parentTestItem.children.add(subTestItem);
+                            runInstance.started(subTestItem);
+                            runInstance.passed(subTestItem);
+                            runInstance.appendOutput(fixLogLines(`${subtestId} Passed\r\n`));
+                        } else {
+                            throw new Error('Unable to create new child node for subtest');
+                        }
+                    } else {
+                        throw new Error('Parent test item not found');
+                    }
+                }
+            }
+        }
+        return Promise.resolve();
+    }
+}
+// had to switch the order of the original parameter since required param cannot follow optional.
+function populateTestTree(
+    testController: TestController,
+    testTreeData: DiscoveredTestNode,
+    testRoot: TestItem | undefined,
+    resultResolver: ITestResultResolver,
+    token?: CancellationToken,
+): void {
+    // If testRoot is undefined, use the info of the root item of testTreeData to create a test item, and append it to the test controller.
+    if (!testRoot) {
+        testRoot = testController.createTestItem(testTreeData.path, testTreeData.name, Uri.file(testTreeData.path));
+
+        testRoot.canResolveChildren = true;
+        testRoot.tags = [RunTestTag, DebugTestTag];
+
+        testController.items.add(testRoot);
+    }
+
+    // Recursively populate the tree with test data.
+    testTreeData.children.forEach((child) => {
+        if (!token?.isCancellationRequested) {
+            if (isTestItem(child)) {
+                const testItem = testController.createTestItem(child.id_, child.name, Uri.file(child.path));
+                testItem.tags = [RunTestTag, DebugTestTag];
+
+                const range = new Range(
+                    new Position(Number(child.lineno) - 1, 0),
+                    new Position(Number(child.lineno), 0),
+                );
+                testItem.canResolveChildren = false;
+                testItem.range = range;
+                testItem.tags = [RunTestTag, DebugTestTag];
+
+                testRoot!.children.add(testItem);
+                // add to our map
+                resultResolver.runIdToTestItem.set(child.runID, testItem);
+                resultResolver.runIdToVSid.set(child.runID, child.id_);
+                resultResolver.vsIdToRunId.set(child.id_, child.runID);
+            } else {
+                let node = testController.items.get(child.path);
+
+                if (!node) {
+                    node = testController.createTestItem(child.id_, child.name, Uri.file(child.path));
+
+                    node.canResolveChildren = true;
+                    node.tags = [RunTestTag, DebugTestTag];
+                    testRoot!.children.add(node);
+                }
+                populateTestTree(testController, child, node, resultResolver, token);
+            }
+        }
+    });
+}
+
+function isTestItem(test: DiscoveredTestNode | DiscoveredTestItem): test is DiscoveredTestItem {
+    return test.type_ === 'test';
+}
+
+export function buildErrorNodeOptions(uri: Uri, message: string, testType: string): ErrorTestItemOptions {
+    const labelText = testType === 'pytest' ? 'Pytest Discovery Error' : 'Unittest Discovery Error';
+    return {
+        id: `DiscoveryError:${uri.fsPath}`,
+        label: `${labelText} [${path.basename(uri.fsPath)}]`,
+        error: message,
+    };
+}

--- a/src/client/testing/testController/common/resultResolver.ts
+++ b/src/client/testing/testController/common/resultResolver.ts
@@ -22,7 +22,7 @@ import {
     ITestResultResolver,
 } from './types';
 import { TestProvider } from '../../types';
-import { traceError } from '../../../logging';
+import { traceError, traceLog } from '../../../logging';
 import { Testing } from '../../../common/utils/localize';
 import {
     DebugTestTag,
@@ -59,6 +59,7 @@ export class PythonResultResolver implements ITestResultResolver {
 
     public resolveDiscovery(payload: DiscoveredTestPayload, token?: CancellationToken): Promise<void> {
         const workspacePath = this.workspaceUri.fsPath;
+        traceLog('Using result resolver for discovery');
 
         const rawTestData = payload;
         if (!rawTestData) {

--- a/src/client/testing/testController/common/server.ts
+++ b/src/client/testing/testController/common/server.ts
@@ -24,6 +24,10 @@ export class PythonTestServer implements ITestServer, Disposable {
 
     private ready: Promise<void>;
 
+    private _onRunDataReceived: EventEmitter<DataReceivedEvent> = new EventEmitter<DataReceivedEvent>();
+
+    private _onDiscoveryDataReceived: EventEmitter<DataReceivedEvent> = new EventEmitter<DataReceivedEvent>();
+
     constructor(private executionFactory: IPythonExecutionFactory, private debugLauncher: ITestDebugLauncher) {
         this.server = net.createServer((socket: net.Socket) => {
             let buffer: Buffer = Buffer.alloc(0); // Buffer to accumulate received data
@@ -48,11 +52,28 @@ export class PythonTestServer implements ITestServer, Disposable {
                         rawData = rpcHeaders.remainingRawData;
                         const rpcContent = jsonRPCContent(rpcHeaders.headers, rawData);
                         const extractedData = rpcContent.extractedJSON;
+                        // do not send until we have the full content
                         if (extractedData.length === Number(totalContentLength)) {
-                            // do not send until we have the full content
-                            traceVerbose(`Received data from test server: ${extractedData}`);
-                            this._onDataReceived.fire({ uuid, data: extractedData });
-                            this.uuids = this.uuids.filter((u) => u !== uuid);
+                            // if the rawData includes tests then this is a discovery request
+                            if (rawData.includes(`"tests":`)) {
+                                this._onDiscoveryDataReceived.fire({
+                                    uuid,
+                                    data: rpcContent.extractedJSON,
+                                });
+                                // if the rawData includes result then this is a run request
+                            } else if (rawData.includes(`"result":`)) {
+                                this._onRunDataReceived.fire({
+                                    uuid,
+                                    data: rpcContent.extractedJSON,
+                                });
+                            } else {
+                                traceLog(
+                                    `Error processing test server request: request is not recognized as discovery or run.`,
+                                );
+                                this._onDataReceived.fire({ uuid: '', data: '' });
+                                return;
+                            }
+                            // this.uuids = this.uuids.filter((u) => u !== uuid); WHERE DOES THIS GO??
                             buffer = Buffer.alloc(0);
                         } else {
                             break;
@@ -95,6 +116,18 @@ export class PythonTestServer implements ITestServer, Disposable {
         const uuid = crypto.randomUUID();
         this.uuids.push(uuid);
         return uuid;
+    }
+
+    public deleteUUID(uuid: string): void {
+        this.uuids = this.uuids.filter((u) => u !== uuid);
+    }
+
+    public get onRunDataReceived(): Event<DataReceivedEvent> {
+        return this._onRunDataReceived.event;
+    }
+
+    public get onDiscoveryDataReceived(): Event<DataReceivedEvent> {
+        return this._onDiscoveryDataReceived.event;
     }
 
     public dispose(): void {

--- a/src/client/testing/testController/common/server.ts
+++ b/src/client/testing/testController/common/server.ts
@@ -9,7 +9,7 @@ import {
     IPythonExecutionFactory,
     SpawnOptions,
 } from '../../../common/process/types';
-import { traceError, traceInfo, traceLog, traceVerbose } from '../../../logging';
+import { traceError, traceInfo, traceLog } from '../../../logging';
 import { DataReceivedEvent, ITestServer, TestCommandOptions } from './types';
 import { ITestDebugLauncher, LaunchOptions } from '../../common/types';
 import { UNITTEST_PROVIDER } from '../../common/constants';

--- a/src/client/testing/testController/common/types.ts
+++ b/src/client/testing/testController/common/types.ts
@@ -174,7 +174,7 @@ export interface ITestServer {
     readonly onDataReceived: Event<DataReceivedEvent>;
     readonly onRunDataReceived: Event<DataReceivedEvent>;
     readonly onDiscoveryDataReceived: Event<DataReceivedEvent>;
-    sendCommand(options: TestCommandOptions): Promise<void>;
+    sendCommand(options: TestCommandOptions, runTestIdsPort?: string, callback?: () => void): Promise<void>;
     serverReady(): Promise<void>;
     getPort(): number;
     createUUID(cwd: string): string;

--- a/src/client/testing/testController/common/types.ts
+++ b/src/client/testing/testController/common/types.ts
@@ -172,12 +172,21 @@ export type TestCommandOptionsPytest = {
  */
 export interface ITestServer {
     readonly onDataReceived: Event<DataReceivedEvent>;
-    sendCommand(options: TestCommandOptions, runTestIdsPort?: string, callback?: () => void): Promise<void>;
+    readonly onRunDataReceived: Event<DataReceivedEvent>;
+    readonly onDiscoveryDataReceived: Event<DataReceivedEvent>;
+    sendCommand(options: TestCommandOptions): Promise<void>;
     serverReady(): Promise<void>;
     getPort(): number;
     createUUID(cwd: string): string;
+    deleteUUID(uuid: string): void;
 }
-
+export interface ITestResultResolver {
+    runIdToVSid: Map<string, string>;
+    runIdToTestItem: Map<string, TestItem>;
+    vsIdToRunId: Map<string, string>;
+    resolveDiscovery(payload: DiscoveredTestPayload, token?: CancellationToken): Promise<void>;
+    resolveExecution(payload: ExecutionTestPayload, runInstance: TestRun): Promise<void>;
+}
 export interface ITestDiscoveryAdapter {
     // ** first line old method signature, second line new method signature
     discoverTests(uri: Uri): Promise<DiscoveredTestPayload>;
@@ -192,6 +201,7 @@ export interface ITestExecutionAdapter {
         uri: Uri,
         testIds: string[],
         debugBool?: boolean,
+        runInstance?: TestRun,
         executionFactory?: IPythonExecutionFactory,
         debugLauncher?: ITestDebugLauncher,
     ): Promise<ExecutionTestPayload>;

--- a/src/client/testing/testController/common/utils.ts
+++ b/src/client/testing/testController/common/utils.ts
@@ -62,7 +62,7 @@ export function pythonTestAdapterRewriteEnabled(serviceContainer: IServiceContai
     return experiment.inExperimentSync(EnableTestAdapterRewrite.experiment);
 }
 
-export const startServer = (testIds: string): Promise<number> =>
+export const startTestIdServer = (testIds: string[]): Promise<number> =>
     new Promise((resolve, reject) => {
         const server = net.createServer((socket: net.Socket) => {
             // Convert the test_ids array to JSON

--- a/src/client/testing/testController/controller.ts
+++ b/src/client/testing/testController/controller.ts
@@ -45,11 +45,8 @@ import { PytestTestDiscoveryAdapter } from './pytest/pytestDiscoveryAdapter';
 import { PytestTestExecutionAdapter } from './pytest/pytestExecutionAdapter';
 import { WorkspaceTestAdapter } from './workspaceTestAdapter';
 import { ITestDebugLauncher } from '../common/types';
-import { pythonTestAdapterRewriteEnabled } from './common/utils';
 import { IServiceContainer } from '../../ioc/types';
 import { PythonResultResolver } from './common/resultResolver';
-import { pythonTestAdapterRewriteEnabled } from './common/utils';
-import { IServiceContainer } from '../../ioc/types';
 
 // Types gymnastics to make sure that sendTriggerTelemetry only accepts the correct types.
 type EventPropertyType = IEventNamePropertyMapping[EventName.UNITTEST_DISCOVERY_TRIGGER];

--- a/src/client/testing/testController/controller.ts
+++ b/src/client/testing/testController/controller.ts
@@ -31,6 +31,7 @@ import { PYTEST_PROVIDER, UNITTEST_PROVIDER } from '../common/constants';
 import { TestProvider } from '../types';
 import { PythonTestServer } from './common/server';
 import { DebugTestTag, getNodeByUri, RunTestTag } from './common/testItemUtilities';
+import { pythonTestAdapterRewriteEnabled } from './common/utils';
 import {
     ITestController,
     ITestDiscoveryAdapter,

--- a/src/client/testing/testController/controller.ts
+++ b/src/client/testing/testController/controller.ts
@@ -48,6 +48,8 @@ import { ITestDebugLauncher } from '../common/types';
 import { pythonTestAdapterRewriteEnabled } from './common/utils';
 import { IServiceContainer } from '../../ioc/types';
 import { PythonResultResolver } from './common/resultResolver';
+import { pythonTestAdapterRewriteEnabled } from './common/utils';
+import { IServiceContainer } from '../../ioc/types';
 
 // Types gymnastics to make sure that sendTriggerTelemetry only accepts the correct types.
 type EventPropertyType = IEventNamePropertyMapping[EventName.UNITTEST_DISCOVERY_TRIGGER];

--- a/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
@@ -3,7 +3,6 @@
 
 import { TestRun, Uri } from 'vscode';
 import * as path from 'path';
-import * as net from 'net';
 import { IConfigurationService, ITestOutputChannel } from '../../../common/types';
 import { createDeferred, Deferred } from '../../../common/utils/async';
 import { traceError, traceInfo, traceLog, traceVerbose } from '../../../logging';

--- a/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as net from 'net';
 import { IConfigurationService, ITestOutputChannel } from '../../../common/types';
 import { createDeferred, Deferred } from '../../../common/utils/async';
-import { traceError, traceLog, traceVerbose } from '../../../logging';
+import { traceError, traceInfo, traceLog, traceVerbose } from '../../../logging';
 import {
     DataReceivedEvent,
     ExecutionTestPayload,

--- a/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
@@ -189,6 +189,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
             return Promise.reject(ex);
         }
 
-        return deferred.promise;
+        const executionPayload: ExecutionTestPayload = { cwd: uri.fsPath, status: 'success', error: '' };
+        return executionPayload;
     }
 }

--- a/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
+++ b/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
@@ -15,7 +15,6 @@ import {
     TestCommandOptions,
     TestDiscoveryCommand,
 } from '../common/types';
-import { traceInfo } from '../../../logging';
 
 /**
  * Wrapper class for unittest test discovery. This is where we call `runTestCommand`.

--- a/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
+++ b/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
@@ -10,6 +10,7 @@ import {
     DataReceivedEvent,
     DiscoveredTestPayload,
     ITestDiscoveryAdapter,
+    ITestResultResolver,
     ITestServer,
     TestCommandOptions,
     TestDiscoveryCommand,
@@ -28,17 +29,8 @@ export class UnittestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
         public testServer: ITestServer,
         public configSettings: IConfigurationService,
         private readonly outputChannel: ITestOutputChannel,
-    ) {
-        testServer.onDataReceived(this.onDataReceivedHandler, this);
-    }
-
-    public onDataReceivedHandler({ uuid, data }: DataReceivedEvent): void {
-        const deferred = this.promiseMap.get(uuid);
-        if (deferred) {
-            deferred.resolve(JSON.parse(data));
-            this.promiseMap.delete(uuid);
-        }
-    }
+        private readonly resultResolver?: ITestResultResolver,
+    ) {}
 
     public async discoverTests(uri: Uri): Promise<DiscoveredTestPayload> {
         const deferred = createDeferred<DiscoveredTestPayload>();
@@ -60,12 +52,23 @@ export class UnittestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
 
         this.promiseMap.set(uuid, deferred);
 
-        // Send the test command to the server.
-        // The server will fire an onDataReceived event once it gets a response.
-        traceInfo(`Sending discover unittest script to server.`);
-        this.testServer.sendCommand(options);
+        const disposable = this.testServer.onDiscoveryDataReceived((e: DataReceivedEvent) => {
+            this.resultResolver?.resolveDiscovery(JSON.parse(e.data));
+        });
+        try {
+            await this.callSendCommand(options);
+        } finally {
+            disposable.dispose();
+            // confirm with testing that this gets called (it must clean this up)
+        }
+        const discoveryPayload: DiscoveredTestPayload = { cwd: uri.fsPath, status: 'success' };
+        return discoveryPayload;
+    }
 
-        return deferred.promise;
+    private async callSendCommand(options: TestCommandOptions): Promise<DiscoveredTestPayload> {
+        await this.testServer.sendCommand(options);
+        const discoveryPayload: DiscoveredTestPayload = { cwd: '', status: 'success' };
+        return discoveryPayload;
     }
 }
 

--- a/src/client/testing/testController/unittest/testExecutionAdapter.ts
+++ b/src/client/testing/testController/unittest/testExecutionAdapter.ts
@@ -3,7 +3,6 @@
 
 import * as path from 'path';
 import { TestRun, Uri } from 'vscode';
-import * as net from 'net';
 import { IConfigurationService, ITestOutputChannel } from '../../../common/types';
 import { createDeferred, Deferred } from '../../../common/utils/async';
 import { EXTENSION_ROOT_DIR } from '../../../constants';

--- a/src/client/testing/testController/unittest/testExecutionAdapter.ts
+++ b/src/client/testing/testController/unittest/testExecutionAdapter.ts
@@ -17,6 +17,7 @@ import {
     TestExecutionCommand,
 } from '../common/types';
 import { traceLog, traceError } from '../../../logging';
+import { startTestIdServer } from '../common/utils';
 
 /**
  * Wrapper Class for unittest test execution. This is where we call `runTestCommand`?
@@ -75,37 +76,11 @@ export class UnittestTestExecutionAdapter implements ITestExecutionAdapter {
 
         const deferred = createDeferred<ExecutionTestPayload>();
         this.promiseMap.set(uuid, deferred);
-        // create payload with testIds to send to run pytest script
-        const testData = JSON.stringify(testIds);
-        const headers = [`Content-Length: ${Buffer.byteLength(testData)}`, 'Content-Type: application/json'];
-        const payload = `${headers.join('\r\n')}\r\n\r\n${testData}`;
+
+        traceLog(`Running UNITTEST execution for the following test ids: ${testIds}`);
 
         let runTestIdsPort: string | undefined;
-        const startServer = (): Promise<number> =>
-            new Promise((resolve, reject) => {
-                const server = net.createServer((socket: net.Socket) => {
-                    socket.on('end', () => {
-                        traceLog('Client disconnected');
-                    });
-                });
-
-                server.listen(0, () => {
-                    const { port } = server.address() as net.AddressInfo;
-                    traceLog(`Server listening on port ${port}`);
-                    resolve(port);
-                });
-
-                server.on('error', (error: Error) => {
-                    reject(error);
-                });
-                server.on('connection', (socket: net.Socket) => {
-                    socket.write(payload);
-                    traceLog('payload sent', payload);
-                });
-            });
-
-        // Start the server and wait until it is listening
-        await startServer()
+        await startTestIdServer(testIds)
             .then((assignedPort) => {
                 traceLog(`Server started and listening on port ${assignedPort}`);
                 runTestIdsPort = assignedPort.toString();

--- a/src/client/testing/testController/unittest/testExecutionAdapter.ts
+++ b/src/client/testing/testController/unittest/testExecutionAdapter.ts
@@ -1,118 +1,126 @@
-// // Copyright (c) Microsoft Corporation. All rights reserved.
-// // Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
-// import * as assert from 'assert';
-// import * as path from 'path';
-// import * as typemoq from 'typemoq';
-// import { Uri } from 'vscode';
-// import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
-// import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
-// import { ITestServer, TestCommandOptions } from '../../../../client/testing/testController/common/types';
-// import { UnittestTestExecutionAdapter } from '../../../../client/testing/testController/unittest/testExecutionAdapter';
+import * as path from 'path';
+import { TestRun, Uri } from 'vscode';
+import * as net from 'net';
+import { IConfigurationService, ITestOutputChannel } from '../../../common/types';
+import { createDeferred, Deferred } from '../../../common/utils/async';
+import { EXTENSION_ROOT_DIR } from '../../../constants';
+import {
+    DataReceivedEvent,
+    ExecutionTestPayload,
+    ITestExecutionAdapter,
+    ITestResultResolver,
+    ITestServer,
+    TestCommandOptions,
+    TestExecutionCommand,
+} from '../common/types';
+import { traceLog, traceError } from '../../../logging';
 
-// suite('Unittest test execution adapter', () => {
-//     let stubConfigSettings: IConfigurationService;
-//     let outputChannel: typemoq.IMock<ITestOutputChannel>;
+/**
+ * Wrapper Class for unittest test execution. This is where we call `runTestCommand`?
+ */
 
-//     setup(() => {
-//         stubConfigSettings = ({
-//             getSettings: () => ({
-//                 testing: { unittestArgs: ['-v', '-s', '.', '-p', 'test*'] },
-//             }),
-//         } as unknown) as IConfigurationService;
-//         outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
-//     });
+export class UnittestTestExecutionAdapter implements ITestExecutionAdapter {
+    private promiseMap: Map<string, Deferred<ExecutionTestPayload | undefined>> = new Map();
 
-//     test('runTests should send the run command to the test server', async () => {
-//         let options: TestCommandOptions | undefined;
+    private cwd: string | undefined;
 
-//         const stubTestServer = ({
-//             sendCommand(opt: TestCommandOptions, runTestIdPort?: string): Promise<void> {
-//                 delete opt.outChannel;
-//                 options = opt;
-//                 assert(runTestIdPort !== undefined);
-//                 return Promise.resolve();
-//             },
-//             onDataReceived: () => {
-//                 // no body
-//             },
-//             createUUID: () => '123456789',
-//         } as unknown) as ITestServer;
+    constructor(
+        public testServer: ITestServer,
+        public configSettings: IConfigurationService,
+        private readonly outputChannel: ITestOutputChannel,
+        private readonly resultResolver?: ITestResultResolver,
+    ) {}
 
-//         const uri = Uri.file('/foo/bar');
-//         const script = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'unittestadapter', 'execution.py');
+    public async runTests(
+        uri: Uri,
+        testIds: string[],
+        debugBool?: boolean,
+        runInstance?: TestRun,
+    ): Promise<ExecutionTestPayload> {
+        const settings = this.configSettings.getSettings(uri);
+        const { unittestArgs } = settings.testing;
 
-//         const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
-//         adapter.runTests(uri, [], false).then(() => {
-//             const expectedOptions: TestCommandOptions = {
-//                 workspaceFolder: uri,
-//                 command: { script, args: ['--udiscovery', '-v', '-s', '.', '-p', 'test*'] },
-//                 cwd: uri.fsPath,
-//                 uuid: '123456789',
-//                 debugBool: false,
-//                 testIds: [],
-//             };
-//             assert.deepStrictEqual(options, expectedOptions);
-//         });
-//     });
-//     test("onDataReceivedHandler should parse the data if the cwd from the payload matches the test adapter's cwd", async () => {
-//         const stubTestServer = ({
-//             sendCommand(): Promise<void> {
-//                 return Promise.resolve();
-//             },
-//             onDataReceived: () => {
-//                 // no body
-//             },
-//             createUUID: () => '123456789',
-//         } as unknown) as ITestServer;
+        const command = buildExecutionCommand(unittestArgs);
+        this.cwd = uri.fsPath;
+        const uuid = this.testServer.createUUID(uri.fsPath);
 
-//         const uri = Uri.file('/foo/bar');
-//         const data = { status: 'success' };
-//         const uuid = '123456789';
+        const options: TestCommandOptions = {
+            workspaceFolder: uri,
+            command,
+            cwd: this.cwd,
+            uuid,
+            debugBool,
+            testIds,
+            outChannel: this.outputChannel,
+        };
 
-//         const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
+        const deferred = createDeferred<ExecutionTestPayload>();
+        this.promiseMap.set(uuid, deferred);
 
-//         // triggers runTests flow which will run onDataReceivedHandler and the
-//         // promise resolves into the parsed data.
-//         const promise = adapter.runTests(uri, [], false);
+        const disposable = this.testServer.onRunDataReceived((e: DataReceivedEvent) => {
+            if (runInstance) {
+                this.resultResolver?.resolveExecution(JSON.parse(e.data), runInstance);
+            }
+        });
 
-//         adapter.onDataReceivedHandler({ uuid, data: JSON.stringify(data) });
+        // create payload with testIds to send to run pytest script
+        const testData = JSON.stringify(testIds);
+        const headers = [`Content-Length: ${Buffer.byteLength(testData)}`, 'Content-Type: application/json'];
+        const payload = `${headers.join('\r\n')}\r\n\r\n${testData}`;
 
-//         const result = await promise;
+        let runTestIdsPort: string | undefined;
+        const startServer = (): Promise<number> =>
+            new Promise((resolve, reject) => {
+                const server = net.createServer((socket: net.Socket) => {
+                    socket.on('end', () => {
+                        traceLog('Client disconnected');
+                    });
+                });
 
-//         assert.deepStrictEqual(result, data);
-//     });
-//     test("onDataReceivedHandler should ignore the data if the cwd from the payload does not match the test adapter's cwd", async () => {
-//         const correctUuid = '123456789';
-//         const incorrectUuid = '987654321';
-//         const stubTestServer = ({
-//             sendCommand(): Promise<void> {
-//                 return Promise.resolve();
-//             },
-//             onDataReceived: () => {
-//                 // no body
-//             },
-//             createUUID: () => correctUuid,
-//         } as unknown) as ITestServer;
+                server.listen(0, () => {
+                    const { port } = server.address() as net.AddressInfo;
+                    traceLog(`Server listening on port ${port}`);
+                    resolve(port);
+                });
 
-//         const uri = Uri.file('/foo/bar');
+                server.on('error', (error: Error) => {
+                    reject(error);
+                });
+                server.on('connection', (socket: net.Socket) => {
+                    socket.write(payload);
+                    traceLog('payload sent', payload);
+                });
+            });
 
-//         const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
+        // Start the server and wait until it is listening
+        await startServer()
+            .then((assignedPort) => {
+                traceLog(`Server started and listening on port ${assignedPort}`);
+                runTestIdsPort = assignedPort.toString();
+                // Send test command to server.
+                // Server fire onDataReceived event once it gets response.
 
-//         // triggers runTests flow which will run onDataReceivedHandler and the
-//         // promise resolves into the parsed data.
-//         const promise = adapter.runTests(uri, [], false);
+                this.testServer.sendCommand(options, runTestIdsPort, () => {
+                    disposable.dispose();
+                    deferred.resolve();
+                });
+            })
+            .catch((error) => {
+                traceError('Error starting server:', error);
+            });
 
-//         const data = { status: 'success' };
-//         // will not resolve due to incorrect UUID
-//         adapter.onDataReceivedHandler({ uuid: incorrectUuid, data: JSON.stringify(data) });
+        return deferred.promise;
+    }
+}
 
-//         const nextData = { status: 'error' };
-//         // will resolve and nextData will be returned as result
-//         adapter.onDataReceivedHandler({ uuid: correctUuid, data: JSON.stringify(nextData) });
+function buildExecutionCommand(args: string[]): TestExecutionCommand {
+    const executionScript = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'unittestadapter', 'execution.py');
 
-//         const result = await promise;
-
-//         assert.deepStrictEqual(result, nextData);
-//     });
-// });
+    return {
+        script: executionScript,
+        args: ['--udiscovery', ...args],
+    };
+}

--- a/src/client/testing/testController/workspaceTestAdapter.ts
+++ b/src/client/testing/testController/workspaceTestAdapter.ts
@@ -151,7 +151,7 @@ export class WorkspaceTestAdapter {
             const errorNode = createErrorTestItem(testController, options);
             testController.items.add(errorNode);
 
-            deferred.reject(ex as Error);
+            return deferred.reject(ex as Error);
         } finally {
             // Discovery has finished running, we have the data,
             // we don't need the deferred promise anymore.

--- a/src/client/testing/testController/workspaceTestAdapter.ts
+++ b/src/client/testing/testController/workspaceTestAdapter.ts
@@ -6,7 +6,7 @@ import * as util from 'util';
 import { CancellationToken, TestController, TestItem, TestRun, Uri } from 'vscode';
 import { createDeferred, Deferred } from '../../common/utils/async';
 import { Testing } from '../../common/utils/localize';
-import { traceError, traceVerbose } from '../../logging';
+import { traceError } from '../../logging';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { TestProvider } from '../types';

--- a/src/client/testing/testController/workspaceTestAdapter.ts
+++ b/src/client/testing/testController/workspaceTestAdapter.ts
@@ -3,34 +3,15 @@
 
 import * as path from 'path';
 import * as util from 'util';
-import {
-    CancellationToken,
-    Position,
-    Range,
-    TestController,
-    TestItem,
-    TestMessage,
-    TestRun,
-    Uri,
-    Location,
-} from 'vscode';
-import { splitLines } from '../../common/stringUtils';
+import { CancellationToken, TestController, TestItem, TestRun, Uri } from 'vscode';
 import { createDeferred, Deferred } from '../../common/utils/async';
 import { Testing } from '../../common/utils/localize';
 import { traceError, traceVerbose } from '../../logging';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { TestProvider } from '../types';
-import {
-    clearAllChildren,
-    createErrorTestItem,
-    DebugTestTag,
-    ErrorTestItemOptions,
-    getTestCaseNodes,
-    RunTestTag,
-} from './common/testItemUtilities';
-import { DiscoveredTestItem, DiscoveredTestNode, ITestDiscoveryAdapter, ITestExecutionAdapter } from './common/types';
-import { fixLogLines } from './common/utils';
+import { createErrorTestItem, ErrorTestItemOptions, getTestCaseNodes } from './common/testItemUtilities';
+import { ITestDiscoveryAdapter, ITestExecutionAdapter, ITestResultResolver } from './common/types';
 import { IPythonExecutionFactory } from '../../common/process/types';
 import { ITestDebugLauncher } from '../common/types';
 
@@ -48,22 +29,13 @@ export class WorkspaceTestAdapter {
 
     private executing: Deferred<void> | undefined;
 
-    runIdToTestItem: Map<string, TestItem>;
-
-    runIdToVSid: Map<string, string>;
-
-    vsIdToRunId: Map<string, string>;
-
     constructor(
         private testProvider: TestProvider,
         private discoveryAdapter: ITestDiscoveryAdapter,
         private executionAdapter: ITestExecutionAdapter,
         private workspaceUri: Uri,
-    ) {
-        this.runIdToTestItem = new Map<string, TestItem>();
-        this.runIdToVSid = new Map<string, string>();
-        this.vsIdToRunId = new Map<string, string>();
-    }
+        private resultResolver: ITestResultResolver,
+    ) {}
 
     public async executeTests(
         testController: TestController,
@@ -81,7 +53,6 @@ export class WorkspaceTestAdapter {
         const deferred = createDeferred<void>();
         this.executing = deferred;
 
-        let rawTestExecData;
         const testCaseNodes: TestItem[] = [];
         const testCaseIdsSet = new Set<string>();
         try {
@@ -93,7 +64,7 @@ export class WorkspaceTestAdapter {
             // iterate through testItems nodes and fetch their unittest runID to pass in as argument
             testCaseNodes.forEach((node) => {
                 runInstance.started(node); // do the vscode ui test item start here before runtest
-                const runId = this.vsIdToRunId.get(node.id);
+                const runId = this.resultResolver.vsIdToRunId.get(node.id);
                 if (runId) {
                     testCaseIdsSet.add(runId);
                 }
@@ -101,16 +72,16 @@ export class WorkspaceTestAdapter {
             const testCaseIds = Array.from(testCaseIdsSet);
             // ** execution factory only defined for new rewrite way
             if (executionFactory !== undefined) {
-                traceVerbose('executionFactory defined');
-                rawTestExecData = await this.executionAdapter.runTests(
+                await this.executionAdapter.runTests(
                     this.workspaceUri,
                     testCaseIds,
                     debugBool,
+                    runInstance,
                     executionFactory,
                     debugLauncher,
                 );
             } else {
-                rawTestExecData = await this.executionAdapter.runTests(this.workspaceUri, testCaseIds, debugBool);
+                await this.executionAdapter.runTests(this.workspaceUri, testCaseIds, debugBool);
             }
             deferred.resolve();
         } catch (ex) {
@@ -136,146 +107,6 @@ export class WorkspaceTestAdapter {
             this.executing = undefined;
         }
 
-        if (rawTestExecData !== undefined && rawTestExecData.result !== undefined) {
-            // Map which holds the subtest information for each test item.
-            const subTestStats: Map<string, { passed: number; failed: number }> = new Map();
-
-            // iterate through payload and update the UI accordingly.
-            for (const keyTemp of Object.keys(rawTestExecData.result)) {
-                const testCases: TestItem[] = [];
-
-                // grab leaf level test items
-                testController.items.forEach((i) => {
-                    const tempArr: TestItem[] = getTestCaseNodes(i);
-                    testCases.push(...tempArr);
-                });
-
-                if (
-                    rawTestExecData.result[keyTemp].outcome === 'failure' ||
-                    rawTestExecData.result[keyTemp].outcome === 'passed-unexpected'
-                ) {
-                    const rawTraceback = rawTestExecData.result[keyTemp].traceback ?? '';
-                    const traceback = splitLines(rawTraceback, {
-                        trim: false,
-                        removeEmptyEntries: true,
-                    }).join('\r\n');
-
-                    const text = `${rawTestExecData.result[keyTemp].test} failed: ${
-                        rawTestExecData.result[keyTemp].message ?? rawTestExecData.result[keyTemp].outcome
-                    }\r\n${traceback}\r\n`;
-                    const message = new TestMessage(text);
-
-                    // note that keyTemp is a runId for unittest library...
-                    const grabVSid = this.runIdToVSid.get(keyTemp);
-                    // search through freshly built array of testItem to find the failed test and update UI.
-                    testCases.forEach((indiItem) => {
-                        if (indiItem.id === grabVSid) {
-                            if (indiItem.uri && indiItem.range) {
-                                message.location = new Location(indiItem.uri, indiItem.range);
-                                runInstance.failed(indiItem, message);
-                                runInstance.appendOutput(fixLogLines(text));
-                            }
-                        }
-                    });
-                } else if (
-                    rawTestExecData.result[keyTemp].outcome === 'success' ||
-                    rawTestExecData.result[keyTemp].outcome === 'expected-failure'
-                ) {
-                    const grabTestItem = this.runIdToTestItem.get(keyTemp);
-                    const grabVSid = this.runIdToVSid.get(keyTemp);
-                    if (grabTestItem !== undefined) {
-                        testCases.forEach((indiItem) => {
-                            if (indiItem.id === grabVSid) {
-                                if (indiItem.uri && indiItem.range) {
-                                    runInstance.passed(grabTestItem);
-                                    runInstance.appendOutput('Passed here');
-                                }
-                            }
-                        });
-                    }
-                } else if (rawTestExecData.result[keyTemp].outcome === 'skipped') {
-                    const grabTestItem = this.runIdToTestItem.get(keyTemp);
-                    const grabVSid = this.runIdToVSid.get(keyTemp);
-                    if (grabTestItem !== undefined) {
-                        testCases.forEach((indiItem) => {
-                            if (indiItem.id === grabVSid) {
-                                if (indiItem.uri && indiItem.range) {
-                                    runInstance.skipped(grabTestItem);
-                                    runInstance.appendOutput('Skipped here');
-                                }
-                            }
-                        });
-                    }
-                } else if (rawTestExecData.result[keyTemp].outcome === 'subtest-failure') {
-                    // split on " " since the subtest ID has the parent test ID in the first part of the ID.
-                    const parentTestCaseId = keyTemp.split(' ')[0];
-                    const parentTestItem = this.runIdToTestItem.get(parentTestCaseId);
-                    const data = rawTestExecData.result[keyTemp];
-                    // find the subtest's parent test item
-                    if (parentTestItem) {
-                        const subtestStats = subTestStats.get(parentTestCaseId);
-                        if (subtestStats) {
-                            subtestStats.failed += 1;
-                        } else {
-                            subTestStats.set(parentTestCaseId, { failed: 1, passed: 0 });
-                            runInstance.appendOutput(fixLogLines(`${parentTestCaseId} [subtests]:\r\n`));
-                            // clear since subtest items don't persist between runs
-                            clearAllChildren(parentTestItem);
-                        }
-                        const subtestId = keyTemp;
-                        const subTestItem = testController?.createTestItem(subtestId, subtestId);
-                        runInstance.appendOutput(fixLogLines(`${subtestId} Failed\r\n`));
-                        // create a new test item for the subtest
-                        if (subTestItem) {
-                            const traceback = data.traceback ?? '';
-                            const text = `${data.subtest} Failed: ${data.message ?? data.outcome}\r\n${traceback}\r\n`;
-                            runInstance.appendOutput(fixLogLines(text));
-                            parentTestItem.children.add(subTestItem);
-                            runInstance.started(subTestItem);
-                            const message = new TestMessage(rawTestExecData?.result[keyTemp].message ?? '');
-                            if (parentTestItem.uri && parentTestItem.range) {
-                                message.location = new Location(parentTestItem.uri, parentTestItem.range);
-                            }
-                            runInstance.failed(subTestItem, message);
-                        } else {
-                            throw new Error('Unable to create new child node for subtest');
-                        }
-                    } else {
-                        throw new Error('Parent test item not found');
-                    }
-                } else if (rawTestExecData.result[keyTemp].outcome === 'subtest-success') {
-                    // split on " " since the subtest ID has the parent test ID in the first part of the ID.
-                    const parentTestCaseId = keyTemp.split(' ')[0];
-                    const parentTestItem = this.runIdToTestItem.get(parentTestCaseId);
-
-                    // find the subtest's parent test item
-                    if (parentTestItem) {
-                        const subtestStats = subTestStats.get(parentTestCaseId);
-                        if (subtestStats) {
-                            subtestStats.passed += 1;
-                        } else {
-                            subTestStats.set(parentTestCaseId, { failed: 0, passed: 1 });
-                            runInstance.appendOutput(fixLogLines(`${parentTestCaseId} [subtests]:\r\n`));
-                            // clear since subtest items don't persist between runs
-                            clearAllChildren(parentTestItem);
-                        }
-                        const subtestId = keyTemp;
-                        const subTestItem = testController?.createTestItem(subtestId, subtestId);
-                        // create a new test item for the subtest
-                        if (subTestItem) {
-                            parentTestItem.children.add(subTestItem);
-                            runInstance.started(subTestItem);
-                            runInstance.passed(subTestItem);
-                            runInstance.appendOutput(fixLogLines(`${subtestId} Passed\r\n`));
-                        } else {
-                            throw new Error('Unable to create new child node for subtest');
-                        }
-                    } else {
-                        throw new Error('Parent test item not found');
-                    }
-                }
-            }
-        }
         return Promise.resolve();
     }
 
@@ -286,8 +117,6 @@ export class WorkspaceTestAdapter {
     ): Promise<void> {
         sendTelemetryEvent(EventName.UNITTEST_DISCOVERING, undefined, { tool: this.testProvider });
 
-        const workspacePath = this.workspaceUri.fsPath;
-
         // Discovery is expensive. If it is already running, use the existing promise.
         if (this.discovering) {
             return this.discovering.promise;
@@ -296,14 +125,12 @@ export class WorkspaceTestAdapter {
         const deferred = createDeferred<void>();
         this.discovering = deferred;
 
-        let rawTestData;
         try {
             // ** execution factory only defined for new rewrite way
             if (executionFactory !== undefined) {
-                traceVerbose('executionFactory defined');
-                rawTestData = await this.discoveryAdapter.discoverTests(this.workspaceUri, executionFactory);
+                await this.discoveryAdapter.discoverTests(this.workspaceUri, executionFactory);
             } else {
-                rawTestData = await this.discoveryAdapter.discoverTests(this.workspaceUri);
+                await this.discoveryAdapter.discoverTests(this.workspaceUri);
             }
             deferred.resolve();
         } catch (ex) {
@@ -331,105 +158,9 @@ export class WorkspaceTestAdapter {
             this.discovering = undefined;
         }
 
-        if (!rawTestData) {
-            // No test data is available
-            return Promise.resolve();
-        }
-
-        // Check if there were any errors in the discovery process.
-        if (rawTestData.status === 'error') {
-            const testingErrorConst =
-                this.testProvider === 'pytest' ? Testing.errorPytestDiscovery : Testing.errorUnittestDiscovery;
-            const { errors } = rawTestData;
-            traceError(testingErrorConst, '\r\n', errors?.join('\r\n\r\n'));
-            let errorNode = testController.items.get(`DiscoveryError:${workspacePath}`);
-            const message = util.format(
-                `${testingErrorConst} ${Testing.seePythonOutput}\r\n`,
-                errors?.join('\r\n\r\n'),
-            );
-
-            if (errorNode === undefined) {
-                const options = buildErrorNodeOptions(this.workspaceUri, message, this.testProvider);
-                errorNode = createErrorTestItem(testController, options);
-                testController.items.add(errorNode);
-            }
-            errorNode.error = message;
-        } else {
-            // Remove the error node if necessary,
-            // then parse and insert test data.
-            testController.items.delete(`DiscoveryError:${workspacePath}`);
-
-            if (rawTestData.tests) {
-                // If the test root for this folder exists: Workspace refresh, update its children.
-                // Otherwise, it is a freshly discovered workspace, and we need to create a new test root and populate the test tree.
-                populateTestTree(testController, rawTestData.tests, undefined, this, token);
-            } else {
-                // Delete everything from the test controller.
-                testController.items.replace([]);
-            }
-        }
-
         sendTelemetryEvent(EventName.UNITTEST_DISCOVERY_DONE, undefined, { tool: this.testProvider, failed: false });
         return Promise.resolve();
     }
-}
-
-function isTestItem(test: DiscoveredTestNode | DiscoveredTestItem): test is DiscoveredTestItem {
-    return test.type_ === 'test';
-}
-
-// had to switch the order of the original parameter since required param cannot follow optional.
-function populateTestTree(
-    testController: TestController,
-    testTreeData: DiscoveredTestNode,
-    testRoot: TestItem | undefined,
-    wstAdapter: WorkspaceTestAdapter,
-    token?: CancellationToken,
-): void {
-    // If testRoot is undefined, use the info of the root item of testTreeData to create a test item, and append it to the test controller.
-    if (!testRoot) {
-        testRoot = testController.createTestItem(testTreeData.path, testTreeData.name, Uri.file(testTreeData.path));
-
-        testRoot.canResolveChildren = true;
-        testRoot.tags = [RunTestTag, DebugTestTag];
-
-        testController.items.add(testRoot);
-    }
-
-    // Recursively populate the tree with test data.
-    testTreeData.children.forEach((child) => {
-        if (!token?.isCancellationRequested) {
-            if (isTestItem(child)) {
-                const testItem = testController.createTestItem(child.id_, child.name, Uri.file(child.path));
-                testItem.tags = [RunTestTag, DebugTestTag];
-
-                const range = new Range(
-                    new Position(Number(child.lineno) - 1, 0),
-                    new Position(Number(child.lineno), 0),
-                );
-                testItem.canResolveChildren = false;
-                testItem.range = range;
-                testItem.tags = [RunTestTag, DebugTestTag];
-
-                testRoot!.children.add(testItem);
-                // add to our map
-                wstAdapter.runIdToTestItem.set(child.runID, testItem);
-                wstAdapter.runIdToVSid.set(child.runID, child.id_);
-                wstAdapter.vsIdToRunId.set(child.id_, child.runID);
-            } else {
-                let node = testController.items.get(child.path);
-
-                if (!node) {
-                    node = testController.createTestItem(child.id_, child.name, Uri.file(child.path));
-
-                    node.canResolveChildren = true;
-                    node.tags = [RunTestTag, DebugTestTag];
-                    testRoot!.children.add(node);
-                }
-                populateTestTree(testController, child, node, wstAdapter, token);
-            }
-        }
-    });
 }
 
 function buildErrorNodeOptions(uri: Uri, message: string, testType: string): ErrorTestItemOptions {

--- a/src/test/testing/testController/pytest/pytestDiscoveryAdapter.unit.test.ts
+++ b/src/test/testing/testController/pytest/pytestDiscoveryAdapter.unit.test.ts
@@ -4,6 +4,7 @@
 import * as assert from 'assert';
 import { Uri } from 'vscode';
 import * as typeMoq from 'typemoq';
+import * as path from 'path';
 import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
 import { PytestTestDiscoveryAdapter } from '../../../../client/testing/testController/pytest/pytestDiscoveryAdapter';
 import { ITestServer } from '../../../../client/testing/testController/common/types';
@@ -38,8 +39,10 @@ suite('pytest test discovery adapter', () => {
         uuid = 'uuid123';
         expectedPath = '/my/test/path/';
         uri = Uri.file(expectedPath);
+        const relativePathToPytest = 'pythonFiles';
+        const fullPluginPath = path.join(EXTENSION_ROOT_DIR, relativePathToPytest);
         expectedExtraVariables = {
-            PYTHONPATH: EXTENSION_ROOT_DIR.concat('/pythonFiles'),
+            PYTHONPATH: fullPluginPath,
             TEST_UUID: uuid,
             TEST_PORT: portNum.toString(),
         };

--- a/src/test/testing/testController/pytest/pytestDiscoveryAdapter.unit.test.ts
+++ b/src/test/testing/testController/pytest/pytestDiscoveryAdapter.unit.test.ts
@@ -13,6 +13,7 @@ import {
     SpawnOptions,
 } from '../../../../client/common/process/types';
 import { createDeferred, Deferred } from '../../../../client/common/utils/async';
+import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
 
 suite('pytest test discovery adapter', () => {
     let testServer: typeMoq.IMock<ITestServer>;
@@ -29,13 +30,16 @@ suite('pytest test discovery adapter', () => {
     let expectedExtraVariables: Record<string, string>;
 
     setup(() => {
+        const mockExtensionRootDir = typeMoq.Mock.ofType<string>();
+        mockExtensionRootDir.setup((m) => m.toString()).returns(() => '/mocked/extension/root/dir');
+
         // constants
         portNum = 12345;
         uuid = 'uuid123';
         expectedPath = '/my/test/path/';
         uri = Uri.file(expectedPath);
         expectedExtraVariables = {
-            PYTHONPATH: '/Users/eleanorboyd/vscode-python/pythonFiles',
+            PYTHONPATH: EXTENSION_ROOT_DIR.concat('/pythonFiles'),
             TEST_UUID: uuid,
             TEST_PORT: portNum.toString(),
         };

--- a/src/test/testing/testController/pytest/pytestDiscoveryAdapter.unit.test.ts
+++ b/src/test/testing/testController/pytest/pytestDiscoveryAdapter.unit.test.ts
@@ -37,7 +37,7 @@ suite('pytest test discovery adapter', () => {
         // constants
         portNum = 12345;
         uuid = 'uuid123';
-        expectedPath = '/my/test/path/';
+        expectedPath = path.join('/', 'my', 'test', 'path');
         uri = Uri.file(expectedPath);
         const relativePathToPytest = 'pythonFiles';
         const fullPluginPath = path.join(EXTENSION_ROOT_DIR, relativePathToPytest);

--- a/src/test/testing/testController/pytest/pytestDiscoveryAdapter.unit.test.ts
+++ b/src/test/testing/testController/pytest/pytestDiscoveryAdapter.unit.test.ts
@@ -1,94 +1,94 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-import * as assert from 'assert';
-import { Uri } from 'vscode';
-import * as typeMoq from 'typemoq';
-import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
-import { PytestTestDiscoveryAdapter } from '../../../../client/testing/testController/pytest/pytestDiscoveryAdapter';
-import { DataReceivedEvent, ITestServer } from '../../../../client/testing/testController/common/types';
-import { IPythonExecutionFactory, IPythonExecutionService } from '../../../../client/common/process/types';
-import { createDeferred, Deferred } from '../../../../client/common/utils/async';
+// /* eslint-disable @typescript-eslint/no-explicit-any */
+// // Copyright (c) Microsoft Corporation. All rights reserved.
+// // Licensed under the MIT License.
+// import * as assert from 'assert';
+// import { Uri } from 'vscode';
+// import * as typeMoq from 'typemoq';
+// import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
+// import { PytestTestDiscoveryAdapter } from '../../../../client/testing/testController/pytest/pytestDiscoveryAdapter';
+// import { DataReceivedEvent, ITestServer } from '../../../../client/testing/testController/common/types';
+// import { IPythonExecutionFactory, IPythonExecutionService } from '../../../../client/common/process/types';
+// import { createDeferred, Deferred } from '../../../../client/common/utils/async';
 
-suite('pytest test discovery adapter', () => {
-    let testServer: typeMoq.IMock<ITestServer>;
-    let configService: IConfigurationService;
-    let execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
-    let adapter: PytestTestDiscoveryAdapter;
-    let execService: typeMoq.IMock<IPythonExecutionService>;
-    let deferred: Deferred<void>;
-    let outputChannel: typeMoq.IMock<ITestOutputChannel>;
+// suite('pytest test discovery adapter', () => {
+//     let testServer: typeMoq.IMock<ITestServer>;
+//     let configService: IConfigurationService;
+//     let execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
+//     let adapter: PytestTestDiscoveryAdapter;
+//     let execService: typeMoq.IMock<IPythonExecutionService>;
+//     let deferred: Deferred<void>;
+//     let outputChannel: typeMoq.IMock<ITestOutputChannel>;
 
-    setup(() => {
-        testServer = typeMoq.Mock.ofType<ITestServer>();
-        testServer.setup((t) => t.getPort()).returns(() => 12345);
-        testServer
-            .setup((t) => t.onDataReceived(typeMoq.It.isAny(), typeMoq.It.isAny()))
-            .returns(() => ({
-                dispose: () => {
-                    /* no-body */
-                },
-            }));
-        configService = ({
-            getSettings: () => ({
-                testing: { pytestArgs: ['.'] },
-            }),
-        } as unknown) as IConfigurationService;
-        execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
-        execService = typeMoq.Mock.ofType<IPythonExecutionService>();
-        execFactory
-            .setup((x) => x.createActivatedEnvironment(typeMoq.It.isAny()))
-            .returns(() => Promise.resolve(execService.object));
-        deferred = createDeferred();
-        execService
-            .setup((x) => x.exec(typeMoq.It.isAny(), typeMoq.It.isAny()))
-            .returns(() => {
-                deferred.resolve();
-                return Promise.resolve({ stdout: '{}' });
-            });
-        execFactory.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
-        execService.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
-        outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
-    });
-    test('onDataReceivedHandler should parse only if known UUID', async () => {
-        const uri = Uri.file('/my/test/path/');
-        const uuid = 'uuid123';
-        const data = { status: 'success' };
-        testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
-        const eventData: DataReceivedEvent = {
-            uuid,
-            data: JSON.stringify(data),
-        };
+//     setup(() => {
+//         testServer = typeMoq.Mock.ofType<ITestServer>();
+//         testServer.setup((t) => t.getPort()).returns(() => 12345);
+//         testServer
+//             .setup((t) => t.onDataReceived(typeMoq.It.isAny(), typeMoq.It.isAny()))
+//             .returns(() => ({
+//                 dispose: () => {
+//                     /* no-body */
+//                 },
+//             }));
+//         configService = ({
+//             getSettings: () => ({
+//                 testing: { pytestArgs: ['.'] },
+//             }),
+//         } as unknown) as IConfigurationService;
+//         execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
+//         execService = typeMoq.Mock.ofType<IPythonExecutionService>();
+//         execFactory
+//             .setup((x) => x.createActivatedEnvironment(typeMoq.It.isAny()))
+//             .returns(() => Promise.resolve(execService.object));
+//         deferred = createDeferred();
+//         execService
+//             .setup((x) => x.exec(typeMoq.It.isAny(), typeMoq.It.isAny()))
+//             .returns(() => {
+//                 deferred.resolve();
+//                 return Promise.resolve({ stdout: '{}' });
+//             });
+//         execFactory.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
+//         execService.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
+//         outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
+//     });
+//     test('onDataReceivedHandler should parse only if known UUID', async () => {
+//         const uri = Uri.file('/my/test/path/');
+//         const uuid = 'uuid123';
+//         const data = { status: 'success' };
+//         testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
+//         const eventData: DataReceivedEvent = {
+//             uuid,
+//             data: JSON.stringify(data),
+//         };
 
-        adapter = new PytestTestDiscoveryAdapter(testServer.object, configService, outputChannel.object);
-        const promise = adapter.discoverTests(uri, execFactory.object);
-        // const promise = adapter.discoverTests(uri);
-        await deferred.promise;
-        adapter.onDataReceivedHandler(eventData);
-        const result = await promise;
-        assert.deepStrictEqual(result, data);
-    });
-    test('onDataReceivedHandler should not parse if it is unknown UUID', async () => {
-        const uri = Uri.file('/my/test/path/');
-        const uuid = 'uuid456';
-        let data = { status: 'error' };
-        testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
-        const wrongUriEventData: DataReceivedEvent = {
-            uuid: 'incorrect-uuid456',
-            data: JSON.stringify(data),
-        };
-        adapter = new PytestTestDiscoveryAdapter(testServer.object, configService, outputChannel.object);
-        const promise = adapter.discoverTests(uri, execFactory.object);
-        // const promise = adapter.discoverTests(uri);
-        adapter.onDataReceivedHandler(wrongUriEventData);
+//         adapter = new PytestTestDiscoveryAdapter(testServer.object, configService, outputChannel.object);
+//         const promise = adapter.discoverTests(uri, execFactory.object);
+//         // const promise = adapter.discoverTests(uri);
+//         await deferred.promise;
+//         adapter.onDataReceivedHandler(eventData);
+//         const result = await promise;
+//         assert.deepStrictEqual(result, data);
+//     });
+//     test('onDataReceivedHandler should not parse if it is unknown UUID', async () => {
+//         const uri = Uri.file('/my/test/path/');
+//         const uuid = 'uuid456';
+//         let data = { status: 'error' };
+//         testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
+//         const wrongUriEventData: DataReceivedEvent = {
+//             uuid: 'incorrect-uuid456',
+//             data: JSON.stringify(data),
+//         };
+//         adapter = new PytestTestDiscoveryAdapter(testServer.object, configService, outputChannel.object);
+//         const promise = adapter.discoverTests(uri, execFactory.object);
+//         // const promise = adapter.discoverTests(uri);
+//         adapter.onDataReceivedHandler(wrongUriEventData);
 
-        data = { status: 'success' };
-        const correctUriEventData: DataReceivedEvent = {
-            uuid,
-            data: JSON.stringify(data),
-        };
-        adapter.onDataReceivedHandler(correctUriEventData);
-        const result = await promise;
-        assert.deepStrictEqual(result, data);
-    });
-});
+//         data = { status: 'success' };
+//         const correctUriEventData: DataReceivedEvent = {
+//             uuid,
+//             data: JSON.stringify(data),
+//         };
+//         adapter.onDataReceivedHandler(correctUriEventData);
+//         const result = await promise;
+//         assert.deepStrictEqual(result, data);
+//     });
+// });

--- a/src/test/testing/testController/pytest/pytestExecutionAdapter.unit.test.ts
+++ b/src/test/testing/testController/pytest/pytestExecutionAdapter.unit.test.ts
@@ -1,141 +1,141 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-//  Copyright (c) Microsoft Corporation. All rights reserved.
-//  Licensed under the MIT License.
-import * as assert from 'assert';
-import { TestRun, Uri } from 'vscode';
-import * as typeMoq from 'typemoq';
-import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
-import { ITestServer } from '../../../../client/testing/testController/common/types';
-import {
-    IPythonExecutionFactory,
-    IPythonExecutionService,
-    SpawnOptions,
-} from '../../../../client/common/process/types';
-import { createDeferred, Deferred } from '../../../../client/common/utils/async';
-import { PytestTestExecutionAdapter } from '../../../../client/testing/testController/pytest/pytestExecutionAdapter';
-import { ITestDebugLauncher, LaunchOptions } from '../../../../client/testing/common/types';
+// /* eslint-disable @typescript-eslint/no-explicit-any */
+// //  Copyright (c) Microsoft Corporation. All rights reserved.
+// //  Licensed under the MIT License.
+// import * as assert from 'assert';
+// import { TestRun, Uri } from 'vscode';
+// import * as typeMoq from 'typemoq';
+// import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
+// import { ITestServer } from '../../../../client/testing/testController/common/types';
+// import {
+//     IPythonExecutionFactory,
+//     IPythonExecutionService,
+//     SpawnOptions,
+// } from '../../../../client/common/process/types';
+// import { createDeferred, Deferred } from '../../../../client/common/utils/async';
+// import { PytestTestExecutionAdapter } from '../../../../client/testing/testController/pytest/pytestExecutionAdapter';
+// import { ITestDebugLauncher, LaunchOptions } from '../../../../client/testing/common/types';
 
-suite('pytest test execution adapter', () => {
-    let testServer: typeMoq.IMock<ITestServer>;
-    let configService: IConfigurationService;
-    let execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
-    let adapter: PytestTestExecutionAdapter;
-    let execService: typeMoq.IMock<IPythonExecutionService>;
-    let deferred: Deferred<void>;
-    let debugLauncher: typeMoq.IMock<ITestDebugLauncher>;
-    setup(() => {
-        testServer = typeMoq.Mock.ofType<ITestServer>();
-        testServer.setup((t) => t.getPort()).returns(() => 12345);
-        testServer
-            .setup((t) => t.onRunDataReceived(typeMoq.It.isAny(), typeMoq.It.isAny()))
-            .returns(() => ({
-                dispose: () => {
-                    /* no-body */
-                },
-            }));
-        configService = ({
-            getSettings: () => ({
-                testing: { pytestArgs: ['.'] },
-            }),
-            isTestExecution: () => false,
-        } as unknown) as IConfigurationService;
-        execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
-        execService = typeMoq.Mock.ofType<IPythonExecutionService>();
-        debugLauncher = typeMoq.Mock.ofType<ITestDebugLauncher>();
-        execFactory
-            .setup((x) => x.createActivatedEnvironment(typeMoq.It.isAny()))
-            .returns(() => Promise.resolve(execService.object));
-        deferred = createDeferred();
-        execService
-            .setup((x) => x.exec(typeMoq.It.isAny(), typeMoq.It.isAny()))
-            .returns(() => {
-                deferred.resolve();
-                return Promise.resolve({ stdout: '{}' });
-            });
-        debugLauncher
-            .setup((d) => d.launchDebugger(typeMoq.It.isAny(), typeMoq.It.isAny()))
-            .returns(() => {
-                deferred.resolve();
-                return Promise.resolve();
-            });
-        execFactory.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
-        execService.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
-        debugLauncher.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
-    });
-    test('pytest execution called with correct args', async () => {
-        const uri = Uri.file('/my/test/path/');
-        const uuid = 'uuid123';
-        // const data = { status: 'success' };
-        testServer
-            .setup((t) => t.onDiscoveryDataReceived(typeMoq.It.isAny(), typeMoq.It.isAny()))
-            .returns(() => ({
-                dispose: () => {
-                    /* no-body */
-                },
-            }));
-        testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
-        const outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
-        const testRun = typeMoq.Mock.ofType<TestRun>();
-        adapter = new PytestTestExecutionAdapter(testServer.object, configService, outputChannel.object);
-        await adapter.runTests(uri, [], false, testRun.object, execFactory.object);
+// suite('pytest test execution adapter', () => {
+//     let testServer: typeMoq.IMock<ITestServer>;
+//     let configService: IConfigurationService;
+//     let execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
+//     let adapter: PytestTestExecutionAdapter;
+//     let execService: typeMoq.IMock<IPythonExecutionService>;
+//     let deferred: Deferred<void>;
+//     let debugLauncher: typeMoq.IMock<ITestDebugLauncher>;
+//     setup(() => {
+//         testServer = typeMoq.Mock.ofType<ITestServer>();
+//         testServer.setup((t) => t.getPort()).returns(() => 12345);
+//         testServer
+//             .setup((t) => t.onRunDataReceived(typeMoq.It.isAny(), typeMoq.It.isAny()))
+//             .returns(() => ({
+//                 dispose: () => {
+//                     /* no-body */
+//                 },
+//             }));
+//         configService = ({
+//             getSettings: () => ({
+//                 testing: { pytestArgs: ['.'] },
+//             }),
+//             isTestExecution: () => false,
+//         } as unknown) as IConfigurationService;
+//         execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
+//         execService = typeMoq.Mock.ofType<IPythonExecutionService>();
+//         debugLauncher = typeMoq.Mock.ofType<ITestDebugLauncher>();
+//         execFactory
+//             .setup((x) => x.createActivatedEnvironment(typeMoq.It.isAny()))
+//             .returns(() => Promise.resolve(execService.object));
+//         deferred = createDeferred();
+//         execService
+//             .setup((x) => x.exec(typeMoq.It.isAny(), typeMoq.It.isAny()))
+//             .returns(() => {
+//                 deferred.resolve();
+//                 return Promise.resolve({ stdout: '{}' });
+//             });
+//         debugLauncher
+//             .setup((d) => d.launchDebugger(typeMoq.It.isAny(), typeMoq.It.isAny()))
+//             .returns(() => {
+//                 deferred.resolve();
+//                 return Promise.resolve();
+//             });
+//         execFactory.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
+//         execService.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
+//         debugLauncher.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
+//     });
+//     test('pytest execution called with correct args', async () => {
+//         const uri = Uri.file('/my/test/path/');
+//         const uuid = 'uuid123';
+//         // const data = { status: 'success' };
+//         testServer
+//             .setup((t) => t.onDiscoveryDataReceived(typeMoq.It.isAny(), typeMoq.It.isAny()))
+//             .returns(() => ({
+//                 dispose: () => {
+//                     /* no-body */
+//                 },
+//             }));
+//         testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
+//         const outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
+//         const testRun = typeMoq.Mock.ofType<TestRun>();
+//         adapter = new PytestTestExecutionAdapter(testServer.object, configService, outputChannel.object);
+//         await adapter.runTests(uri, [], false, testRun.object, execFactory.object);
 
-        const expectedArgs = [
-            '/Users/eleanorboyd/vscode-python/pythonFiles/vscode_pytest/run_pytest_script.py',
-            '--rootdir',
-            '/my/test/path/',
-        ];
-        const expectedExtraVariables = {
-            PYTHONPATH: '/Users/eleanorboyd/vscode-python/pythonFiles',
-            TEST_UUID: 'uuid123',
-            TEST_PORT: '12345',
-        };
-        execService.verify(
-            (x) =>
-                x.exec(
-                    expectedArgs,
-                    typeMoq.It.is<SpawnOptions>((options) => {
-                        assert.equal(options.extraVariables?.PYTHONPATH, expectedExtraVariables.PYTHONPATH);
-                        assert.equal(options.extraVariables?.TEST_UUID, expectedExtraVariables.TEST_UUID);
-                        assert.equal(options.extraVariables?.TEST_PORT, expectedExtraVariables.TEST_PORT);
-                        assert.strictEqual(typeof options.extraVariables?.RUN_TEST_IDS_PORT, 'string');
-                        assert.equal(options.cwd, uri.fsPath);
-                        assert.equal(options.throwOnStdErr, true);
-                        return true;
-                    }),
-                ),
-            typeMoq.Times.once(),
-        );
-    });
-    test('Debug launched correctly for pytest', async () => {
-        const uri = Uri.file('/my/test/path/');
-        const uuid = 'uuid123';
-        testServer
-            .setup((t) => t.onDiscoveryDataReceived(typeMoq.It.isAny(), typeMoq.It.isAny()))
-            .returns(() => ({
-                dispose: () => {
-                    /* no-body */
-                },
-            }));
-        testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
-        const outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
-        const testRun = typeMoq.Mock.ofType<TestRun>();
-        adapter = new PytestTestExecutionAdapter(testServer.object, configService, outputChannel.object);
-        await adapter.runTests(uri, [], true, testRun.object, execFactory.object, debugLauncher.object);
-        debugLauncher.verify(
-            (x) =>
-                x.launchDebugger(
-                    typeMoq.It.is<LaunchOptions>((launchOptions) => {
-                        assert.equal(launchOptions.cwd, uri.fsPath);
-                        assert.deepEqual(launchOptions.args, ['--rootdir', '/my/test/path/', '--capture', 'no']);
-                        assert.equal(launchOptions.testProvider, 'pytest');
-                        assert.equal(launchOptions.pytestPort, '12345');
-                        assert.equal(launchOptions.pytestUUID, 'uuid123');
-                        assert.strictEqual(typeof launchOptions.runTestIdsPort, 'string');
-                        return true;
-                    }),
-                    typeMoq.It.isAny(),
-                ),
-            typeMoq.Times.once(),
-        );
-    });
-});
+//         const expectedArgs = [
+//             '/Users/eleanorboyd/vscode-python/pythonFiles/vscode_pytest/run_pytest_script.py',
+//             '--rootdir',
+//             '/my/test/path/',
+//         ];
+//         const expectedExtraVariables = {
+//             PYTHONPATH: '/Users/eleanorboyd/vscode-python/pythonFiles',
+//             TEST_UUID: 'uuid123',
+//             TEST_PORT: '12345',
+//         };
+//         execService.verify(
+//             (x) =>
+//                 x.exec(
+//                     expectedArgs,
+//                     typeMoq.It.is<SpawnOptions>((options) => {
+//                         assert.equal(options.extraVariables?.PYTHONPATH, expectedExtraVariables.PYTHONPATH);
+//                         assert.equal(options.extraVariables?.TEST_UUID, expectedExtraVariables.TEST_UUID);
+//                         assert.equal(options.extraVariables?.TEST_PORT, expectedExtraVariables.TEST_PORT);
+//                         assert.strictEqual(typeof options.extraVariables?.RUN_TEST_IDS_PORT, 'string');
+//                         assert.equal(options.cwd, uri.fsPath);
+//                         assert.equal(options.throwOnStdErr, true);
+//                         return true;
+//                     }),
+//                 ),
+//             typeMoq.Times.once(),
+//         );
+//     });
+//     test('Debug launched correctly for pytest', async () => {
+//         const uri = Uri.file('/my/test/path/');
+//         const uuid = 'uuid123';
+//         testServer
+//             .setup((t) => t.onDiscoveryDataReceived(typeMoq.It.isAny(), typeMoq.It.isAny()))
+//             .returns(() => ({
+//                 dispose: () => {
+//                     /* no-body */
+//                 },
+//             }));
+//         testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
+//         const outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
+//         const testRun = typeMoq.Mock.ofType<TestRun>();
+//         adapter = new PytestTestExecutionAdapter(testServer.object, configService, outputChannel.object);
+//         await adapter.runTests(uri, [], true, testRun.object, execFactory.object, debugLauncher.object);
+//         debugLauncher.verify(
+//             (x) =>
+//                 x.launchDebugger(
+//                     typeMoq.It.is<LaunchOptions>((launchOptions) => {
+//                         assert.equal(launchOptions.cwd, uri.fsPath);
+//                         assert.deepEqual(launchOptions.args, ['--rootdir', '/my/test/path/', '--capture', 'no']);
+//                         assert.equal(launchOptions.testProvider, 'pytest');
+//                         assert.equal(launchOptions.pytestPort, '12345');
+//                         assert.equal(launchOptions.pytestUUID, 'uuid123');
+//                         assert.strictEqual(typeof launchOptions.runTestIdsPort, 'string');
+//                         return true;
+//                     }),
+//                     typeMoq.It.isAny(),
+//                 ),
+//             typeMoq.Times.once(),
+//         );
+//     });
+// });

--- a/src/test/testing/testController/pytest/pytestExecutionAdapter.unit.test.ts
+++ b/src/test/testing/testController/pytest/pytestExecutionAdapter.unit.test.ts
@@ -4,10 +4,8 @@
 import * as assert from 'assert';
 import { TestRun, Uri } from 'vscode';
 import * as typeMoq from 'typemoq';
-import { debug } from 'console';
-import * as net from 'net';
 import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
-import { DataReceivedEvent, ITestServer } from '../../../../client/testing/testController/common/types';
+import { ITestServer } from '../../../../client/testing/testController/common/types';
 import {
     IPythonExecutionFactory,
     IPythonExecutionService,
@@ -16,7 +14,6 @@ import {
 import { createDeferred, Deferred } from '../../../../client/common/utils/async';
 import { PytestTestExecutionAdapter } from '../../../../client/testing/testController/pytest/pytestExecutionAdapter';
 import { ITestDebugLauncher, LaunchOptions } from '../../../../client/testing/common/types';
-import { DebugLauncher } from '../../../../client/testing/common/debugLauncher';
 
 suite('pytest test execution adapter', () => {
     let testServer: typeMoq.IMock<ITestServer>;
@@ -65,83 +62,51 @@ suite('pytest test execution adapter', () => {
         execService.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
         debugLauncher.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
     });
-    // test('onDataReceivedHandler call exec with correct args', async () => {
-    //     const uri = Uri.file('/my/test/path/');
-    //     const uuid = 'uuid123';
-    //     // const data = { status: 'success' };
-    //     testServer
-    //         .setup((t) => t.onDiscoveryDataReceived(typeMoq.It.isAny(), typeMoq.It.isAny()))
-    //         .returns(() => ({
-    //             dispose: () => {
-    //                 /* no-body */
-    //             },
-    //         }));
-    //     testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
-    //     const outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
-    //     const testRun = typeMoq.Mock.ofType<TestRun>();
-    //     adapter = new PytestTestExecutionAdapter(testServer.object, configService, outputChannel.object);
-    //     await adapter.runTests(uri, [], false, testRun.object, execFactory.object);
+    test('pytest execution called with correct args', async () => {
+        const uri = Uri.file('/my/test/path/');
+        const uuid = 'uuid123';
+        // const data = { status: 'success' };
+        testServer
+            .setup((t) => t.onDiscoveryDataReceived(typeMoq.It.isAny(), typeMoq.It.isAny()))
+            .returns(() => ({
+                dispose: () => {
+                    /* no-body */
+                },
+            }));
+        testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
+        const outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
+        const testRun = typeMoq.Mock.ofType<TestRun>();
+        adapter = new PytestTestExecutionAdapter(testServer.object, configService, outputChannel.object);
+        await adapter.runTests(uri, [], false, testRun.object, execFactory.object);
 
-    //     const expectedArgs = [
-    //         '/Users/eleanorboyd/vscode-python/pythonFiles/vscode_pytest/run_pytest_script.py',
-    //         '--rootdir',
-    //         '/my/test/path/',
-    //     ];
-    //     const expectedExtraVariables = {
-    //         PYTHONPATH: '/Users/eleanorboyd/vscode-python/pythonFiles',
-    //         TEST_UUID: 'uuid123',
-    //         TEST_PORT: '12345',
-    //     };
-    //     execService.verify(
-    //         (x) =>
-    //             x.exec(
-    //                 expectedArgs,
-    //                 typeMoq.It.is<SpawnOptions>((options) => {
-    //                     assert.equal(options.extraVariables?.PYTHONPATH, expectedExtraVariables.PYTHONPATH);
-    //                     assert.equal(options.extraVariables?.TEST_UUID, expectedExtraVariables.TEST_UUID);
-    //                     assert.equal(options.extraVariables?.TEST_PORT, expectedExtraVariables.TEST_PORT);
-    //                     assert.strictEqual(typeof options.extraVariables?.RUN_TEST_IDS_PORT, 'string');
-    //                     assert.equal(options.cwd, uri.fsPath);
-    //                     assert.equal(options.throwOnStdErr, true);
-    //                     return true;
-    //                 }),
-    //             ),
-    //         typeMoq.Times.once(),
-    //     );
-    // });
-    // test('debug called if boolean true and debug launch options are correct', async () => {
-    //     const uri = Uri.file('/my/test/path/');
-    //     const uuid = 'uuid123';
-    //     testServer
-    //         .setup((t) => t.onDiscoveryDataReceived(typeMoq.It.isAny(), typeMoq.It.isAny()))
-    //         .returns(() => ({
-    //             dispose: () => {
-    //                 /* no-body */
-    //             },
-    //         }));
-    //     testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
-    //     const outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
-    //     const testRun = typeMoq.Mock.ofType<TestRun>();
-    //     adapter = new PytestTestExecutionAdapter(testServer.object, configService, outputChannel.object);
-    //     await adapter.runTests(uri, [], true, testRun.object, execFactory.object, debugLauncher.object);
-    //     debugLauncher.verify(
-    //         (x) =>
-    //             x.launchDebugger(
-    //                 typeMoq.It.is<LaunchOptions>((launchOptions) => {
-    //                     assert.equal(launchOptions.cwd, uri.fsPath);
-    //                     assert.deepEqual(launchOptions.args, ['--rootdir', '/my/test/path/', '--capture', 'no']);
-    //                     assert.equal(launchOptions.testProvider, 'pytest');
-    //                     assert.equal(launchOptions.pytestPort, '12345');
-    //                     assert.equal(launchOptions.pytestUUID, 'uuid123');
-    //                     assert.strictEqual(typeof launchOptions.runTestIdsPort, 'string');
-    //                     return true;
-    //                 }),
-    //                 typeMoq.It.isAny(),
-    //             ),
-    //         typeMoq.Times.once(),
-    //     );
-    // });
-    test('dafdsaljfj;a4wfadss', async () => {
+        const expectedArgs = [
+            '/Users/eleanorboyd/vscode-python/pythonFiles/vscode_pytest/run_pytest_script.py',
+            '--rootdir',
+            '/my/test/path/',
+        ];
+        const expectedExtraVariables = {
+            PYTHONPATH: '/Users/eleanorboyd/vscode-python/pythonFiles',
+            TEST_UUID: 'uuid123',
+            TEST_PORT: '12345',
+        };
+        execService.verify(
+            (x) =>
+                x.exec(
+                    expectedArgs,
+                    typeMoq.It.is<SpawnOptions>((options) => {
+                        assert.equal(options.extraVariables?.PYTHONPATH, expectedExtraVariables.PYTHONPATH);
+                        assert.equal(options.extraVariables?.TEST_UUID, expectedExtraVariables.TEST_UUID);
+                        assert.equal(options.extraVariables?.TEST_PORT, expectedExtraVariables.TEST_PORT);
+                        assert.strictEqual(typeof options.extraVariables?.RUN_TEST_IDS_PORT, 'string');
+                        assert.equal(options.cwd, uri.fsPath);
+                        assert.equal(options.throwOnStdErr, true);
+                        return true;
+                    }),
+                ),
+            typeMoq.Times.once(),
+        );
+    });
+    test('Debug launched correctly for pytest', async () => {
         const uri = Uri.file('/my/test/path/');
         const uuid = 'uuid123';
         testServer
@@ -154,7 +119,6 @@ suite('pytest test execution adapter', () => {
         testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
         const outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
         const testRun = typeMoq.Mock.ofType<TestRun>();
-
         adapter = new PytestTestExecutionAdapter(testServer.object, configService, outputChannel.object);
         await adapter.runTests(uri, [], true, testRun.object, execFactory.object, debugLauncher.object);
         debugLauncher.verify(

--- a/src/test/testing/testController/pytest/pytestExecutionAdapter.unit.test.ts
+++ b/src/test/testing/testController/pytest/pytestExecutionAdapter.unit.test.ts
@@ -1,90 +1,177 @@
-// /* eslint-disable @typescript-eslint/no-explicit-any */
-// //  Copyright (c) Microsoft Corporation. All rights reserved.
-// //  Licensed under the MIT License.
-// import * as assert from 'assert';
-// import { Uri } from 'vscode';
-// import * as typeMoq from 'typemoq';
-// import { IConfigurationService } from '../../../../client/common/types';
-// import { DataReceivedEvent, ITestServer } from '../../../../client/testing/testController/common/types';
-// import { IPythonExecutionFactory, IPythonExecutionService } from '../../../../client/common/process/types';
-// import { createDeferred, Deferred } from '../../../../client/common/utils/async';
-// import { PytestTestExecutionAdapter } from '../../../../client/testing/testController/pytest/pytestExecutionAdapter';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+import * as assert from 'assert';
+import { TestRun, Uri } from 'vscode';
+import * as typeMoq from 'typemoq';
+import { debug } from 'console';
+import * as net from 'net';
+import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
+import { DataReceivedEvent, ITestServer } from '../../../../client/testing/testController/common/types';
+import {
+    IPythonExecutionFactory,
+    IPythonExecutionService,
+    SpawnOptions,
+} from '../../../../client/common/process/types';
+import { createDeferred, Deferred } from '../../../../client/common/utils/async';
+import { PytestTestExecutionAdapter } from '../../../../client/testing/testController/pytest/pytestExecutionAdapter';
+import { ITestDebugLauncher, LaunchOptions } from '../../../../client/testing/common/types';
+import { DebugLauncher } from '../../../../client/testing/common/debugLauncher';
 
-// suite('pytest test execution adapter', () => {
-//     let testServer: typeMoq.IMock<ITestServer>;
-//     let configService: IConfigurationService;
-//     let execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
-//     let adapter: PytestTestExecutionAdapter;
-//     let execService: typeMoq.IMock<IPythonExecutionService>;
-//     let deferred: Deferred<void>;
-//     setup(() => {
-//         testServer = typeMoq.Mock.ofType<ITestServer>();
-//         testServer.setup((t) => t.getPort()).returns(() => 12345);
-//         testServer
-//             .setup((t) => t.onDataReceived(typeMoq.It.isAny(), typeMoq.It.isAny()))
-//             .returns(() => ({
-//                 dispose: () => {
-//                     /* no-body */
-//                 },
-//             }));
-//         configService = ({
-//             getSettings: () => ({
-//                 testing: { pytestArgs: ['.'] },
-//             }),
-//             isTestExecution: () => false,
-//         } as unknown) as IConfigurationService;
-//         execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
-//         execService = typeMoq.Mock.ofType<IPythonExecutionService>();
-//         execFactory
-//             .setup((x) => x.createActivatedEnvironment(typeMoq.It.isAny()))
-//             .returns(() => Promise.resolve(execService.object));
-//         deferred = createDeferred();
-//         execService
-//             .setup((x) => x.exec(typeMoq.It.isAny(), typeMoq.It.isAny()))
-//             .returns(() => {
-//                 deferred.resolve();
-//                 return Promise.resolve({ stdout: '{}' });
-//             });
-//         execFactory.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
-//         execService.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
-//     });
-//     test('onDataReceivedHandler should parse only if known UUID', async () => {
-//         const uri = Uri.file('/my/test/path/');
-//         const uuid = 'uuid123';
-//         const data = { status: 'success' };
-//         testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
-//         const eventData: DataReceivedEvent = {
-//             uuid,
-//             data: JSON.stringify(data),
-//         };
+suite('pytest test execution adapter', () => {
+    let testServer: typeMoq.IMock<ITestServer>;
+    let configService: IConfigurationService;
+    let execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
+    let adapter: PytestTestExecutionAdapter;
+    let execService: typeMoq.IMock<IPythonExecutionService>;
+    let deferred: Deferred<void>;
+    let debugLauncher: typeMoq.IMock<ITestDebugLauncher>;
+    setup(() => {
+        testServer = typeMoq.Mock.ofType<ITestServer>();
+        testServer.setup((t) => t.getPort()).returns(() => 12345);
+        testServer
+            .setup((t) => t.onRunDataReceived(typeMoq.It.isAny(), typeMoq.It.isAny()))
+            .returns(() => ({
+                dispose: () => {
+                    /* no-body */
+                },
+            }));
+        configService = ({
+            getSettings: () => ({
+                testing: { pytestArgs: ['.'] },
+            }),
+            isTestExecution: () => false,
+        } as unknown) as IConfigurationService;
+        execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
+        execService = typeMoq.Mock.ofType<IPythonExecutionService>();
+        debugLauncher = typeMoq.Mock.ofType<ITestDebugLauncher>();
+        execFactory
+            .setup((x) => x.createActivatedEnvironment(typeMoq.It.isAny()))
+            .returns(() => Promise.resolve(execService.object));
+        deferred = createDeferred();
+        execService
+            .setup((x) => x.exec(typeMoq.It.isAny(), typeMoq.It.isAny()))
+            .returns(() => {
+                deferred.resolve();
+                return Promise.resolve({ stdout: '{}' });
+            });
+        debugLauncher
+            .setup((d) => d.launchDebugger(typeMoq.It.isAny(), typeMoq.It.isAny()))
+            .returns(() => {
+                deferred.resolve();
+                return Promise.resolve();
+            });
+        execFactory.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
+        execService.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
+        debugLauncher.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
+    });
+    // test('onDataReceivedHandler call exec with correct args', async () => {
+    //     const uri = Uri.file('/my/test/path/');
+    //     const uuid = 'uuid123';
+    //     // const data = { status: 'success' };
+    //     testServer
+    //         .setup((t) => t.onDiscoveryDataReceived(typeMoq.It.isAny(), typeMoq.It.isAny()))
+    //         .returns(() => ({
+    //             dispose: () => {
+    //                 /* no-body */
+    //             },
+    //         }));
+    //     testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
+    //     const outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
+    //     const testRun = typeMoq.Mock.ofType<TestRun>();
+    //     adapter = new PytestTestExecutionAdapter(testServer.object, configService, outputChannel.object);
+    //     await adapter.runTests(uri, [], false, testRun.object, execFactory.object);
 
-//         adapter = new PytestTestExecutionAdapter(testServer.object, configService);
-//         const promise = adapter.runTests(uri, [], false);
-//         await deferred.promise;
-//         adapter.onDataReceivedHandler(eventData);
-//         const result = await promise;
-//         assert.deepStrictEqual(result, data);
-//     });
-//     test('onDataReceivedHandler should not parse if it is unknown UUID', async () => {
-//         const uri = Uri.file('/my/test/path/');
-//         const uuid = 'uuid456';
-//         let data = { status: 'error' };
-//         testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
-//         const wrongUriEventData: DataReceivedEvent = {
-//             uuid: 'incorrect-uuid456',
-//             data: JSON.stringify(data),
-//         };
-//         adapter = new PytestTestExecutionAdapter(testServer.object, configService);
-//         const promise = adapter.runTests(uri, [], false);
-//         adapter.onDataReceivedHandler(wrongUriEventData);
+    //     const expectedArgs = [
+    //         '/Users/eleanorboyd/vscode-python/pythonFiles/vscode_pytest/run_pytest_script.py',
+    //         '--rootdir',
+    //         '/my/test/path/',
+    //     ];
+    //     const expectedExtraVariables = {
+    //         PYTHONPATH: '/Users/eleanorboyd/vscode-python/pythonFiles',
+    //         TEST_UUID: 'uuid123',
+    //         TEST_PORT: '12345',
+    //     };
+    //     execService.verify(
+    //         (x) =>
+    //             x.exec(
+    //                 expectedArgs,
+    //                 typeMoq.It.is<SpawnOptions>((options) => {
+    //                     assert.equal(options.extraVariables?.PYTHONPATH, expectedExtraVariables.PYTHONPATH);
+    //                     assert.equal(options.extraVariables?.TEST_UUID, expectedExtraVariables.TEST_UUID);
+    //                     assert.equal(options.extraVariables?.TEST_PORT, expectedExtraVariables.TEST_PORT);
+    //                     assert.strictEqual(typeof options.extraVariables?.RUN_TEST_IDS_PORT, 'string');
+    //                     assert.equal(options.cwd, uri.fsPath);
+    //                     assert.equal(options.throwOnStdErr, true);
+    //                     return true;
+    //                 }),
+    //             ),
+    //         typeMoq.Times.once(),
+    //     );
+    // });
+    // test('debug called if boolean true and debug launch options are correct', async () => {
+    //     const uri = Uri.file('/my/test/path/');
+    //     const uuid = 'uuid123';
+    //     testServer
+    //         .setup((t) => t.onDiscoveryDataReceived(typeMoq.It.isAny(), typeMoq.It.isAny()))
+    //         .returns(() => ({
+    //             dispose: () => {
+    //                 /* no-body */
+    //             },
+    //         }));
+    //     testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
+    //     const outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
+    //     const testRun = typeMoq.Mock.ofType<TestRun>();
+    //     adapter = new PytestTestExecutionAdapter(testServer.object, configService, outputChannel.object);
+    //     await adapter.runTests(uri, [], true, testRun.object, execFactory.object, debugLauncher.object);
+    //     debugLauncher.verify(
+    //         (x) =>
+    //             x.launchDebugger(
+    //                 typeMoq.It.is<LaunchOptions>((launchOptions) => {
+    //                     assert.equal(launchOptions.cwd, uri.fsPath);
+    //                     assert.deepEqual(launchOptions.args, ['--rootdir', '/my/test/path/', '--capture', 'no']);
+    //                     assert.equal(launchOptions.testProvider, 'pytest');
+    //                     assert.equal(launchOptions.pytestPort, '12345');
+    //                     assert.equal(launchOptions.pytestUUID, 'uuid123');
+    //                     assert.strictEqual(typeof launchOptions.runTestIdsPort, 'string');
+    //                     return true;
+    //                 }),
+    //                 typeMoq.It.isAny(),
+    //             ),
+    //         typeMoq.Times.once(),
+    //     );
+    // });
+    test('dafdsaljfj;a4wfadss', async () => {
+        const uri = Uri.file('/my/test/path/');
+        const uuid = 'uuid123';
+        testServer
+            .setup((t) => t.onDiscoveryDataReceived(typeMoq.It.isAny(), typeMoq.It.isAny()))
+            .returns(() => ({
+                dispose: () => {
+                    /* no-body */
+                },
+            }));
+        testServer.setup((t) => t.createUUID(typeMoq.It.isAny())).returns(() => uuid);
+        const outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
+        const testRun = typeMoq.Mock.ofType<TestRun>();
 
-//         data = { status: 'success' };
-//         const correctUriEventData: DataReceivedEvent = {
-//             uuid,
-//             data: JSON.stringify(data),
-//         };
-//         adapter.onDataReceivedHandler(correctUriEventData);
-//         const result = await promise;
-//         assert.deepStrictEqual(result, data);
-//     });
-// });
+        adapter = new PytestTestExecutionAdapter(testServer.object, configService, outputChannel.object);
+        await adapter.runTests(uri, [], true, testRun.object, execFactory.object, debugLauncher.object);
+        debugLauncher.verify(
+            (x) =>
+                x.launchDebugger(
+                    typeMoq.It.is<LaunchOptions>((launchOptions) => {
+                        assert.equal(launchOptions.cwd, uri.fsPath);
+                        assert.deepEqual(launchOptions.args, ['--rootdir', '/my/test/path/', '--capture', 'no']);
+                        assert.equal(launchOptions.testProvider, 'pytest');
+                        assert.equal(launchOptions.pytestPort, '12345');
+                        assert.equal(launchOptions.pytestUUID, 'uuid123');
+                        assert.strictEqual(typeof launchOptions.runTestIdsPort, 'string');
+                        return true;
+                    }),
+                    typeMoq.It.isAny(),
+                ),
+            typeMoq.Times.once(),
+        );
+    });
+});

--- a/src/test/testing/testController/server.unit.test.ts
+++ b/src/test/testing/testController/server.unit.test.ts
@@ -45,78 +45,259 @@ suite('Python Test Server', () => {
         server.dispose();
     });
 
-    test('sendCommand should add the port to the command being sent', async () => {
-        const options = {
-            command: { script: 'myscript', args: ['-foo', 'foo'] },
-            workspaceFolder: Uri.file('/foo/bar'),
-            cwd: '/foo/bar',
-            uuid: fakeUuid,
-        };
+    // test('sendCommand should add the port to the command being sent', async () => {
+    //     const options = {
+    //         command: { script: 'myscript', args: ['-foo', 'foo'] },
+    //         workspaceFolder: Uri.file('/foo/bar'),
+    //         cwd: '/foo/bar',
+    //         uuid: fakeUuid,
+    //     };
 
-        server = new PythonTestServer(stubExecutionFactory, debugLauncher);
-        await server.serverReady();
+    //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
+    //     await server.serverReady();
 
-        await server.sendCommand(options);
-        const port = server.getPort();
+    //     await server.sendCommand(options);
+    //     const port = server.getPort();
 
-        assert.deepStrictEqual(execArgs, ['myscript', '--port', `${port}`, '--uuid', fakeUuid, '-foo', 'foo']);
-    });
+    //     assert.deepStrictEqual(execArgs, ['myscript', '--port', `${port}`, '--uuid', fakeUuid, '-foo', 'foo']);
+    // });
 
-    test('sendCommand should write to an output channel if it is provided as an option', async () => {
-        const output: string[] = [];
-        const outChannel = {
-            appendLine: (str: string) => {
-                output.push(str);
-            },
-        } as OutputChannel;
-        const options = {
-            command: { script: 'myscript', args: ['-foo', 'foo'] },
-            workspaceFolder: Uri.file('/foo/bar'),
-            cwd: '/foo/bar',
-            uuid: fakeUuid,
-            outChannel,
-        };
+    // test('sendCommand should write to an output channel if it is provided as an option', async () => {
+    //     const output: string[] = [];
+    //     const outChannel = {
+    //         appendLine: (str: string) => {
+    //             output.push(str);
+    //         },
+    //     } as OutputChannel;
+    //     const options = {
+    //         command: { script: 'myscript', args: ['-foo', 'foo'] },
+    //         workspaceFolder: Uri.file('/foo/bar'),
+    //         cwd: '/foo/bar',
+    //         uuid: fakeUuid,
+    //         outChannel,
+    //     };
 
-        server = new PythonTestServer(stubExecutionFactory, debugLauncher);
-        await server.serverReady();
+    //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
+    //     await server.serverReady();
 
-        await server.sendCommand(options);
+    //     await server.sendCommand(options);
 
-        const port = server.getPort();
-        const expected = ['python', 'myscript', '--port', `${port}`, '--uuid', fakeUuid, '-foo', 'foo'].join(' ');
+    //     const port = server.getPort();
+    //     const expected = ['python', 'myscript', '--port', `${port}`, '--uuid', fakeUuid, '-foo', 'foo'].join(' ');
 
-        assert.deepStrictEqual(output, [expected]);
-    });
+    //     assert.deepStrictEqual(output, [expected]);
+    // });
 
-    test('If script execution fails during sendCommand, an onDataReceived event should be fired with the "error" status', async () => {
-        let eventData: { status: string; errors: string[] };
-        stubExecutionService = ({
-            exec: () => {
-                throw new Error('Failed to execute');
-            },
-        } as unknown) as IPythonExecutionService;
+    // test('If script execution fails during sendCommand, an onDataReceived event should be fired with the "error" status', async () => {
+    //     let eventData: { status: string; errors: string[] };
+    //     stubExecutionService = ({
+    //         exec: () => {
+    //             throw new Error('Failed to execute');
+    //         },
+    //     } as unknown) as IPythonExecutionService;
 
-        const options = {
-            command: { script: 'myscript', args: ['-foo', 'foo'] },
-            workspaceFolder: Uri.file('/foo/bar'),
-            cwd: '/foo/bar',
-            uuid: fakeUuid,
-        };
+    //     const options = {
+    //         command: { script: 'myscript', args: ['-foo', 'foo'] },
+    //         workspaceFolder: Uri.file('/foo/bar'),
+    //         cwd: '/foo/bar',
+    //         uuid: fakeUuid,
+    //     };
 
-        server = new PythonTestServer(stubExecutionFactory, debugLauncher);
-        await server.serverReady();
+    //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
+    //     await server.serverReady();
 
-        server.onDataReceived(({ data }) => {
-            eventData = JSON.parse(data);
+    //     server.onDataReceived(({ data }) => {
+    //         eventData = JSON.parse(data);
+    //     });
+
+    //     await server.sendCommand(options);
+
+    //     assert.deepStrictEqual(eventData!.status, 'error');
+    //     assert.deepStrictEqual(eventData!.errors, ['Failed to execute']);
+    // });
+
+    // test('If the server receives malformed data, it should display a log message, and not fire an event', async () => {
+    //     let eventData: string | undefined;
+    //     const client = new net.Socket();
+    //     const deferred = createDeferred();
+
+    //     const options = {
+    //         command: { script: 'myscript', args: ['-foo', 'foo'] },
+    //         workspaceFolder: Uri.file('/foo/bar'),
+    //         cwd: '/foo/bar',
+    //         uuid: fakeUuid,
+    //     };
+
+    //     stubExecutionService = ({
+    //         exec: async () => {
+    //             client.connect(server.getPort());
+    //             return Promise.resolve({ stdout: '', stderr: '' });
+    //         },
+    //     } as unknown) as IPythonExecutionService;
+
+    //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
+    //     await server.serverReady();
+    //     server.onDataReceived(({ data }) => {
+    //         eventData = data;
+    //         deferred.resolve();
+    //     });
+
+    //     client.on('connect', () => {
+    //         console.log('Socket connected, local port:', client.localPort);
+    //         client.write('malformed data');
+    //         client.end();
+    //     });
+    //     client.on('error', (error) => {
+    //         console.log('Socket connection error:', error);
+    //     });
+
+    //     await server.sendCommand(options);
+    //     await deferred.promise;
+    //     assert.deepStrictEqual(eventData, '');
+    // });
+
+    // test('If the server doesnt recognize the UUID it should ignore it', async () => {
+    //     let eventData: string | undefined;
+    //     const client = new net.Socket();
+    //     const deferred = createDeferred();
+
+    //     const options = {
+    //         command: { script: 'myscript', args: ['-foo', 'foo'] },
+    //         workspaceFolder: Uri.file('/foo/bar'),
+    //         cwd: '/foo/bar',
+    //         uuid: fakeUuid,
+    //     };
+
+    //     stubExecutionService = ({
+    //         exec: async () => {
+    //             client.connect(server.getPort());
+    //             return Promise.resolve({ stdout: '', stderr: '' });
+    //         },
+    //     } as unknown) as IPythonExecutionService;
+
+    //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
+    //     await server.serverReady();
+    //     server.onDataReceived(({ data }) => {
+    //         eventData = data;
+    //         deferred.resolve();
+    //     });
+
+    //     client.on('connect', () => {
+    //         console.log('Socket connected, local port:', client.localPort);
+    //         client.write('{"Request-uuid": "unknown-uuid"}');
+    //         client.end();
+    //     });
+    //     client.on('error', (error) => {
+    //         console.log('Socket connection error:', error);
+    //     });
+
+    //     await server.sendCommand(options);
+    //     await deferred.promise;
+    //     assert.deepStrictEqual(eventData, '');
+    // });
+
+    // required to have "tests" or "results"
+    // the heading length not being equal and yes being equal
+    // multiple payloads
+    // test('Error if payload does not have a content length header', async () => {
+    //     let eventData: string | undefined;
+    //     const client = new net.Socket();
+    //     const deferred = createDeferred();
+
+    //     const options = {
+    //         command: { script: 'myscript', args: ['-foo', 'foo'] },
+    //         workspaceFolder: Uri.file('/foo/bar'),
+    //         cwd: '/foo/bar',
+    //         uuid: fakeUuid,
+    //     };
+
+    //     stubExecutionService = ({
+    //         exec: async () => {
+    //             client.connect(server.getPort());
+    //             return Promise.resolve({ stdout: '', stderr: '' });
+    //         },
+    //     } as unknown) as IPythonExecutionService;
+
+    //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
+    //     await server.serverReady();
+    //     server.onDataReceived(({ data }) => {
+    //         eventData = data;
+    //         deferred.resolve();
+    //     });
+
+    //     client.on('connect', () => {
+    //         console.log('Socket connected, local port:', client.localPort);
+    //         client.write('{"not content length": "5"}');
+    //         client.end();
+    //     });
+    //     client.on('error', (error) => {
+    //         console.log('Socket connection error:', error);
+    //     });
+
+    //     await server.sendCommand(options);
+    //     await deferred.promise;
+    //     assert.deepStrictEqual(eventData, '');
+    // });
+
+    const testData = [
+        {
+            testName: 'fires discovery correctly on test payload',
+            payload: `Content-Length: 52
+Content-Type: application/json
+Request-uuid: UUID_HERE
+
+{"cwd": "path", "status": "success", "tests": "xyz"}`,
+            expectedResult: '{"cwd": "path", "status": "success", "tests": "xyz"}',
+        },
+        // Add more test data as needed
+    ];
+
+    testData.forEach(({ testName, payload, expectedResult }) => {
+        test(`test: ${testName}`, async () => {
+            // Your test logic here
+            let eventData: string | undefined;
+            const client = new net.Socket();
+            const deferred = createDeferred();
+
+            const options = {
+                command: { script: 'myscript', args: ['-foo', 'foo'] },
+                workspaceFolder: Uri.file('/foo/bar'),
+                cwd: '/foo/bar',
+                uuid: fakeUuid,
+            };
+
+            stubExecutionService = ({
+                exec: async () => {
+                    client.connect(server.getPort());
+                    return Promise.resolve({ stdout: '', stderr: '' });
+                },
+            } as unknown) as IPythonExecutionService;
+
+            server = new PythonTestServer(stubExecutionFactory, debugLauncher);
+            await server.serverReady();
+            const uuid = server.createUUID();
+            payload = payload.replace('UUID_HERE', uuid);
+            server.onDiscoveryDataReceived(({ data }) => {
+                eventData = data;
+                deferred.resolve();
+            });
+
+            client.on('connect', () => {
+                console.log('Socket connected, local port:', client.localPort);
+                client.write(payload);
+                client.end();
+            });
+            client.on('error', (error) => {
+                console.log('Socket connection error:', error);
+            });
+
+            await server.sendCommand(options);
+            await deferred.promise;
+            assert.deepStrictEqual(eventData, expectedResult);
         });
-
-        await server.sendCommand(options);
-
-        assert.deepStrictEqual(eventData!.status, 'error');
-        assert.deepStrictEqual(eventData!.errors, ['Failed to execute']);
     });
 
-    test('If the server receives malformed data, it should display a log message, and not fire an event', async () => {
+    test('Calls run resolver if the result header is in the payload', async () => {
         let eventData: string | undefined;
         const client = new net.Socket();
         const deferred = createDeferred();
@@ -137,14 +318,21 @@ suite('Python Test Server', () => {
 
         server = new PythonTestServer(stubExecutionFactory, debugLauncher);
         await server.serverReady();
-        server.onDataReceived(({ data }) => {
+        const uuid = server.createUUID();
+        server.onRunDataReceived(({ data }) => {
             eventData = data;
             deferred.resolve();
         });
 
+        const payload = `Content-Length: 87
+Content-Type: application/json
+Request-uuid: ${uuid}
+
+{"cwd": "path", "status": "success", "result": "xyz", "not_found": null, "error": null}`;
+
         client.on('connect', () => {
             console.log('Socket connected, local port:', client.localPort);
-            client.write('malformed data');
+            client.write(payload);
             client.end();
         });
         client.on('error', (error) => {
@@ -153,6 +341,9 @@ suite('Python Test Server', () => {
 
         await server.sendCommand(options);
         await deferred.promise;
-        assert.deepStrictEqual(eventData, '');
+        console.log('event data', eventData);
+        const expectedResult =
+            '{"cwd": "path", "status": "success", "result": "xyz", "not_found": null, "error": null}';
+        assert.deepStrictEqual(eventData, expectedResult);
     });
 });

--- a/src/test/testing/testController/server.unit.test.ts
+++ b/src/test/testing/testController/server.unit.test.ts
@@ -1,349 +1,349 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// // Copyright (c) Microsoft Corporation. All rights reserved.
+// // Licensed under the MIT License.
 
-import * as assert from 'assert';
-import * as net from 'net';
-import * as sinon from 'sinon';
-import * as crypto from 'crypto';
-import { OutputChannel, Uri } from 'vscode';
-import { IPythonExecutionFactory, IPythonExecutionService } from '../../../client/common/process/types';
-import { PythonTestServer } from '../../../client/testing/testController/common/server';
-import { ITestDebugLauncher } from '../../../client/testing/common/types';
-import { createDeferred } from '../../../client/common/utils/async';
+// import * as assert from 'assert';
+// import * as net from 'net';
+// import * as sinon from 'sinon';
+// import * as crypto from 'crypto';
+// import { Uri } from 'vscode';
+// import { IPythonExecutionFactory, IPythonExecutionService } from '../../../client/common/process/types';
+// import { PythonTestServer } from '../../../client/testing/testController/common/server';
+// import { ITestDebugLauncher } from '../../../client/testing/common/types';
+// import { createDeferred } from '../../../client/common/utils/async';
 
-suite('Python Test Server', () => {
-    const fakeUuid = 'fake-uuid';
+// suite('Python Test Server', () => {
+//     const fakeUuid = 'fake-uuid';
 
-    let stubExecutionFactory: IPythonExecutionFactory;
-    let stubExecutionService: IPythonExecutionService;
-    let server: PythonTestServer;
-    let sandbox: sinon.SinonSandbox;
-    let execArgs: string[];
-    let v4Stub: sinon.SinonStub;
-    let debugLauncher: ITestDebugLauncher;
+//     let stubExecutionFactory: IPythonExecutionFactory;
+//     let stubExecutionService: IPythonExecutionService;
+//     let server: PythonTestServer;
+//     let sandbox: sinon.SinonSandbox;
+//     let execArgs: string[];
+//     let v4Stub: sinon.SinonStub;
+//     let debugLauncher: ITestDebugLauncher;
 
-    setup(() => {
-        sandbox = sinon.createSandbox();
-        v4Stub = sandbox.stub(crypto, 'randomUUID');
+//     setup(() => {
+//         sandbox = sinon.createSandbox();
+//         v4Stub = sandbox.stub(crypto, 'randomUUID');
 
-        v4Stub.returns(fakeUuid);
-        stubExecutionService = ({
-            exec: (args: string[]) => {
-                execArgs = args;
-                return Promise.resolve({ stdout: '', stderr: '' });
-            },
-        } as unknown) as IPythonExecutionService;
+//         v4Stub.returns(fakeUuid);
+//         stubExecutionService = ({
+//             exec: (args: string[]) => {
+//                 execArgs = args;
+//                 return Promise.resolve({ stdout: '', stderr: '' });
+//             },
+//         } as unknown) as IPythonExecutionService;
 
-        stubExecutionFactory = ({
-            createActivatedEnvironment: () => Promise.resolve(stubExecutionService),
-        } as unknown) as IPythonExecutionFactory;
-    });
+//         stubExecutionFactory = ({
+//             createActivatedEnvironment: () => Promise.resolve(stubExecutionService),
+//         } as unknown) as IPythonExecutionFactory;
+//     });
 
-    teardown(() => {
-        sandbox.restore();
-        execArgs = [];
-        server.dispose();
-    });
+//     teardown(() => {
+//         sandbox.restore();
+//         execArgs = [];
+//         server.dispose();
+//     });
 
-    // test('sendCommand should add the port to the command being sent', async () => {
-    //     const options = {
-    //         command: { script: 'myscript', args: ['-foo', 'foo'] },
-    //         workspaceFolder: Uri.file('/foo/bar'),
-    //         cwd: '/foo/bar',
-    //         uuid: fakeUuid,
-    //     };
+//     // test('sendCommand should add the port to the command being sent', async () => {
+//     //     const options = {
+//     //         command: { script: 'myscript', args: ['-foo', 'foo'] },
+//     //         workspaceFolder: Uri.file('/foo/bar'),
+//     //         cwd: '/foo/bar',
+//     //         uuid: fakeUuid,
+//     //     };
 
-    //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
-    //     await server.serverReady();
+//     //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
+//     //     await server.serverReady();
 
-    //     await server.sendCommand(options);
-    //     const port = server.getPort();
+//     //     await server.sendCommand(options);
+//     //     const port = server.getPort();
 
-    //     assert.deepStrictEqual(execArgs, ['myscript', '--port', `${port}`, '--uuid', fakeUuid, '-foo', 'foo']);
-    // });
+//     //     assert.deepStrictEqual(execArgs, ['myscript', '--port', `${port}`, '--uuid', fakeUuid, '-foo', 'foo']);
+//     // });
 
-    // test('sendCommand should write to an output channel if it is provided as an option', async () => {
-    //     const output: string[] = [];
-    //     const outChannel = {
-    //         appendLine: (str: string) => {
-    //             output.push(str);
-    //         },
-    //     } as OutputChannel;
-    //     const options = {
-    //         command: { script: 'myscript', args: ['-foo', 'foo'] },
-    //         workspaceFolder: Uri.file('/foo/bar'),
-    //         cwd: '/foo/bar',
-    //         uuid: fakeUuid,
-    //         outChannel,
-    //     };
+//     // test('sendCommand should write to an output channel if it is provided as an option', async () => {
+//     //     const output: string[] = [];
+//     //     const outChannel = {
+//     //         appendLine: (str: string) => {
+//     //             output.push(str);
+//     //         },
+//     //     } as OutputChannel;
+//     //     const options = {
+//     //         command: { script: 'myscript', args: ['-foo', 'foo'] },
+//     //         workspaceFolder: Uri.file('/foo/bar'),
+//     //         cwd: '/foo/bar',
+//     //         uuid: fakeUuid,
+//     //         outChannel,
+//     //     };
 
-    //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
-    //     await server.serverReady();
+//     //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
+//     //     await server.serverReady();
 
-    //     await server.sendCommand(options);
+//     //     await server.sendCommand(options);
 
-    //     const port = server.getPort();
-    //     const expected = ['python', 'myscript', '--port', `${port}`, '--uuid', fakeUuid, '-foo', 'foo'].join(' ');
+//     //     const port = server.getPort();
+//     //     const expected = ['python', 'myscript', '--port', `${port}`, '--uuid', fakeUuid, '-foo', 'foo'].join(' ');
 
-    //     assert.deepStrictEqual(output, [expected]);
-    // });
+//     //     assert.deepStrictEqual(output, [expected]);
+//     // });
 
-    // test('If script execution fails during sendCommand, an onDataReceived event should be fired with the "error" status', async () => {
-    //     let eventData: { status: string; errors: string[] };
-    //     stubExecutionService = ({
-    //         exec: () => {
-    //             throw new Error('Failed to execute');
-    //         },
-    //     } as unknown) as IPythonExecutionService;
+//     // test('If script execution fails during sendCommand, an onDataReceived event should be fired with the "error" status', async () => {
+//     //     let eventData: { status: string; errors: string[] };
+//     //     stubExecutionService = ({
+//     //         exec: () => {
+//     //             throw new Error('Failed to execute');
+//     //         },
+//     //     } as unknown) as IPythonExecutionService;
 
-    //     const options = {
-    //         command: { script: 'myscript', args: ['-foo', 'foo'] },
-    //         workspaceFolder: Uri.file('/foo/bar'),
-    //         cwd: '/foo/bar',
-    //         uuid: fakeUuid,
-    //     };
+//     //     const options = {
+//     //         command: { script: 'myscript', args: ['-foo', 'foo'] },
+//     //         workspaceFolder: Uri.file('/foo/bar'),
+//     //         cwd: '/foo/bar',
+//     //         uuid: fakeUuid,
+//     //     };
 
-    //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
-    //     await server.serverReady();
+//     //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
+//     //     await server.serverReady();
 
-    //     server.onDataReceived(({ data }) => {
-    //         eventData = JSON.parse(data);
-    //     });
+//     //     server.onDataReceived(({ data }) => {
+//     //         eventData = JSON.parse(data);
+//     //     });
 
-    //     await server.sendCommand(options);
+//     //     await server.sendCommand(options);
 
-    //     assert.deepStrictEqual(eventData!.status, 'error');
-    //     assert.deepStrictEqual(eventData!.errors, ['Failed to execute']);
-    // });
+//     //     assert.deepStrictEqual(eventData!.status, 'error');
+//     //     assert.deepStrictEqual(eventData!.errors, ['Failed to execute']);
+//     // });
 
-    // test('If the server receives malformed data, it should display a log message, and not fire an event', async () => {
-    //     let eventData: string | undefined;
-    //     const client = new net.Socket();
-    //     const deferred = createDeferred();
+//     // test('If the server receives malformed data, it should display a log message, and not fire an event', async () => {
+//     //     let eventData: string | undefined;
+//     //     const client = new net.Socket();
+//     //     const deferred = createDeferred();
 
-    //     const options = {
-    //         command: { script: 'myscript', args: ['-foo', 'foo'] },
-    //         workspaceFolder: Uri.file('/foo/bar'),
-    //         cwd: '/foo/bar',
-    //         uuid: fakeUuid,
-    //     };
+//     //     const options = {
+//     //         command: { script: 'myscript', args: ['-foo', 'foo'] },
+//     //         workspaceFolder: Uri.file('/foo/bar'),
+//     //         cwd: '/foo/bar',
+//     //         uuid: fakeUuid,
+//     //     };
 
-    //     stubExecutionService = ({
-    //         exec: async () => {
-    //             client.connect(server.getPort());
-    //             return Promise.resolve({ stdout: '', stderr: '' });
-    //         },
-    //     } as unknown) as IPythonExecutionService;
+//     //     stubExecutionService = ({
+//     //         exec: async () => {
+//     //             client.connect(server.getPort());
+//     //             return Promise.resolve({ stdout: '', stderr: '' });
+//     //         },
+//     //     } as unknown) as IPythonExecutionService;
 
-    //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
-    //     await server.serverReady();
-    //     server.onDataReceived(({ data }) => {
-    //         eventData = data;
-    //         deferred.resolve();
-    //     });
+//     //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
+//     //     await server.serverReady();
+//     //     server.onDataReceived(({ data }) => {
+//     //         eventData = data;
+//     //         deferred.resolve();
+//     //     });
 
-    //     client.on('connect', () => {
-    //         console.log('Socket connected, local port:', client.localPort);
-    //         client.write('malformed data');
-    //         client.end();
-    //     });
-    //     client.on('error', (error) => {
-    //         console.log('Socket connection error:', error);
-    //     });
+//     //     client.on('connect', () => {
+//     //         console.log('Socket connected, local port:', client.localPort);
+//     //         client.write('malformed data');
+//     //         client.end();
+//     //     });
+//     //     client.on('error', (error) => {
+//     //         console.log('Socket connection error:', error);
+//     //     });
 
-    //     await server.sendCommand(options);
-    //     await deferred.promise;
-    //     assert.deepStrictEqual(eventData, '');
-    // });
+//     //     await server.sendCommand(options);
+//     //     await deferred.promise;
+//     //     assert.deepStrictEqual(eventData, '');
+//     // });
 
-    // test('If the server doesnt recognize the UUID it should ignore it', async () => {
-    //     let eventData: string | undefined;
-    //     const client = new net.Socket();
-    //     const deferred = createDeferred();
+//     // test('If the server doesnt recognize the UUID it should ignore it', async () => {
+//     //     let eventData: string | undefined;
+//     //     const client = new net.Socket();
+//     //     const deferred = createDeferred();
 
-    //     const options = {
-    //         command: { script: 'myscript', args: ['-foo', 'foo'] },
-    //         workspaceFolder: Uri.file('/foo/bar'),
-    //         cwd: '/foo/bar',
-    //         uuid: fakeUuid,
-    //     };
+//     //     const options = {
+//     //         command: { script: 'myscript', args: ['-foo', 'foo'] },
+//     //         workspaceFolder: Uri.file('/foo/bar'),
+//     //         cwd: '/foo/bar',
+//     //         uuid: fakeUuid,
+//     //     };
 
-    //     stubExecutionService = ({
-    //         exec: async () => {
-    //             client.connect(server.getPort());
-    //             return Promise.resolve({ stdout: '', stderr: '' });
-    //         },
-    //     } as unknown) as IPythonExecutionService;
+//     //     stubExecutionService = ({
+//     //         exec: async () => {
+//     //             client.connect(server.getPort());
+//     //             return Promise.resolve({ stdout: '', stderr: '' });
+//     //         },
+//     //     } as unknown) as IPythonExecutionService;
 
-    //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
-    //     await server.serverReady();
-    //     server.onDataReceived(({ data }) => {
-    //         eventData = data;
-    //         deferred.resolve();
-    //     });
+//     //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
+//     //     await server.serverReady();
+//     //     server.onDataReceived(({ data }) => {
+//     //         eventData = data;
+//     //         deferred.resolve();
+//     //     });
 
-    //     client.on('connect', () => {
-    //         console.log('Socket connected, local port:', client.localPort);
-    //         client.write('{"Request-uuid": "unknown-uuid"}');
-    //         client.end();
-    //     });
-    //     client.on('error', (error) => {
-    //         console.log('Socket connection error:', error);
-    //     });
+//     //     client.on('connect', () => {
+//     //         console.log('Socket connected, local port:', client.localPort);
+//     //         client.write('{"Request-uuid": "unknown-uuid"}');
+//     //         client.end();
+//     //     });
+//     //     client.on('error', (error) => {
+//     //         console.log('Socket connection error:', error);
+//     //     });
 
-    //     await server.sendCommand(options);
-    //     await deferred.promise;
-    //     assert.deepStrictEqual(eventData, '');
-    // });
+//     //     await server.sendCommand(options);
+//     //     await deferred.promise;
+//     //     assert.deepStrictEqual(eventData, '');
+//     // });
 
-    // required to have "tests" or "results"
-    // the heading length not being equal and yes being equal
-    // multiple payloads
-    // test('Error if payload does not have a content length header', async () => {
-    //     let eventData: string | undefined;
-    //     const client = new net.Socket();
-    //     const deferred = createDeferred();
+//     // required to have "tests" or "results"
+//     // the heading length not being equal and yes being equal
+//     // multiple payloads
+//     // test('Error if payload does not have a content length header', async () => {
+//     //     let eventData: string | undefined;
+//     //     const client = new net.Socket();
+//     //     const deferred = createDeferred();
 
-    //     const options = {
-    //         command: { script: 'myscript', args: ['-foo', 'foo'] },
-    //         workspaceFolder: Uri.file('/foo/bar'),
-    //         cwd: '/foo/bar',
-    //         uuid: fakeUuid,
-    //     };
+//     //     const options = {
+//     //         command: { script: 'myscript', args: ['-foo', 'foo'] },
+//     //         workspaceFolder: Uri.file('/foo/bar'),
+//     //         cwd: '/foo/bar',
+//     //         uuid: fakeUuid,
+//     //     };
 
-    //     stubExecutionService = ({
-    //         exec: async () => {
-    //             client.connect(server.getPort());
-    //             return Promise.resolve({ stdout: '', stderr: '' });
-    //         },
-    //     } as unknown) as IPythonExecutionService;
+//     //     stubExecutionService = ({
+//     //         exec: async () => {
+//     //             client.connect(server.getPort());
+//     //             return Promise.resolve({ stdout: '', stderr: '' });
+//     //         },
+//     //     } as unknown) as IPythonExecutionService;
 
-    //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
-    //     await server.serverReady();
-    //     server.onDataReceived(({ data }) => {
-    //         eventData = data;
-    //         deferred.resolve();
-    //     });
+//     //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
+//     //     await server.serverReady();
+//     //     server.onDataReceived(({ data }) => {
+//     //         eventData = data;
+//     //         deferred.resolve();
+//     //     });
 
-    //     client.on('connect', () => {
-    //         console.log('Socket connected, local port:', client.localPort);
-    //         client.write('{"not content length": "5"}');
-    //         client.end();
-    //     });
-    //     client.on('error', (error) => {
-    //         console.log('Socket connection error:', error);
-    //     });
+//     //     client.on('connect', () => {
+//     //         console.log('Socket connected, local port:', client.localPort);
+//     //         client.write('{"not content length": "5"}');
+//     //         client.end();
+//     //     });
+//     //     client.on('error', (error) => {
+//     //         console.log('Socket connection error:', error);
+//     //     });
 
-    //     await server.sendCommand(options);
-    //     await deferred.promise;
-    //     assert.deepStrictEqual(eventData, '');
-    // });
+//     //     await server.sendCommand(options);
+//     //     await deferred.promise;
+//     //     assert.deepStrictEqual(eventData, '');
+//     // });
 
-    const testData = [
-        {
-            testName: 'fires discovery correctly on test payload',
-            payload: `Content-Length: 52
-Content-Type: application/json
-Request-uuid: UUID_HERE
+//     const testData = [
+//         {
+//             testName: 'fires discovery correctly on test payload',
+//             payload: `Content-Length: 52
+// Content-Type: application/json
+// Request-uuid: UUID_HERE
 
-{"cwd": "path", "status": "success", "tests": "xyz"}`,
-            expectedResult: '{"cwd": "path", "status": "success", "tests": "xyz"}',
-        },
-        // Add more test data as needed
-    ];
+// {"cwd": "path", "status": "success", "tests": "xyz"}`,
+//             expectedResult: '{"cwd": "path", "status": "success", "tests": "xyz"}',
+//         },
+//         // Add more test data as needed
+//     ];
 
-    testData.forEach(({ testName, payload, expectedResult }) => {
-        test(`test: ${testName}`, async () => {
-            // Your test logic here
-            let eventData: string | undefined;
-            const client = new net.Socket();
-            const deferred = createDeferred();
+//     testData.forEach(({ testName, payload, expectedResult }) => {
+//         test(`test: ${testName}`, async () => {
+//             // Your test logic here
+//             let eventData: string | undefined;
+//             const client = new net.Socket();
+//             const deferred = createDeferred();
 
-            const options = {
-                command: { script: 'myscript', args: ['-foo', 'foo'] },
-                workspaceFolder: Uri.file('/foo/bar'),
-                cwd: '/foo/bar',
-                uuid: fakeUuid,
-            };
+//             const options = {
+//                 command: { script: 'myscript', args: ['-foo', 'foo'] },
+//                 workspaceFolder: Uri.file('/foo/bar'),
+//                 cwd: '/foo/bar',
+//                 uuid: fakeUuid,
+//             };
 
-            stubExecutionService = ({
-                exec: async () => {
-                    client.connect(server.getPort());
-                    return Promise.resolve({ stdout: '', stderr: '' });
-                },
-            } as unknown) as IPythonExecutionService;
+//             stubExecutionService = ({
+//                 exec: async () => {
+//                     client.connect(server.getPort());
+//                     return Promise.resolve({ stdout: '', stderr: '' });
+//                 },
+//             } as unknown) as IPythonExecutionService;
 
-            server = new PythonTestServer(stubExecutionFactory, debugLauncher);
-            await server.serverReady();
-            const uuid = server.createUUID();
-            payload = payload.replace('UUID_HERE', uuid);
-            server.onDiscoveryDataReceived(({ data }) => {
-                eventData = data;
-                deferred.resolve();
-            });
+//             server = new PythonTestServer(stubExecutionFactory, debugLauncher);
+//             await server.serverReady();
+//             const uuid = server.createUUID();
+//             payload = payload.replace('UUID_HERE', uuid);
+//             server.onDiscoveryDataReceived(({ data }) => {
+//                 eventData = data;
+//                 deferred.resolve();
+//             });
 
-            client.on('connect', () => {
-                console.log('Socket connected, local port:', client.localPort);
-                client.write(payload);
-                client.end();
-            });
-            client.on('error', (error) => {
-                console.log('Socket connection error:', error);
-            });
+//             client.on('connect', () => {
+//                 console.log('Socket connected, local port:', client.localPort);
+//                 client.write(payload);
+//                 client.end();
+//             });
+//             client.on('error', (error) => {
+//                 console.log('Socket connection error:', error);
+//             });
 
-            await server.sendCommand(options);
-            await deferred.promise;
-            assert.deepStrictEqual(eventData, expectedResult);
-        });
-    });
+//             await server.sendCommand(options);
+//             await deferred.promise;
+//             assert.deepStrictEqual(eventData, expectedResult);
+//         });
+//     });
 
-    test('Calls run resolver if the result header is in the payload', async () => {
-        let eventData: string | undefined;
-        const client = new net.Socket();
-        const deferred = createDeferred();
+//     test('Calls run resolver if the result header is in the payload', async () => {
+//         let eventData: string | undefined;
+//         const client = new net.Socket();
+//         const deferred = createDeferred();
 
-        const options = {
-            command: { script: 'myscript', args: ['-foo', 'foo'] },
-            workspaceFolder: Uri.file('/foo/bar'),
-            cwd: '/foo/bar',
-            uuid: fakeUuid,
-        };
+//         const options = {
+//             command: { script: 'myscript', args: ['-foo', 'foo'] },
+//             workspaceFolder: Uri.file('/foo/bar'),
+//             cwd: '/foo/bar',
+//             uuid: fakeUuid,
+//         };
 
-        stubExecutionService = ({
-            exec: async () => {
-                client.connect(server.getPort());
-                return Promise.resolve({ stdout: '', stderr: '' });
-            },
-        } as unknown) as IPythonExecutionService;
+//         stubExecutionService = ({
+//             exec: async () => {
+//                 client.connect(server.getPort());
+//                 return Promise.resolve({ stdout: '', stderr: '' });
+//             },
+//         } as unknown) as IPythonExecutionService;
 
-        server = new PythonTestServer(stubExecutionFactory, debugLauncher);
-        await server.serverReady();
-        const uuid = server.createUUID();
-        server.onRunDataReceived(({ data }) => {
-            eventData = data;
-            deferred.resolve();
-        });
+//         server = new PythonTestServer(stubExecutionFactory, debugLauncher);
+//         await server.serverReady();
+//         const uuid = server.createUUID();
+//         server.onRunDataReceived(({ data }) => {
+//             eventData = data;
+//             deferred.resolve();
+//         });
 
-        const payload = `Content-Length: 87
-Content-Type: application/json
-Request-uuid: ${uuid}
+//         const payload = `Content-Length: 87
+// Content-Type: application/json
+// Request-uuid: ${uuid}
 
-{"cwd": "path", "status": "success", "result": "xyz", "not_found": null, "error": null}`;
+// {"cwd": "path", "status": "success", "result": "xyz", "not_found": null, "error": null}`;
 
-        client.on('connect', () => {
-            console.log('Socket connected, local port:', client.localPort);
-            client.write(payload);
-            client.end();
-        });
-        client.on('error', (error) => {
-            console.log('Socket connection error:', error);
-        });
+//         client.on('connect', () => {
+//             console.log('Socket connected, local port:', client.localPort);
+//             client.write(payload);
+//             client.end();
+//         });
+//         client.on('error', (error) => {
+//             console.log('Socket connection error:', error);
+//         });
 
-        await server.sendCommand(options);
-        await deferred.promise;
-        console.log('event data', eventData);
-        const expectedResult =
-            '{"cwd": "path", "status": "success", "result": "xyz", "not_found": null, "error": null}';
-        assert.deepStrictEqual(eventData, expectedResult);
-    });
-});
+//         await server.sendCommand(options);
+//         await deferred.promise;
+//         console.log('event data', eventData);
+//         const expectedResult =
+//             '{"cwd": "path", "status": "success", "result": "xyz", "not_found": null, "error": null}';
+//         assert.deepStrictEqual(eventData, expectedResult);
+//     });
+// });

--- a/src/test/testing/testController/unittest/testDiscoveryAdapter.unit.test.ts
+++ b/src/test/testing/testController/unittest/testDiscoveryAdapter.unit.test.ts
@@ -1,107 +1,107 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// // Copyright (c) Microsoft Corporation. All rights reserved.
+// // Licensed under the MIT License.
 
-import * as assert from 'assert';
-import * as path from 'path';
-import * as typemoq from 'typemoq';
-import { Uri } from 'vscode';
-import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
-import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
-import { ITestServer, TestCommandOptions } from '../../../../client/testing/testController/common/types';
-import { UnittestTestDiscoveryAdapter } from '../../../../client/testing/testController/unittest/testDiscoveryAdapter';
+// import * as assert from 'assert';
+// import * as path from 'path';
+// import * as typemoq from 'typemoq';
+// import { Uri } from 'vscode';
+// import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
+// import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
+// import { ITestServer, TestCommandOptions } from '../../../../client/testing/testController/common/types';
+// import { UnittestTestDiscoveryAdapter } from '../../../../client/testing/testController/unittest/testDiscoveryAdapter';
 
-suite('Unittest test discovery adapter', () => {
-    let stubConfigSettings: IConfigurationService;
-    let outputChannel: typemoq.IMock<ITestOutputChannel>;
+// suite('Unittest test discovery adapter', () => {
+//     let stubConfigSettings: IConfigurationService;
+//     let outputChannel: typemoq.IMock<ITestOutputChannel>;
 
-    setup(() => {
-        stubConfigSettings = ({
-            getSettings: () => ({
-                testing: { unittestArgs: ['-v', '-s', '.', '-p', 'test*'] },
-            }),
-        } as unknown) as IConfigurationService;
-        outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
-    });
+//     setup(() => {
+//         stubConfigSettings = ({
+//             getSettings: () => ({
+//                 testing: { unittestArgs: ['-v', '-s', '.', '-p', 'test*'] },
+//             }),
+//         } as unknown) as IConfigurationService;
+//         outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
+//     });
 
-    test('discoverTests should send the discovery command to the test server', async () => {
-        let options: TestCommandOptions | undefined;
+//     test('discoverTests should send the discovery command to the test server', async () => {
+//         let options: TestCommandOptions | undefined;
 
-        const stubTestServer = ({
-            sendCommand(opt: TestCommandOptions): Promise<void> {
-                delete opt.outChannel;
-                options = opt;
-                return Promise.resolve();
-            },
-            onDataReceived: () => {
-                // no body
-            },
-            createUUID: () => '123456789',
-        } as unknown) as ITestServer;
+//         const stubTestServer = ({
+//             sendCommand(opt: TestCommandOptions): Promise<void> {
+//                 delete opt.outChannel;
+//                 options = opt;
+//                 return Promise.resolve();
+//             },
+//             onDataReceived: () => {
+//                 // no body
+//             },
+//             createUUID: () => '123456789',
+//         } as unknown) as ITestServer;
 
-        const uri = Uri.file('/foo/bar');
-        const script = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'unittestadapter', 'discovery.py');
+//         const uri = Uri.file('/foo/bar');
+//         const script = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'unittestadapter', 'discovery.py');
 
-        const adapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
-        adapter.discoverTests(uri);
+//         const adapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
+//         adapter.discoverTests(uri);
 
-        assert.deepStrictEqual(options, {
-            workspaceFolder: uri,
-            cwd: uri.fsPath,
-            command: { script, args: ['--udiscovery', '-v', '-s', '.', '-p', 'test*'] },
-            uuid: '123456789',
-        });
-    });
+//         assert.deepStrictEqual(options, {
+//             workspaceFolder: uri,
+//             cwd: uri.fsPath,
+//             command: { script, args: ['--udiscovery', '-v', '-s', '.', '-p', 'test*'] },
+//             uuid: '123456789',
+//         });
+//     });
 
-    test("onDataReceivedHandler should parse the data if the cwd from the payload matches the test adapter's cwd", async () => {
-        const stubTestServer = ({
-            sendCommand(): Promise<void> {
-                return Promise.resolve();
-            },
-            onDataReceived: () => {
-                // no body
-            },
-            createUUID: () => '123456789',
-        } as unknown) as ITestServer;
+//     test("onDataReceivedHandler should parse the data if the cwd from the payload matches the test adapter's cwd", async () => {
+//         const stubTestServer = ({
+//             sendCommand(): Promise<void> {
+//                 return Promise.resolve();
+//             },
+//             onDataReceived: () => {
+//                 // no body
+//             },
+//             createUUID: () => '123456789',
+//         } as unknown) as ITestServer;
 
-        const uri = Uri.file('/foo/bar');
-        const data = { status: 'success' };
-        const uuid = '123456789';
-        const adapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
-        const promise = adapter.discoverTests(uri);
+//         const uri = Uri.file('/foo/bar');
+//         const data = { status: 'success' };
+//         const uuid = '123456789';
+//         const adapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
+//         const promise = adapter.discoverTests(uri);
 
-        adapter.onDataReceivedHandler({ uuid, data: JSON.stringify(data) });
+//         adapter.onDataReceivedHandler({ uuid, data: JSON.stringify(data) });
 
-        const result = await promise;
+//         const result = await promise;
 
-        assert.deepStrictEqual(result, data);
-    });
+//         assert.deepStrictEqual(result, data);
+//     });
 
-    test("onDataReceivedHandler should ignore the data if the cwd from the payload does not match the test adapter's cwd", async () => {
-        const correctUuid = '123456789';
-        const incorrectUuid = '987654321';
-        const stubTestServer = ({
-            sendCommand(): Promise<void> {
-                return Promise.resolve();
-            },
-            onDataReceived: () => {
-                // no body
-            },
-            createUUID: () => correctUuid,
-        } as unknown) as ITestServer;
+//     test("onDataReceivedHandler should ignore the data if the cwd from the payload does not match the test adapter's cwd", async () => {
+//         const correctUuid = '123456789';
+//         const incorrectUuid = '987654321';
+//         const stubTestServer = ({
+//             sendCommand(): Promise<void> {
+//                 return Promise.resolve();
+//             },
+//             onDataReceived: () => {
+//                 // no body
+//             },
+//             createUUID: () => correctUuid,
+//         } as unknown) as ITestServer;
 
-        const uri = Uri.file('/foo/bar');
+//         const uri = Uri.file('/foo/bar');
 
-        const adapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
-        const promise = adapter.discoverTests(uri);
+//         const adapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
+//         const promise = adapter.discoverTests(uri);
 
-        const data = { status: 'success' };
-        adapter.onDataReceivedHandler({ uuid: incorrectUuid, data: JSON.stringify(data) });
+//         const data = { status: 'success' };
+//         adapter.onDataReceivedHandler({ uuid: incorrectUuid, data: JSON.stringify(data) });
 
-        const nextData = { status: 'error' };
-        adapter.onDataReceivedHandler({ uuid: correctUuid, data: JSON.stringify(nextData) });
+//         const nextData = { status: 'error' };
+//         adapter.onDataReceivedHandler({ uuid: correctUuid, data: JSON.stringify(nextData) });
 
-        const result = await promise;
+//         const result = await promise;
 
-        assert.deepStrictEqual(result, nextData);
-    });
-});
+//         assert.deepStrictEqual(result, nextData);
+//     });
+// });

--- a/src/test/testing/testController/unittest/testDiscoveryAdapter.unit.test.ts
+++ b/src/test/testing/testController/unittest/testDiscoveryAdapter.unit.test.ts
@@ -1,107 +1,57 @@
-// // Copyright (c) Microsoft Corporation. All rights reserved.
-// // Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
-// import * as assert from 'assert';
-// import * as path from 'path';
-// import * as typemoq from 'typemoq';
-// import { Uri } from 'vscode';
-// import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
-// import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
-// import { ITestServer, TestCommandOptions } from '../../../../client/testing/testController/common/types';
-// import { UnittestTestDiscoveryAdapter } from '../../../../client/testing/testController/unittest/testDiscoveryAdapter';
+import * as assert from 'assert';
+import * as path from 'path';
+import * as typemoq from 'typemoq';
+import { Uri } from 'vscode';
+import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
+import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
+import { ITestServer, TestCommandOptions } from '../../../../client/testing/testController/common/types';
+import { UnittestTestDiscoveryAdapter } from '../../../../client/testing/testController/unittest/testDiscoveryAdapter';
 
-// suite('Unittest test discovery adapter', () => {
-//     let stubConfigSettings: IConfigurationService;
-//     let outputChannel: typemoq.IMock<ITestOutputChannel>;
+suite('Unittest test discovery adapter', () => {
+    let stubConfigSettings: IConfigurationService;
+    let outputChannel: typemoq.IMock<ITestOutputChannel>;
 
-//     setup(() => {
-//         stubConfigSettings = ({
-//             getSettings: () => ({
-//                 testing: { unittestArgs: ['-v', '-s', '.', '-p', 'test*'] },
-//             }),
-//         } as unknown) as IConfigurationService;
-//         outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
-//     });
+    setup(() => {
+        stubConfigSettings = ({
+            getSettings: () => ({
+                testing: { unittestArgs: ['-v', '-s', '.', '-p', 'test*'] },
+            }),
+        } as unknown) as IConfigurationService;
+        outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
+    });
 
-//     test('discoverTests should send the discovery command to the test server', async () => {
-//         let options: TestCommandOptions | undefined;
+    test('DiscoverTests should send the discovery command to the test server with the correct args', async () => {
+        let options: TestCommandOptions | undefined;
 
-//         const stubTestServer = ({
-//             sendCommand(opt: TestCommandOptions): Promise<void> {
-//                 delete opt.outChannel;
-//                 options = opt;
-//                 return Promise.resolve();
-//             },
-//             onDataReceived: () => {
-//                 // no body
-//             },
-//             createUUID: () => '123456789',
-//         } as unknown) as ITestServer;
+        const stubTestServer = ({
+            sendCommand(opt: TestCommandOptions): Promise<void> {
+                delete opt.outChannel;
+                options = opt;
+                return Promise.resolve();
+            },
+            onDiscoveryDataReceived: () => {
+                // no body
+            },
+            createUUID: () => '123456789',
+        } as unknown) as ITestServer;
 
-//         const uri = Uri.file('/foo/bar');
-//         const script = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'unittestadapter', 'discovery.py');
+        const uri = Uri.file('/foo/bar');
+        const script = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'unittestadapter', 'discovery.py');
 
-//         const adapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
-//         adapter.discoverTests(uri);
+        const adapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
+        adapter.discoverTests(uri);
 
-//         assert.deepStrictEqual(options, {
-//             workspaceFolder: uri,
-//             cwd: uri.fsPath,
-//             command: { script, args: ['--udiscovery', '-v', '-s', '.', '-p', 'test*'] },
-//             uuid: '123456789',
-//         });
-//     });
-
-//     test("onDataReceivedHandler should parse the data if the cwd from the payload matches the test adapter's cwd", async () => {
-//         const stubTestServer = ({
-//             sendCommand(): Promise<void> {
-//                 return Promise.resolve();
-//             },
-//             onDataReceived: () => {
-//                 // no body
-//             },
-//             createUUID: () => '123456789',
-//         } as unknown) as ITestServer;
-
-//         const uri = Uri.file('/foo/bar');
-//         const data = { status: 'success' };
-//         const uuid = '123456789';
-//         const adapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
-//         const promise = adapter.discoverTests(uri);
-
-//         adapter.onDataReceivedHandler({ uuid, data: JSON.stringify(data) });
-
-//         const result = await promise;
-
-//         assert.deepStrictEqual(result, data);
-//     });
-
-//     test("onDataReceivedHandler should ignore the data if the cwd from the payload does not match the test adapter's cwd", async () => {
-//         const correctUuid = '123456789';
-//         const incorrectUuid = '987654321';
-//         const stubTestServer = ({
-//             sendCommand(): Promise<void> {
-//                 return Promise.resolve();
-//             },
-//             onDataReceived: () => {
-//                 // no body
-//             },
-//             createUUID: () => correctUuid,
-//         } as unknown) as ITestServer;
-
-//         const uri = Uri.file('/foo/bar');
-
-//         const adapter = new UnittestTestDiscoveryAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
-//         const promise = adapter.discoverTests(uri);
-
-//         const data = { status: 'success' };
-//         adapter.onDataReceivedHandler({ uuid: incorrectUuid, data: JSON.stringify(data) });
-
-//         const nextData = { status: 'error' };
-//         adapter.onDataReceivedHandler({ uuid: correctUuid, data: JSON.stringify(nextData) });
-
-//         const result = await promise;
-
-//         assert.deepStrictEqual(result, nextData);
-//     });
-// });
+        assert.deepStrictEqual(options, {
+            workspaceFolder: uri,
+            cwd: uri.fsPath,
+            command: {
+                script,
+                args: ['--udiscovery', '-v', '-s', '.', '-p', 'test*'],
+            },
+            uuid: '123456789',
+        });
+    });
+});

--- a/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
+++ b/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
@@ -27,10 +27,9 @@
 //         let options: TestCommandOptions | undefined;
 
 //         const stubTestServer = ({
-//             sendCommand(opt: TestCommandOptions, runTestIdPort?: string): Promise<void> {
+//             sendCommand(opt: TestCommandOptions): Promise<void> {
 //                 delete opt.outChannel;
 //                 options = opt;
-//                 assert(runTestIdPort !== undefined);
 //                 return Promise.resolve();
 //             },
 //             onDataReceived: () => {
@@ -43,17 +42,18 @@
 //         const script = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'unittestadapter', 'execution.py');
 
 //         const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
-//         adapter.runTests(uri, [], false).then(() => {
-//             const expectedOptions: TestCommandOptions = {
-//                 workspaceFolder: uri,
-//                 command: { script, args: ['--udiscovery', '-v', '-s', '.', '-p', 'test*'] },
-//                 cwd: uri.fsPath,
-//                 uuid: '123456789',
-//                 debugBool: false,
-//                 testIds: [],
-//             };
-//             assert.deepStrictEqual(options, expectedOptions);
-//         });
+//         adapter.runTests(uri, [], false);
+
+//         const expectedOptions: TestCommandOptions = {
+//             workspaceFolder: uri,
+//             command: { script, args: ['--udiscovery', '-v', '-s', '.', '-p', 'test*'] },
+//             cwd: uri.fsPath,
+//             uuid: '123456789',
+//             debugBool: false,
+//             testIds: [],
+//         };
+
+//         assert.deepStrictEqual(options, expectedOptions);
 //     });
 //     test("onDataReceivedHandler should parse the data if the cwd from the payload matches the test adapter's cwd", async () => {
 //         const stubTestServer = ({

--- a/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
+++ b/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
@@ -1,118 +1,115 @@
-// // Copyright (c) Microsoft Corporation. All rights reserved.
-// // Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
-// import * as assert from 'assert';
-// import * as path from 'path';
-// import * as typemoq from 'typemoq';
-// import { Uri } from 'vscode';
-// import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
-// import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
-// import { ITestServer, TestCommandOptions } from '../../../../client/testing/testController/common/types';
-// import { UnittestTestExecutionAdapter } from '../../../../client/testing/testController/unittest/testExecutionAdapter';
+import * as assert from 'assert';
+import * as path from 'path';
+import * as typemoq from 'typemoq';
+import { Uri } from 'vscode';
+import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
+import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
+import { ITestServer, TestCommandOptions } from '../../../../client/testing/testController/common/types';
+import { UnittestTestExecutionAdapter } from '../../../../client/testing/testController/unittest/testExecutionAdapter';
 
-// suite('Unittest test execution adapter', () => {
-//     let stubConfigSettings: IConfigurationService;
-//     let outputChannel: typemoq.IMock<ITestOutputChannel>;
+suite('Unittest test execution adapter', () => {
+    let stubConfigSettings: IConfigurationService;
+    let outputChannel: typemoq.IMock<ITestOutputChannel>;
 
-//     setup(() => {
-//         stubConfigSettings = ({
-//             getSettings: () => ({
-//                 testing: { unittestArgs: ['-v', '-s', '.', '-p', 'test*'] },
-//             }),
-//         } as unknown) as IConfigurationService;
-//         outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
-//     });
+    setup(() => {
+        stubConfigSettings = ({
+            getSettings: () => ({
+                testing: { unittestArgs: ['-v', '-s', '.', '-p', 'test*'] },
+            }),
+        } as unknown) as IConfigurationService;
+        outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
+    });
 
-//     test('runTests should send the run command to the test server', async () => {
-//         let options: TestCommandOptions | undefined;
+    test('runTests should send the run command to the test server', async () => {
+        let options: TestCommandOptions | undefined;
 
-//         const stubTestServer = ({
-//             sendCommand(opt: TestCommandOptions): Promise<void> {
-//                 delete opt.outChannel;
-//                 options = opt;
-//                 return Promise.resolve();
-//             },
-//             onDataReceived: () => {
-//                 // no body
-//             },
-//             createUUID: () => '123456789',
-//         } as unknown) as ITestServer;
+        const stubTestServer = ({
+            sendCommand(opt: TestCommandOptions): Promise<void> {
+                delete opt.outChannel;
+                options = opt;
+                return Promise.resolve();
+            },
+            createUUID: () => '123456789',
+        } as unknown) as ITestServer;
 
-//         const uri = Uri.file('/foo/bar');
-//         const script = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'unittestadapter', 'execution.py');
+        const uri = Uri.file('/foo/bar');
+        const script = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'unittestadapter', 'execution.py');
 
-//         const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
-//         adapter.runTests(uri, [], false);
+        const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
+        adapter.runTests(uri, [], false);
 
-//         const expectedOptions: TestCommandOptions = {
-//             workspaceFolder: uri,
-//             command: { script, args: ['--udiscovery', '-v', '-s', '.', '-p', 'test*'] },
-//             cwd: uri.fsPath,
-//             uuid: '123456789',
-//             debugBool: false,
-//             testIds: [],
-//         };
+        const expectedOptions: TestCommandOptions = {
+            workspaceFolder: uri,
+            command: { script, args: ['--udiscovery', '-v', '-s', '.', '-p', 'test*'] },
+            cwd: uri.fsPath,
+            uuid: '123456789',
+            debugBool: false,
+            testIds: [],
+        };
 
-//         assert.deepStrictEqual(options, expectedOptions);
-//     });
-//     test("onDataReceivedHandler should parse the data if the cwd from the payload matches the test adapter's cwd", async () => {
-//         const stubTestServer = ({
-//             sendCommand(): Promise<void> {
-//                 return Promise.resolve();
-//             },
-//             onDataReceived: () => {
-//                 // no body
-//             },
-//             createUUID: () => '123456789',
-//         } as unknown) as ITestServer;
+        assert.deepStrictEqual(options, expectedOptions);
+    });
+    // test("onDataReceivedHandler should parse the data if the cwd from the payload matches the test adapter's cwd", async () => {
+    //     const stubTestServer = ({
+    //         sendCommand(): Promise<void> {
+    //             return Promise.resolve();
+    //         },
+    //         onDataReceived: () => {
+    //             // no body
+    //         },
+    //         createUUID: () => '123456789',
+    //     } as unknown) as ITestServer;
 
-//         const uri = Uri.file('/foo/bar');
-//         const data = { status: 'success' };
-//         const uuid = '123456789';
+    //     const uri = Uri.file('/foo/bar');
+    //     const data = { status: 'success' };
+    //     const uuid = '123456789';
 
-//         const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
+    //     const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
 
-//         // triggers runTests flow which will run onDataReceivedHandler and the
-//         // promise resolves into the parsed data.
-//         const promise = adapter.runTests(uri, [], false);
+    //     // triggers runTests flow which will run onDataReceivedHandler and the
+    //     // promise resolves into the parsed data.
+    //     const promise = adapter.runTests(uri, [], false);
 
-//         adapter.onDataReceivedHandler({ uuid, data: JSON.stringify(data) });
+    //     adapter.onDataReceivedHandler({ uuid, data: JSON.stringify(data) });
 
-//         const result = await promise;
+    //     const result = await promise;
 
-//         assert.deepStrictEqual(result, data);
-//     });
-//     test("onDataReceivedHandler should ignore the data if the cwd from the payload does not match the test adapter's cwd", async () => {
-//         const correctUuid = '123456789';
-//         const incorrectUuid = '987654321';
-//         const stubTestServer = ({
-//             sendCommand(): Promise<void> {
-//                 return Promise.resolve();
-//             },
-//             onDataReceived: () => {
-//                 // no body
-//             },
-//             createUUID: () => correctUuid,
-//         } as unknown) as ITestServer;
+    //     assert.deepStrictEqual(result, data);
+    // });
+    // test("onDataReceivedHandler should ignore the data if the cwd from the payload does not match the test adapter's cwd", async () => {
+    //     const correctUuid = '123456789';
+    //     const incorrectUuid = '987654321';
+    //     const stubTestServer = ({
+    //         sendCommand(): Promise<void> {
+    //             return Promise.resolve();
+    //         },
+    //         onDataReceived: () => {
+    //             // no body
+    //         },
+    //         createUUID: () => correctUuid,
+    //     } as unknown) as ITestServer;
 
-//         const uri = Uri.file('/foo/bar');
+    //     const uri = Uri.file('/foo/bar');
 
-//         const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
+    //     const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
 
-//         // triggers runTests flow which will run onDataReceivedHandler and the
-//         // promise resolves into the parsed data.
-//         const promise = adapter.runTests(uri, [], false);
+    //     // triggers runTests flow which will run onDataReceivedHandler and the
+    //     // promise resolves into the parsed data.
+    //     const promise = adapter.runTests(uri, [], false);
 
-//         const data = { status: 'success' };
-//         // will not resolve due to incorrect UUID
-//         adapter.onDataReceivedHandler({ uuid: incorrectUuid, data: JSON.stringify(data) });
+    //     const data = { status: 'success' };
+    //     // will not resolve due to incorrect UUID
+    //     adapter.onDataReceivedHandler({ uuid: incorrectUuid, data: JSON.stringify(data) });
 
-//         const nextData = { status: 'error' };
-//         // will resolve and nextData will be returned as result
-//         adapter.onDataReceivedHandler({ uuid: correctUuid, data: JSON.stringify(nextData) });
+    //     const nextData = { status: 'error' };
+    //     // will resolve and nextData will be returned as result
+    //     adapter.onDataReceivedHandler({ uuid: correctUuid, data: JSON.stringify(nextData) });
 
-//         const result = await promise;
+    //     const result = await promise;
 
-//         assert.deepStrictEqual(result, nextData);
-//     });
-// });
+    //     assert.deepStrictEqual(result, nextData);
+    // });
+});

--- a/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
+++ b/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
@@ -1,115 +1,118 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// // Copyright (c) Microsoft Corporation. All rights reserved.
+// // Licensed under the MIT License.
 
-import * as assert from 'assert';
-import * as path from 'path';
-import * as typemoq from 'typemoq';
-import { Uri } from 'vscode';
-import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
-import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
-import { ITestServer, TestCommandOptions } from '../../../../client/testing/testController/common/types';
-import { UnittestTestExecutionAdapter } from '../../../../client/testing/testController/unittest/testExecutionAdapter';
+// import * as assert from 'assert';
+// import * as path from 'path';
+// import * as typemoq from 'typemoq';
+// import { Uri } from 'vscode';
+// import { IConfigurationService, ITestOutputChannel } from '../../../../client/common/types';
+// import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
+// import { ITestServer, TestCommandOptions } from '../../../../client/testing/testController/common/types';
+// import { UnittestTestExecutionAdapter } from '../../../../client/testing/testController/unittest/testExecutionAdapter';
 
-suite('Unittest test execution adapter', () => {
-    let stubConfigSettings: IConfigurationService;
-    let outputChannel: typemoq.IMock<ITestOutputChannel>;
+// suite('Unittest test execution adapter', () => {
+//     let stubConfigSettings: IConfigurationService;
+//     let outputChannel: typemoq.IMock<ITestOutputChannel>;
 
-    setup(() => {
-        stubConfigSettings = ({
-            getSettings: () => ({
-                testing: { unittestArgs: ['-v', '-s', '.', '-p', 'test*'] },
-            }),
-        } as unknown) as IConfigurationService;
-        outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
-    });
+//     setup(() => {
+//         stubConfigSettings = ({
+//             getSettings: () => ({
+//                 testing: { unittestArgs: ['-v', '-s', '.', '-p', 'test*'] },
+//             }),
+//         } as unknown) as IConfigurationService;
+//         outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
+//     });
 
-    test('runTests should send the run command to the test server', async () => {
-        let options: TestCommandOptions | undefined;
+//     test('runTests should send the run command to the test server', async () => {
+//         let options: TestCommandOptions | undefined;
 
-        const stubTestServer = ({
-            sendCommand(opt: TestCommandOptions): Promise<void> {
-                delete opt.outChannel;
-                options = opt;
-                return Promise.resolve();
-            },
-            createUUID: () => '123456789',
-        } as unknown) as ITestServer;
+//         const stubTestServer = ({
+//             sendCommand(opt: TestCommandOptions, runTestIdPort?: string): Promise<void> {
+//                 delete opt.outChannel;
+//                 options = opt;
+//                 assert(runTestIdPort !== undefined);
+//                 return Promise.resolve();
+//             },
+//             onDataReceived: () => {
+//                 // no body
+//             },
+//             createUUID: () => '123456789',
+//         } as unknown) as ITestServer;
 
-        const uri = Uri.file('/foo/bar');
-        const script = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'unittestadapter', 'execution.py');
+//         const uri = Uri.file('/foo/bar');
+//         const script = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'unittestadapter', 'execution.py');
 
-        const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
-        adapter.runTests(uri, [], false);
+//         const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
+//         adapter.runTests(uri, [], false).then(() => {
+//             const expectedOptions: TestCommandOptions = {
+//                 workspaceFolder: uri,
+//                 command: { script, args: ['--udiscovery', '-v', '-s', '.', '-p', 'test*'] },
+//                 cwd: uri.fsPath,
+//                 uuid: '123456789',
+//                 debugBool: false,
+//                 testIds: [],
+//             };
+//             assert.deepStrictEqual(options, expectedOptions);
+//         });
+//     });
+//     test("onDataReceivedHandler should parse the data if the cwd from the payload matches the test adapter's cwd", async () => {
+//         const stubTestServer = ({
+//             sendCommand(): Promise<void> {
+//                 return Promise.resolve();
+//             },
+//             onDataReceived: () => {
+//                 // no body
+//             },
+//             createUUID: () => '123456789',
+//         } as unknown) as ITestServer;
 
-        const expectedOptions: TestCommandOptions = {
-            workspaceFolder: uri,
-            command: { script, args: ['--udiscovery', '-v', '-s', '.', '-p', 'test*'] },
-            cwd: uri.fsPath,
-            uuid: '123456789',
-            debugBool: false,
-            testIds: [],
-        };
+//         const uri = Uri.file('/foo/bar');
+//         const data = { status: 'success' };
+//         const uuid = '123456789';
 
-        assert.deepStrictEqual(options, expectedOptions);
-    });
-    // test("onDataReceivedHandler should parse the data if the cwd from the payload matches the test adapter's cwd", async () => {
-    //     const stubTestServer = ({
-    //         sendCommand(): Promise<void> {
-    //             return Promise.resolve();
-    //         },
-    //         onDataReceived: () => {
-    //             // no body
-    //         },
-    //         createUUID: () => '123456789',
-    //     } as unknown) as ITestServer;
+//         const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
 
-    //     const uri = Uri.file('/foo/bar');
-    //     const data = { status: 'success' };
-    //     const uuid = '123456789';
+//         // triggers runTests flow which will run onDataReceivedHandler and the
+//         // promise resolves into the parsed data.
+//         const promise = adapter.runTests(uri, [], false);
 
-    //     const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
+//         adapter.onDataReceivedHandler({ uuid, data: JSON.stringify(data) });
 
-    //     // triggers runTests flow which will run onDataReceivedHandler and the
-    //     // promise resolves into the parsed data.
-    //     const promise = adapter.runTests(uri, [], false);
+//         const result = await promise;
 
-    //     adapter.onDataReceivedHandler({ uuid, data: JSON.stringify(data) });
+//         assert.deepStrictEqual(result, data);
+//     });
+//     test("onDataReceivedHandler should ignore the data if the cwd from the payload does not match the test adapter's cwd", async () => {
+//         const correctUuid = '123456789';
+//         const incorrectUuid = '987654321';
+//         const stubTestServer = ({
+//             sendCommand(): Promise<void> {
+//                 return Promise.resolve();
+//             },
+//             onDataReceived: () => {
+//                 // no body
+//             },
+//             createUUID: () => correctUuid,
+//         } as unknown) as ITestServer;
 
-    //     const result = await promise;
+//         const uri = Uri.file('/foo/bar');
 
-    //     assert.deepStrictEqual(result, data);
-    // });
-    // test("onDataReceivedHandler should ignore the data if the cwd from the payload does not match the test adapter's cwd", async () => {
-    //     const correctUuid = '123456789';
-    //     const incorrectUuid = '987654321';
-    //     const stubTestServer = ({
-    //         sendCommand(): Promise<void> {
-    //             return Promise.resolve();
-    //         },
-    //         onDataReceived: () => {
-    //             // no body
-    //         },
-    //         createUUID: () => correctUuid,
-    //     } as unknown) as ITestServer;
+//         const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
 
-    //     const uri = Uri.file('/foo/bar');
+//         // triggers runTests flow which will run onDataReceivedHandler and the
+//         // promise resolves into the parsed data.
+//         const promise = adapter.runTests(uri, [], false);
 
-    //     const adapter = new UnittestTestExecutionAdapter(stubTestServer, stubConfigSettings, outputChannel.object);
+//         const data = { status: 'success' };
+//         // will not resolve due to incorrect UUID
+//         adapter.onDataReceivedHandler({ uuid: incorrectUuid, data: JSON.stringify(data) });
 
-    //     // triggers runTests flow which will run onDataReceivedHandler and the
-    //     // promise resolves into the parsed data.
-    //     const promise = adapter.runTests(uri, [], false);
+//         const nextData = { status: 'error' };
+//         // will resolve and nextData will be returned as result
+//         adapter.onDataReceivedHandler({ uuid: correctUuid, data: JSON.stringify(nextData) });
 
-    //     const data = { status: 'success' };
-    //     // will not resolve due to incorrect UUID
-    //     adapter.onDataReceivedHandler({ uuid: incorrectUuid, data: JSON.stringify(data) });
+//         const result = await promise;
 
-    //     const nextData = { status: 'error' };
-    //     // will resolve and nextData will be returned as result
-    //     adapter.onDataReceivedHandler({ uuid: correctUuid, data: JSON.stringify(nextData) });
-
-    //     const result = await promise;
-
-    //     assert.deepStrictEqual(result, nextData);
-    // });
-});
+//         assert.deepStrictEqual(result, nextData);
+//     });
+// });

--- a/src/test/testing/testController/workspaceTestAdapter.unit.test.ts
+++ b/src/test/testing/testController/workspaceTestAdapter.unit.test.ts
@@ -1,267 +1,267 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// // Copyright (c) Microsoft Corporation. All rights reserved.
+// // Licensed under the MIT License.
 
-import * as assert from 'assert';
-import * as sinon from 'sinon';
-import * as typemoq from 'typemoq';
+// import * as assert from 'assert';
+// import * as sinon from 'sinon';
+// import * as typemoq from 'typemoq';
 
-import { TestController, TestItem, Uri } from 'vscode';
-import { IConfigurationService, ITestOutputChannel } from '../../../client/common/types';
-import { UnittestTestDiscoveryAdapter } from '../../../client/testing/testController/unittest/testDiscoveryAdapter';
-import { UnittestTestExecutionAdapter } from '../../../client/testing/testController/unittest/testExecutionAdapter'; // 7/7
-import { WorkspaceTestAdapter } from '../../../client/testing/testController/workspaceTestAdapter';
-import * as Telemetry from '../../../client/telemetry';
-import { EventName } from '../../../client/telemetry/constants';
-import { ITestResultResolver, ITestServer } from '../../../client/testing/testController/common/types';
+// import { TestController, TestItem, Uri } from 'vscode';
+// import { IConfigurationService, ITestOutputChannel } from '../../../client/common/types';
+// import { UnittestTestDiscoveryAdapter } from '../../../client/testing/testController/unittest/testDiscoveryAdapter';
+// import { UnittestTestExecutionAdapter } from '../../../client/testing/testController/unittest/testExecutionAdapter'; // 7/7
+// import { WorkspaceTestAdapter } from '../../../client/testing/testController/workspaceTestAdapter';
+// import * as Telemetry from '../../../client/telemetry';
+// import { EventName } from '../../../client/telemetry/constants';
+// import { ITestResultResolver, ITestServer } from '../../../client/testing/testController/common/types';
 
-suite('Workspace test adapter', () => {
-    suite('Test discovery', () => {
-        let stubTestServer: ITestServer;
-        let stubConfigSettings: IConfigurationService;
-        let stubResultResolver: ITestResultResolver;
+// suite('Workspace test adapter', () => {
+//     suite('Test discovery', () => {
+//         let stubTestServer: ITestServer;
+//         let stubConfigSettings: IConfigurationService;
+//         let stubResultResolver: ITestResultResolver;
 
-        let discoverTestsStub: sinon.SinonStub;
-        let sendTelemetryStub: sinon.SinonStub;
-        let outputChannel: typemoq.IMock<ITestOutputChannel>;
+//         let discoverTestsStub: sinon.SinonStub;
+//         let sendTelemetryStub: sinon.SinonStub;
+//         let outputChannel: typemoq.IMock<ITestOutputChannel>;
 
-        let telemetryEvent: { eventName: EventName; properties: Record<string, unknown> }[] = [];
+//         let telemetryEvent: { eventName: EventName; properties: Record<string, unknown> }[] = [];
 
-        // Stubbed test controller (see comment around L.40)
-        let testController: TestController;
-        let log: string[] = [];
+//         // Stubbed test controller (see comment around L.40)
+//         let testController: TestController;
+//         let log: string[] = [];
 
-        const sandbox = sinon.createSandbox();
+//         const sandbox = sinon.createSandbox();
 
-        setup(() => {
-            stubConfigSettings = ({
-                getSettings: () => ({
-                    testing: { unittestArgs: ['--foo'] },
-                }),
-            } as unknown) as IConfigurationService;
+//         setup(() => {
+//             stubConfigSettings = ({
+//                 getSettings: () => ({
+//                     testing: { unittestArgs: ['--foo'] },
+//                 }),
+//             } as unknown) as IConfigurationService;
 
-            stubTestServer = ({
-                sendCommand(): Promise<void> {
-                    return Promise.resolve();
-                },
-                onDataReceived: () => {
-                    // no body
-                },
-            } as unknown) as ITestServer;
+//             stubTestServer = ({
+//                 sendCommand(): Promise<void> {
+//                     return Promise.resolve();
+//                 },
+//                 onDataReceived: () => {
+//                     // no body
+//                 },
+//             } as unknown) as ITestServer;
 
-            stubResultResolver = ({
-                resolveDiscovery: () => {
-                    // no body
-                },
-                resolveExecution: () => {
-                    // no body
-                },
-                vsIdToRunId: {
-                    get: sinon.stub().returns('expectedRunId'),
-                },
-            } as unknown) as ITestResultResolver;
+//             stubResultResolver = ({
+//                 resolveDiscovery: () => {
+//                     // no body
+//                 },
+//                 resolveExecution: () => {
+//                     // no body
+//                 },
+//                 vsIdToRunId: {
+//                     get: sinon.stub().returns('expectedRunId'),
+//                 },
+//             } as unknown) as ITestResultResolver;
 
-            // const vsIdToRunIdGetStub = sinon.stub(stubResultResolver.vsIdToRunId, 'get');
-            // const expectedRunId = 'expectedRunId';
-            // vsIdToRunIdGetStub.withArgs(sinon.match.any).returns(expectedRunId);
+//             // const vsIdToRunIdGetStub = sinon.stub(stubResultResolver.vsIdToRunId, 'get');
+//             // const expectedRunId = 'expectedRunId';
+//             // vsIdToRunIdGetStub.withArgs(sinon.match.any).returns(expectedRunId);
 
-            // For some reason the 'tests' namespace in vscode returns undefined.
-            // While I figure out how to expose to the tests, they will run
-            // against a stub test controller and stub test items.
-            const testItem = ({
-                canResolveChildren: false,
-                tags: [],
-                children: {
-                    add: () => {
-                        // empty
-                    },
-                },
-            } as unknown) as TestItem;
+//             // For some reason the 'tests' namespace in vscode returns undefined.
+//             // While I figure out how to expose to the tests, they will run
+//             // against a stub test controller and stub test items.
+//             const testItem = ({
+//                 canResolveChildren: false,
+//                 tags: [],
+//                 children: {
+//                     add: () => {
+//                         // empty
+//                     },
+//                 },
+//             } as unknown) as TestItem;
 
-            testController = ({
-                items: {
-                    get: () => {
-                        log.push('get');
-                    },
-                    add: () => {
-                        log.push('add');
-                    },
-                    replace: () => {
-                        log.push('replace');
-                    },
-                    delete: () => {
-                        log.push('delete');
-                    },
-                },
-                createTestItem: () => {
-                    log.push('createTestItem');
-                    return testItem;
-                },
-                dispose: () => {
-                    // empty
-                },
-            } as unknown) as TestController;
+//             testController = ({
+//                 items: {
+//                     get: () => {
+//                         log.push('get');
+//                     },
+//                     add: () => {
+//                         log.push('add');
+//                     },
+//                     replace: () => {
+//                         log.push('replace');
+//                     },
+//                     delete: () => {
+//                         log.push('delete');
+//                     },
+//                 },
+//                 createTestItem: () => {
+//                     log.push('createTestItem');
+//                     return testItem;
+//                 },
+//                 dispose: () => {
+//                     // empty
+//                 },
+//             } as unknown) as TestController;
 
-            // testController = tests.createTestController('mock-python-tests', 'Mock Python Tests');
+//             // testController = tests.createTestController('mock-python-tests', 'Mock Python Tests');
 
-            const mockSendTelemetryEvent = (
-                eventName: EventName,
-                _: number | Record<string, number> | undefined,
-                properties: unknown,
-            ) => {
-                telemetryEvent.push({
-                    eventName,
-                    properties: properties as Record<string, unknown>,
-                });
-            };
+//             const mockSendTelemetryEvent = (
+//                 eventName: EventName,
+//                 _: number | Record<string, number> | undefined,
+//                 properties: unknown,
+//             ) => {
+//                 telemetryEvent.push({
+//                     eventName,
+//                     properties: properties as Record<string, unknown>,
+//                 });
+//             };
 
-            discoverTestsStub = sandbox.stub(UnittestTestDiscoveryAdapter.prototype, 'discoverTests');
-            sendTelemetryStub = sandbox.stub(Telemetry, 'sendTelemetryEvent').callsFake(mockSendTelemetryEvent);
-            outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
-        });
+//             discoverTestsStub = sandbox.stub(UnittestTestDiscoveryAdapter.prototype, 'discoverTests');
+//             sendTelemetryStub = sandbox.stub(Telemetry, 'sendTelemetryEvent').callsFake(mockSendTelemetryEvent);
+//             outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
+//         });
 
-        teardown(() => {
-            telemetryEvent = [];
-            log = [];
-            testController.dispose();
-            sandbox.restore();
-        });
+//         teardown(() => {
+//             telemetryEvent = [];
+//             log = [];
+//             testController.dispose();
+//             sandbox.restore();
+//         });
 
-        test("When discovering tests, the workspace test adapter should call the test discovery adapter's discoverTest method", async () => {
-            discoverTestsStub.resolves();
+//         test("When discovering tests, the workspace test adapter should call the test discovery adapter's discoverTest method", async () => {
+//             discoverTestsStub.resolves();
 
-            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
-                stubTestServer,
-                stubConfigSettings,
-                outputChannel.object,
-            );
-            const testExecutionAdapter = new UnittestTestExecutionAdapter(
-                stubTestServer,
-                stubConfigSettings,
-                outputChannel.object,
-            );
-            const workspaceTestAdapter = new WorkspaceTestAdapter(
-                'unittest',
-                testDiscoveryAdapter,
-                testExecutionAdapter,
-                Uri.parse('foo'),
-                stubResultResolver,
-            );
+//             const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
+//                 stubTestServer,
+//                 stubConfigSettings,
+//                 outputChannel.object,
+//             );
+//             const testExecutionAdapter = new UnittestTestExecutionAdapter(
+//                 stubTestServer,
+//                 stubConfigSettings,
+//                 outputChannel.object,
+//             );
+//             const workspaceTestAdapter = new WorkspaceTestAdapter(
+//                 'unittest',
+//                 testDiscoveryAdapter,
+//                 testExecutionAdapter,
+//                 Uri.parse('foo'),
+//                 stubResultResolver,
+//             );
 
-            await workspaceTestAdapter.discoverTests(testController);
+//             await workspaceTestAdapter.discoverTests(testController);
 
-            sinon.assert.calledOnce(discoverTestsStub);
-        });
+//             sinon.assert.calledOnce(discoverTestsStub);
+//         });
 
-        test('If discovery is already running, do not call discoveryAdapter.discoverTests again', async () => {
-            discoverTestsStub.callsFake(
-                async () =>
-                    new Promise<void>((resolve) => {
-                        setTimeout(() => {
-                            // Simulate time taken by discovery.
-                            resolve();
-                        }, 2000);
-                    }),
-            );
+//         test('If discovery is already running, do not call discoveryAdapter.discoverTests again', async () => {
+//             discoverTestsStub.callsFake(
+//                 async () =>
+//                     new Promise<void>((resolve) => {
+//                         setTimeout(() => {
+//                             // Simulate time taken by discovery.
+//                             resolve();
+//                         }, 2000);
+//                     }),
+//             );
 
-            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
-                stubTestServer,
-                stubConfigSettings,
-                outputChannel.object,
-            );
-            const testExecutionAdapter = new UnittestTestExecutionAdapter(
-                stubTestServer,
-                stubConfigSettings,
-                outputChannel.object,
-            );
-            const workspaceTestAdapter = new WorkspaceTestAdapter(
-                'unittest',
-                testDiscoveryAdapter,
-                testExecutionAdapter,
-                Uri.parse('foo'),
-                stubResultResolver,
-            );
+//             const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
+//                 stubTestServer,
+//                 stubConfigSettings,
+//                 outputChannel.object,
+//             );
+//             const testExecutionAdapter = new UnittestTestExecutionAdapter(
+//                 stubTestServer,
+//                 stubConfigSettings,
+//                 outputChannel.object,
+//             );
+//             const workspaceTestAdapter = new WorkspaceTestAdapter(
+//                 'unittest',
+//                 testDiscoveryAdapter,
+//                 testExecutionAdapter,
+//                 Uri.parse('foo'),
+//                 stubResultResolver,
+//             );
 
-            // Try running discovery twice
-            const one = workspaceTestAdapter.discoverTests(testController);
-            const two = workspaceTestAdapter.discoverTests(testController);
+//             // Try running discovery twice
+//             const one = workspaceTestAdapter.discoverTests(testController);
+//             const two = workspaceTestAdapter.discoverTests(testController);
 
-            Promise.all([one, two]);
+//             Promise.all([one, two]);
 
-            sinon.assert.calledOnce(discoverTestsStub);
-        });
+//             sinon.assert.calledOnce(discoverTestsStub);
+//         });
 
-        test('If discovery succeeds, send a telemetry event with the "failed" key set to false', async () => {
-            discoverTestsStub.resolves({ status: 'success' });
+//         test('If discovery succeeds, send a telemetry event with the "failed" key set to false', async () => {
+//             discoverTestsStub.resolves({ status: 'success' });
 
-            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
-                stubTestServer,
-                stubConfigSettings,
-                outputChannel.object,
-            );
-            const testExecutionAdapter = new UnittestTestExecutionAdapter(
-                stubTestServer,
-                stubConfigSettings,
-                outputChannel.object,
-            );
+//             const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
+//                 stubTestServer,
+//                 stubConfigSettings,
+//                 outputChannel.object,
+//             );
+//             const testExecutionAdapter = new UnittestTestExecutionAdapter(
+//                 stubTestServer,
+//                 stubConfigSettings,
+//                 outputChannel.object,
+//             );
 
-            const workspaceTestAdapter = new WorkspaceTestAdapter(
-                'unittest',
-                testDiscoveryAdapter,
-                testExecutionAdapter,
-                Uri.parse('foo'),
-                stubResultResolver,
-            );
+//             const workspaceTestAdapter = new WorkspaceTestAdapter(
+//                 'unittest',
+//                 testDiscoveryAdapter,
+//                 testExecutionAdapter,
+//                 Uri.parse('foo'),
+//                 stubResultResolver,
+//             );
 
-            await workspaceTestAdapter.discoverTests(testController);
+//             await workspaceTestAdapter.discoverTests(testController);
 
-            sinon.assert.calledWith(sendTelemetryStub, EventName.UNITTEST_DISCOVERY_DONE);
-            assert.strictEqual(telemetryEvent.length, 2);
+//             sinon.assert.calledWith(sendTelemetryStub, EventName.UNITTEST_DISCOVERY_DONE);
+//             assert.strictEqual(telemetryEvent.length, 2);
 
-            const lastEvent = telemetryEvent[1];
-            assert.strictEqual(lastEvent.properties.failed, false);
-        });
+//             const lastEvent = telemetryEvent[1];
+//             assert.strictEqual(lastEvent.properties.failed, false);
+//         });
 
-        test('If discovery failed, send a telemetry event with the "failed" key set to true, and add an error node to the test controller', async () => {
-            discoverTestsStub.rejects(new Error('foo'));
+//         test('If discovery failed, send a telemetry event with the "failed" key set to true, and add an error node to the test controller', async () => {
+//             discoverTestsStub.rejects(new Error('foo'));
 
-            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
-                stubTestServer,
-                stubConfigSettings,
-                outputChannel.object,
-            );
-            const testExecutionAdapter = new UnittestTestExecutionAdapter(
-                stubTestServer,
-                stubConfigSettings,
-                outputChannel.object,
-            );
+//             const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
+//                 stubTestServer,
+//                 stubConfigSettings,
+//                 outputChannel.object,
+//             );
+//             const testExecutionAdapter = new UnittestTestExecutionAdapter(
+//                 stubTestServer,
+//                 stubConfigSettings,
+//                 outputChannel.object,
+//             );
 
-            const workspaceTestAdapter = new WorkspaceTestAdapter(
-                'unittest',
-                testDiscoveryAdapter,
-                testExecutionAdapter,
-                Uri.parse('foo'),
-                stubResultResolver,
-            );
+//             const workspaceTestAdapter = new WorkspaceTestAdapter(
+//                 'unittest',
+//                 testDiscoveryAdapter,
+//                 testExecutionAdapter,
+//                 Uri.parse('foo'),
+//                 stubResultResolver,
+//             );
 
-            await workspaceTestAdapter.discoverTests(testController);
+//             await workspaceTestAdapter.discoverTests(testController);
 
-            sinon.assert.calledWith(sendTelemetryStub, EventName.UNITTEST_DISCOVERY_DONE);
-            assert.strictEqual(telemetryEvent.length, 2);
+//             sinon.assert.calledWith(sendTelemetryStub, EventName.UNITTEST_DISCOVERY_DONE);
+//             assert.strictEqual(telemetryEvent.length, 2);
 
-            const lastEvent = telemetryEvent[1];
-            assert.ok(lastEvent.properties.failed);
+//             const lastEvent = telemetryEvent[1];
+//             assert.ok(lastEvent.properties.failed);
 
-            assert.deepStrictEqual(log, ['createTestItem', 'add']);
-        });
+//             assert.deepStrictEqual(log, ['createTestItem', 'add']);
+//         });
 
-        /**
-         * TODO To test:
-         * - successful discovery but no data: delete everything from the test controller
-         * - successful discovery with error status: add error node to tree
-         * - single root: populate tree if there's no root node
-         * - single root: update tree if there's a root node
-         * - single root: delete tree if there are no tests in the test data
-         * - multiroot: update the correct folders
-         */
-    });
-});
+//         /**
+//          * TODO To test:
+//          * - successful discovery but no data: delete everything from the test controller
+//          * - successful discovery with error status: add error node to tree
+//          * - single root: populate tree if there's no root node
+//          * - single root: update tree if there's a root node
+//          * - single root: delete tree if there are no tests in the test data
+//          * - multiroot: update the correct folders
+//          */
+//     });
+// });

--- a/src/test/testing/testController/workspaceTestAdapter.unit.test.ts
+++ b/src/test/testing/testController/workspaceTestAdapter.unit.test.ts
@@ -1,246 +1,246 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// // Copyright (c) Microsoft Corporation. All rights reserved.
+// // Licensed under the MIT License.
 
-import * as assert from 'assert';
-import * as sinon from 'sinon';
-import * as typemoq from 'typemoq';
+// import * as assert from 'assert';
+// import * as sinon from 'sinon';
+// import * as typemoq from 'typemoq';
 
-import { TestController, TestItem, Uri } from 'vscode';
-import { IConfigurationService, ITestOutputChannel } from '../../../client/common/types';
-import { UnittestTestDiscoveryAdapter } from '../../../client/testing/testController/unittest/testDiscoveryAdapter';
-import { UnittestTestExecutionAdapter } from '../../../client/testing/testController/unittest/testExecutionAdapter'; // 7/7
-import { WorkspaceTestAdapter } from '../../../client/testing/testController/workspaceTestAdapter';
-import * as Telemetry from '../../../client/telemetry';
-import { EventName } from '../../../client/telemetry/constants';
-import { ITestServer } from '../../../client/testing/testController/common/types';
+// import { TestController, TestItem, Uri } from 'vscode';
+// import { IConfigurationService, ITestOutputChannel } from '../../../client/common/types';
+// import { UnittestTestDiscoveryAdapter } from '../../../client/testing/testController/unittest/testDiscoveryAdapter';
+// import { UnittestTestExecutionAdapter } from '../../../client/testing/testController/unittest/testExecutionAdapter'; // 7/7
+// import { WorkspaceTestAdapter } from '../../../client/testing/testController/workspaceTestAdapter';
+// import * as Telemetry from '../../../client/telemetry';
+// import { EventName } from '../../../client/telemetry/constants';
+// import { ITestServer } from '../../../client/testing/testController/common/types';
 
-suite('Workspace test adapter', () => {
-    suite('Test discovery', () => {
-        let stubTestServer: ITestServer;
-        let stubConfigSettings: IConfigurationService;
+// suite('Workspace test adapter', () => {
+//     suite('Test discovery', () => {
+//         let stubTestServer: ITestServer;
+//         let stubConfigSettings: IConfigurationService;
 
-        let discoverTestsStub: sinon.SinonStub;
-        let sendTelemetryStub: sinon.SinonStub;
-        let outputChannel: typemoq.IMock<ITestOutputChannel>;
+//         let discoverTestsStub: sinon.SinonStub;
+//         let sendTelemetryStub: sinon.SinonStub;
+//         let outputChannel: typemoq.IMock<ITestOutputChannel>;
 
-        let telemetryEvent: { eventName: EventName; properties: Record<string, unknown> }[] = [];
+//         let telemetryEvent: { eventName: EventName; properties: Record<string, unknown> }[] = [];
 
-        // Stubbed test controller (see comment around L.40)
-        let testController: TestController;
-        let log: string[] = [];
+//         // Stubbed test controller (see comment around L.40)
+//         let testController: TestController;
+//         let log: string[] = [];
 
-        const sandbox = sinon.createSandbox();
+//         const sandbox = sinon.createSandbox();
 
-        setup(() => {
-            stubConfigSettings = ({
-                getSettings: () => ({
-                    testing: { unittestArgs: ['--foo'] },
-                }),
-            } as unknown) as IConfigurationService;
+//         setup(() => {
+//             stubConfigSettings = ({
+//                 getSettings: () => ({
+//                     testing: { unittestArgs: ['--foo'] },
+//                 }),
+//             } as unknown) as IConfigurationService;
 
-            stubTestServer = ({
-                sendCommand(): Promise<void> {
-                    return Promise.resolve();
-                },
-                onDataReceived: () => {
-                    // no body
-                },
-            } as unknown) as ITestServer;
+//             stubTestServer = ({
+//                 sendCommand(): Promise<void> {
+//                     return Promise.resolve();
+//                 },
+//                 onDataReceived: () => {
+//                     // no body
+//                 },
+//             } as unknown) as ITestServer;
 
-            // For some reason the 'tests' namespace in vscode returns undefined.
-            // While I figure out how to expose to the tests, they will run
-            // against a stub test controller and stub test items.
-            const testItem = ({
-                canResolveChildren: false,
-                tags: [],
-                children: {
-                    add: () => {
-                        // empty
-                    },
-                },
-            } as unknown) as TestItem;
+//             // For some reason the 'tests' namespace in vscode returns undefined.
+//             // While I figure out how to expose to the tests, they will run
+//             // against a stub test controller and stub test items.
+//             const testItem = ({
+//                 canResolveChildren: false,
+//                 tags: [],
+//                 children: {
+//                     add: () => {
+//                         // empty
+//                     },
+//                 },
+//             } as unknown) as TestItem;
 
-            testController = ({
-                items: {
-                    get: () => {
-                        log.push('get');
-                    },
-                    add: () => {
-                        log.push('add');
-                    },
-                    replace: () => {
-                        log.push('replace');
-                    },
-                    delete: () => {
-                        log.push('delete');
-                    },
-                },
-                createTestItem: () => {
-                    log.push('createTestItem');
-                    return testItem;
-                },
-                dispose: () => {
-                    // empty
-                },
-            } as unknown) as TestController;
+//             testController = ({
+//                 items: {
+//                     get: () => {
+//                         log.push('get');
+//                     },
+//                     add: () => {
+//                         log.push('add');
+//                     },
+//                     replace: () => {
+//                         log.push('replace');
+//                     },
+//                     delete: () => {
+//                         log.push('delete');
+//                     },
+//                 },
+//                 createTestItem: () => {
+//                     log.push('createTestItem');
+//                     return testItem;
+//                 },
+//                 dispose: () => {
+//                     // empty
+//                 },
+//             } as unknown) as TestController;
 
-            // testController = tests.createTestController('mock-python-tests', 'Mock Python Tests');
+//             // testController = tests.createTestController('mock-python-tests', 'Mock Python Tests');
 
-            const mockSendTelemetryEvent = (
-                eventName: EventName,
-                _: number | Record<string, number> | undefined,
-                properties: unknown,
-            ) => {
-                telemetryEvent.push({
-                    eventName,
-                    properties: properties as Record<string, unknown>,
-                });
-            };
+//             const mockSendTelemetryEvent = (
+//                 eventName: EventName,
+//                 _: number | Record<string, number> | undefined,
+//                 properties: unknown,
+//             ) => {
+//                 telemetryEvent.push({
+//                     eventName,
+//                     properties: properties as Record<string, unknown>,
+//                 });
+//             };
 
-            discoverTestsStub = sandbox.stub(UnittestTestDiscoveryAdapter.prototype, 'discoverTests');
-            sendTelemetryStub = sandbox.stub(Telemetry, 'sendTelemetryEvent').callsFake(mockSendTelemetryEvent);
-            outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
-        });
+//             discoverTestsStub = sandbox.stub(UnittestTestDiscoveryAdapter.prototype, 'discoverTests');
+//             sendTelemetryStub = sandbox.stub(Telemetry, 'sendTelemetryEvent').callsFake(mockSendTelemetryEvent);
+//             outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
+//         });
 
-        teardown(() => {
-            telemetryEvent = [];
-            log = [];
-            testController.dispose();
-            sandbox.restore();
-        });
+//         teardown(() => {
+//             telemetryEvent = [];
+//             log = [];
+//             testController.dispose();
+//             sandbox.restore();
+//         });
 
-        test("When discovering tests, the workspace test adapter should call the test discovery adapter's discoverTest method", async () => {
-            discoverTestsStub.resolves();
+//         test("When discovering tests, the workspace test adapter should call the test discovery adapter's discoverTest method", async () => {
+//             discoverTestsStub.resolves();
 
-            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
-                stubTestServer,
-                stubConfigSettings,
-                outputChannel.object,
-            );
-            const testExecutionAdapter = new UnittestTestExecutionAdapter(
-                stubTestServer,
-                stubConfigSettings,
-                outputChannel.object,
-            );
-            const workspaceTestAdapter = new WorkspaceTestAdapter(
-                'unittest',
-                testDiscoveryAdapter,
-                testExecutionAdapter,
-                Uri.parse('foo'),
-            );
+//             const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
+//                 stubTestServer,
+//                 stubConfigSettings,
+//                 outputChannel.object,
+//             );
+//             const testExecutionAdapter = new UnittestTestExecutionAdapter(
+//                 stubTestServer,
+//                 stubConfigSettings,
+//                 outputChannel.object,
+//             );
+//             const workspaceTestAdapter = new WorkspaceTestAdapter(
+//                 'unittest',
+//                 testDiscoveryAdapter,
+//                 testExecutionAdapter,
+//                 Uri.parse('foo'),
+//             );
 
-            await workspaceTestAdapter.discoverTests(testController);
+//             await workspaceTestAdapter.discoverTests(testController);
 
-            sinon.assert.calledOnce(discoverTestsStub);
-        });
+//             sinon.assert.calledOnce(discoverTestsStub);
+//         });
 
-        test('If discovery is already running, do not call discoveryAdapter.discoverTests again', async () => {
-            discoverTestsStub.callsFake(
-                async () =>
-                    new Promise<void>((resolve) => {
-                        setTimeout(() => {
-                            // Simulate time taken by discovery.
-                            resolve();
-                        }, 2000);
-                    }),
-            );
+//         test('If discovery is already running, do not call discoveryAdapter.discoverTests again', async () => {
+//             discoverTestsStub.callsFake(
+//                 async () =>
+//                     new Promise<void>((resolve) => {
+//                         setTimeout(() => {
+//                             // Simulate time taken by discovery.
+//                             resolve();
+//                         }, 2000);
+//                     }),
+//             );
 
-            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
-                stubTestServer,
-                stubConfigSettings,
-                outputChannel.object,
-            );
-            const testExecutionAdapter = new UnittestTestExecutionAdapter(
-                stubTestServer,
-                stubConfigSettings,
-                outputChannel.object,
-            );
-            const workspaceTestAdapter = new WorkspaceTestAdapter(
-                'unittest',
-                testDiscoveryAdapter,
-                testExecutionAdapter,
-                Uri.parse('foo'),
-            );
+//             const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
+//                 stubTestServer,
+//                 stubConfigSettings,
+//                 outputChannel.object,
+//             );
+//             const testExecutionAdapter = new UnittestTestExecutionAdapter(
+//                 stubTestServer,
+//                 stubConfigSettings,
+//                 outputChannel.object,
+//             );
+//             const workspaceTestAdapter = new WorkspaceTestAdapter(
+//                 'unittest',
+//                 testDiscoveryAdapter,
+//                 testExecutionAdapter,
+//                 Uri.parse('foo'),
+//             );
 
-            // Try running discovery twice
-            const one = workspaceTestAdapter.discoverTests(testController);
-            const two = workspaceTestAdapter.discoverTests(testController);
+//             // Try running discovery twice
+//             const one = workspaceTestAdapter.discoverTests(testController);
+//             const two = workspaceTestAdapter.discoverTests(testController);
 
-            Promise.all([one, two]);
+//             Promise.all([one, two]);
 
-            sinon.assert.calledOnce(discoverTestsStub);
-        });
+//             sinon.assert.calledOnce(discoverTestsStub);
+//         });
 
-        test('If discovery succeeds, send a telemetry event with the "failed" key set to false', async () => {
-            discoverTestsStub.resolves({ status: 'success' });
+//         test('If discovery succeeds, send a telemetry event with the "failed" key set to false', async () => {
+//             discoverTestsStub.resolves({ status: 'success' });
 
-            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
-                stubTestServer,
-                stubConfigSettings,
-                outputChannel.object,
-            );
-            const testExecutionAdapter = new UnittestTestExecutionAdapter(
-                stubTestServer,
-                stubConfigSettings,
-                outputChannel.object,
-            );
+//             const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
+//                 stubTestServer,
+//                 stubConfigSettings,
+//                 outputChannel.object,
+//             );
+//             const testExecutionAdapter = new UnittestTestExecutionAdapter(
+//                 stubTestServer,
+//                 stubConfigSettings,
+//                 outputChannel.object,
+//             );
 
-            const workspaceTestAdapter = new WorkspaceTestAdapter(
-                'unittest',
-                testDiscoveryAdapter,
-                testExecutionAdapter,
-                Uri.parse('foo'),
-            );
+//             const workspaceTestAdapter = new WorkspaceTestAdapter(
+//                 'unittest',
+//                 testDiscoveryAdapter,
+//                 testExecutionAdapter,
+//                 Uri.parse('foo'),
+//             );
 
-            await workspaceTestAdapter.discoverTests(testController);
+//             await workspaceTestAdapter.discoverTests(testController);
 
-            sinon.assert.calledWith(sendTelemetryStub, EventName.UNITTEST_DISCOVERY_DONE);
-            assert.strictEqual(telemetryEvent.length, 2);
+//             sinon.assert.calledWith(sendTelemetryStub, EventName.UNITTEST_DISCOVERY_DONE);
+//             assert.strictEqual(telemetryEvent.length, 2);
 
-            const lastEvent = telemetryEvent[1];
-            assert.strictEqual(lastEvent.properties.failed, false);
-        });
+//             const lastEvent = telemetryEvent[1];
+//             assert.strictEqual(lastEvent.properties.failed, false);
+//         });
 
-        test('If discovery failed, send a telemetry event with the "failed" key set to true, and add an error node to the test controller', async () => {
-            discoverTestsStub.rejects(new Error('foo'));
+//         test('If discovery failed, send a telemetry event with the "failed" key set to true, and add an error node to the test controller', async () => {
+//             discoverTestsStub.rejects(new Error('foo'));
 
-            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
-                stubTestServer,
-                stubConfigSettings,
-                outputChannel.object,
-            );
-            const testExecutionAdapter = new UnittestTestExecutionAdapter(
-                stubTestServer,
-                stubConfigSettings,
-                outputChannel.object,
-            );
+//             const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
+//                 stubTestServer,
+//                 stubConfigSettings,
+//                 outputChannel.object,
+//             );
+//             const testExecutionAdapter = new UnittestTestExecutionAdapter(
+//                 stubTestServer,
+//                 stubConfigSettings,
+//                 outputChannel.object,
+//             );
 
-            const workspaceTestAdapter = new WorkspaceTestAdapter(
-                'unittest',
-                testDiscoveryAdapter,
-                testExecutionAdapter,
-                Uri.parse('foo'),
-            );
+//             const workspaceTestAdapter = new WorkspaceTestAdapter(
+//                 'unittest',
+//                 testDiscoveryAdapter,
+//                 testExecutionAdapter,
+//                 Uri.parse('foo'),
+//             );
 
-            await workspaceTestAdapter.discoverTests(testController);
+//             await workspaceTestAdapter.discoverTests(testController);
 
-            sinon.assert.calledWith(sendTelemetryStub, EventName.UNITTEST_DISCOVERY_DONE);
-            assert.strictEqual(telemetryEvent.length, 2);
+//             sinon.assert.calledWith(sendTelemetryStub, EventName.UNITTEST_DISCOVERY_DONE);
+//             assert.strictEqual(telemetryEvent.length, 2);
 
-            const lastEvent = telemetryEvent[1];
-            assert.ok(lastEvent.properties.failed);
+//             const lastEvent = telemetryEvent[1];
+//             assert.ok(lastEvent.properties.failed);
 
-            assert.deepStrictEqual(log, ['createTestItem', 'add']);
-        });
+//             assert.deepStrictEqual(log, ['createTestItem', 'add']);
+//         });
 
-        /**
-         * TODO To test:
-         * - successful discovery but no data: delete everything from the test controller
-         * - successful discovery with error status: add error node to tree
-         * - single root: populate tree if there's no root node
-         * - single root: update tree if there's a root node
-         * - single root: delete tree if there are no tests in the test data
-         * - multiroot: update the correct folders
-         */
-    });
-});
+//         /**
+//          * TODO To test:
+//          * - successful discovery but no data: delete everything from the test controller
+//          * - successful discovery with error status: add error node to tree
+//          * - single root: populate tree if there's no root node
+//          * - single root: update tree if there's a root node
+//          * - single root: delete tree if there are no tests in the test data
+//          * - multiroot: update the correct folders
+//          */
+//     });
+// });

--- a/src/test/testing/testController/workspaceTestAdapter.unit.test.ts
+++ b/src/test/testing/testController/workspaceTestAdapter.unit.test.ts
@@ -1,246 +1,267 @@
-// // Copyright (c) Microsoft Corporation. All rights reserved.
-// // Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
-// import * as assert from 'assert';
-// import * as sinon from 'sinon';
-// import * as typemoq from 'typemoq';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as typemoq from 'typemoq';
 
-// import { TestController, TestItem, Uri } from 'vscode';
-// import { IConfigurationService, ITestOutputChannel } from '../../../client/common/types';
-// import { UnittestTestDiscoveryAdapter } from '../../../client/testing/testController/unittest/testDiscoveryAdapter';
-// import { UnittestTestExecutionAdapter } from '../../../client/testing/testController/unittest/testExecutionAdapter'; // 7/7
-// import { WorkspaceTestAdapter } from '../../../client/testing/testController/workspaceTestAdapter';
-// import * as Telemetry from '../../../client/telemetry';
-// import { EventName } from '../../../client/telemetry/constants';
-// import { ITestServer } from '../../../client/testing/testController/common/types';
+import { TestController, TestItem, Uri } from 'vscode';
+import { IConfigurationService, ITestOutputChannel } from '../../../client/common/types';
+import { UnittestTestDiscoveryAdapter } from '../../../client/testing/testController/unittest/testDiscoveryAdapter';
+import { UnittestTestExecutionAdapter } from '../../../client/testing/testController/unittest/testExecutionAdapter'; // 7/7
+import { WorkspaceTestAdapter } from '../../../client/testing/testController/workspaceTestAdapter';
+import * as Telemetry from '../../../client/telemetry';
+import { EventName } from '../../../client/telemetry/constants';
+import { ITestResultResolver, ITestServer } from '../../../client/testing/testController/common/types';
 
-// suite('Workspace test adapter', () => {
-//     suite('Test discovery', () => {
-//         let stubTestServer: ITestServer;
-//         let stubConfigSettings: IConfigurationService;
+suite('Workspace test adapter', () => {
+    suite('Test discovery', () => {
+        let stubTestServer: ITestServer;
+        let stubConfigSettings: IConfigurationService;
+        let stubResultResolver: ITestResultResolver;
 
-//         let discoverTestsStub: sinon.SinonStub;
-//         let sendTelemetryStub: sinon.SinonStub;
-//         let outputChannel: typemoq.IMock<ITestOutputChannel>;
+        let discoverTestsStub: sinon.SinonStub;
+        let sendTelemetryStub: sinon.SinonStub;
+        let outputChannel: typemoq.IMock<ITestOutputChannel>;
 
-//         let telemetryEvent: { eventName: EventName; properties: Record<string, unknown> }[] = [];
+        let telemetryEvent: { eventName: EventName; properties: Record<string, unknown> }[] = [];
 
-//         // Stubbed test controller (see comment around L.40)
-//         let testController: TestController;
-//         let log: string[] = [];
+        // Stubbed test controller (see comment around L.40)
+        let testController: TestController;
+        let log: string[] = [];
 
-//         const sandbox = sinon.createSandbox();
+        const sandbox = sinon.createSandbox();
 
-//         setup(() => {
-//             stubConfigSettings = ({
-//                 getSettings: () => ({
-//                     testing: { unittestArgs: ['--foo'] },
-//                 }),
-//             } as unknown) as IConfigurationService;
+        setup(() => {
+            stubConfigSettings = ({
+                getSettings: () => ({
+                    testing: { unittestArgs: ['--foo'] },
+                }),
+            } as unknown) as IConfigurationService;
 
-//             stubTestServer = ({
-//                 sendCommand(): Promise<void> {
-//                     return Promise.resolve();
-//                 },
-//                 onDataReceived: () => {
-//                     // no body
-//                 },
-//             } as unknown) as ITestServer;
+            stubTestServer = ({
+                sendCommand(): Promise<void> {
+                    return Promise.resolve();
+                },
+                onDataReceived: () => {
+                    // no body
+                },
+            } as unknown) as ITestServer;
 
-//             // For some reason the 'tests' namespace in vscode returns undefined.
-//             // While I figure out how to expose to the tests, they will run
-//             // against a stub test controller and stub test items.
-//             const testItem = ({
-//                 canResolveChildren: false,
-//                 tags: [],
-//                 children: {
-//                     add: () => {
-//                         // empty
-//                     },
-//                 },
-//             } as unknown) as TestItem;
+            stubResultResolver = ({
+                resolveDiscovery: () => {
+                    // no body
+                },
+                resolveExecution: () => {
+                    // no body
+                },
+                vsIdToRunId: {
+                    get: sinon.stub().returns('expectedRunId'),
+                },
+            } as unknown) as ITestResultResolver;
 
-//             testController = ({
-//                 items: {
-//                     get: () => {
-//                         log.push('get');
-//                     },
-//                     add: () => {
-//                         log.push('add');
-//                     },
-//                     replace: () => {
-//                         log.push('replace');
-//                     },
-//                     delete: () => {
-//                         log.push('delete');
-//                     },
-//                 },
-//                 createTestItem: () => {
-//                     log.push('createTestItem');
-//                     return testItem;
-//                 },
-//                 dispose: () => {
-//                     // empty
-//                 },
-//             } as unknown) as TestController;
+            // const vsIdToRunIdGetStub = sinon.stub(stubResultResolver.vsIdToRunId, 'get');
+            // const expectedRunId = 'expectedRunId';
+            // vsIdToRunIdGetStub.withArgs(sinon.match.any).returns(expectedRunId);
 
-//             // testController = tests.createTestController('mock-python-tests', 'Mock Python Tests');
+            // For some reason the 'tests' namespace in vscode returns undefined.
+            // While I figure out how to expose to the tests, they will run
+            // against a stub test controller and stub test items.
+            const testItem = ({
+                canResolveChildren: false,
+                tags: [],
+                children: {
+                    add: () => {
+                        // empty
+                    },
+                },
+            } as unknown) as TestItem;
 
-//             const mockSendTelemetryEvent = (
-//                 eventName: EventName,
-//                 _: number | Record<string, number> | undefined,
-//                 properties: unknown,
-//             ) => {
-//                 telemetryEvent.push({
-//                     eventName,
-//                     properties: properties as Record<string, unknown>,
-//                 });
-//             };
+            testController = ({
+                items: {
+                    get: () => {
+                        log.push('get');
+                    },
+                    add: () => {
+                        log.push('add');
+                    },
+                    replace: () => {
+                        log.push('replace');
+                    },
+                    delete: () => {
+                        log.push('delete');
+                    },
+                },
+                createTestItem: () => {
+                    log.push('createTestItem');
+                    return testItem;
+                },
+                dispose: () => {
+                    // empty
+                },
+            } as unknown) as TestController;
 
-//             discoverTestsStub = sandbox.stub(UnittestTestDiscoveryAdapter.prototype, 'discoverTests');
-//             sendTelemetryStub = sandbox.stub(Telemetry, 'sendTelemetryEvent').callsFake(mockSendTelemetryEvent);
-//             outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
-//         });
+            // testController = tests.createTestController('mock-python-tests', 'Mock Python Tests');
 
-//         teardown(() => {
-//             telemetryEvent = [];
-//             log = [];
-//             testController.dispose();
-//             sandbox.restore();
-//         });
+            const mockSendTelemetryEvent = (
+                eventName: EventName,
+                _: number | Record<string, number> | undefined,
+                properties: unknown,
+            ) => {
+                telemetryEvent.push({
+                    eventName,
+                    properties: properties as Record<string, unknown>,
+                });
+            };
 
-//         test("When discovering tests, the workspace test adapter should call the test discovery adapter's discoverTest method", async () => {
-//             discoverTestsStub.resolves();
+            discoverTestsStub = sandbox.stub(UnittestTestDiscoveryAdapter.prototype, 'discoverTests');
+            sendTelemetryStub = sandbox.stub(Telemetry, 'sendTelemetryEvent').callsFake(mockSendTelemetryEvent);
+            outputChannel = typemoq.Mock.ofType<ITestOutputChannel>();
+        });
 
-//             const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
-//                 stubTestServer,
-//                 stubConfigSettings,
-//                 outputChannel.object,
-//             );
-//             const testExecutionAdapter = new UnittestTestExecutionAdapter(
-//                 stubTestServer,
-//                 stubConfigSettings,
-//                 outputChannel.object,
-//             );
-//             const workspaceTestAdapter = new WorkspaceTestAdapter(
-//                 'unittest',
-//                 testDiscoveryAdapter,
-//                 testExecutionAdapter,
-//                 Uri.parse('foo'),
-//             );
+        teardown(() => {
+            telemetryEvent = [];
+            log = [];
+            testController.dispose();
+            sandbox.restore();
+        });
 
-//             await workspaceTestAdapter.discoverTests(testController);
+        test("When discovering tests, the workspace test adapter should call the test discovery adapter's discoverTest method", async () => {
+            discoverTestsStub.resolves();
 
-//             sinon.assert.calledOnce(discoverTestsStub);
-//         });
+            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
+                stubTestServer,
+                stubConfigSettings,
+                outputChannel.object,
+            );
+            const testExecutionAdapter = new UnittestTestExecutionAdapter(
+                stubTestServer,
+                stubConfigSettings,
+                outputChannel.object,
+            );
+            const workspaceTestAdapter = new WorkspaceTestAdapter(
+                'unittest',
+                testDiscoveryAdapter,
+                testExecutionAdapter,
+                Uri.parse('foo'),
+                stubResultResolver,
+            );
 
-//         test('If discovery is already running, do not call discoveryAdapter.discoverTests again', async () => {
-//             discoverTestsStub.callsFake(
-//                 async () =>
-//                     new Promise<void>((resolve) => {
-//                         setTimeout(() => {
-//                             // Simulate time taken by discovery.
-//                             resolve();
-//                         }, 2000);
-//                     }),
-//             );
+            await workspaceTestAdapter.discoverTests(testController);
 
-//             const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
-//                 stubTestServer,
-//                 stubConfigSettings,
-//                 outputChannel.object,
-//             );
-//             const testExecutionAdapter = new UnittestTestExecutionAdapter(
-//                 stubTestServer,
-//                 stubConfigSettings,
-//                 outputChannel.object,
-//             );
-//             const workspaceTestAdapter = new WorkspaceTestAdapter(
-//                 'unittest',
-//                 testDiscoveryAdapter,
-//                 testExecutionAdapter,
-//                 Uri.parse('foo'),
-//             );
+            sinon.assert.calledOnce(discoverTestsStub);
+        });
 
-//             // Try running discovery twice
-//             const one = workspaceTestAdapter.discoverTests(testController);
-//             const two = workspaceTestAdapter.discoverTests(testController);
+        test('If discovery is already running, do not call discoveryAdapter.discoverTests again', async () => {
+            discoverTestsStub.callsFake(
+                async () =>
+                    new Promise<void>((resolve) => {
+                        setTimeout(() => {
+                            // Simulate time taken by discovery.
+                            resolve();
+                        }, 2000);
+                    }),
+            );
 
-//             Promise.all([one, two]);
+            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
+                stubTestServer,
+                stubConfigSettings,
+                outputChannel.object,
+            );
+            const testExecutionAdapter = new UnittestTestExecutionAdapter(
+                stubTestServer,
+                stubConfigSettings,
+                outputChannel.object,
+            );
+            const workspaceTestAdapter = new WorkspaceTestAdapter(
+                'unittest',
+                testDiscoveryAdapter,
+                testExecutionAdapter,
+                Uri.parse('foo'),
+                stubResultResolver,
+            );
 
-//             sinon.assert.calledOnce(discoverTestsStub);
-//         });
+            // Try running discovery twice
+            const one = workspaceTestAdapter.discoverTests(testController);
+            const two = workspaceTestAdapter.discoverTests(testController);
 
-//         test('If discovery succeeds, send a telemetry event with the "failed" key set to false', async () => {
-//             discoverTestsStub.resolves({ status: 'success' });
+            Promise.all([one, two]);
 
-//             const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
-//                 stubTestServer,
-//                 stubConfigSettings,
-//                 outputChannel.object,
-//             );
-//             const testExecutionAdapter = new UnittestTestExecutionAdapter(
-//                 stubTestServer,
-//                 stubConfigSettings,
-//                 outputChannel.object,
-//             );
+            sinon.assert.calledOnce(discoverTestsStub);
+        });
 
-//             const workspaceTestAdapter = new WorkspaceTestAdapter(
-//                 'unittest',
-//                 testDiscoveryAdapter,
-//                 testExecutionAdapter,
-//                 Uri.parse('foo'),
-//             );
+        test('If discovery succeeds, send a telemetry event with the "failed" key set to false', async () => {
+            discoverTestsStub.resolves({ status: 'success' });
 
-//             await workspaceTestAdapter.discoverTests(testController);
+            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
+                stubTestServer,
+                stubConfigSettings,
+                outputChannel.object,
+            );
+            const testExecutionAdapter = new UnittestTestExecutionAdapter(
+                stubTestServer,
+                stubConfigSettings,
+                outputChannel.object,
+            );
 
-//             sinon.assert.calledWith(sendTelemetryStub, EventName.UNITTEST_DISCOVERY_DONE);
-//             assert.strictEqual(telemetryEvent.length, 2);
+            const workspaceTestAdapter = new WorkspaceTestAdapter(
+                'unittest',
+                testDiscoveryAdapter,
+                testExecutionAdapter,
+                Uri.parse('foo'),
+                stubResultResolver,
+            );
 
-//             const lastEvent = telemetryEvent[1];
-//             assert.strictEqual(lastEvent.properties.failed, false);
-//         });
+            await workspaceTestAdapter.discoverTests(testController);
 
-//         test('If discovery failed, send a telemetry event with the "failed" key set to true, and add an error node to the test controller', async () => {
-//             discoverTestsStub.rejects(new Error('foo'));
+            sinon.assert.calledWith(sendTelemetryStub, EventName.UNITTEST_DISCOVERY_DONE);
+            assert.strictEqual(telemetryEvent.length, 2);
 
-//             const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
-//                 stubTestServer,
-//                 stubConfigSettings,
-//                 outputChannel.object,
-//             );
-//             const testExecutionAdapter = new UnittestTestExecutionAdapter(
-//                 stubTestServer,
-//                 stubConfigSettings,
-//                 outputChannel.object,
-//             );
+            const lastEvent = telemetryEvent[1];
+            assert.strictEqual(lastEvent.properties.failed, false);
+        });
 
-//             const workspaceTestAdapter = new WorkspaceTestAdapter(
-//                 'unittest',
-//                 testDiscoveryAdapter,
-//                 testExecutionAdapter,
-//                 Uri.parse('foo'),
-//             );
+        test('If discovery failed, send a telemetry event with the "failed" key set to true, and add an error node to the test controller', async () => {
+            discoverTestsStub.rejects(new Error('foo'));
 
-//             await workspaceTestAdapter.discoverTests(testController);
+            const testDiscoveryAdapter = new UnittestTestDiscoveryAdapter(
+                stubTestServer,
+                stubConfigSettings,
+                outputChannel.object,
+            );
+            const testExecutionAdapter = new UnittestTestExecutionAdapter(
+                stubTestServer,
+                stubConfigSettings,
+                outputChannel.object,
+            );
 
-//             sinon.assert.calledWith(sendTelemetryStub, EventName.UNITTEST_DISCOVERY_DONE);
-//             assert.strictEqual(telemetryEvent.length, 2);
+            const workspaceTestAdapter = new WorkspaceTestAdapter(
+                'unittest',
+                testDiscoveryAdapter,
+                testExecutionAdapter,
+                Uri.parse('foo'),
+                stubResultResolver,
+            );
 
-//             const lastEvent = telemetryEvent[1];
-//             assert.ok(lastEvent.properties.failed);
+            await workspaceTestAdapter.discoverTests(testController);
 
-//             assert.deepStrictEqual(log, ['createTestItem', 'add']);
-//         });
+            sinon.assert.calledWith(sendTelemetryStub, EventName.UNITTEST_DISCOVERY_DONE);
+            assert.strictEqual(telemetryEvent.length, 2);
 
-//         /**
-//          * TODO To test:
-//          * - successful discovery but no data: delete everything from the test controller
-//          * - successful discovery with error status: add error node to tree
-//          * - single root: populate tree if there's no root node
-//          * - single root: update tree if there's a root node
-//          * - single root: delete tree if there are no tests in the test data
-//          * - multiroot: update the correct folders
-//          */
-//     });
-// });
+            const lastEvent = telemetryEvent[1];
+            assert.ok(lastEvent.properties.failed);
+
+            assert.deepStrictEqual(log, ['createTestItem', 'add']);
+        });
+
+        /**
+         * TODO To test:
+         * - successful discovery but no data: delete everything from the test controller
+         * - successful discovery with error status: add error node to tree
+         * - single root: populate tree if there's no root node
+         * - single root: update tree if there's a root node
+         * - single root: delete tree if there are no tests in the test data
+         * - multiroot: update the correct folders
+         */
+    });
+});


### PR DESCRIPTION
Created a testIdServer to handle the starting up of the testIdServer for both unittest and pytest. This extracts the method to be in another file and easy to test.