### PR TITLE
Check that Python binary path is a file

### DIFF
--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -678,6 +678,7 @@ function getPythonExecutable(pythonPath: string): string {
 function isValidPythonPath(pythonPath: string): boolean {
     return (
         fs.existsSync(pythonPath) &&
+        fs.statSync(pythonPath).isFile() &&
         path.basename(getOSType() === OSType.Windows ? pythonPath.toLowerCase() : pythonPath).startsWith('python')
     );
 }


### PR DESCRIPTION
Current validation checks path's existence and name (basename must start with 'python'), which results in false positives when a virtualenv directory name starts with 'python' (e.g. ~/venv/python-3.11/bin/python results in ~/venv/python-3.11 being validated as the binary path).