### PR TITLE
Move more workflows to python

### DIFF
--- a/.github/workflows/community-feedback-auto-comment.yml
+++ b/.github/workflows/community-feedback-auto-comment.yml
@@ -8,22 +8,21 @@ jobs:
   add-comment:
     if: github.event.label.name == 'needs community feedback'
     runs-on: ubuntu-latest
-
     permissions:
       issues: write
-
     steps:
-      - name: Checkout Actions
-        uses: actions/checkout@v3
-        with:
-          repository: 'microsoft/vscode-github-triage-actions'
-          ref: stable
-          path: ./actions
-
-      - name: Install Actions
-        run: npm install --production --prefix ./actions
-
-      - name: Add Community Feedback Comment if applicable
-        uses: ./actions/python-community-feedback-auto-comment
+      - name: Check For Existing Comment
+        uses: peter-evans/find-comment@v2
+        id: finder
         with:
           issue-number: ${{ github.event.issue.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: 'Thanks for the feature request! We are going to give the community'
+
+      - name: Add Community Feedback Comment
+        if: steps.finder.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Thanks for the feature request! We are going to give the community 60 days from when this issue was created to provide 7 👍 upvotes on the opening comment to gauge general interest in this idea. If there's enough upvotes then we will consider this feature request in our future planning. If there's unfortunately not enough upvotes then we will close this issue.

--- a/.github/workflows/pr-file-check.yml
+++ b/.github/workflows/pr-file-check.yml
@@ -1,4 +1,5 @@
 name: PR files
+
 on:
   pull_request:
     types:
@@ -15,15 +16,29 @@ jobs:
     name: 'Check for changed files'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Actions
-        uses: actions/checkout@v3
+      - name: 'package-lock.json matches package.json'
+        uses: brettcannon/check-for-changed-files@v1.1.0
         with:
-          repository: 'microsoft/vscode-github-triage-actions'
-          ref: stable
-          path: ./actions
+          prereq-pattern: 'package.json'
+          file-pattern: 'package-lock.json'
+          skip-label: 'skip package*.json'
+          failure-message: '${prereq-pattern} was edited but ${file-pattern} was not (the ${skip-label} label can be used to pass this check)'
 
-      - name: Install Actions
-        run: npm install --production --prefix ./actions
+      - name: 'package.json matches package-lock.json'
+        uses: brettcannon/check-for-changed-files@v1.1.0
+        with:
+          prereq-pattern: 'package-lock.json'
+          file-pattern: 'package.json'
+          skip-label: 'skip package*.json'
+          failure-message: '${prereq-pattern} was edited but ${file-pattern} was not (the ${skip-label} label can be used to pass this check)'
 
-      - name: Check for changed files
-        uses: ./actions/python-pr-file-check
+      - name: 'Tests'
+        uses: brettcannon/check-for-changed-files@v1.1.0
+        with:
+          prereq-pattern: src/**/*.ts
+          file-pattern: |
+            src/**/*.test.ts
+            src/**/*.testvirtualenvs.ts
+            .github/test_plan.md
+          skip-label: 'skip tests'
+          failure-message: 'TypeScript code was edited without also editing a ${file-pattern} file; see the Testing page in our wiki on testing guidelines (the ${skip-label} label can be used to pass this check)'

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -13,15 +13,9 @@ jobs:
     name: 'Classify PR'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Actions
-        uses: actions/checkout@v3
+      - name: 'PR impact specified'
+        uses: mheap/github-action-required-labels@v4
         with:
-          repository: 'microsoft/vscode-github-triage-actions'
-          ref: stable
-          path: ./actions
-
-      - name: Install Actions
-        run: npm install --production --prefix ./actions
-
-      - name: Classify PR
-        uses: ./actions/python-pr-labels
+          mode: exactly
+          count: 1
+          labels: 'bug, debt, feature-request, no-changelog'

--- a/.github/workflows/remove-needs-labels.yml
+++ b/.github/workflows/remove-needs-labels.yml
@@ -5,18 +5,18 @@ on:
 
 jobs:
   classify:
-    name: 'Remove needs labels on issue clos'
+    name: 'Remove needs labels on issue closing'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v3
         with:
-          repository: 'eleanorjboyd/vscode-github-triage-actions'
+          repository: 'microsoft/vscode-github-triage-actions'
           ref: stable
           path: ./actions
 
       - name: Install Actions
         run: npm install --production --prefix ./actions
 
-      - name: Classify PR
+      - name: Remove Any Needs Labels
         uses: ./actions/python-remove-needs-label

--- a/.github/workflows/remove-needs-labels.yml
+++ b/.github/workflows/remove-needs-labels.yml
@@ -5,10 +5,10 @@ on:
 
 jobs:
   changed-files-in-pr:
-    name: 'Check for needs label on closed issues'
+    name: 'Removes needs label on closed issues'
     runs-on: ubuntu-latest
     steps:
-      - name: 'Remove needs labels on issue close'
+      - name: 'Removes needs labels on issue close'
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: |
@@ -16,17 +16,3 @@ jobs:
             needs spike
             needs community feedback
             needs proposal
-
-
-    # steps:
-    #   - name: Checkout Actions
-    #     uses: actions/checkout@v3
-    #     with:
-    #       repository: 'eleanorjboyd/inc_dec_example_repo'
-    #       path: ./actions
-
-    #   - name: Install Actions
-    #     run: npm install --prefix ./actions
-
-    #   - name: Check for changed files
-    #     uses: ./actions/remove-needs-label

--- a/.github/workflows/remove-needs-labels.yml
+++ b/.github/workflows/remove-needs-labels.yml
@@ -8,15 +8,11 @@ jobs:
     name: 'Remove needs labels on issue closing'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Actions
-        uses: actions/checkout@v3
-        with:
-          repository: 'microsoft/vscode-github-triage-actions'
-          ref: stable
-          path: ./actions
-
-      - name: Install Actions
-        run: npm install --production --prefix ./actions
-
-      - name: Remove Any Needs Labels
-        uses: ./actions/python-remove-needs-label
+    - name: 'Removes needs labels on issue close'
+      uses: actions-ecosystem/action-remove-labels@v1
+      with:
+        labels: |
+          needs PR
+          needs spike
+          needs community feedback
+          needs proposal

--- a/.github/workflows/remove-needs-labels.yml
+++ b/.github/workflows/remove-needs-labels.yml
@@ -1,22 +1,22 @@
-name: 'Remove Needs Label'
+name: Remove Needs Label
 on:
   issues:
     types: [closed]
 
 jobs:
-  classify:
-    name: 'Remove needs labels on issue closing'
+  changed-files-in-pr:
+    name: 'Check for needs label on closed issues'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v3
         with:
-          repository: 'microsoft/vscode-github-triage-actions'
+          repository: 'eleanorjboyd/inc_dec_example_repo'
           ref: stable
           path: ./actions
 
       - name: Install Actions
         run: npm install --production --prefix ./actions
 
-      - name: Remove Any Needs Labels
-        uses: ./actions/python-remove-needs-label
+      - name: Check for changed files
+        uses: ./actions/remove-needs-label

--- a/.github/workflows/remove-needs-labels.yml
+++ b/.github/workflows/remove-needs-labels.yml
@@ -8,14 +8,21 @@ jobs:
     name: 'Check for needs label on closed issues'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Actions
-        uses: actions/checkout@v3
+      - name: 'Remove needs labels on issue close'
+        uses: actions-ecosystem/action-remove-labels@v1
         with:
-          repository: 'eleanorjboyd/inc_dec_example_repo'
-          path: ./actions
+          labels: |
+            needs PR
+            needs spike
+    # steps:
+    #   - name: Checkout Actions
+    #     uses: actions/checkout@v3
+    #     with:
+    #       repository: 'eleanorjboyd/inc_dec_example_repo'
+    #       path: ./actions
 
-      - name: Install Actions
-        run: npm install --prefix ./actions
+    #   - name: Install Actions
+    #     run: npm install --prefix ./actions
 
-      - name: Check for changed files
-        uses: ./actions/remove-needs-label
+    #   - name: Check for changed files
+    #     uses: ./actions/remove-needs-label

--- a/.github/workflows/remove-needs-labels.yml
+++ b/.github/workflows/remove-needs-labels.yml
@@ -15,7 +15,7 @@ jobs:
           path: ./actions
 
       - name: Install Actions
-        run: npm install --production --prefix ./actions
+        run: npm install --omit=dev --prefix ./actions
 
       - name: Check for changed files
         uses: ./actions/remove-needs-label

--- a/.github/workflows/remove-needs-labels.yml
+++ b/.github/workflows/remove-needs-labels.yml
@@ -1,18 +1,22 @@
-name: Remove Needs Label
+name: 'Remove Needs Label'
 on:
   issues:
     types: [closed]
 
 jobs:
-  changed-files-in-pr:
-    name: 'Removes needs label on closed issues'
+  classify:
+    name: 'Remove needs labels on issue clos'
     runs-on: ubuntu-latest
     steps:
-      - name: 'Removes needs labels on issue close'
-        uses: actions-ecosystem/action-remove-labels@v1
+      - name: Checkout Actions
+        uses: actions/checkout@v3
         with:
-          labels: |
-            needs PR
-            needs spike
-            needs community feedback
-            needs proposal
+          repository: 'microsoft/vscode-github-triage-actions'
+          ref: stable
+          path: ./actions
+
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+
+      - name: Classify PR
+        uses: ./actions/python-remove-needs-label

--- a/.github/workflows/remove-needs-labels.yml
+++ b/.github/workflows/remove-needs-labels.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@v3
         with:
-          repository: 'microsoft/vscode-github-triage-actions'
+          repository: 'eleanorjboyd/vscode-github-triage-actions'
           ref: stable
           path: ./actions
 

--- a/.github/workflows/remove-needs-labels.yml
+++ b/.github/workflows/remove-needs-labels.yml
@@ -12,7 +12,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'eleanorjboyd/inc_dec_example_repo'
-          ref: stable
           path: ./actions
 
       - name: Install Actions

--- a/.github/workflows/remove-needs-labels.yml
+++ b/.github/workflows/remove-needs-labels.yml
@@ -14,6 +14,10 @@ jobs:
           labels: |
             needs PR
             needs spike
+            needs community feedback
+            needs proposal
+
+
     # steps:
     #   - name: Checkout Actions
     #     uses: actions/checkout@v3

--- a/.github/workflows/remove-needs-labels.yml
+++ b/.github/workflows/remove-needs-labels.yml
@@ -8,11 +8,11 @@ jobs:
     name: 'Remove needs labels on issue closing'
     runs-on: ubuntu-latest
     steps:
-    - name: 'Removes needs labels on issue close'
-      uses: actions-ecosystem/action-remove-labels@v1
-      with:
-        labels: |
-          needs PR
-          needs spike
-          needs community feedback
-          needs proposal
+      - name: 'Removes needs labels on issue close'
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: |
+            needs PR
+            needs spike
+            needs community feedback
+            needs proposal

--- a/.github/workflows/remove-needs-labels.yml
+++ b/.github/workflows/remove-needs-labels.yml
@@ -15,7 +15,7 @@ jobs:
           path: ./actions
 
       - name: Install Actions
-        run: npm install --omit=dev --prefix ./actions
+        run: npm install --prefix ./actions
 
       - name: Check for changed files
         uses: ./actions/remove-needs-label


### PR DESCRIPTION
move logic for lock issue workflow back to python repo to avoid extra work of checking out and cloning vscode-github-triage-actions repo. Should reduce time it takes to run github actions.