### PR TITLE
Handle error tests as a different test icon

### DIFF
--- a/pythonFiles/tests/pytestadapter/expected_execution_test_output.py
+++ b/pythonFiles/tests/pytestadapter/expected_execution_test_output.py
@@ -157,7 +157,7 @@ unit_pytest_same_file_execution_expected_output = {
 error_raised_exception_execution_expected_output = {
     "error_raise_exception.py::TestSomething::test_a": {
         "test": "error_raise_exception.py::TestSomething::test_a",
-        "outcome": "failure",
+        "outcome": "error",
         "message": "ERROR MESSAGE",
         "traceback": "TRACEBACK",
         "subtest": None,

--- a/pythonFiles/tests/pytestadapter/test_execution.py
+++ b/pythonFiles/tests/pytestadapter/test_execution.py
@@ -174,7 +174,10 @@ def test_pytest_execution(test_ids, expected_const):
         assert a["cwd"] == os.fspath(TEST_DATA_PATH)
         actual_result_dict.update(a["result"])
     for key in actual_result_dict:
-        if actual_result_dict[key]["outcome"] == "failure":
+        if (
+            actual_result_dict[key]["outcome"] == "failure"
+            or actual_result_dict[key]["outcome"] == "error"
+        ):
             actual_result_dict[key]["message"] = "ERROR MESSAGE"
         if actual_result_dict[key]["traceback"] != None:
             actual_result_dict[key]["traceback"] = "TRACEBACK"

--- a/pythonFiles/vscode_pytest/__init__.py
+++ b/pythonFiles/vscode_pytest/__init__.py
@@ -82,7 +82,9 @@ def pytest_exception_interact(node, call, report):
             )
     else:
         # if execution, send this data that the given node failed.
-        report_value = "failure"
+        report_value = "error"
+        if call.excinfo.typename == "AssertionError":
+            report_value = "failure"
         node_id = str(node.nodeid)
         if node_id not in collected_tests_so_far:
             collected_tests_so_far.append(node_id)
@@ -119,7 +121,7 @@ class TestOutcome(Dict):
     """
 
     test: str
-    outcome: Literal["success", "failure", "skipped"]
+    outcome: Literal["success", "failure", "skipped", "error"]
     message: Union[str, None]
     traceback: Union[str, None]
     subtest: Optional[str]


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python/issues/21625

adds a few things:
- returns error on any caught errors in pytest that aren't assertion errors
- add error node type handling to result resolver
- update tests for both files