### PR TITLE
Remove optionalDependencies from API npm package and document to install vscode types separately

### DIFF
--- a/pythonExtensionApi/README.md
+++ b/pythonExtensionApi/README.md
@@ -17,10 +17,13 @@ First we need to define a `package.json` for the extension that wants to use the
 	// Depend on the Python extension facade npm module to get easier API access to the
 	// core extension.
 	"dependencies": {
-		"@vscode/python-extension": "..."
+		"@vscode/python-extension": "...",
+        "@types/vscode": "..."
 	},
 }
 ```
+
+Update `"@types/vscode"` to [a recent version](https://code.visualstudio.com/updates/) of VS Code, say `"^1.81.0"` for VS Code version `"1.81"`, in case there are any conflicts.
 
 The actual source code to get the active environment to run some script could look like this:
 

--- a/pythonExtensionApi/package-lock.json
+++ b/pythonExtensionApi/package-lock.json
@@ -15,9 +15,6 @@
             "engines": {
                 "node": ">=16.17.1",
                 "vscode": "^1.78.0"
-            },
-            "optionalDependencies": {
-                "@types/vscode": "^1.78.0"
             }
         },
         "node_modules/@types/vscode": {

--- a/pythonExtensionApi/package.json
+++ b/pythonExtensionApi/package.json
@@ -25,9 +25,6 @@
     "bugs": {
         "url": "https://github.com/Microsoft/vscode-python/issues"
     },
-    "optionalDependencies": {
-        "@types/vscode": "^1.78.0"
-    },
     "devDependencies": {
         "typescript": "5.0.4",
         "@types/vscode": "^1.78.0"


### PR DESCRIPTION
Closes It still leads to conflicts due to double installation of vscode types when testing through the cases, removing vscode types as dependencies altogether and documenting to install it separately instead.