### PR TITLE
Use correct `tsconfig.json` when generating npm package

### DIFF
--- a/pythonExtensionApi/.eslintrc
+++ b/pythonExtensionApi/.eslintrc
@@ -1,0 +1,8 @@
+{
+    "rules": {
+        "padding-line-between-statements": [
+            "error",
+            { "blankLine": "always", "prev": "export", "next": "*" }
+        ]
+    }
+}

--- a/pythonExtensionApi/README.md
+++ b/pythonExtensionApi/README.md
@@ -28,6 +28,8 @@ The actual source code to get the active environment to run some script could lo
 // Import the API
 import { PythonExtension } from '@vscode/python-extension';
 
+...
+
 // Load the Python extension API
 const pythonApi: PythonExtension = await PythonExtension.api();
 

--- a/pythonExtensionApi/package-lock.json
+++ b/pythonExtensionApi/package-lock.json
@@ -11,6 +11,9 @@
             "dependencies": {
                 "@types/vscode": "^1.78.0"
             },
+            "devDependencies": {
+                "typescript": "5.0.4"
+            },
             "engines": {
                 "node": ">=16.17.1",
                 "vscode": "^1.78.0"
@@ -20,6 +23,19 @@
             "version": "1.80.0",
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.80.0.tgz",
             "integrity": "sha512-qK/CmOdS2o7ry3k6YqU4zD3R2AYlJfbwBoSbKpBoP+GpXNE+0NEgJOli4n0bm0diK5kfBnchgCEj4igQz/44Hg=="
+        },
+        "node_modules/typescript": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+            "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=12.20"
+            }
         }
     },
     "dependencies": {
@@ -27,6 +43,12 @@
             "version": "1.80.0",
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.80.0.tgz",
             "integrity": "sha512-qK/CmOdS2o7ry3k6YqU4zD3R2AYlJfbwBoSbKpBoP+GpXNE+0NEgJOli4n0bm0diK5kfBnchgCEj4igQz/44Hg=="
+        },
+        "typescript": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+            "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+            "dev": true
         }
     }
 }

--- a/pythonExtensionApi/package-lock.json
+++ b/pythonExtensionApi/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@vscode/python-extension",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@vscode/python-extension",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "license": "MIT",
             "dependencies": {
                 "@types/vscode": "^1.78.0"

--- a/pythonExtensionApi/package.json
+++ b/pythonExtensionApi/package.json
@@ -28,10 +28,13 @@
     "dependencies": {
         "@types/vscode": "^1.78.0"
     },
+    "devDependencies": {
+        "typescript": "5.0.4"
+    },
     "scripts": {
         "prepublishOnly": "echo \"⛔ Can only publish from a secure pipeline ⛔\" && node ../build/fail",
 		"prepack": "npm run all:publish",
-		"compile": "node ../node_modules/typescript/lib/tsc.js -b ./tsconfig.json",
+		"compile": "node ./node_modules/typescript/lib/tsc.js -b ./tsconfig.json",
 		"clean": "node ../node_modules/rimraf/bin.js out",
 		"lint": "node ../node_modules/eslint/bin/eslint.js --ext ts src",
 		"all": "npm run clean && npm run compile",

--- a/pythonExtensionApi/package.json
+++ b/pythonExtensionApi/package.json
@@ -38,6 +38,7 @@
 		"clean": "node ../node_modules/rimraf/bin.js out",
 		"lint": "node ../node_modules/eslint/bin/eslint.js --ext ts src",
 		"all": "npm run clean && npm run compile",
-		"all:publish": "git clean -xfd . && npm install && npm run compile"
+        "formatTypings": "node ../node_modules/eslint/bin/eslint.js --fix ./out/main.d.ts",
+		"all:publish": "git clean -xfd . && npm install && npm run compile && npm run formatTypings"
     }
 }

--- a/pythonExtensionApi/package.json
+++ b/pythonExtensionApi/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@vscode/python-extension",
     "description": "An API facade for the Python extension in VS Code",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "author": {
       "name": "Microsoft Corporation"
     },

--- a/pythonExtensionApi/src/main.ts
+++ b/pythonExtensionApi/src/main.ts
@@ -392,6 +392,9 @@ export const PVSC_EXTENSION_ID = 'ms-python.python';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace PythonExtension {
+    /**
+     * Returns the API exposed by the Python extension in VS Code.
+     */
     export async function api(): Promise<PythonExtension> {
         const extension = extensions.getExtension(PVSC_EXTENSION_ID);
         if (extension === undefined) {

--- a/pythonExtensionApi/src/main.ts
+++ b/pythonExtensionApi/src/main.ts
@@ -316,6 +316,7 @@ export type EnvironmentPath = {
  * was contributed.
  */
 export type EnvironmentTools = KnownEnvironmentTools | string;
+
 /**
  * Tools or plugins the Python extension currently has built-in support for. Note this list is expected to shrink
  * once tools have their own separate extensions.
@@ -334,6 +335,7 @@ export type KnownEnvironmentTools =
  * Type of the environment. It can be {@link KnownEnvironmentTypes} or custom string which was contributed.
  */
 export type EnvironmentType = KnownEnvironmentTypes | string;
+
 /**
  * Environment types the Python extension is aware of. Note this list is expected to shrink once tools have their
  * own separate extensions, in which case they're expected to provide the type themselves.

--- a/pythonExtensionApi/tsconfig.json
+++ b/pythonExtensionApi/tsconfig.json
@@ -25,7 +25,7 @@
         "noUnusedParameters": true,
         "noFallthroughCasesInSwitch": true,
         "resolveJsonModule": true,
-        "removeComments": true
+        "declaration": true
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
For #21631 

- Unset `removeComment` as that leads to declarations without docstrings
- Set to generate declarations
- Use updated typescript which results in cleaner declaration files