### PR TITLE
Add `language_server.jinja_usage` to `pylance.ts`

### DIFF
--- a/src/client/telemetry/pylance.ts
+++ b/src/client/telemetry/pylance.ts
@@ -7,6 +7,12 @@
    }
 */
 /* __GDPR__
+   "language_server.jinja_usage" : {
+      "lsversion" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+      "openfileextensions" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+   }
+*/
+/* __GDPR__
    "language_server.ready" : {
       "duration" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
       "errorname" : { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth" },


### PR DESCRIPTION
Added new `language_server.jinja_usage` event to list of Pylance events so it gets classified by Logan's telemetry script.