### PR TITLE
Fix `service.test.ts` to stop disposing of all services

### DIFF
--- a/src/test/common/configuration/service.test.ts
+++ b/src/test/common/configuration/service.test.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 import { expect } from 'chai';
 import { workspace } from 'vscode';
-import { IConfigurationService, IDisposableRegistry } from '../../../client/common/types';
-import { disposeAll } from '../../../client/common/utils/resourceLifecycle';
+import { IConfigurationService, IDisposableRegistry, IExtensionContext } from '../../../client/common/types';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { getExtensionSettings } from '../../extensionSettings';
 import { initialize } from '../../initialize';
@@ -23,15 +22,16 @@ suite('Configuration Service', () => {
 
     test('Ensure async registry works', async () => {
         const asyncRegistry = serviceContainer.get<IDisposableRegistry>(IDisposableRegistry);
-        let disposed = false;
+        let subs = serviceContainer.get<IExtensionContext>(IExtensionContext).subscriptions;
+        const oldLength = subs.length;
         const disposable = {
             dispose(): Promise<void> {
-                disposed = true;
                 return Promise.resolve();
             },
         };
         asyncRegistry.push(disposable);
-        await disposeAll(asyncRegistry);
-        expect(disposed).to.be.equal(true, "Didn't dispose during async registry cleanup");
+        subs = serviceContainer.get<IExtensionContext>(IExtensionContext).subscriptions;
+        const newLength = subs.length;
+        expect(newLength).to.be.equal(oldLength + 1, 'Subscription not added');
     });
 });

--- a/src/test/common/configuration/service.test.ts
+++ b/src/test/common/configuration/service.test.ts
@@ -33,5 +33,6 @@ suite('Configuration Service', () => {
         subs = serviceContainer.get<IExtensionContext>(IExtensionContext).subscriptions;
         const newLength = subs.length;
         expect(newLength).to.be.equal(oldLength + 1, 'Subscription not added');
+        // serviceContainer subscriptions are not disposed of as this breaks other tests that use the service container.
     });
 });


### PR DESCRIPTION
file `service.test.ts` was calling to dispose of all items related to the service container for clean up. This led to services in later tests failing since they were close already. Fixes here allow for new tests in the test adapter to be written.

fix helps https://github.com/microsoft/vscode-python/pull/21803