### PR TITLE
Use `optionalDependencies` instead of `peerDependencies` for `@vscode/python-extension` npm package

### DIFF
--- a/pythonExtensionApi/package-lock.json
+++ b/pythonExtensionApi/package-lock.json
@@ -16,7 +16,7 @@
                 "node": ">=16.17.1",
                 "vscode": "^1.78.0"
             },
-            "peerDependencies": {
+            "optionalDependencies": {
                 "@types/vscode": "^1.78.0"
             }
         },

--- a/pythonExtensionApi/package.json
+++ b/pythonExtensionApi/package.json
@@ -25,7 +25,7 @@
     "bugs": {
         "url": "https://github.com/Microsoft/vscode-python/issues"
     },
-    "peerDependencies": {
+    "optionalDependencies": {
         "@types/vscode": "^1.78.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/21720