### PR TITLE
Prefer prepending to PATH instead of replacing it

### DIFF
--- a/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
@@ -167,7 +167,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
             if (shouldSkip(key)) {
                 return;
             }
-            const value = env[key];
+            let value = env[key];
             const prevValue = processEnv[key];
             if (prevValue !== value) {
                 if (value !== undefined) {
@@ -179,6 +179,20 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
                             applyAtProcessCreation: false,
                         });
                         return;
+                    }
+                    if (key === 'PATH') {
+                        if (processEnv.PATH && env.PATH?.endsWith(processEnv.PATH)) {
+                            // Prefer prepending to PATH instead of replacing it, as we do not want to replace any
+                            // changes to PATH users might have made it in their init scripts (~/.bashrc etc.)
+                            const prependedPart = env.PATH.slice(0, -processEnv.PATH.length);
+                            value = prependedPart;
+                            traceVerbose(`Prepending environment variable ${key} in collection with ${value}`);
+                            envVarCollection.prepend(key, value, {
+                                applyAtShellIntegration: true,
+                                applyAtProcessCreation: true,
+                            });
+                            return;
+                        }
                     }
                     traceVerbose(`Setting environment variable ${key} in collection to ${value}`);
                     envVarCollection.replace(key, value, {

--- a/src/test/interpreters/activation/terminalEnvVarCollectionService.unit.test.ts
+++ b/src/test/interpreters/activation/terminalEnvVarCollectionService.unit.test.ts
@@ -216,6 +216,38 @@ suite('Terminal Environment Variable Collection Service', () => {
         assert.deepEqual(opts, { applyAtProcessCreation: false, applyAtShellIntegration: true });
     });
 
+    test('Prepend PATH instead of replacing it, where possible', async () => {
+        const processEnv = { PATH: 'hello/1/2/3' };
+        reset(environmentActivationService);
+        when(environmentActivationService.getProcessEnvironmentVariables(anything(), anything())).thenResolve(
+            processEnv,
+        );
+        const prependedPart = 'path/to/activate/dir:';
+        const envVars: NodeJS.ProcessEnv = { PATH: `${prependedPart}${processEnv.PATH}` };
+        when(
+            environmentActivationService.getActivatedEnvironmentVariables(
+                anything(),
+                undefined,
+                undefined,
+                customShell,
+            ),
+        ).thenResolve(envVars);
+
+        when(collection.replace(anything(), anything(), anything())).thenResolve();
+        when(collection.delete(anything())).thenResolve();
+        let opts: EnvironmentVariableMutatorOptions | undefined;
+        when(collection.prepend('PATH', anything(), anything())).thenCall((_, _v, o) => {
+            opts = o;
+        });
+
+        await terminalEnvVarCollectionService._applyCollection(undefined, customShell);
+
+        verify(collection.clear()).once();
+        verify(collection.prepend('PATH', prependedPart, anything())).once();
+        verify(collection.replace('PATH', anything(), anything())).never();
+        assert.deepEqual(opts, { applyAtProcessCreation: true, applyAtShellIntegration: true });
+    });
+
     test('Verify envs are not applied if env activation is disabled', async () => {
         const envVars: NodeJS.ProcessEnv = { CONDA_PREFIX: 'prefix/to/conda', ...process.env };
         when(


### PR DESCRIPTION
For #20822 

For eg. pyenv asks their users to manipulate `PATH` in their init script: https://github.com/pyenv/pyenv#set-up-your-shell-environment-for-pyenv, which we could end up replacing.

![image](https://github.com/microsoft/vscode-python/assets/13199757/cc904f76-8d42-47e1-a6c8-6cfff6543db8)

Particularly for pyenv, it mean users not being able to find pyenv:

![image](https://github.com/microsoft/vscode-python/assets/13199757/26100328-c227-435b-a4f2-ec168099f4c1)

We may still run into stuff like this for conda, but this atleast solves it for venv:

![image](https://github.com/microsoft/vscode-python/assets/13199757/a95e4ffd-68dc-4e73-905e-504b3051324f)
