### PR TITLE
add std out to subprocess to stop overflow

### DIFF
--- a/pythonFiles/tests/pytestadapter/helpers.py
+++ b/pythonFiles/tests/pytestadapter/helpers.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import threading
 import uuid
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 TEST_DATA_PATH = pathlib.Path(__file__).parent / ".data"
 from typing_extensions import TypedDict

--- a/pythonFiles/tests/pytestadapter/test_execution.py
+++ b/pythonFiles/tests/pytestadapter/test_execution.py
@@ -179,6 +179,6 @@ def test_pytest_execution(test_ids, expected_const):
             or actual_result_dict[key]["outcome"] == "error"
         ):
             actual_result_dict[key]["message"] = "ERROR MESSAGE"
-        if actual_result_dict[key]["traceback"] != None:
+        if actual_result_dict[key]["traceback"] is not None:
             actual_result_dict[key]["traceback"] = "TRACEBACK"
     assert actual_result_dict == expected_const

--- a/pythonFiles/tests/pytestadapter/test_execution.py
+++ b/pythonFiles/tests/pytestadapter/test_execution.py
@@ -1,6 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-import json
 import os
 import shutil
 

--- a/src/client/testing/testController/common/server.ts
+++ b/src/client/testing/testController/common/server.ts
@@ -209,7 +209,16 @@ export class PythonTestServer implements ITestServer, Disposable {
                 runInstance?.token.onCancellationRequested(() => {
                     result?.proc?.kill();
                 });
-                result?.proc?.on('close', () => {
+
+                // Take all output from the subprocess and add it to the test output channel. This will be the pytest output.
+                // Displays output to user and ensure the subprocess doesn't run into buffer overflow.
+                result?.proc?.stdout?.on('data', (data) => {
+                    spawnOptions?.outputChannel?.append(data);
+                });
+                result?.proc?.stderr?.on('data', (data) => {
+                    spawnOptions?.outputChannel?.append(data);
+                });
+                result?.proc?.on('exit', () => {
                     traceLog('Exec server closed.', uuid);
                     deferred.resolve({ stdout: '', stderr: '' });
                     callback?.();

--- a/src/client/testing/testController/pytest/pytestDiscoveryAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestDiscoveryAdapter.ts
@@ -83,7 +83,15 @@ export class PytestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
         const execArgs = ['-m', 'pytest', '-p', 'vscode_pytest', '--collect-only'].concat(pytestArgs);
         const result = execService?.execObservable(execArgs, spawnOptions);
 
-        result?.proc?.on('close', () => {
+        // Take all output from the subprocess and add it to the test output channel. This will be the pytest output.
+        // Displays output to user and ensure the subprocess doesn't run into buffer overflow.
+        result?.proc?.stdout?.on('data', (data) => {
+            spawnOptions.outputChannel?.append(data);
+        });
+        result?.proc?.stderr?.on('data', (data) => {
+            spawnOptions.outputChannel?.append(data);
+        });
+        result?.proc?.on('exit', () => {
             deferredExec.resolve({ stdout: '', stderr: '' });
             this.testServer.deleteUUID(uuid);
             deferred.resolve();

--- a/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
@@ -47,7 +47,6 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
             if (runInstance) {
                 this.resultResolver?.resolveExecution(JSON.parse(e.data), runInstance);
             }
-            disposedDataReceived.dispose();
         });
         const dispose = function (testServer: ITestServer) {
             testServer.deleteUUID(uuid);

--- a/src/test/mocks/helper.ts
+++ b/src/test/mocks/helper.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Readable } from 'stream';
+
+export class MyReadableStream extends Readable {
+    _read(size: unknown): void | null {
+        // custom reading logic here
+        console.log(size);
+        this.push(null); // end the stream
+    }
+}

--- a/src/test/mocks/helper.ts
+++ b/src/test/mocks/helper.ts
@@ -4,9 +4,8 @@
 import { Readable } from 'stream';
 
 export class MyReadableStream extends Readable {
-    _read(size: unknown): void | null {
+    _read(_size: unknown): void | null {
         // custom reading logic here
-        console.log(size);
         this.push(null); // end the stream
     }
 }

--- a/src/test/mocks/helper.ts
+++ b/src/test/mocks/helper.ts
@@ -3,7 +3,7 @@
 
 import { Readable } from 'stream';
 
-export class MyReadableStream extends Readable {
+export class FakeReadableStream extends Readable {
     _read(_size: unknown): void | null {
         // custom reading logic here
         this.push(null); // end the stream

--- a/src/test/mocks/mockChildProcess.ts
+++ b/src/test/mocks/mockChildProcess.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Serializable, SendHandle, MessageOptions } from 'child_process';
-import { Writable, Readable, Pipe } from 'stream';
 import { EventEmitter } from 'node:events';
+import { Writable, Readable, Pipe } from 'stream';
+import { MyReadableStream } from './helper';
 
 export class MockChildProcess extends EventEmitter {
     constructor(spawnfile: string, spawnargs: string[]) {
@@ -10,8 +11,8 @@ export class MockChildProcess extends EventEmitter {
         this.spawnfile = spawnfile;
         this.spawnargs = spawnargs;
         this.stdin = new Writable();
-        this.stdout = new Readable();
-        this.stderr = null;
+        this.stdout = new MyReadableStream();
+        this.stderr = new MyReadableStream();
         this.channel = null;
         this.stdio = [this.stdin, this.stdout, this.stdout, this.stderr, null];
         this.killed = false;

--- a/src/test/mocks/mockChildProcess.ts
+++ b/src/test/mocks/mockChildProcess.ts
@@ -3,7 +3,7 @@
 import { Serializable, SendHandle, MessageOptions } from 'child_process';
 import { EventEmitter } from 'node:events';
 import { Writable, Readable, Pipe } from 'stream';
-import { MyReadableStream } from './helper';
+import { FakeReadableStream } from './helper';
 
 export class MockChildProcess extends EventEmitter {
     constructor(spawnfile: string, spawnargs: string[]) {
@@ -11,8 +11,8 @@ export class MockChildProcess extends EventEmitter {
         this.spawnfile = spawnfile;
         this.spawnargs = spawnargs;
         this.stdin = new Writable();
-        this.stdout = new MyReadableStream();
-        this.stderr = new MyReadableStream();
+        this.stdout = new FakeReadableStream();
+        this.stderr = new FakeReadableStream();
         this.channel = null;
         this.stdio = [this.stdin, this.stdout, this.stdout, this.stderr, null];
         this.killed = false;


### PR DESCRIPTION
Displays output to the user and ensures the subprocess doesn't run into buffer overflow. Bug was introduced with the switch to the execObservable in https://github.com/microsoft/vscode-python/pull/21667. Only occurs for large repos where output from pytest was large enough to reach buffer overflow.