### PR TITLE
Correct PATH env var name for non-Windows when applying env var collection for microvenv

### DIFF
--- a/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
@@ -32,6 +32,7 @@ import { IInterpreterService } from '../contracts';
 import { defaultShells } from './service';
 import { IEnvironmentActivationService } from './types';
 import { EnvironmentType } from '../../pythonEnvironments/info';
+import { getSearchPathEnvVarNames } from '../../common/utils/exec';
 
 @injectable()
 export class TerminalEnvVarCollectionService implements IExtensionActivationService {
@@ -172,9 +173,10 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
             const activatePath = path.join(path.dirname(interpreter.path), 'activate');
             if (!(await pathExists(activatePath))) {
                 const envVarCollection = this.getEnvironmentVariableCollection(workspaceFolder);
+                const pathVarName = getSearchPathEnvVarNames()[0];
                 envVarCollection.replace(
                     'PATH',
-                    `${path.dirname(interpreter.path)}${path.delimiter}${process.env.Path}`,
+                    `${path.dirname(interpreter.path)}${path.delimiter}${process.env[pathVarName]}`,
                     { applyAtShellIntegration: true },
                 );
                 return;


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/21422

This is likely the cause for:
```
## Extension: ms-python.python
- `PATH=/path/to/my/python/bin:undefined`
```