### PR TITLE
Add pythonwelcome2 walkthrough to activation reason

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "onDebugDynamicConfigurations:python",
         "onDebugResolve:python",
         "onWalkthrough:pythonWelcome",
-        "onWalkthrough:pythonWelcomeWithDS",
+        "onWalkthrough:pythonWelcome2",
         "onWalkthrough:pythonDataScienceWelcome",
         "workspaceContains:mspythonconfig.json",
         "workspaceContains:pyproject.toml",


### PR DESCRIPTION
pythonWelcomeWithDS no longer exists, but we're currently rolling out a second version of the walkthrough so it'd be nice to get the Python extension to auto activate like it does with pythonWelcome so we can compare apples to apples 