### PR TITLE
Compare global storage data using only `key`

### DIFF
--- a/src/client/common/persistentState.ts
+++ b/src/client/common/persistentState.ts
@@ -173,7 +173,7 @@ export interface IPersistentStorage<T> {
  */
 export function getGlobalStorage<T>(context: IExtensionContext, key: string, defaultValue?: T): IPersistentStorage<T> {
     const globalKeysStorage = new PersistentState<KeysStorage[]>(context.globalState, GLOBAL_PERSISTENT_KEYS, []);
-    const found = globalKeysStorage.value.find((value) => value.key === key && value.defaultValue === defaultValue);
+    const found = globalKeysStorage.value.find((value) => value.key === key);
     if (!found) {
         const newValue = [{ key, defaultValue }, ...globalKeysStorage.value];
         globalKeysStorage.updateValue(newValue).ignoreErrors();


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/21635 by applying the same fix as done in https://github.com/microsoft/vscode-python/pull/17627.