### PR TITLE
Show `Python: Clear Workspace interpreter` command regardless of whether a Python file is opened

### DIFF
--- a/package.json
+++ b/package.json
@@ -1787,7 +1787,7 @@
                     "category": "Python",
                     "command": "python.clearWorkspaceInterpreter",
                     "title": "%python.command.python.clearWorkspaceInterpreter.title%",
-                    "when": "!virtualWorkspace && shellExecutionSupported && editorLangId == python"
+                    "when": "!virtualWorkspace && shellExecutionSupported"
                 },
                 {
                     "category": "Python",


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/21850