### PR TITLE
Add new telemetry property to GPDR

### DIFF
--- a/src/client/telemetry/pylance.ts
+++ b/src/client/telemetry/pylance.ts
@@ -50,7 +50,8 @@
       "numfilesinprogram" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
       "peakrssmb" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" },
       "resolverid" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" },
-      "rssmb" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" }
+      "rssmb" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" },
+      "diagnosticsseen" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
    }
 */
 /* __GDPR__


### PR DESCRIPTION
This property was added for tracking diagnostics we emit in Pylance. 