### PR TITLE
Show notification reaffirming Python extension still handles activation when in `pythonTerminalEnvVarActivation` experiment

### DIFF
--- a/src/client/activation/extensionSurvey.ts
+++ b/src/client/activation/extensionSurvey.ts
@@ -83,10 +83,10 @@ export class ExtensionSurveyPrompt implements IExtensionSingleActivationService 
     @traceDecoratorError('Failed to display prompt for extension survey')
     public async showSurvey() {
         const prompts = [ExtensionSurveyBanner.bannerLabelYes, ExtensionSurveyBanner.maybeLater, Common.doNotShowAgain];
-        const telemetrySelections: ['Yes', 'Maybe later', 'Do not show again'] = [
+        const telemetrySelections: ['Yes', 'Maybe later', "Don't show again"] = [
             'Yes',
             'Maybe later',
-            'Do not show again',
+            "Don't show again",
         ];
         const selection = await this.appShell.showInformationMessage(ExtensionSurveyBanner.bannerMessage, ...prompts);
         sendTelemetryEvent(EventName.EXTENSION_SURVEY_PROMPT, undefined, {

--- a/src/client/common/experiments/helpers.ts
+++ b/src/client/common/experiments/helpers.ts
@@ -3,10 +3,15 @@
 
 'use strict';
 
+import { env, workspace } from 'vscode';
 import { IExperimentService } from '../types';
 import { TerminalEnvVarActivation } from './groups';
 
 export function inTerminalEnvVarExperiment(experimentService: IExperimentService): boolean {
+    if (workspace.workspaceFile && env.remoteName) {
+        // TODO: Remove this if statement once https://github.com/microsoft/vscode/issues/180486 is fixed.
+        return false;
+    }
     if (!experimentService.inExperimentSync(TerminalEnvVarActivation.experiment)) {
         return false;
     }

--- a/src/client/common/experiments/helpers.ts
+++ b/src/client/common/experiments/helpers.ts
@@ -6,9 +6,10 @@
 import { env, workspace } from 'vscode';
 import { IExperimentService } from '../types';
 import { TerminalEnvVarActivation } from './groups';
+import { isTestExecution } from '../constants';
 
 export function inTerminalEnvVarExperiment(experimentService: IExperimentService): boolean {
-    if (workspace.workspaceFile && env.remoteName) {
+    if (!isTestExecution() && workspace.workspaceFile && env.remoteName) {
         // TODO: Remove this if statement once https://github.com/microsoft/vscode/issues/180486 is fixed.
         return false;
     }

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -198,6 +198,9 @@ export namespace Interpreters {
     );
     export const activatingTerminals = l10n.t('Reactivating terminals...');
     export const activateTerminalDescription = l10n.t('Activated environment for');
+    export const terminalEnvVarCollectionPrompt = l10n.t(
+        'Python extension automatically activates all terminals using the selected environment. You can hover over the terminal tab to get information about the activation. [Learn more](https://aka.ms/vscodePythonTerminalActivation).',
+    );
     export const activatedCondaEnvLaunch = l10n.t(
         'We noticed VS Code was launched from an activated conda environment, would you like to select it?',
     );

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -63,7 +63,7 @@ export namespace Common {
     export const openOutputPanel = l10n.t('Show output');
     export const noIWillDoItLater = l10n.t('No, I will do it later');
     export const notNow = l10n.t('Not now');
-    export const doNotShowAgain = l10n.t('Do not show again');
+    export const doNotShowAgain = l10n.t("Don't show again");
     export const reload = l10n.t('Reload');
     export const moreInfo = l10n.t('More Info');
     export const learnMore = l10n.t('Learn more');
@@ -199,7 +199,7 @@ export namespace Interpreters {
     export const activatingTerminals = l10n.t('Reactivating terminals...');
     export const activateTerminalDescription = l10n.t('Activated environment for');
     export const terminalEnvVarCollectionPrompt = l10n.t(
-        'Python extension automatically activates all terminals using the selected environment. You can hover over the terminal tab to get information about the activation. [Learn more](https://aka.ms/vscodePythonTerminalActivation).',
+        'The Python extension automatically activates all terminals using the selected environment. You can hover over the terminal tab to see more information about the activation. [Learn more](https://aka.ms/vscodePythonTerminalActivation).',
     );
     export const activatedCondaEnvLaunch = l10n.t(
         'We noticed VS Code was launched from an activated conda environment, would you like to select it?',

--- a/src/client/interpreter/activation/terminalEnvVarCollectionPrompt.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionPrompt.ts
@@ -32,20 +32,20 @@ export class TerminalEnvVarCollectionPrompt implements IExtensionSingleActivatio
             return;
         }
         this.disposableRegistry.push(
-            this.terminalManager.onDidOpenTerminal((terminal) => {
+            this.terminalManager.onDidOpenTerminal(async (terminal) => {
                 const cwd =
                     'cwd' in terminal.creationOptions && terminal.creationOptions.cwd
                         ? terminal.creationOptions.cwd
                         : this.activeResourceService.getActiveResource();
                 const resource = typeof cwd === 'string' ? Uri.file(cwd) : cwd;
                 if (!this.terminalEnvVarCollectionService.isTerminalPromptSet(resource)) {
-                    this.showPrompt().ignoreErrors();
+                    await this.notifyUsers();
                 }
             }),
         );
     }
 
-    private async showPrompt(): Promise<void> {
+    private async notifyUsers(): Promise<void> {
         const notificationPromptEnabled = this.persistentStateFactory.createGlobalPersistentState(
             terminalEnvCollectionPromptKey,
             true,

--- a/src/client/interpreter/activation/terminalEnvVarCollectionPrompt.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionPrompt.ts
@@ -38,7 +38,7 @@ export class TerminalEnvVarCollectionPrompt implements IExtensionSingleActivatio
                         ? terminal.creationOptions.cwd
                         : this.activeResourceService.getActiveResource();
                 const resource = typeof cwd === 'string' ? Uri.file(cwd) : cwd;
-                if (!this.terminalEnvVarCollectionService.isTerminalPromptSet(resource)) {
+                if (!this.terminalEnvVarCollectionService.isTerminalPromptSetCorrectly(resource)) {
                     await this.notifyUsers();
                 }
             }),

--- a/src/client/interpreter/activation/terminalEnvVarCollectionPrompt.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionPrompt.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { inject, injectable } from 'inversify';
+import { Uri } from 'vscode';
+import { IActiveResourceService, IApplicationShell, ITerminalManager } from '../../common/application/types';
+import { IDisposableRegistry, IExperimentService, IPersistentStateFactory } from '../../common/types';
+import { Common, Interpreters } from '../../common/utils/localize';
+import { IExtensionSingleActivationService } from '../../activation/types';
+import { ITerminalEnvVarCollectionService } from './types';
+import { inTerminalEnvVarExperiment } from '../../common/experiments/helpers';
+
+export const terminalEnvCollectionPromptKey = 'TERMINAL_ENV_COLLECTION_PROMPT_KEY';
+
+@injectable()
+export class TerminalEnvVarCollectionPrompt implements IExtensionSingleActivationService {
+    public readonly supportedWorkspaceTypes = { untrustedWorkspace: false, virtualWorkspace: false };
+
+    constructor(
+        @inject(IApplicationShell) private readonly appShell: IApplicationShell,
+        @inject(IPersistentStateFactory) private readonly persistentStateFactory: IPersistentStateFactory,
+        @inject(ITerminalManager) private readonly terminalManager: ITerminalManager,
+        @inject(IDisposableRegistry) private readonly disposableRegistry: IDisposableRegistry,
+        @inject(IActiveResourceService) private readonly activeResourceService: IActiveResourceService,
+        @inject(ITerminalEnvVarCollectionService)
+        private readonly terminalEnvVarCollectionService: ITerminalEnvVarCollectionService,
+        @inject(IExperimentService) private readonly experimentService: IExperimentService,
+    ) {}
+
+    public async activate(): Promise<void> {
+        if (!inTerminalEnvVarExperiment(this.experimentService)) {
+            return;
+        }
+        this.disposableRegistry.push(
+            this.terminalManager.onDidOpenTerminal((terminal) => {
+                const cwd =
+                    'cwd' in terminal.creationOptions && terminal.creationOptions.cwd
+                        ? terminal.creationOptions.cwd
+                        : this.activeResourceService.getActiveResource();
+                const resource = typeof cwd === 'string' ? Uri.file(cwd) : cwd;
+                if (!this.terminalEnvVarCollectionService.isTerminalPromptSet(resource)) {
+                    this.showPrompt().ignoreErrors();
+                }
+            }),
+        );
+    }
+
+    private async showPrompt(): Promise<void> {
+        const notificationPromptEnabled = this.persistentStateFactory.createGlobalPersistentState(
+            terminalEnvCollectionPromptKey,
+            true,
+        );
+        if (!notificationPromptEnabled.value) {
+            return;
+        }
+        const prompts = [Common.doNotShowAgain];
+        const selection = await this.appShell.showInformationMessage(
+            Interpreters.terminalEnvVarCollectionPrompt,
+            ...prompts,
+        );
+        if (!selection) {
+            return;
+        }
+        if (selection === prompts[0]) {
+            await notificationPromptEnabled.updateValue(false);
+        }
+    }
+}

--- a/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
@@ -23,13 +23,13 @@ import { Interpreters } from '../../common/utils/localize';
 import { traceDecoratorVerbose, traceVerbose } from '../../logging';
 import { IInterpreterService } from '../contracts';
 import { defaultShells } from './service';
-import { IEnvironmentActivationService } from './types';
+import { IEnvironmentActivationService, ITerminalEnvVarCollectionService } from './types';
 import { EnvironmentType } from '../../pythonEnvironments/info';
 import { getSearchPathEnvVarNames } from '../../common/utils/exec';
 import { EnvironmentVariables } from '../../common/variables/types';
 
 @injectable()
-export class TerminalEnvVarCollectionService implements IExtensionActivationService {
+export class TerminalEnvVarCollectionService implements IExtensionActivationService, ITerminalEnvVarCollectionService {
     public readonly supportedWorkspaceTypes = {
         untrustedWorkspace: false,
         virtualWorkspace: false,
@@ -165,6 +165,13 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
         const displayPath = this.pathUtils.getDisplayName(settings.pythonPath, workspaceFolder?.uri.fsPath);
         const description = new MarkdownString(`${Interpreters.activateTerminalDescription} \`${displayPath}\``);
         envVarCollection.description = description;
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    public isTerminalPromptSet(_resource?: Resource): boolean {
+        // Returns true if we know for sure that the terminal prompt is set correctly for a particular resource.
+        // TODO: For now return false for simplicity.
+        return false;
     }
 
     private async handleMicroVenv(resource: Resource) {

--- a/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
@@ -149,7 +149,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
             if (prevValue !== value) {
                 if (value !== undefined) {
                     if (key === 'PS1') {
-                        // We cannot have the full PS1 without executing in terminal, which do not. Hence prepend it.
+                        // We cannot have the full PS1 without executing in terminal, which we do not. Hence prepend it.
                         traceVerbose(`Prepending environment variable ${key} in collection with ${value}`);
                         envVarCollection.prepend(key, value, {
                             applyAtShellIntegration: true,

--- a/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
@@ -172,7 +172,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
         const description = new MarkdownString(`${Interpreters.activateTerminalDescription} \`${displayPath}\``);
         envVarCollection.description = description;
 
-        await this.setPromptIfEligle(shell, resource, isPS1Set);
+        await this.trackTerminalPrompts(shell, resource, isPS1Set);
     }
 
     private isPromptSet = new Map<number | undefined, boolean>();
@@ -196,7 +196,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
         this.isPromptSet.delete(key);
     }
 
-    private async setPromptIfEligle(shell: string, resource: Resource, isPS1Set: boolean) {
+    private async trackTerminalPrompts(shell: string, resource: Resource, isPS1Set: boolean) {
         // Prompts for these shells cannot be set using variables
         const exceptionShells = [
             TerminalShellType.powershell,

--- a/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
@@ -189,7 +189,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
         this.isPromptSet.set(key, true);
     }
 
-    private terminalPromptIsNotCorrect(resource: Resource) {
+    private terminalPromptIsUnknown(resource: Resource) {
         const key = this.getWorkspaceFolder(resource)?.index;
         this.isPromptSet.delete(key);
     }
@@ -198,7 +198,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
      * Tracks whether prompt for terminal was correctly set.
      */
     private async trackTerminalPrompt(shell: string, resource: Resource, env: EnvironmentVariables | undefined) {
-        this.terminalPromptIsNotCorrect(resource); // Assume terminal prompt is not correct to begin with.
+        this.terminalPromptIsUnknown(resource);
         if (!env) {
             this.terminalPromptIsCorrect(resource);
             return;

--- a/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
@@ -227,7 +227,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
                 envVarCollection.replace(
                     'PATH',
                     `${path.dirname(interpreter.path)}${path.delimiter}${process.env[pathVarName]}`,
-                    { applyAtShellIntegration: true },
+                    { applyAtShellIntegration: true, applyAtProcessCreation: true },
                 );
                 return;
             }

--- a/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
@@ -110,7 +110,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
         const envVarCollection = this.context.getEnvironmentVariableCollection({ workspaceFolder });
         // Clear any previously set env vars from collection
         envVarCollection.clear();
-        this.promptIsNotSet();
+        this.promptIsNotSet(resource);
         if (!settings.terminal.activateEnvironment) {
             traceVerbose('Activating environments in terminal is disabled for', resource?.fsPath);
             return;
@@ -186,14 +186,14 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
     /**
      * Call this once we know terminal prompt is set correctly for resoure.
      */
-    private promptIsSet(resource?: Resource) {
-        const workspaceFolder = this.getWorkspaceFolder(resource);
-        this.isPromptSet.set(workspaceFolder?.index, true);
+    private promptIsSet(resource: Resource) {
+        const key = this.getWorkspaceFolder(resource)?.index;
+        this.isPromptSet.set(key, true);
     }
 
-    private promptIsNotSet(resource?: Resource) {
-        const workspaceFolder = this.getWorkspaceFolder(resource);
-        this.isPromptSet.delete(workspaceFolder?.index);
+    private promptIsNotSet(resource: Resource) {
+        const key = this.getWorkspaceFolder(resource)?.index;
+        this.isPromptSet.delete(key);
     }
 
     private async setPromptIfEligle(shell: string, resource: Resource, isPS1Set: boolean) {

--- a/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
@@ -129,7 +129,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
                 await this._applyCollection(resource, defaultShell?.shell);
                 return;
             }
-            await this.trackTerminalPromptStatus(shell, resource, env);
+            await this.trackTerminalPrompt(shell, resource, env);
             this.processEnvVars = undefined;
             return;
         }
@@ -170,7 +170,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
         const description = new MarkdownString(`${Interpreters.activateTerminalDescription} \`${displayPath}\``);
         envVarCollection.description = description;
 
-        await this.trackTerminalPromptStatus(shell, resource, env);
+        await this.trackTerminalPrompt(shell, resource, env);
     }
 
     private isPromptSet = new Map<number | undefined, boolean>();
@@ -184,12 +184,12 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
     /**
      * Call this once we know terminal prompt is set correctly for terminal owned by this resource.
      */
-    private setTerminalPromptStatus(resource: Resource) {
+    private terminalPromptIsCorrect(resource: Resource) {
         const key = this.getWorkspaceFolder(resource)?.index;
         this.isPromptSet.set(key, true);
     }
 
-    private clearTerminalPromptStatus(resource: Resource) {
+    private terminalPromptIsNotCorrect(resource: Resource) {
         const key = this.getWorkspaceFolder(resource)?.index;
         this.isPromptSet.delete(key);
     }
@@ -197,10 +197,10 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
     /**
      * Tracks whether prompt for terminal was correctly set.
      */
-    private async trackTerminalPromptStatus(shell: string, resource: Resource, env: EnvironmentVariables | undefined) {
-        this.clearTerminalPromptStatus(resource);
+    private async trackTerminalPrompt(shell: string, resource: Resource, env: EnvironmentVariables | undefined) {
+        this.terminalPromptIsNotCorrect(resource); // Assume terminal prompt is not correct to begin with.
         if (!env) {
-            this.setTerminalPromptStatus(resource);
+            this.terminalPromptIsCorrect(resource);
             return;
         }
         // Prompts for these shells cannot be set reliably using variables
@@ -223,7 +223,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
                 return;
             }
         }
-        this.setTerminalPromptStatus(resource);
+        this.terminalPromptIsCorrect(resource);
     }
 
     private async handleMicroVenv(resource: Resource) {

--- a/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
@@ -184,7 +184,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
     }
 
     /**
-     * Call this once we know terminal prompt is set correctly for resoure.
+     * Call this once we know terminal prompt is set correctly for terminal owned by this resource.
      */
     private promptIsSet(resource: Resource) {
         const key = this.getWorkspaceFolder(resource)?.index;

--- a/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
@@ -197,7 +197,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
     }
 
     private async trackTerminalPrompts(shell: string, resource: Resource, isPS1Set: boolean) {
-        // Prompts for these shells cannot be set using variables
+        // Prompts for these shells cannot be set reliably using variables
         const exceptionShells = [
             TerminalShellType.powershell,
             TerminalShellType.powershellCore,

--- a/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
@@ -28,7 +28,7 @@ import { EnvironmentType } from '../../pythonEnvironments/info';
 import { getSearchPathEnvVarNames } from '../../common/utils/exec';
 import { EnvironmentVariables } from '../../common/variables/types';
 import { TerminalShellType } from '../../common/terminal/types';
-import { OSType, getOSType } from '../../common/utils/platform';
+import { OSType } from '../../common/utils/platform';
 
 @injectable()
 export class TerminalEnvVarCollectionService implements IExtensionActivationService, ITerminalEnvVarCollectionService {
@@ -209,7 +209,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
             return;
         }
         const interpreter = await this.interpreterService.getActiveInterpreter(resource);
-        const shouldPS1BeSet = interpreter?.type && getOSType() !== OSType.Windows;
+        const shouldPS1BeSet = interpreter?.type && this.platform.osType !== OSType.Windows;
         if (shouldPS1BeSet && !isPS1Set) {
             return;
         }

--- a/src/client/interpreter/activation/types.ts
+++ b/src/client/interpreter/activation/types.ts
@@ -25,7 +25,7 @@ export interface IEnvironmentActivationService {
 export const ITerminalEnvVarCollectionService = Symbol('ITerminalEnvVarCollectionService');
 export interface ITerminalEnvVarCollectionService {
     /**
-     * Returns true if we know for sure that the terminal prompt is set correctly for a particular resource.
+     * Returns true if we know with high certainity the terminal prompt is set correctly for a particular resource.
      */
     isTerminalPromptSet(resource?: Resource): boolean;
 }

--- a/src/client/interpreter/activation/types.ts
+++ b/src/client/interpreter/activation/types.ts
@@ -27,5 +27,5 @@ export interface ITerminalEnvVarCollectionService {
     /**
      * Returns true if we know with high certainity the terminal prompt is set correctly for a particular resource.
      */
-    isTerminalPromptSet(resource?: Resource): boolean;
+    isTerminalPromptSetCorrectly(resource?: Resource): boolean;
 }

--- a/src/client/interpreter/activation/types.ts
+++ b/src/client/interpreter/activation/types.ts
@@ -21,3 +21,11 @@ export interface IEnvironmentActivationService {
         interpreter?: PythonEnvironment,
     ): Promise<string[] | undefined>;
 }
+
+export const ITerminalEnvVarCollectionService = Symbol('ITerminalEnvVarCollectionService');
+export interface ITerminalEnvVarCollectionService {
+    /**
+     * Returns true if we know for sure that the terminal prompt is set correctly for a particular resource.
+     */
+    isTerminalPromptSet(resource?: Resource): boolean;
+}

--- a/src/client/interpreter/serviceRegistry.ts
+++ b/src/client/interpreter/serviceRegistry.ts
@@ -114,7 +114,7 @@ export function registerTypes(serviceManager: IServiceManager): void {
         ITerminalEnvVarCollectionService,
         TerminalEnvVarCollectionService,
     );
-    serviceManager.addBinding(ITerminalEnvVarCollectionService, IExtensionSingleActivationService);
+    serviceManager.addBinding(ITerminalEnvVarCollectionService, IExtensionActivationService);
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,
         TerminalEnvVarCollectionPrompt,

--- a/src/client/interpreter/serviceRegistry.ts
+++ b/src/client/interpreter/serviceRegistry.ts
@@ -6,8 +6,9 @@
 import { IExtensionActivationService, IExtensionSingleActivationService } from '../activation/types';
 import { IServiceManager } from '../ioc/types';
 import { EnvironmentActivationService } from './activation/service';
+import { TerminalEnvVarCollectionPrompt } from './activation/terminalEnvVarCollectionPrompt';
 import { TerminalEnvVarCollectionService } from './activation/terminalEnvVarCollectionService';
-import { IEnvironmentActivationService } from './activation/types';
+import { IEnvironmentActivationService, ITerminalEnvVarCollectionService } from './activation/types';
 import { InterpreterAutoSelectionService } from './autoSelection/index';
 import { InterpreterAutoSelectionProxyService } from './autoSelection/proxy';
 import { IInterpreterAutoSelectionService, IInterpreterAutoSelectionProxyService } from './autoSelection/types';
@@ -109,8 +110,13 @@ export function registerTypes(serviceManager: IServiceManager): void {
         IEnvironmentActivationService,
         EnvironmentActivationService,
     );
-    serviceManager.addSingleton<IExtensionActivationService>(
-        IExtensionActivationService,
+    serviceManager.addSingleton<ITerminalEnvVarCollectionService>(
+        ITerminalEnvVarCollectionService,
         TerminalEnvVarCollectionService,
+    );
+    serviceManager.addBinding(ITerminalEnvVarCollectionService, IExtensionSingleActivationService);
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        TerminalEnvVarCollectionPrompt,
     );
 }

--- a/src/client/pythonEnvironments/info/index.ts
+++ b/src/client/pythonEnvironments/info/index.ts
@@ -4,6 +4,7 @@
 'use strict';
 
 import { Architecture } from '../../common/utils/platform';
+import { PythonEnvType } from '../base/info';
 import { PythonVersion } from './pythonVersion';
 
 /**
@@ -85,7 +86,7 @@ export type PythonEnvironment = InterpreterInformation & {
     envName?: string;
     envPath?: string;
     cachedEntry?: boolean;
-    type?: string;
+    type?: PythonEnvType;
 };
 
 /**

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -945,7 +945,7 @@ export interface IEventNamePropertyMapping {
         tool?: LinterId;
         /**
          * `select` When 'Select linter' option is selected
-         * `disablePrompt` When 'Do not show again' option is selected
+         * `disablePrompt` When "Don't show again" option is selected
          * `install` When 'Install' option is selected
          *
          * @type {('select' | 'disablePrompt' | 'install')}
@@ -1369,7 +1369,7 @@ export interface IEventNamePropertyMapping {
         /**
          * `Yes` When 'Yes' option is selected
          * `No` When 'No' option is selected
-         * `Ignore` When 'Do not show again' option is clicked
+         * `Ignore` When "Don't show again" option is clicked
          *
          * @type {('Yes' | 'No' | 'Ignore' | undefined)}
          */
@@ -1549,7 +1549,7 @@ export interface IEventNamePropertyMapping {
      * This event also has a measure, "resultLength", which records the number of completions provided.
      */
     /* __GDPR__
-       "jedi_language_server.request" : { 
+       "jedi_language_server.request" : {
            "method": {"classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "karthiknadig"}
        }
      */
@@ -1566,7 +1566,7 @@ export interface IEventNamePropertyMapping {
         /**
          * Carries the selection of user when they are asked to take the extension survey
          */
-        selection: 'Yes' | 'Maybe later' | 'Do not show again' | undefined;
+        selection: 'Yes' | 'Maybe later' | "Don't show again" | undefined;
     };
     /**
      * Telemetry event sent when starting REPL

--- a/src/test/activation/extensionSurvey.unit.test.ts
+++ b/src/test/activation/extensionSurvey.unit.test.ts
@@ -355,7 +355,7 @@ suite('Extension survey prompt - showSurvey()', () => {
         platformService.verifyAll();
     });
 
-    test("Disable prompt if \"Don't show again\" option is clicked", async () => {
+    test('Disable prompt if "Don\'t show again" option is clicked', async () => {
         const prompts = [ExtensionSurveyBanner.bannerLabelYes, ExtensionSurveyBanner.maybeLater, Common.doNotShowAgain];
         platformService.setup((p) => p.osType).verifiable(TypeMoq.Times.never());
         appShell

--- a/src/test/activation/extensionSurvey.unit.test.ts
+++ b/src/test/activation/extensionSurvey.unit.test.ts
@@ -355,7 +355,7 @@ suite('Extension survey prompt - showSurvey()', () => {
         platformService.verifyAll();
     });
 
-    test("Disable prompt if 'Do not show again' option is clicked", async () => {
+    test("Disable prompt if \"Don't show again\" option is clicked", async () => {
         const prompts = [ExtensionSurveyBanner.bannerLabelYes, ExtensionSurveyBanner.maybeLater, Common.doNotShowAgain];
         platformService.setup((p) => p.osType).verifiable(TypeMoq.Times.never());
         appShell

--- a/src/test/application/diagnostics/checks/macPythonInterpreter.unit.test.ts
+++ b/src/test/application/diagnostics/checks/macPythonInterpreter.unit.test.ts
@@ -220,7 +220,7 @@ suite('Application Diagnostics - Checks Mac Python Interpreter', () => {
             expect(messagePrompt).not.be.equal(undefined, 'Message prompt not set');
             expect(messagePrompt!.commandPrompts).to.be.deep.equal([
                 { prompt: 'Select Python Interpreter', command: cmd },
-                { prompt: 'Do not show again', command: cmdIgnore },
+                { prompt: "Don't show again", command: cmdIgnore },
             ]);
         });
         test('Should not display a message if No Interpreters diagnostic has been ignored', async () => {

--- a/src/test/common/installer/installer.unit.test.ts
+++ b/src/test/common/installer/installer.unit.test.ts
@@ -307,10 +307,10 @@ suite('Module Installer only', () => {
                                         TypeMoq.It.isAnyString(),
                                         TypeMoq.It.isValue('Install'),
                                         TypeMoq.It.isValue('Select Linter'),
-                                        TypeMoq.It.isValue('Do not show again'),
+                                        TypeMoq.It.isValue("Don't show again"),
                                     ),
                                 )
-                                    .returns(async () => 'Do not show again')
+                                    .returns(async () => "Don't show again")
                                     .verifiable(TypeMoq.Times.once());
                                 const persistVal = TypeMoq.Mock.ofType<IPersistentState<boolean>>();
                                 let mockPersistVal = false;
@@ -367,7 +367,7 @@ suite('Module Installer only', () => {
                                         TypeMoq.It.isAnyString(),
                                         TypeMoq.It.isValue('Install'),
                                         TypeMoq.It.isValue('Select Linter'),
-                                        TypeMoq.It.isValue('Do not show again'),
+                                        TypeMoq.It.isValue("Don't show again"),
                                     ),
                                 )
                                     .returns(async () => undefined)
@@ -864,7 +864,7 @@ suite('Module Installer only', () => {
 
         test('Ensure 3 options for pylint', async () => {
             const product = Product.pylint;
-            const options = ['Select Linter', 'Do not show again'];
+            const options = ['Select Linter', "Don't show again"];
             const productName = ProductNames.get(product)!;
 
             await installer.promptToInstallImplementation(product, resource);
@@ -875,7 +875,7 @@ suite('Module Installer only', () => {
         });
         test('Ensure select linter command is invoked', async () => {
             const product = Product.pylint;
-            const options = ['Select Linter', 'Do not show again'];
+            const options = ['Select Linter', "Don't show again"];
             const productName = ProductNames.get(product)!;
             when(
                 appShell.showErrorMessage(`Linter ${productName} is not installed.`, 'Install', options[0], options[1]),
@@ -892,7 +892,7 @@ suite('Module Installer only', () => {
         });
         test('If install button is selected, install linter and return response', async () => {
             const product = Product.pylint;
-            const options = ['Select Linter', 'Do not show again'];
+            const options = ['Select Linter', "Don't show again"];
             const productName = ProductNames.get(product)!;
             when(
                 appShell.showErrorMessage(`Linter ${productName} is not installed.`, 'Install', options[0], options[1]),

--- a/src/test/interpreters/activation/terminalEnvVarCollectionPrompt.unit.test.ts
+++ b/src/test/interpreters/activation/terminalEnvVarCollectionPrompt.unit.test.ts
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { mock, when, anything, instance, verify, reset } from 'ts-mockito';
+import { EventEmitter, Terminal, Uri } from 'vscode';
+import { IActiveResourceService, IApplicationShell, ITerminalManager } from '../../../client/common/application/types';
+import { IExperimentService, IPersistentState, IPersistentStateFactory } from '../../../client/common/types';
+import { TerminalEnvVarCollectionPrompt } from '../../../client/interpreter/activation/terminalEnvVarCollectionPrompt';
+import { ITerminalEnvVarCollectionService } from '../../../client/interpreter/activation/types';
+import { Common, Interpreters } from '../../../client/common/utils/localize';
+import { TerminalEnvVarActivation } from '../../../client/common/experiments/groups';
+import { sleep } from '../../core';
+
+suite('Terminal Environment Variable Collection Prompt', () => {
+    let shell: IApplicationShell;
+    let terminalManager: ITerminalManager;
+    let experimentService: IExperimentService;
+    let activeResourceService: IActiveResourceService;
+    let terminalEnvVarCollectionService: ITerminalEnvVarCollectionService;
+    let persistentStateFactory: IPersistentStateFactory;
+    let terminalEnvVarCollectionPrompt: TerminalEnvVarCollectionPrompt;
+    let terminalEventEmitter: EventEmitter<Terminal>;
+    let notificationEnabled: IPersistentState<boolean>;
+    const prompts = [Common.doNotShowAgain];
+    const message = Interpreters.terminalEnvVarCollectionPrompt;
+
+    setup(async () => {
+        shell = mock<IApplicationShell>();
+        terminalManager = mock<ITerminalManager>();
+        experimentService = mock<IExperimentService>();
+        activeResourceService = mock<IActiveResourceService>();
+        persistentStateFactory = mock<IPersistentStateFactory>();
+        terminalEnvVarCollectionService = mock<ITerminalEnvVarCollectionService>();
+        notificationEnabled = mock<IPersistentState<boolean>>();
+        terminalEventEmitter = new EventEmitter<Terminal>();
+        when(persistentStateFactory.createGlobalPersistentState(anything(), true)).thenReturn(
+            instance(notificationEnabled),
+        );
+        when(experimentService.inExperimentSync(TerminalEnvVarActivation.experiment)).thenReturn(true);
+        when(terminalManager.onDidOpenTerminal).thenReturn(terminalEventEmitter.event);
+        terminalEnvVarCollectionPrompt = new TerminalEnvVarCollectionPrompt(
+            instance(shell),
+            instance(persistentStateFactory),
+            instance(terminalManager),
+            [],
+            instance(activeResourceService),
+            instance(terminalEnvVarCollectionService),
+            instance(experimentService),
+        );
+    });
+
+    test('Show notification when a new terminal is opened for which there is no prompt set', async () => {
+        const resource = Uri.file('a');
+        const terminal = ({
+            creationOptions: {
+                cwd: resource,
+            },
+        } as unknown) as Terminal;
+        when(terminalEnvVarCollectionService.isTerminalPromptSet(resource)).thenReturn(false);
+        when(notificationEnabled.value).thenReturn(true);
+        when(shell.showInformationMessage(message, ...prompts)).thenResolve(undefined);
+
+        await terminalEnvVarCollectionPrompt.activate();
+        terminalEventEmitter.fire(terminal);
+        await sleep(1);
+
+        verify(shell.showInformationMessage(message, ...prompts)).once();
+    });
+
+    test('When not in experiment, do not show notification for the same', async () => {
+        const resource = Uri.file('a');
+        const terminal = ({
+            creationOptions: {
+                cwd: resource,
+            },
+        } as unknown) as Terminal;
+        when(terminalEnvVarCollectionService.isTerminalPromptSet(resource)).thenReturn(false);
+        when(notificationEnabled.value).thenReturn(true);
+        when(shell.showInformationMessage(message, ...prompts)).thenResolve(undefined);
+
+        reset(experimentService);
+        when(experimentService.inExperimentSync(TerminalEnvVarActivation.experiment)).thenReturn(false);
+        await terminalEnvVarCollectionPrompt.activate();
+        terminalEventEmitter.fire(terminal);
+        await sleep(1);
+
+        verify(shell.showInformationMessage(message, ...prompts)).never();
+    });
+
+    test('Do not show notification if notification is disabled', async () => {
+        const resource = Uri.file('a');
+        const terminal = ({
+            creationOptions: {
+                cwd: resource,
+            },
+        } as unknown) as Terminal;
+        when(terminalEnvVarCollectionService.isTerminalPromptSet(resource)).thenReturn(false);
+        when(notificationEnabled.value).thenReturn(false);
+        when(shell.showInformationMessage(message, ...prompts)).thenResolve(undefined);
+
+        await terminalEnvVarCollectionPrompt.activate();
+        terminalEventEmitter.fire(terminal);
+        await sleep(1);
+
+        verify(shell.showInformationMessage(message, ...prompts)).never();
+    });
+
+    test('Do not show notification when a new terminal is opened for which there is prompt set', async () => {
+        const resource = Uri.file('a');
+        const terminal = ({
+            creationOptions: {
+                cwd: resource,
+            },
+        } as unknown) as Terminal;
+        when(terminalEnvVarCollectionService.isTerminalPromptSet(resource)).thenReturn(true);
+        when(notificationEnabled.value).thenReturn(true);
+        when(shell.showInformationMessage(message, ...prompts)).thenResolve(undefined);
+
+        await terminalEnvVarCollectionPrompt.activate();
+        terminalEventEmitter.fire(terminal);
+        await sleep(1);
+
+        verify(shell.showInformationMessage(message, ...prompts)).never();
+    });
+
+    test("Disable notification if `Don't show again` is clicked", async () => {
+        const resource = Uri.file('a');
+        const terminal = ({
+            creationOptions: {
+                cwd: resource,
+            },
+        } as unknown) as Terminal;
+        when(terminalEnvVarCollectionService.isTerminalPromptSet(resource)).thenReturn(false);
+        when(notificationEnabled.value).thenReturn(true);
+        when(notificationEnabled.updateValue(false)).thenResolve();
+        when(shell.showInformationMessage(message, ...prompts)).thenReturn(Promise.resolve(Common.doNotShowAgain));
+
+        await terminalEnvVarCollectionPrompt.activate();
+        terminalEventEmitter.fire(terminal);
+        await sleep(1);
+
+        verify(notificationEnabled.updateValue(false)).once();
+    });
+
+    test('Do not disable notification if prompt is closed', async () => {
+        const resource = Uri.file('a');
+        const terminal = ({
+            creationOptions: {
+                cwd: resource,
+            },
+        } as unknown) as Terminal;
+        when(terminalEnvVarCollectionService.isTerminalPromptSet(resource)).thenReturn(false);
+        when(notificationEnabled.value).thenReturn(true);
+        when(notificationEnabled.updateValue(false)).thenResolve();
+        when(shell.showInformationMessage(message, ...prompts)).thenReturn(Promise.resolve(undefined));
+
+        await terminalEnvVarCollectionPrompt.activate();
+        terminalEventEmitter.fire(terminal);
+        await sleep(1);
+
+        verify(notificationEnabled.updateValue(false)).never();
+    });
+});

--- a/src/test/interpreters/activation/terminalEnvVarCollectionPrompt.unit.test.ts
+++ b/src/test/interpreters/activation/terminalEnvVarCollectionPrompt.unit.test.ts
@@ -58,7 +58,7 @@ suite('Terminal Environment Variable Collection Prompt', () => {
                 cwd: resource,
             },
         } as unknown) as Terminal;
-        when(terminalEnvVarCollectionService.isTerminalPromptSet(resource)).thenReturn(false);
+        when(terminalEnvVarCollectionService.isTerminalPromptSetCorrectly(resource)).thenReturn(false);
         when(notificationEnabled.value).thenReturn(true);
         when(shell.showInformationMessage(message, ...prompts)).thenResolve(undefined);
 
@@ -76,7 +76,7 @@ suite('Terminal Environment Variable Collection Prompt', () => {
                 cwd: resource,
             },
         } as unknown) as Terminal;
-        when(terminalEnvVarCollectionService.isTerminalPromptSet(resource)).thenReturn(false);
+        when(terminalEnvVarCollectionService.isTerminalPromptSetCorrectly(resource)).thenReturn(false);
         when(notificationEnabled.value).thenReturn(true);
         when(shell.showInformationMessage(message, ...prompts)).thenResolve(undefined);
 
@@ -96,7 +96,7 @@ suite('Terminal Environment Variable Collection Prompt', () => {
                 cwd: resource,
             },
         } as unknown) as Terminal;
-        when(terminalEnvVarCollectionService.isTerminalPromptSet(resource)).thenReturn(false);
+        when(terminalEnvVarCollectionService.isTerminalPromptSetCorrectly(resource)).thenReturn(false);
         when(notificationEnabled.value).thenReturn(false);
         when(shell.showInformationMessage(message, ...prompts)).thenResolve(undefined);
 
@@ -114,7 +114,7 @@ suite('Terminal Environment Variable Collection Prompt', () => {
                 cwd: resource,
             },
         } as unknown) as Terminal;
-        when(terminalEnvVarCollectionService.isTerminalPromptSet(resource)).thenReturn(true);
+        when(terminalEnvVarCollectionService.isTerminalPromptSetCorrectly(resource)).thenReturn(true);
         when(notificationEnabled.value).thenReturn(true);
         when(shell.showInformationMessage(message, ...prompts)).thenResolve(undefined);
 
@@ -132,7 +132,7 @@ suite('Terminal Environment Variable Collection Prompt', () => {
                 cwd: resource,
             },
         } as unknown) as Terminal;
-        when(terminalEnvVarCollectionService.isTerminalPromptSet(resource)).thenReturn(false);
+        when(terminalEnvVarCollectionService.isTerminalPromptSetCorrectly(resource)).thenReturn(false);
         when(notificationEnabled.value).thenReturn(true);
         when(notificationEnabled.updateValue(false)).thenResolve();
         when(shell.showInformationMessage(message, ...prompts)).thenReturn(Promise.resolve(Common.doNotShowAgain));
@@ -151,7 +151,7 @@ suite('Terminal Environment Variable Collection Prompt', () => {
                 cwd: resource,
             },
         } as unknown) as Terminal;
-        when(terminalEnvVarCollectionService.isTerminalPromptSet(resource)).thenReturn(false);
+        when(terminalEnvVarCollectionService.isTerminalPromptSetCorrectly(resource)).thenReturn(false);
         when(notificationEnabled.value).thenReturn(true);
         when(notificationEnabled.updateValue(false)).thenResolve();
         when(shell.showInformationMessage(message, ...prompts)).thenReturn(Promise.resolve(undefined));

--- a/src/test/interpreters/activation/terminalEnvVarCollectionPrompt.unit.test.ts
+++ b/src/test/interpreters/activation/terminalEnvVarCollectionPrompt.unit.test.ts
@@ -6,7 +6,13 @@
 import { mock, when, anything, instance, verify, reset } from 'ts-mockito';
 import { EventEmitter, Terminal, Uri } from 'vscode';
 import { IActiveResourceService, IApplicationShell, ITerminalManager } from '../../../client/common/application/types';
-import { IExperimentService, IPersistentState, IPersistentStateFactory } from '../../../client/common/types';
+import {
+    IConfigurationService,
+    IExperimentService,
+    IPersistentState,
+    IPersistentStateFactory,
+    IPythonSettings,
+} from '../../../client/common/types';
 import { TerminalEnvVarCollectionPrompt } from '../../../client/interpreter/activation/terminalEnvVarCollectionPrompt';
 import { ITerminalEnvVarCollectionService } from '../../../client/interpreter/activation/types';
 import { Common, Interpreters } from '../../../client/common/utils/localize';
@@ -23,6 +29,7 @@ suite('Terminal Environment Variable Collection Prompt', () => {
     let terminalEnvVarCollectionPrompt: TerminalEnvVarCollectionPrompt;
     let terminalEventEmitter: EventEmitter<Terminal>;
     let notificationEnabled: IPersistentState<boolean>;
+    let configurationService: IConfigurationService;
     const prompts = [Common.doNotShowAgain];
     const message = Interpreters.terminalEnvVarCollectionPrompt;
 
@@ -33,6 +40,12 @@ suite('Terminal Environment Variable Collection Prompt', () => {
         activeResourceService = mock<IActiveResourceService>();
         persistentStateFactory = mock<IPersistentStateFactory>();
         terminalEnvVarCollectionService = mock<ITerminalEnvVarCollectionService>();
+        configurationService = mock<IConfigurationService>();
+        when(configurationService.getSettings(anything())).thenReturn(({
+            terminal: {
+                activateEnvironment: true,
+            },
+        } as unknown) as IPythonSettings);
         notificationEnabled = mock<IPersistentState<boolean>>();
         terminalEventEmitter = new EventEmitter<Terminal>();
         when(persistentStateFactory.createGlobalPersistentState(anything(), true)).thenReturn(
@@ -47,6 +60,7 @@ suite('Terminal Environment Variable Collection Prompt', () => {
             [],
             instance(activeResourceService),
             instance(terminalEnvVarCollectionService),
+            instance(configurationService),
             instance(experimentService),
         );
     });

--- a/src/test/interpreters/activation/terminalEnvVarCollectionPrompt.unit.test.ts
+++ b/src/test/interpreters/activation/terminalEnvVarCollectionPrompt.unit.test.ts
@@ -83,6 +83,30 @@ suite('Terminal Environment Variable Collection Prompt', () => {
         verify(shell.showInformationMessage(message, ...prompts)).once();
     });
 
+    test('Do not show notification if automatic terminal activation is turned off', async () => {
+        reset(configurationService);
+        when(configurationService.getSettings(anything())).thenReturn(({
+            terminal: {
+                activateEnvironment: false,
+            },
+        } as unknown) as IPythonSettings);
+        const resource = Uri.file('a');
+        const terminal = ({
+            creationOptions: {
+                cwd: resource,
+            },
+        } as unknown) as Terminal;
+        when(terminalEnvVarCollectionService.isTerminalPromptSetCorrectly(resource)).thenReturn(false);
+        when(notificationEnabled.value).thenReturn(true);
+        when(shell.showInformationMessage(message, ...prompts)).thenResolve(undefined);
+
+        await terminalEnvVarCollectionPrompt.activate();
+        terminalEventEmitter.fire(terminal);
+        await sleep(1);
+
+        verify(shell.showInformationMessage(message, ...prompts)).never();
+    });
+
     test('When not in experiment, do not show notification for the same', async () => {
         const resource = Uri.file('a');
         const terminal = ({

--- a/src/test/interpreters/virtualEnvs/virtualEnvPrompt.unit.test.ts
+++ b/src/test/interpreters/virtualEnvs/virtualEnvPrompt.unit.test.ts
@@ -223,7 +223,7 @@ suite('Virtual Environment Prompt', () => {
         notificationPromptEnabled.verifyAll();
     });
 
-    test("If user selects 'Do not show again', prompt is disabled", async () => {
+    test('If user selects "Don\'t show again", prompt is disabled', async () => {
         const resource = Uri.file('a');
         const interpreter1 = { path: 'path/to/interpreter1' };
         const prompts = [Common.bannerLabelYes, Common.bannerLabelNo, Common.doNotShowAgain];


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/21793

Only show notification when terminal prompt does not already indicate that env is activated.