### PR TITLE
Return environment selected at workspace level when using `getActiveEnvironmentPath()` API with resource `undefined`

### DIFF
--- a/pythonExtensionApi/package-lock.json
+++ b/pythonExtensionApi/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@vscode/python-extension",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@vscode/python-extension",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "license": "MIT",
             "devDependencies": {
                 "@types/vscode": "^1.78.0",

--- a/pythonExtensionApi/package.json
+++ b/pythonExtensionApi/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@vscode/python-extension",
     "description": "An API facade for the Python extension in VS Code",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "author": {
       "name": "Microsoft Corporation"
     },

--- a/pythonExtensionApi/src/main.ts
+++ b/pythonExtensionApi/src/main.ts
@@ -39,8 +39,12 @@ export interface PythonExtension {
         /**
          * Returns the environment configured by user in settings. Note that this can be an invalid environment, use
          * {@link resolveEnvironment} to get full details.
-         * @param resource : Uri of a file or workspace folder. This is used to determine the env in a multi-root
-         * scenario. If `undefined`, then the API returns what ever is set for the workspace.
+         * @param resource : Uri of a file or workspace folder, which used to determine the env in a multi-root
+         * scenario.
+         *
+         * If `undefined`, then the API returns what ever is set for the workspace. For multi-root workspace, this
+         * ignores all environments within the workspace folder, and returns configured environment at workspace
+         * level.
          */
         getActiveEnvironmentPath(resource?: Resource): EnvironmentPath;
         /**

--- a/pythonExtensionApi/src/main.ts
+++ b/pythonExtensionApi/src/main.ts
@@ -43,8 +43,8 @@ export interface PythonExtension {
          * scenario.
          *
          * If `undefined`, then the API returns what ever is set for the workspace. For multi-root workspace, this
-         * ignores all environments within the workspace folder, and returns configured environment at workspace
-         * level.
+         * returns configured environment at workspace level. Configurations at the workspace folder level are
+         * ignored.
          */
         getActiveEnvironmentPath(resource?: Resource): EnvironmentPath;
         /**

--- a/src/client/api/types.ts
+++ b/src/client/api/types.ts
@@ -39,8 +39,12 @@ export interface PythonExtension {
         /**
          * Returns the environment configured by user in settings. Note that this can be an invalid environment, use
          * {@link resolveEnvironment} to get full details.
-         * @param resource : Uri of a file or workspace folder. This is used to determine the env in a multi-root
-         * scenario. If `undefined`, then the API returns what ever is set for the workspace.
+         * @param resource : Uri of a file or workspace folder, which used to determine the env in a multi-root
+         * scenario.
+         *
+         * If `undefined`, then the API returns what ever is set for the workspace. For multi-root workspace, this
+         * ignores all environments within the workspace folder, and returns configured environment at workspace
+         * level.
          */
         getActiveEnvironmentPath(resource?: Resource): EnvironmentPath;
         /**

--- a/src/client/api/types.ts
+++ b/src/client/api/types.ts
@@ -43,8 +43,8 @@ export interface PythonExtension {
          * scenario.
          *
          * If `undefined`, then the API returns what ever is set for the workspace. For multi-root workspace, this
-         * ignores all environments within the workspace folder, and returns configured environment at workspace
-         * level.
+         * returns configured environment at workspace level. Configurations at the workspace folder level are
+         * ignored.
          */
         getActiveEnvironmentPath(resource?: Resource): EnvironmentPath;
         /**

--- a/src/client/interpreter/autoSelection/index.ts
+++ b/src/client/interpreter/autoSelection/index.ts
@@ -3,6 +3,7 @@
 
 'use strict';
 
+import * as path from 'path';
 import { inject, injectable } from 'inversify';
 import { Event, EventEmitter, Uri } from 'vscode';
 import { IWorkspaceService } from '../../common/application/types';
@@ -115,7 +116,7 @@ export class InterpreterAutoSelectionService implements IInterpreterAutoSelectio
         if (workspaceFileState && workspaceFile) {
             // Choose environments immediately under the workspace file directory, but make sure they do not belong to any workspace folder.
             const workspaceInterpreters = interpreters.filter(
-                (item) => !item.workspaceFolder && isParentPath(item.path, workspaceFile.fsPath),
+                (item) => !item.workspaceFolder && isParentPath(item.path, path.dirname(workspaceFile.fsPath)),
             );
             const recommendedInterpreter = this.envTypeComparer.getRecommended(workspaceInterpreters, undefined);
             if (recommendedInterpreter) {

--- a/src/client/interpreter/autoSelection/proxy.ts
+++ b/src/client/interpreter/autoSelection/proxy.ts
@@ -32,6 +32,10 @@ export class InterpreterAutoSelectionProxyService implements IInterpreterAutoSel
         return this.instance ? this.instance.getAutoSelectedInterpreter(resource) : undefined;
     }
 
+    public getAutoSelectedInterpreterForWorkspaceFile(): PythonEnvironment | undefined {
+        return this.instance ? this.instance.getAutoSelectedInterpreterForWorkspaceFile() : undefined;
+    }
+
     public async setWorkspaceInterpreter(resource: Uri, interpreter: PythonEnvironment | undefined): Promise<void> {
         return this.instance ? this.instance.setWorkspaceInterpreter(resource, interpreter) : undefined;
     }

--- a/src/client/interpreter/autoSelection/types.ts
+++ b/src/client/interpreter/autoSelection/types.ts
@@ -23,6 +23,7 @@ export interface IInterpreterAutoSelectionProxyService {
     getAutoSelectedInterpreter(resource: Resource): PythonEnvironment | undefined;
     registerInstance?(instance: IInterpreterAutoSelectionProxyService): void;
     setWorkspaceInterpreter(resource: Uri, interpreter: PythonEnvironment | undefined): Promise<void>;
+    getAutoSelectedInterpreterForWorkspaceFile(): PythonEnvironment | undefined;
 }
 
 export const IInterpreterAutoSelectionService = Symbol('IInterpreterAutoSelectionService');
@@ -30,6 +31,7 @@ export interface IInterpreterAutoSelectionService extends IInterpreterAutoSelect
     readonly onDidChangeAutoSelectedInterpreter: Event<void>;
     autoSelectInterpreter(resource: Resource): Promise<void>;
     getAutoSelectedInterpreter(resource: Resource): PythonEnvironment | undefined;
+    getAutoSelectedInterpreterForWorkspaceFile(): PythonEnvironment | undefined;
     setGlobalInterpreter(interpreter: PythonEnvironment | undefined): Promise<void>;
 }
 

--- a/src/client/interpreter/helpers.ts
+++ b/src/client/interpreter/helpers.ts
@@ -4,7 +4,6 @@ import { IDocumentManager, IWorkspaceService } from '../common/application/types
 import { FileSystemPaths } from '../common/platform/fs-paths';
 import { Resource } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
-import { PythonEnvSource } from '../pythonEnvironments/base/info';
 import { compareSemVerLikeVersions } from '../pythonEnvironments/base/info/pythonVersion';
 import { EnvironmentType, getEnvironmentTypeName, PythonEnvironment } from '../pythonEnvironments/info';
 import { IComponentAdapter, IInterpreterHelper, WorkspacePythonPath } from './contracts';
@@ -66,13 +65,6 @@ export class InterpreterHelper implements IInterpreterHelper {
 
     public async getInterpreterInformation(pythonPath: string): Promise<undefined | Partial<PythonEnvironment>> {
         return this.pyenvs.getInterpreterInformation(pythonPath);
-    }
-
-    public async getInterpreters({ resource, source }: { resource?: Uri; source?: PythonEnvSource[] } = {}): Promise<
-        PythonEnvironment[]
-    > {
-        const interpreters = await this.pyenvs.getInterpreters(resource, source);
-        return sortInterpreters(interpreters);
     }
 
     public async getInterpreterPath(pythonPath: string): Promise<string> {

--- a/src/client/pythonEnvironments/index.ts
+++ b/src/client/pythonEnvironments/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { Uri } from 'vscode';
 import { cloneDeep } from 'lodash';
@@ -142,6 +143,10 @@ function createNonWorkspaceLocators(ext: ExtensionState): ILocator<BasicEnvInfo>
         new GlobalVirtualEnvironmentLocator(),
         new CustomVirtualEnvironmentLocator(),
     );
+
+    if (vscode.workspace.workspaceFile) {
+        locators.push(new WorkspaceVirtualEnvironmentLocator(path.dirname(vscode.workspace.workspaceFile.fsPath), 1));
+    }
 
     if (getOSType() === OSType.Windows) {
         locators.push(

--- a/src/client/pythonEnvironments/info/index.ts
+++ b/src/client/pythonEnvironments/info/index.ts
@@ -53,7 +53,7 @@ export enum ModuleInstallerType {
  * @prop sysVersion - the raw value of `sys.version`
  * @prop architecture - of the host CPU (e.g. `x86`)
  * @prop sysPrefix - the environment's install root (`sys.prefix`)
- * @prop pipEnvWorkspaceFolder - the pipenv root, if applicable
+ * @prop workspaceFolder - the workspaceFolder root, if applicable
  */
 export type InterpreterInformation = {
     path: string;
@@ -61,7 +61,7 @@ export type InterpreterInformation = {
     sysVersion?: string;
     architecture: Architecture;
     sysPrefix: string;
-    pipEnvWorkspaceFolder?: string;
+    workspaceFolder?: string;
 };
 
 /**

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -76,6 +76,7 @@ function convertEnvInfo(info: PythonEnvInfo): PythonEnvironment {
     env.displayName = info.display;
     env.detailedDisplayName = info.detailedDisplayName;
     env.type = info.type;
+    env.workspaceFolder = info.searchLocation?.fsPath;
     // We do not worry about using distro.defaultDisplayName.
 
     return env;

--- a/src/test/extensionSettings.ts
+++ b/src/test/extensionSettings.ts
@@ -29,6 +29,10 @@ export function getExtensionSettings(resource: Uri | undefined): IPythonSettings
             return undefined;
         }
 
+        public getAutoSelectedInterpreterForWorkspaceFile(): PythonEnvironment | undefined {
+            return undefined;
+        }
+
         public async setWorkspaceInterpreter(
             _resource: Uri,
             _interpreter: PythonEnvironment | undefined,

--- a/src/test/interpreters/autoSelection/proxy.unit.test.ts
+++ b/src/test/interpreters/autoSelection/proxy.unit.test.ts
@@ -25,6 +25,11 @@ suite('Interpreters - Auto Selection Proxy', () => {
         }
 
         // eslint-disable-next-line class-methods-use-this
+        public getAutoSelectedInterpreterForWorkspaceFile(): PythonEnvironment | undefined {
+            return undefined;
+        }
+
+        // eslint-disable-next-line class-methods-use-this
         public async setWorkspaceInterpreter(): Promise<void> {
             return Promise.resolve();
         }

--- a/src/test/mocks/autoSelector.ts
+++ b/src/test/mocks/autoSelector.ts
@@ -38,6 +38,11 @@ export class MockAutoSelectionService
         return undefined;
     }
 
+    // eslint-disable-next-line class-methods-use-this
+    public getAutoSelectedInterpreterForWorkspaceFile(): PythonEnvironment | undefined {
+        return undefined;
+    }
+
     // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-empty-function
     public registerInstance(_instance: IInterpreterAutoSelectionProxyService): void {}
 }


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/21818 closes https://github.com/microsoft/vscode-python/issues/21256