### PR TITLE
Set PS1 for conda environments in non-Windows when in `pythonTerminalEnvVarActivation` experiment

### DIFF
--- a/src/test/interpreters/activation/terminalEnvVarCollectionService.unit.test.ts
+++ b/src/test/interpreters/activation/terminalEnvVarCollectionService.unit.test.ts
@@ -321,7 +321,7 @@ suite('Terminal Environment Variable Collection Service', () => {
         expect(result).to.equal(false);
     });
 
-    test('Correct track that prompt was not set for non-Windows where PS1 is not set', async () => {
+    test('Correct track that prompt was set for non-Windows where PS1 is not set but should be set', async () => {
         when(platform.osType).thenReturn(OSType.Linux);
         const envVars: NodeJS.ProcessEnv = { CONDA_PREFIX: 'prefix/to/conda', ...process.env };
         const ps1Shell = 'zsh';
@@ -333,6 +333,36 @@ suite('Terminal Environment Variable Collection Service', () => {
         };
         when(interpreterService.getActiveInterpreter(resource)).thenResolve(({
             type: PythonEnvType.Conda,
+            envName: 'envName',
+            envPath: 'prefix/to/conda',
+        } as unknown) as PythonEnvironment);
+        when(workspaceService.getWorkspaceFolder(resource)).thenReturn(workspaceFolder);
+        when(
+            environmentActivationService.getActivatedEnvironmentVariables(resource, undefined, undefined, ps1Shell),
+        ).thenResolve(envVars);
+        when(collection.replace(anything(), anything(), anything())).thenReturn();
+
+        await terminalEnvVarCollectionService._applyCollection(resource, ps1Shell);
+
+        const result = terminalEnvVarCollectionService.isTerminalPromptSetCorrectly(resource);
+
+        expect(result).to.equal(true);
+    });
+
+    test('Correct track that prompt was not set for non-Windows fish where PS1 is not set', async () => {
+        when(platform.osType).thenReturn(OSType.Linux);
+        const envVars: NodeJS.ProcessEnv = { CONDA_PREFIX: 'prefix/to/conda', ...process.env };
+        const ps1Shell = 'fish';
+        const resource = Uri.file('a');
+        const workspaceFolder: WorkspaceFolder = {
+            uri: Uri.file('workspacePath'),
+            name: 'workspace1',
+            index: 0,
+        };
+        when(interpreterService.getActiveInterpreter(resource)).thenResolve(({
+            type: PythonEnvType.Conda,
+            envName: 'envName',
+            envPath: 'prefix/to/conda',
         } as unknown) as PythonEnvironment);
         when(workspaceService.getWorkspaceFolder(resource)).thenReturn(workspaceFolder);
         when(

--- a/src/test/interpreters/activation/terminalEnvVarCollectionService.unit.test.ts
+++ b/src/test/interpreters/activation/terminalEnvVarCollectionService.unit.test.ts
@@ -321,32 +321,6 @@ suite('Terminal Environment Variable Collection Service', () => {
         expect(result).to.equal(false);
     });
 
-    test('Correct track that prompt was not set for non-Windows zsh where PS1 is set', async () => {
-        when(platform.osType).thenReturn(OSType.Linux);
-        const envVars: NodeJS.ProcessEnv = { VIRTUAL_ENV: 'prefix/to/venv', PS1: '(.venv)', ...process.env };
-        const ps1Shell = 'zsh';
-        const resource = Uri.file('a');
-        const workspaceFolder: WorkspaceFolder = {
-            uri: Uri.file('workspacePath'),
-            name: 'workspace1',
-            index: 0,
-        };
-        when(interpreterService.getActiveInterpreter(resource)).thenResolve(({
-            type: PythonEnvType.Virtual,
-        } as unknown) as PythonEnvironment);
-        when(workspaceService.getWorkspaceFolder(resource)).thenReturn(workspaceFolder);
-        when(
-            environmentActivationService.getActivatedEnvironmentVariables(resource, undefined, undefined, ps1Shell),
-        ).thenResolve(envVars);
-        when(collection.replace(anything(), anything(), anything())).thenReturn();
-
-        await terminalEnvVarCollectionService._applyCollection(resource, ps1Shell);
-
-        const result = terminalEnvVarCollectionService.isTerminalPromptSetCorrectly(resource);
-
-        expect(result).to.equal(false);
-    });
-
     test('Correct track that prompt was not set for non-Windows where PS1 is not set', async () => {
         when(platform.osType).thenReturn(OSType.Linux);
         const envVars: NodeJS.ProcessEnv = { CONDA_PREFIX: 'prefix/to/conda', ...process.env };


### PR DESCRIPTION
For #20822 

![image](https://github.com/microsoft/vscode-python/assets/13199757/8c9d4c87-54f2-4661-b6c6-c3b49ee3ff7a)