### PR TITLE
Do not filter using scheme when filtering environments

### DIFF
--- a/src/client/common/utils/misc.ts
+++ b/src/client/common/utils/misc.ts
@@ -60,7 +60,7 @@ function isUri(resource?: Uri | any): resource is Uri {
 /**
  * Create a filter func that determine if the given URI and candidate match.
  *
- * The scheme must match, as well as path.
+ * Only compares path.
  *
  * @param checkParent - if `true`, match if the candidate is rooted under `uri`
  * or if the candidate matches `uri` exactly.

--- a/src/client/common/utils/misc.ts
+++ b/src/client/common/utils/misc.ts
@@ -80,9 +80,8 @@ export function getURIFilter(
     }
     const uriRoot = `${uriPath}/`;
     function filter(candidate: Uri): boolean {
-        if (candidate.scheme !== uri.scheme) {
-            return false;
-        }
+        // Do not compare schemes as it is sometimes not available, in
+        // which case file is assumed as scheme.
         let candidatePath = candidate.path;
         while (candidatePath.endsWith('/')) {
             candidatePath = candidatePath.slice(0, -1);

--- a/src/client/pythonEnvironments/base/info/env.ts
+++ b/src/client/pythonEnvironments/base/info/env.ts
@@ -87,7 +87,13 @@ export function areEnvsDeepEqual(env1: PythonEnvInfo, env2: PythonEnvInfo): bool
     env2Clone.source = env2Clone.source.sort();
     const searchLocation1 = env1.searchLocation?.fsPath ?? '';
     const searchLocation2 = env2.searchLocation?.fsPath ?? '';
-    return isEqual(env1Clone, env2Clone) && arePathsSame(searchLocation1, searchLocation2);
+    const searchLocation1Scheme = env1.searchLocation?.scheme ?? '';
+    const searchLocation2Scheme = env2.searchLocation?.scheme ?? '';
+    return (
+        isEqual(env1Clone, env2Clone) &&
+        arePathsSame(searchLocation1, searchLocation2) &&
+        searchLocation1Scheme === searchLocation2Scheme
+    );
 }
 
 /**


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/21825

On codespaces, it was leading to workspace environments not being displayed, which could mess up auto-selection.