### PR TITLE
Remove unneeded print statements on successful post

### DIFF
--- a/pythonFiles/testing_tools/socket_manager.py
+++ b/pythonFiles/testing_tools/socket_manager.py
@@ -23,6 +23,12 @@ class SocketManager(object):
         self.socket = None
 
     def __enter__(self):
+        return self.connect()
+
+    def __exit__(self, *_):
+        self.close()
+
+    def connect(self):
         self.socket = socket.socket(
             socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP
         )
@@ -35,7 +41,7 @@ class SocketManager(object):
 
         return self
 
-    def __exit__(self, *_):
+    def close(self):
         if self.socket:
             try:
                 self.socket.shutdown(socket.SHUT_RDWR)

--- a/pythonFiles/unittestadapter/execution.py
+++ b/pythonFiles/unittestadapter/execution.py
@@ -225,8 +225,10 @@ def run_tests(
 
     return payload
 
+
 __socket = None
 atexit.register(lambda: __socket.close() if __socket else None)
+
 
 def send_run_data(raw_data, port, uuid):
     # Build the request data (it has to be a POST request or the Node side will not process it), and send it.
@@ -256,7 +258,7 @@ Request-uuid: {uuid}
 
 {data}"""
     try:
-        if __socket.socket is not None:
+        if __socket is not None and __socket.socket is not None:
             __socket.socket.sendall(request.encode("utf-8"))
     except Exception as ex:
         print(f"Error sending response: {ex}")

--- a/pythonFiles/unittestadapter/execution.py
+++ b/pythonFiles/unittestadapter/execution.py
@@ -256,9 +256,8 @@ Request-uuid: {uuid}
 
 {data}"""
     try:
-        with socket_manager.SocketManager(addr) as s:
-            if __socket.socket is not None:
-                __socket.socket.sendall(request.encode("utf-8"))
+        if __socket.socket is not None:
+            __socket.socket.sendall(request.encode("utf-8"))
     except Exception as ex:
         print(f"Error sending response: {ex}")
         print(f"Request data: {request}")

--- a/pythonFiles/vscode_pytest/__init__.py
+++ b/pythonFiles/vscode_pytest/__init__.py
@@ -627,6 +627,7 @@ def execution_post(
     session_node -- the status of running the tests
     tests -- the tests that were run and their status.
     """
+    print("sending execution post!")
     testPort = os.getenv("TEST_PORT", 45454)
     testuuid = os.getenv("TEST_UUID")
     addr = ("localhost", int(testPort))

--- a/pythonFiles/vscode_pytest/__init__.py
+++ b/pythonFiles/vscode_pytest/__init__.py
@@ -610,8 +610,10 @@ class ExecutionPayloadDict(Dict):
 def get_node_path(node: Any) -> pathlib.Path:
     return getattr(node, "path", pathlib.Path(node.fspath))
 
+
 __socket = None
 atexit.register(lambda: __socket.close() if __socket else None)
+
 
 def execution_post(
     cwd: str,
@@ -648,7 +650,7 @@ Request-uuid: {testuuid}
 
 {data}"""
     try:
-        if __socket.socket is not None:
+        if __socket is not None and __socket.socket is not None:
             __socket.socket.sendall(request.encode("utf-8"))
         else:
             print(f"Plugin error connection error[vscode-pytest]")

--- a/pythonFiles/vscode_pytest/__init__.py
+++ b/pythonFiles/vscode_pytest/__init__.py
@@ -306,12 +306,12 @@ def pytest_sessionfinish(session, exitstatus):
     4: Pytest encountered an internal error or exception during test execution.
     5: Pytest was unable to find any tests to run.
     """
-    print(
-        "pytest session has finished, exit status: ",
-        exitstatus,
-        "in discovery? ",
-        IS_DISCOVERY,
-    )
+    # print(
+    #     "pytest session has finished, exit status: ",
+    #     exitstatus,
+    #     "in discovery? ",
+    #     IS_DISCOVERY,
+    # )
     cwd = pathlib.Path.cwd()
     if IS_DISCOVERY:
         if not (exitstatus == 0 or exitstatus == 1 or exitstatus == 5):
@@ -628,7 +628,7 @@ def execution_post(
     session_node -- the status of running the tests
     tests -- the tests that were run and their status.
     """
-    print("sending execution post!", tests)
+    # print("sending execution post!", tests)
     testPort = os.getenv("TEST_PORT", 45454)
     testuuid = os.getenv("TEST_UUID")
     addr = ("localhost", int(testPort))
@@ -660,6 +660,7 @@ Request-uuid: {testuuid}
             if __socket is not None and __socket.socket is not None:
                 __socket.socket.sendall(request.encode("utf-8"))
                 print("Execution post sent successfully!")
+                print("data sent", tests, "end of data")
                 break  # Exit the loop if the send was successful
             else:
                 print("Plugin error connection error[vscode-pytest]")
@@ -674,15 +675,15 @@ Request-uuid: {testuuid}
             else:
                 print("Maximum retry attempts reached. Cannot send execution post.")
 
-    try:
-        if __socket is not None and __socket.socket is not None:
-            __socket.socket.sendall(request.encode("utf-8"))
-        else:
-            print("Plugin error connection error[vscode-pytest]")
-            print(f"[vscode-pytest] data: {request}")
-    except Exception as e:
-        print(f"Plugin error connection error[vscode-pytest]: {e}")
-        print(f"[vscode-pytest] data: {request}")
+    # try:
+    #     if __socket is not None and __socket.socket is not None:
+    #         __socket.socket.sendall(request.encode("utf-8"))
+    #     else:
+    #         print("Plugin error connection error[vscode-pytest]")
+    #         print(f"[vscode-pytest] data: {request}")
+    # except Exception as e:
+    #     print(f"Plugin error connection error[vscode-pytest]: {e}")
+    #     print(f"[vscode-pytest] data: {request}")
 
 
 class PathEncoder(json.JSONEncoder):

--- a/pythonFiles/vscode_pytest/__init__.py
+++ b/pythonFiles/vscode_pytest/__init__.py
@@ -632,6 +632,7 @@ def execution_post(
     testuuid = os.getenv("TEST_UUID")
     addr = ("localhost", int(testPort))
     global __socket
+
     if __socket is None:
         try:
             __socket = socket_manager.SocketManager(addr)
@@ -650,6 +651,28 @@ Content-Type: application/json
 Request-uuid: {testuuid}
 
 {data}"""
+
+    max_retries = 3
+    retries = 0
+    while retries < max_retries:
+        try:
+            if __socket is not None and __socket.socket is not None:
+                __socket.socket.sendall(request.encode("utf-8"))
+                print("Execution post sent successfully!")
+                break  # Exit the loop if the send was successful
+            else:
+                print("Plugin error connection error[vscode-pytest]")
+                print(f"[vscode-pytest] data: {request}")
+        except Exception as e:
+            print(f"Plugin error connection error[vscode-pytest]: {e}")
+            print(f"[vscode-pytest] data: {request}")
+            retries += 1  # Increment retry counter
+            if retries < max_retries:
+                print(f"Retrying ({retries}/{max_retries}) in 2 seconds...")
+                time.sleep(2)  # Wait for a short duration before retrying
+            else:
+                print("Maximum retry attempts reached. Cannot send execution post.")
+
     try:
         if __socket is not None and __socket.socket is not None:
             __socket.socket.sendall(request.encode("utf-8"))

--- a/pythonFiles/vscode_pytest/__init__.py
+++ b/pythonFiles/vscode_pytest/__init__.py
@@ -653,7 +653,7 @@ Request-uuid: {testuuid}
         if __socket is not None and __socket.socket is not None:
             __socket.socket.sendall(request.encode("utf-8"))
         else:
-            print(f"Plugin error connection error[vscode-pytest]")
+            print("Plugin error connection error[vscode-pytest]")
             print(f"[vscode-pytest] data: {request}")
     except Exception as e:
         print(f"Plugin error connection error[vscode-pytest]: {e}")

--- a/pythonFiles/vscode_pytest/__init__.py
+++ b/pythonFiles/vscode_pytest/__init__.py
@@ -6,6 +6,7 @@ import json
 import os
 import pathlib
 import sys
+import time
 import traceback
 
 import pytest

--- a/pythonFiles/vscode_pytest/__init__.py
+++ b/pythonFiles/vscode_pytest/__init__.py
@@ -306,12 +306,6 @@ def pytest_sessionfinish(session, exitstatus):
     4: Pytest encountered an internal error or exception during test execution.
     5: Pytest was unable to find any tests to run.
     """
-    # print(
-    #     "pytest session has finished, exit status: ",
-    #     exitstatus,
-    #     "in discovery? ",
-    #     IS_DISCOVERY,
-    # )
     cwd = pathlib.Path.cwd()
     if IS_DISCOVERY:
         if not (exitstatus == 0 or exitstatus == 1 or exitstatus == 5):
@@ -628,7 +622,6 @@ def execution_post(
     session_node -- the status of running the tests
     tests -- the tests that were run and their status.
     """
-    # print("sending execution post!", tests)
     testPort = os.getenv("TEST_PORT", 45454)
     testuuid = os.getenv("TEST_UUID")
     addr = ("localhost", int(testPort))
@@ -659,8 +652,6 @@ Request-uuid: {testuuid}
         try:
             if __socket is not None and __socket.socket is not None:
                 __socket.socket.sendall(request.encode("utf-8"))
-                print("Execution post sent successfully!")
-                print("data sent", tests, "end of data")
                 break  # Exit the loop if the send was successful
             else:
                 print("Plugin error connection error[vscode-pytest]")
@@ -674,16 +665,6 @@ Request-uuid: {testuuid}
                 time.sleep(2)  # Wait for a short duration before retrying
             else:
                 print("Maximum retry attempts reached. Cannot send execution post.")
-
-    # try:
-    #     if __socket is not None and __socket.socket is not None:
-    #         __socket.socket.sendall(request.encode("utf-8"))
-    #     else:
-    #         print("Plugin error connection error[vscode-pytest]")
-    #         print(f"[vscode-pytest] data: {request}")
-    # except Exception as e:
-    #     print(f"Plugin error connection error[vscode-pytest]: {e}")
-    #     print(f"[vscode-pytest] data: {request}")
 
 
 class PathEncoder(json.JSONEncoder):

--- a/pythonFiles/vscode_pytest/__init__.py
+++ b/pythonFiles/vscode_pytest/__init__.py
@@ -627,7 +627,7 @@ def execution_post(
     session_node -- the status of running the tests
     tests -- the tests that were run and their status.
     """
-    print("sending execution post!")
+    print("sending execution post!", tests)
     testPort = os.getenv("TEST_PORT", 45454)
     testuuid = os.getenv("TEST_UUID")
     addr = ("localhost", int(testPort))

--- a/src/client/testing/testController/common/server.ts
+++ b/src/client/testing/testController/common/server.ts
@@ -15,7 +15,7 @@ import { traceError, traceInfo, traceLog } from '../../../logging';
 import { DataReceivedEvent, ITestServer, TestCommandOptions } from './types';
 import { ITestDebugLauncher, LaunchOptions } from '../../common/types';
 import { UNITTEST_PROVIDER } from '../../common/constants';
-import { jsonRPCHeaders, jsonRPCContent, JSONRPC_UUID_HEADER } from './utils';
+import { containsHeaders, extractJsonPayload } from './utils';
 import { createDeferred } from '../../../common/utils/async';
 
 export class PythonTestServer implements ITestServer, Disposable {
@@ -37,55 +37,33 @@ export class PythonTestServer implements ITestServer, Disposable {
             socket.on('data', (data: Buffer) => {
                 try {
                     console.log('\n&&&& raw Data: ', data.toString(), '&&&& \n');
-                    let rawData: string = data.toString();
                     buffer = Buffer.concat([buffer, data]);
                     while (buffer.length > 0) {
-                        const rpcHeaders = jsonRPCHeaders(buffer.toString());
-                        const uuid = rpcHeaders.headers.get(JSONRPC_UUID_HEADER);
-                        const totalContentLength = rpcHeaders.headers.get('Content-Length');
-                        if (!uuid) {
-                            traceError('On data received: Error occurred because payload UUID is undefined');
-                            this._onDataReceived.fire({ uuid: '', data: '' });
-                            return;
-                        }
-                        if (!this.uuids.includes(uuid)) {
-                            traceError('On data received: Error occurred because the payload UUID is not recognized');
-                            this._onDataReceived.fire({ uuid: '', data: '' });
-                            return;
-                        }
-                        rawData = rpcHeaders.remainingRawData;
-                        const rpcContent = jsonRPCContent(rpcHeaders.headers, rawData);
-                        const extractedData = rpcContent.extractedJSON;
-                        // do not send until we have the full content
-                        if (extractedData.length === Number(totalContentLength)) {
-                            // if the rawData includes tests then this is a discovery request
-                            if (rawData.includes(`"tests":`)) {
-                                this._onDiscoveryDataReceived.fire({
-                                    uuid,
-                                    data: rpcContent.extractedJSON,
-                                });
-                                // if the rawData includes result then this is a run request
-                            } else if (rawData.includes(`"result":`)) {
-                                console.log(
-                                    '\n *** fire run data received: \n',
-                                    rpcContent.extractedJSON,
-                                    '\n *** end',
-                                );
-                                this._onRunDataReceived.fire({
-                                    uuid,
-                                    data: rpcContent.extractedJSON,
-                                });
-                            } else {
-                                traceLog(
-                                    `Error processing test server request: request is not recognized as discovery or run.`,
-                                );
-                                this._onDataReceived.fire({ uuid: '', data: '' });
-                                return;
+                        try {
+                            const extractedJsonPayload = extractJsonPayload(buffer.toString(), this.uuids);
+                            if (
+                                extractedJsonPayload.uuid !== undefined &&
+                                extractedJsonPayload.cleanedJsonData !== undefined
+                            ) {
+                                // if a full json was found in the buffer, fire the data received event then keep cycling with the remaining raw data.
+                                this._fireDataReceived(extractedJsonPayload.uuid, extractedJsonPayload.cleanedJsonData);
                             }
-                            // this.uuids = this.uuids.filter((u) => u !== uuid); WHERE DOES THIS GO??
-                            buffer = Buffer.alloc(0);
-                        } else {
-                            break;
+                            buffer = Buffer.from(extractedJsonPayload.remainingRawData);
+                            if (!containsHeaders(extractedJsonPayload.remainingRawData)) {
+                                // if the remaining data does not contain headers, then there is no more data to process.
+                                // break to get more data from the socket.
+                                break;
+                            }
+                            if (buffer.length === 0) {
+                                // if the buffer is empty, then there is no more data to process.
+                                // break to get more data from the socket.
+                                buffer = Buffer.alloc(0);
+                                break;
+                            }
+                        } catch (ex) {
+                            traceError(`Error:: ${ex}`);
+                            this._onDataReceived.fire({ uuid: '', data: '' });
+                            return;
                         }
                     }
                 } catch (ex) {
@@ -111,6 +89,25 @@ export class PythonTestServer implements ITestServer, Disposable {
         this.server.on('connection', () => {
             traceLog('Test server connected to a client.');
         });
+    }
+
+    private _fireDataReceived(uuid: string, extractedJSON: string): void {
+        if (extractedJSON.includes(`"tests":`)) {
+            this._onDiscoveryDataReceived.fire({
+                uuid,
+                data: extractedJSON,
+            });
+            // if the rawData includes result then this is a run request
+        } else if (extractedJSON.includes(`"result":`)) {
+            console.log('\n *** fire run data received: \n', extractedJSON, '\n *** end');
+            this._onRunDataReceived.fire({
+                uuid,
+                data: extractedJSON,
+            });
+        } else {
+            traceLog(`Error processing test server request: request is not recognized as discovery or run.`);
+            this._onDataReceived.fire({ uuid: '', data: '' });
+        }
     }
 
     public serverReady(): Promise<void> {

--- a/src/client/testing/testController/common/server.ts
+++ b/src/client/testing/testController/common/server.ts
@@ -36,7 +36,7 @@ export class PythonTestServer implements ITestServer, Disposable {
             let buffer: Buffer = Buffer.alloc(0); // Buffer to accumulate received data
             socket.on('data', (data: Buffer) => {
                 try {
-                    console.log('raw Data: ', data.toString());
+                    console.log('\n&&&& raw Data: ', data.toString(), '&&&& \n');
                     let rawData: string = data.toString();
                     buffer = Buffer.concat([buffer, data]);
                     while (buffer.length > 0) {

--- a/src/client/testing/testController/common/server.ts
+++ b/src/client/testing/testController/common/server.ts
@@ -36,6 +36,7 @@ export class PythonTestServer implements ITestServer, Disposable {
             let buffer: Buffer = Buffer.alloc(0); // Buffer to accumulate received data
             socket.on('data', (data: Buffer) => {
                 try {
+                    console.log('raw Data: ', data.toString());
                     let rawData: string = data.toString();
                     buffer = Buffer.concat([buffer, data]);
                     while (buffer.length > 0) {
@@ -65,6 +66,7 @@ export class PythonTestServer implements ITestServer, Disposable {
                                 });
                                 // if the rawData includes result then this is a run request
                             } else if (rawData.includes(`"result":`)) {
+                                console.log('fire run data received');
                                 this._onRunDataReceived.fire({
                                     uuid,
                                     data: rpcContent.extractedJSON,

--- a/src/client/testing/testController/common/server.ts
+++ b/src/client/testing/testController/common/server.ts
@@ -66,7 +66,11 @@ export class PythonTestServer implements ITestServer, Disposable {
                                 });
                                 // if the rawData includes result then this is a run request
                             } else if (rawData.includes(`"result":`)) {
-                                console.log('fire run data received');
+                                console.log(
+                                    '\n *** fire run data received: \n',
+                                    rpcContent.extractedJSON,
+                                    '\n *** end',
+                                );
                                 this._onRunDataReceived.fire({
                                     uuid,
                                     data: rpcContent.extractedJSON,

--- a/src/client/testing/testController/common/utils.ts
+++ b/src/client/testing/testController/common/utils.ts
@@ -15,13 +15,19 @@ export function fixLogLines(content: string): string {
     const lines = content.split(/\r?\n/g);
     return `${lines.join('\r\n')}\r\n`;
 }
-export interface IJSONRPCContent {
+export interface IJSONRPCData {
     extractedJSON: string;
     remainingRawData: string;
 }
 
-export interface IJSONRPCHeaders {
+export interface ParsedRPCHeadersAndData {
     headers: Map<string, string>;
+    remainingRawData: string;
+}
+
+export interface ExtractOutput {
+    uuid: string | undefined;
+    cleanedJsonData: string | undefined;
     remainingRawData: string;
 }
 
@@ -29,7 +35,72 @@ export const JSONRPC_UUID_HEADER = 'Request-uuid';
 export const JSONRPC_CONTENT_LENGTH_HEADER = 'Content-Length';
 export const JSONRPC_CONTENT_TYPE_HEADER = 'Content-Type';
 
-export function jsonRPCHeaders(rawData: string): IJSONRPCHeaders {
+export function extractJsonPayload(rawData: string, uuids: Array<string>): ExtractOutput {
+    /**
+     * Extracts JSON-RPC payload from the provided raw data.
+     * @param {string} rawData - The raw string data from which the JSON payload will be extracted.
+     * @param {Array<string>} uuids - The list of UUIDs that are active.
+     * @returns {string} The remaining raw data after the JSON payload is extracted.
+     */
+
+    const rpcHeaders: ParsedRPCHeadersAndData = parseJsonRPCHeadersAndData(rawData);
+
+    // verify the RPC has a UUID and that it is recognized
+    let uuid = rpcHeaders.headers.get(JSONRPC_UUID_HEADER);
+    uuid = checkUuid(uuid, uuids);
+
+    const payloadLength = rpcHeaders.headers.get('Content-Length');
+
+    // separate out the data within context length of the given payload from the remaining data in the buffer
+    const rpcContent: IJSONRPCData = ExtractJsonRPCData(payloadLength, rpcHeaders.remainingRawData);
+    const cleanedJsonData = rpcContent.extractedJSON;
+    const { remainingRawData } = rpcContent;
+
+    // if the given payload has the complete json, process it otherwise wait for the rest in the buffer
+    if (cleanedJsonData.length === Number(payloadLength)) {
+        // call to process this data
+        // remove this data from the buffer
+        return { uuid, cleanedJsonData, remainingRawData };
+    }
+    // wait for the remaining
+    return { uuid: undefined, cleanedJsonData: undefined, remainingRawData: rawData };
+}
+
+export function containsHeaders(rawData: string): boolean {
+    /**
+     * Checks if the provided raw data contains JSON-RPC specific headers.
+     */
+    return (
+        rawData.includes(JSONRPC_CONTENT_LENGTH_HEADER) &&
+        rawData.includes(JSONRPC_CONTENT_TYPE_HEADER) &&
+        rawData.includes(JSONRPC_UUID_HEADER)
+    );
+}
+
+export function checkUuid(uuid: string | undefined, uuids: Array<string>): string {
+    if (!uuid) {
+        throw new Error('On data received: Error occurred because payload UUID is undefined');
+    }
+    if (!uuids.includes(uuid)) {
+        throw new Error('On data received: Error occurred because the payload UUID is not recognized');
+    }
+    return uuid;
+}
+
+export function parseJsonRPCHeadersAndData(rawData: string): ParsedRPCHeadersAndData {
+    /**
+     * Parses the provided raw data to extract JSON-RPC specific headers and remaining data.
+     *
+     * This function aims to extract specific JSON-RPC headers (like UUID, content length,
+     * and content type) from the provided raw string data. Headers are expected to be
+     * delimited by newlines and the format should be "key:value". The function stops parsing
+     * once it encounters an empty line, and the rest of the data after this line is treated
+     * as the remaining raw data.
+     *
+     * @param {string} rawData - The raw string containing headers and possibly other data.
+     * @returns {ParsedRPCHeadersAndData} An object containing the parsed headers as a map and the
+     * remaining raw data after the headers.
+     */
     const lines = rawData.split('\n');
     let remainingRawData = '';
     const headerMap = new Map<string, string>();
@@ -51,8 +122,21 @@ export function jsonRPCHeaders(rawData: string): IJSONRPCHeaders {
     };
 }
 
-export function jsonRPCContent(headers: Map<string, string>, rawData: string): IJSONRPCContent {
-    const length = parseInt(headers.get('Content-Length') ?? '0', 10);
+export function ExtractJsonRPCData(payloadLength: string | undefined, rawData: string): IJSONRPCData {
+    /**
+     * Extracts JSON-RPC content based on provided headers and raw data.
+     *
+     * This function uses the `Content-Length` header from the provided headers map
+     * to determine how much of the rawData string represents the actual JSON content.
+     * After extracting the expected content, it also returns any remaining data
+     * that comes after the extracted content as remaining raw data.
+     *
+     * @param {string | undefined} payloadLength - The value of the `Content-Length` header.
+     * @param {string} rawData - The raw string data from which the JSON content will be extracted.
+     *
+     * @returns {IJSONRPCContent} An object containing the extracted JSON content and any remaining raw data.
+     */
+    const length = parseInt(payloadLength ?? '0', 10);
     const data = rawData.slice(0, length);
     const remainingRawData = rawData.slice(length);
     return {

--- a/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
@@ -176,6 +176,9 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                 });
 
                 result?.proc?.on('exit', () => {
+                    setTimeout(() => {
+                        console.log('exit timeout');
+                    }, 3000);
                     deferredExec.resolve({ stdout: '', stderr: '' });
                     deferred.resolve();
                     disposeDataReceiver?.(this.testServer);

--- a/src/test/testing/common/testingAdapter.test.ts
+++ b/src/test/testing/common/testingAdapter.test.ts
@@ -392,14 +392,11 @@ suite('End to End Tests: test adapters', () => {
 
         // set workspace to test workspace folder
         workspaceUri = Uri.parse(rootPathLargeWorkspace);
-        const parts = rootPathLargeWorkspace.split(path.sep);
-
-        const rootPathLargeWorkspaceAsId = parts.join('/');
 
         // generate list of test_ids
         const testIds: string[] = [];
         for (let i = 0; i < 200; i = i + 1) {
-            const testId = `${rootPathLargeWorkspaceAsId}/test_parameterized_subtest.py::test_odd_even[${i}]`;
+            const testId = `${rootPathLargeWorkspace}/test_parameterized_subtest.py::test_odd_even[${i}]`;
             testIds.push(testId);
         }
 

--- a/src/test/testing/common/testingAdapter.test.ts
+++ b/src/test/testing/common/testingAdapter.test.ts
@@ -25,9 +25,9 @@ suite('End to End Tests: test adapters', () => {
     let pythonExecFactory: IPythonExecutionFactory;
     let debugLauncher: ITestDebugLauncher;
     let configService: IConfigurationService;
-    let testOutputChannel: ITestOutputChannel;
     let serviceContainer: IServiceContainer;
     let workspaceUri: Uri;
+    let testOutputChannel: typeMoq.IMock<ITestOutputChannel>;
     const rootPathSmallWorkspace = path.join(
         EXTENSION_ROOT_DIR_FOR_TESTS,
         'src',
@@ -49,7 +49,6 @@ suite('End to End Tests: test adapters', () => {
         configService = serviceContainer.get<IConfigurationService>(IConfigurationService);
         pythonExecFactory = serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
         debugLauncher = serviceContainer.get<ITestDebugLauncher>(ITestDebugLauncher);
-        testOutputChannel = serviceContainer.get<ITestOutputChannel>(ITestOutputChannel);
 
         // create mock resultResolver object
         resultResolver = typeMoq.Mock.ofType<ITestResultResolver>();
@@ -57,6 +56,24 @@ suite('End to End Tests: test adapters', () => {
         // create objects that were not injected
         pythonTestServer = new PythonTestServer(pythonExecFactory, debugLauncher);
         await pythonTestServer.serverReady();
+
+        testOutputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
+        testOutputChannel
+            .setup((x) => x.append(typeMoq.It.isAny()))
+            .callback((appendVal: any) => {
+                console.log('out - ', appendVal);
+            })
+            .returns(() => {
+                // Whatever you need to return
+            });
+        testOutputChannel
+            .setup((x) => x.appendLine(typeMoq.It.isAny()))
+            .callback((appendVal: any) => {
+                console.log('outL - ', appendVal);
+            })
+            .returns(() => {
+                // Whatever you need to return
+            });
     });
     teardown(async () => {
         pythonTestServer.dispose();
@@ -84,7 +101,7 @@ suite('End to End Tests: test adapters', () => {
         const discoveryAdapter = new UnittestTestDiscoveryAdapter(
             pythonTestServer,
             configService,
-            testOutputChannel,
+            testOutputChannel.object,
             resultResolver.object,
         );
 
@@ -126,7 +143,7 @@ suite('End to End Tests: test adapters', () => {
         const discoveryAdapter = new UnittestTestDiscoveryAdapter(
             pythonTestServer,
             configService,
-            testOutputChannel,
+            testOutputChannel.object,
             resultResolver.object,
         );
 
@@ -163,7 +180,7 @@ suite('End to End Tests: test adapters', () => {
         const discoveryAdapter = new PytestTestDiscoveryAdapter(
             pythonTestServer,
             configService,
-            testOutputChannel,
+            testOutputChannel.object,
             resultResolver.object,
         );
 
@@ -203,7 +220,7 @@ suite('End to End Tests: test adapters', () => {
         const discoveryAdapter = new PytestTestDiscoveryAdapter(
             pythonTestServer,
             configService,
-            testOutputChannel,
+            testOutputChannel.object,
             resultResolver.object,
         );
 
@@ -247,7 +264,7 @@ suite('End to End Tests: test adapters', () => {
         const executionAdapter = new UnittestTestExecutionAdapter(
             pythonTestServer,
             configService,
-            testOutputChannel,
+            testOutputChannel.object,
             resultResolver.object,
         );
         const testRun = typeMoq.Mock.ofType<TestRun>();
@@ -300,7 +317,7 @@ suite('End to End Tests: test adapters', () => {
         const executionAdapter = new UnittestTestExecutionAdapter(
             pythonTestServer,
             configService,
-            testOutputChannel,
+            testOutputChannel.object,
             resultResolver.object,
         );
         const testRun = typeMoq.Mock.ofType<TestRun>();
@@ -354,7 +371,7 @@ suite('End to End Tests: test adapters', () => {
         const executionAdapter = new PytestTestExecutionAdapter(
             pythonTestServer,
             configService,
-            testOutputChannel,
+            testOutputChannel.object,
             resultResolver.object,
         );
         const testRun = typeMoq.Mock.ofType<TestRun>();
@@ -423,7 +440,7 @@ suite('End to End Tests: test adapters', () => {
         const executionAdapter = new PytestTestExecutionAdapter(
             pythonTestServer,
             configService,
-            testOutputChannel,
+            testOutputChannel.object,
             resultResolver.object,
         );
         const testRun = typeMoq.Mock.ofType<TestRun>();

--- a/src/test/testing/common/testingAdapter.test.ts
+++ b/src/test/testing/common/testingAdapter.test.ts
@@ -324,7 +324,7 @@ suite('End to End Tests: test adapters', () => {
                 );
                 resultResolver.verify(
                     (x) => x.resolveExecution(typeMoq.It.isAny(), typeMoq.It.isAny()),
-                    typeMoq.Times.atLeast(2000),
+                    typeMoq.Times.atLeast(200),
                 );
             })
             .finally(() => {
@@ -414,7 +414,7 @@ suite('End to End Tests: test adapters', () => {
 
         // generate list of test_ids
         const testIds: string[] = [];
-        for (let i = 0; i < 2000; i = i + 1) {
+        for (let i = 0; i < 200; i = i + 1) {
             const testId = `${rootPathLargeWorkspace}/test_parameterized_subtest.py::test_odd_even[${i}]`;
             testIds.push(testId);
         }
@@ -436,7 +436,7 @@ suite('End to End Tests: test adapters', () => {
                     } as any),
             );
         await executionAdapter.runTests(workspaceUri, testIds, false, testRun.object, pythonExecFactory).then(() => {
-            // resolve execution should be called 2000 times since there are 2000 tests run.
+            // resolve execution should be called 200 times since there are 200 tests run.
             assert.strictEqual(
                 errorMessages.length,
                 0,
@@ -444,7 +444,7 @@ suite('End to End Tests: test adapters', () => {
             );
             resultResolver.verify(
                 (x) => x.resolveExecution(typeMoq.It.isAny(), typeMoq.It.isAny()),
-                typeMoq.Times.atLeast(2000),
+                typeMoq.Times.atLeast(200),
             );
         });
     });

--- a/src/test/testing/common/testingAdapter.test.ts
+++ b/src/test/testing/common/testingAdapter.test.ts
@@ -61,7 +61,7 @@ suite('End to End Tests: test adapters', () => {
         testOutputChannel
             .setup((x) => x.append(typeMoq.It.isAny()))
             .callback((appendVal: any) => {
-                console.log('out - ', appendVal);
+                console.log('out - ', appendVal.toString());
             })
             .returns(() => {
                 // Whatever you need to return
@@ -69,7 +69,7 @@ suite('End to End Tests: test adapters', () => {
         testOutputChannel
             .setup((x) => x.appendLine(typeMoq.It.isAny()))
             .callback((appendVal: any) => {
-                console.log('outL - ', appendVal);
+                console.log('outL - ', appendVal.toString());
             })
             .returns(() => {
                 // Whatever you need to return

--- a/src/test/testing/common/testingAdapter.test.ts
+++ b/src/test/testing/common/testingAdapter.test.ts
@@ -392,11 +392,14 @@ suite('End to End Tests: test adapters', () => {
 
         // set workspace to test workspace folder
         workspaceUri = Uri.parse(rootPathLargeWorkspace);
+        const parts = rootPathLargeWorkspace.split(path.sep);
+
+        const rootPathLargeWorkspaceAsId = parts.join('/');
 
         // generate list of test_ids
         const testIds: string[] = [];
         for (let i = 0; i < 200; i = i + 1) {
-            const testId = `${rootPathLargeWorkspace}/test_parameterized_subtest.py::test_odd_even[${i}]`;
+            const testId = `${rootPathLargeWorkspaceAsId}/test_parameterized_subtest.py::test_odd_even[${i}]`;
             testIds.push(testId);
         }
 

--- a/src/test/testing/common/testingAdapter.test.ts
+++ b/src/test/testing/common/testingAdapter.test.ts
@@ -314,7 +314,7 @@ suite('End to End Tests: test adapters', () => {
                 // verification after discovery is complete
                 resultResolver.verify(
                     (x) => x.resolveExecution(typeMoq.It.isAny(), typeMoq.It.isAny()),
-                    typeMoq.Times.atLeastOnce(),
+                    typeMoq.Times.atLeast(200),
                 );
             });
     });
@@ -420,7 +420,7 @@ suite('End to End Tests: test adapters', () => {
             // resolve execution should be called 200 times since there are 200 tests run.
             resultResolver.verify(
                 (x) => x.resolveExecution(typeMoq.It.isAny(), typeMoq.It.isAny()),
-                typeMoq.Times.exactly(200),
+                typeMoq.Times.atLeast(200),
             );
         });
     });

--- a/src/test/testing/common/testingAdapter.test.ts
+++ b/src/test/testing/common/testingAdapter.test.ts
@@ -324,7 +324,7 @@ suite('End to End Tests: test adapters', () => {
                 );
                 resultResolver.verify(
                     (x) => x.resolveExecution(typeMoq.It.isAny(), typeMoq.It.isAny()),
-                    typeMoq.Times.atLeast(200),
+                    typeMoq.Times.atLeast(20),
                 );
             })
             .finally(() => {
@@ -414,7 +414,7 @@ suite('End to End Tests: test adapters', () => {
 
         // generate list of test_ids
         const testIds: string[] = [];
-        for (let i = 0; i < 200; i = i + 1) {
+        for (let i = 0; i < 20; i = i + 1) {
             const testId = `${rootPathLargeWorkspace}/test_parameterized_subtest.py::test_odd_even[${i}]`;
             testIds.push(testId);
         }
@@ -436,7 +436,6 @@ suite('End to End Tests: test adapters', () => {
                     } as any),
             );
         await executionAdapter.runTests(workspaceUri, testIds, false, testRun.object, pythonExecFactory).then(() => {
-            // resolve execution should be called 200 times since there are 200 tests run.
             assert.strictEqual(
                 errorMessages.length,
                 0,
@@ -444,7 +443,7 @@ suite('End to End Tests: test adapters', () => {
             );
             resultResolver.verify(
                 (x) => x.resolveExecution(typeMoq.It.isAny(), typeMoq.It.isAny()),
-                typeMoq.Times.atLeast(200),
+                typeMoq.Times.atLeast(20),
             );
         });
     });

--- a/src/test/testing/testController/payloadTestCases.ts
+++ b/src/test/testing/testController/payloadTestCases.ts
@@ -1,0 +1,113 @@
+export interface PayloadChunk {
+    payload: string[];
+    data: string;
+}
+
+export function PAYLOAD_SINGLE_CHUNK(uuid: string): PayloadChunk {
+    const val = `{"cwd": "/home/runner/work/vscode-python/vscode-python/path with spaces/src/testTestingRootWkspc/largeWorkspace", "status": "subtest-success", "result": {"test_parameterized_subtest.NumbersTest.test_even (i=0)": {"test": "test_parameterized_subtest.NumbersTest.test_even", "outcome": "subtest-success", "message": "None", "traceback": null, "subtest": "test_parameterized_subtest.NumbersTest.test_even (i=0)"}}}`;
+    const payload = `Content-Length: 411
+Content-Type: application/json
+Request-uuid: ${uuid}
+
+${val}`;
+    return {
+        payload: [payload],
+        data: val,
+    };
+}
+
+export function PAYLOAD_MULTI_CHUNK(uuid: string): PayloadChunk {
+    const val = `{abc}`;
+    return {
+        payload: [
+            `Content-Length: 5
+Content-Type: application/json
+Request-uuid: ${uuid}
+
+${val}Content-Length: 5
+Content-Type: application/json
+Request-uuid: ${uuid}
+
+${val}Content-Length: 5
+Content-Type: application/json
+Request-uuid: ${uuid}
+
+${val}Content-Length: 5
+Content-Type: application/json
+Request-uuid: ${uuid}
+
+${val}`,
+        ],
+        data: val + val + val + val,
+    };
+}
+
+export function PAYLOAD_SPLIT_ACROSS_CHUNKS_ARRAY(uuid: string): Array<string> {
+    return [
+        `Content-Length: 411
+Content-Type: application/json
+Request-uuid: ${uuid}
+
+{"cwd": "/home/runner/work/vsc`,
+        `ode-python/vscode-python/path with spaces/src/testTestingRootWkspc/largeWorkspace", "status": "subtest-success", "result": {"test_parameterized_subtest.NumbersTest.te`,
+        `st_even (i=0)": {"test": "test_parameterized_subtest.NumbersTest.test_even", "outcome": "subtest-success", "message": "None", "traceback": null, "subtest": "test_parameterized_subtest.NumbersTest.test_even (i=0)"}}}`,
+    ];
+}
+
+export function PAYLOAD_SPLIT_MULTI_CHUNK_ARRAY(uuid: string): Array<string> {
+    return [
+        `Content-Length: 411
+Content-Type: application/json
+Request-uuid: ${uuid}
+
+{"cwd": "/home/runner/work/vscode-python/vscode-python/path with spaces/src/testTestingRootWkspc/largeWorkspace", "status": "subtest-success", "result": {"test_parameterized_subtest.NumbersTest.test_even (i=0)": {"test": "test_parameterized_subtest.NumbersTest.test_even", "outcome": "subtest-success", "message": "None", "traceback": null, "subtest": "test_parameterized_subtest.NumbersTest.test_even (i=0)"}}}
+
+Content-Length: 411
+Content-Type: application/json
+Request-uuid: ${uuid}
+
+{"cwd": "/home/runner/work/vscode-python/vscode-python/path with spaces/src"
+
+Content-Length: 959
+Content-Type: application/json
+Request-uuid: ${uuid}
+
+{"cwd": "/home/runner/work/vscode-python/vscode-python/path with spaces/src/testTestingRootWkspc/largeWorkspace", "status": "subtest-failure", "result": {"test_parameterized_subtest.NumbersTest.test_even (i=1)": {"test": "test_parameterized_subtest.NumbersTest.test_even", "outcome": "subtest-failure", "message": "(<class 'AssertionError'>, AssertionError('1 != 0'), <traceback object at 0x7fd86fc47580>)", "traceback": "  File \"/opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/unittest/case.py\", line 57, in testPartExecutor\n    yield\n  File \"/opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/unittest/case.py\", line 538, in subTest\n    yield\n  File \"/home/runner/work/vscode-python/vscode-python/path with spaces/src/testTestingRootWkspc/largeWorkspace/test_parameterized_subtest.py\", line 16, in test_even\n    self.assertEqual(i % 2, 0)\nAssertionError: 1 != 0\n", "subtest": "test_parameterized_subtest.NumbersTest.test_even (i=1)"}}}
+Content-Length: 411
+Content-Type: application/json
+Request-uuid: ${uuid}
+
+{"cwd": "/home/ru`,
+        `nner/work/vscode-python/vscode-python/path with spaces/src/testTestingRootWkspc/largeWorkspace", "status": "subtest-success", "result": {"test_parameterized_subtest.Numbers`,
+        `Test.test_even (i=2)": {"test": "test_parameterized_subtest.NumbersTest.test_even", "outcome": "subtest-success", "message": "None", "traceback": null, "subtest": "test_parameterized_subtest.NumbersTest.test_even (i=2)"}}}`,
+    ];
+}
+
+export function PAYLOAD_SPLIT_MULTI_CHUNK_RAN_ORDER_ARRAY(uuid: string): Array<string> {
+    return [
+        `Content-Length: 411
+Content-Type: application/json
+Request-uuid: ${uuid}
+
+{"cwd": "/home/runner/work/vscode-python/vscode-python/path with spaces/src/testTestingRootWkspc/largeWorkspace", "status": "subtest-success", "result": {"test_parameterized_subtest.NumbersTest.test_even (i=0)": {"test": "test_parameterized_subtest.NumbersTest.test_even", "outcome": "subtest-success", "message": "None", "traceback": null, "subtest": "test_parameterized_subtest.NumbersTest.test_even (i=0)"}}}
+
+Content-Length: 411
+Content-Type: application/json
+Request-uuid: 9${uuid}
+
+{"cwd": "/home/runner/work/vscode-`,
+        `python/vscode-python/path with`,
+        ` spaces/src"
+
+Content-Length: 959
+Content-Type: application/json
+Request-uuid: ${uuid}
+
+{"cwd": "/home/runner/work/vscode-python/vscode-python/path with spaces/src/testTestingRootWkspc/largeWorkspace", "status": "subtest-failure", "result": {"test_parameterized_subtest.NumbersTest.test_even (i=1)": {"test": "test_parameterized_subtest.NumbersTest.test_even", "outcome": "subtest-failure", "message": "(<class 'AssertionError'>, AssertionError('1 != 0'), <traceback object at 0x7fd86fc47580>)", "traceback": "  File \"/opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/unittest/case.py\", line 57, in testPartExecutor\n    yield\n  File \"/opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/unittest/case.py\", line 538, in subTest\n    yield\n  File \"/home/runner/work/vscode-python/vscode-python/path with spaces/src/testTestingRootWkspc/largeWorkspace/test_parameterized_subtest.py\", line 16, in test_even\n    self.assertEqual(i % 2, 0)\nAssertionError: 1 != 0\n", "subtest": "test_parameterized_subtest.NumbersTest.test_even (i=1)"}}}
+Content-Length: 411
+Content-Type: application/json
+Request-uuid: ${uuid}
+
+{"cwd": "/home/runner/work/vscode-python/vscode-python/path with spaces/src/testTestingRootWkspc/largeWorkspace", "status": "subtest-success", "result": {"test_parameterized_subtest.NumbersTest.test_even (i=2)": {"test": "test_parameterized_subtest.NumbersTest.test_even", "outcome": "subtest-success", "message": "None", "traceback": null, "subtest": "test_parameterized_subtest.NumbersTest.test_even (i=2)"}}}`,
+    ];
+}

--- a/src/test/testing/testController/server.unit.test.ts
+++ b/src/test/testing/testController/server.unit.test.ts
@@ -6,58 +6,43 @@ import * as assert from 'assert';
 import * as net from 'net';
 import * as sinon from 'sinon';
 import * as crypto from 'crypto';
-import { OutputChannel, Uri } from 'vscode';
 import { Observable } from 'rxjs';
 import * as typeMoq from 'typemoq';
-import {
-    IPythonExecutionFactory,
-    IPythonExecutionService,
-    Output,
-    SpawnOptions,
-} from '../../../client/common/process/types';
+import { Uri } from 'vscode';
+import { IPythonExecutionFactory, IPythonExecutionService, Output } from '../../../client/common/process/types';
 import { PythonTestServer } from '../../../client/testing/testController/common/server';
 import { ITestDebugLauncher } from '../../../client/testing/common/types';
 import { Deferred, createDeferred } from '../../../client/common/utils/async';
 import { MockChildProcess } from '../../mocks/mockChildProcess';
+import { PAYLOAD_MULTI_CHUNK, PAYLOAD_SINGLE_CHUNK } from './payloadTestCases';
 
 suite('Python Test Server', () => {
-    const fakeUuid = 'fake-uuid';
-
-    let stubExecutionFactory: IPythonExecutionFactory;
-    let stubExecutionService: IPythonExecutionService;
+    const FAKE_UUID = 'fake-uuid';
     let server: PythonTestServer;
-    let sandbox: sinon.SinonSandbox;
     let v4Stub: sinon.SinonStub;
     let debugLauncher: ITestDebugLauncher;
     let mockProc: MockChildProcess;
     let execService: typeMoq.IMock<IPythonExecutionService>;
     let deferred: Deferred<void>;
-    let execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
+    const sandbox = sinon.createSandbox();
 
-    setup(() => {
-        sandbox = sinon.createSandbox();
+    setup(async () => {
+        // set up test command options
+
         v4Stub = sandbox.stub(crypto, 'randomUUID');
-
-        v4Stub.returns(fakeUuid);
-        stubExecutionService = ({
-            execObservable: () => Promise.resolve({ stdout: '', stderr: '' }),
-        } as unknown) as IPythonExecutionService;
-
-        stubExecutionFactory = ({
-            createActivatedEnvironment: () => Promise.resolve(stubExecutionService),
-        } as unknown) as IPythonExecutionFactory;
+        v4Stub.returns(FAKE_UUID);
 
         // set up exec service with child process
         mockProc = new MockChildProcess('', ['']);
         execService = typeMoq.Mock.ofType<IPythonExecutionService>();
-        const output = new Observable<Output<string>>(() => {
+        const outputObservable = new Observable<Output<string>>(() => {
             /* no op */
         });
         execService
             .setup((x) => x.execObservable(typeMoq.It.isAny(), typeMoq.It.isAny()))
             .returns(() => ({
                 proc: mockProc,
-                out: output,
+                out: outputObservable,
                 dispose: () => {
                     /* no-body */
                 },
@@ -69,128 +54,13 @@ suite('Python Test Server', () => {
         sandbox.restore();
         server.dispose();
     });
-
-    test('sendCommand should add the port to the command being sent and add the correct extra spawn variables', async () => {
-        const options = {
-            command: {
-                script: 'myscript',
-                args: ['-foo', 'foo'],
-            },
-            workspaceFolder: Uri.file('/foo/bar'),
-            cwd: '/foo/bar',
-            uuid: fakeUuid,
-        };
-        const expectedSpawnOptions = {
-            cwd: '/foo/bar',
-            outputChannel: undefined,
-            token: undefined,
-            throwOnStdErr: true,
-            extraVariables: {
-                PYTHONPATH: '/foo/bar',
-                RUN_TEST_IDS_PORT: '56789',
-            },
-        } as SpawnOptions;
-        const deferred2 = createDeferred();
-        execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
-        execFactory
-            .setup((x) => x.createActivatedEnvironment(typeMoq.It.isAny()))
-            .returns(() => {
-                deferred2.resolve();
-                return Promise.resolve(execService.object);
-            });
-
-        server = new PythonTestServer(execFactory.object, debugLauncher);
-        await server.serverReady();
-
-        server.sendCommand(options, '56789');
-        // add in await and trigger
-        await deferred2.promise;
-        mockProc.trigger('close');
-
-        const port = server.getPort();
-        const expectedArgs = ['myscript', '--port', `${port}`, '--uuid', fakeUuid, '-foo', 'foo'];
-        execService.verify((x) => x.execObservable(expectedArgs, expectedSpawnOptions), typeMoq.Times.once());
-    });
-
-    test('sendCommand should write to an output channel if it is provided as an option', async () => {
-        const output: string[] = [];
-        const outChannel = {
-            appendLine: (str: string) => {
-                output.push(str);
-            },
-        } as OutputChannel;
-        const options = {
-            command: {
-                script: 'myscript',
-                args: ['-foo', 'foo'],
-            },
-            workspaceFolder: Uri.file('/foo/bar'),
-            cwd: '/foo/bar',
-            uuid: fakeUuid,
-            outChannel,
-        };
-        deferred = createDeferred();
-        execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
-        execFactory
-            .setup((x) => x.createActivatedEnvironment(typeMoq.It.isAny()))
-            .returns(() => {
-                deferred.resolve();
-                return Promise.resolve(execService.object);
-            });
-
-        server = new PythonTestServer(execFactory.object, debugLauncher);
-        await server.serverReady();
-
-        server.sendCommand(options);
-        // add in await and trigger
-        await deferred.promise;
-        mockProc.trigger('close');
-
-        const port = server.getPort();
-        const expected = ['python', 'myscript', '--port', `${port}`, '--uuid', fakeUuid, '-foo', 'foo'].join(' ');
-
-        assert.deepStrictEqual(output, [expected]);
-    });
-
-    test('If script execution fails during sendCommand, an onDataReceived event should be fired with the "error" status', async () => {
-        let eventData: { status: string; errors: string[] } | undefined;
-        stubExecutionService = ({
-            execObservable: () => {
-                throw new Error('Failed to execute');
-            },
-        } as unknown) as IPythonExecutionService;
-        const options = {
-            command: { script: 'myscript', args: ['-foo', 'foo'] },
-            workspaceFolder: Uri.file('/foo/bar'),
-            cwd: '/foo/bar',
-            uuid: fakeUuid,
-        };
-
-        server = new PythonTestServer(stubExecutionFactory, debugLauncher);
-        await server.serverReady();
-
-        server.onDataReceived(({ data }) => {
-            eventData = JSON.parse(data);
-        });
-
-        await server.sendCommand(options);
-
-        assert.notEqual(eventData, undefined);
-        assert.deepStrictEqual(eventData?.status, 'error');
-        assert.deepStrictEqual(eventData?.errors, ['Failed to execute']);
-    });
-
-    test('If the server receives malformed data, it should display a log message, and not fire an event', async () => {
-        let eventData: string | undefined;
+    test('basic payload', async () => {
+        let eventData = '';
         const client = new net.Socket();
-        const options = {
-            command: { script: 'myscript', args: ['-foo', 'foo'] },
-            workspaceFolder: Uri.file('/foo/bar'),
-            cwd: '/foo/bar',
-            uuid: fakeUuid,
-        };
+
+        deferred = createDeferred();
         mockProc = new MockChildProcess('', ['']);
-        const output = new Observable<Output<string>>(() => {
+        const output2 = new Observable<Output<string>>(() => {
             /* no op */
         });
         const stubExecutionService2 = ({
@@ -198,64 +68,7 @@ suite('Python Test Server', () => {
                 client.connect(server.getPort());
                 return {
                     proc: mockProc,
-                    out: output,
-                    dispose: () => {
-                        /* no-body */
-                    },
-                };
-            },
-        } as unknown) as IPythonExecutionService;
-
-        const stubExecutionFactory2 = ({
-            createActivatedEnvironment: () => Promise.resolve(stubExecutionService2),
-        } as unknown) as IPythonExecutionFactory;
-
-        deferred = createDeferred();
-        server = new PythonTestServer(stubExecutionFactory2, debugLauncher);
-        await server.serverReady();
-        server.onDataReceived(({ data }) => {
-            eventData = data;
-            deferred.resolve();
-        });
-
-        client.on('connect', () => {
-            console.log('Socket connected, local port:', client.localPort);
-            client.write('malformed data');
-            client.end();
-        });
-        client.on('error', (error) => {
-            console.log('Socket connection error:', error);
-        });
-
-        server.sendCommand(options);
-        // add in await and trigger
-        await deferred.promise;
-        mockProc.trigger('close');
-
-        assert.deepStrictEqual(eventData, '');
-    });
-
-    test('If the server doesnt recognize the UUID it should ignore it', async () => {
-        let eventData: string | undefined;
-        const client = new net.Socket();
-        const options = {
-            command: { script: 'myscript', args: ['-foo', 'foo'] },
-            workspaceFolder: Uri.file('/foo/bar'),
-            cwd: '/foo/bar',
-            uuid: fakeUuid,
-        };
-
-        deferred = createDeferred();
-        mockProc = new MockChildProcess('', ['']);
-        const output = new Observable<Output<string>>(() => {
-            /* no op */
-        });
-        const stubExecutionService2 = ({
-            execObservable: () => {
-                client.connect(server.getPort());
-                return {
-                    proc: mockProc,
-                    out: output,
+                    out: output2,
                     dispose: () => {
                         /* no-body */
                     },
@@ -267,199 +80,26 @@ suite('Python Test Server', () => {
             createActivatedEnvironment: () => Promise.resolve(stubExecutionService2),
         } as unknown) as IPythonExecutionFactory;
         server = new PythonTestServer(stubExecutionFactory2, debugLauncher);
-        await server.serverReady();
-        server.onDataReceived(({ data }) => {
-            eventData = data;
-            deferred.resolve();
-        });
-
-        client.on('connect', () => {
-            console.log('Socket connected, local port:', client.localPort);
-            client.write('{"Request-uuid": "unknown-uuid"}');
-            client.end();
-        });
-        client.on('error', (error) => {
-            console.log('Socket connection error:', error);
-        });
-
-        server.sendCommand(options);
-        await deferred.promise;
-        assert.deepStrictEqual(eventData, '');
-    });
-
-    // required to have "tests" or "results"
-    // the heading length not being equal and yes being equal
-    // multiple payloads
-    test('Error if payload does not have a content length header', async () => {
-        let eventData: string | undefined;
-        const client = new net.Socket();
-        const options = {
-            command: { script: 'myscript', args: ['-foo', 'foo'] },
-            workspaceFolder: Uri.file('/foo/bar'),
-            cwd: '/foo/bar',
-            uuid: fakeUuid,
-        };
-        deferred = createDeferred();
-        mockProc = new MockChildProcess('', ['']);
-        const output = new Observable<Output<string>>(() => {
-            /* no op */
-        });
-        const stubExecutionService2 = ({
-            execObservable: () => {
-                client.connect(server.getPort());
-                return {
-                    proc: mockProc,
-                    out: output,
-                    dispose: () => {
-                        /* no-body */
-                    },
-                };
-            },
-        } as unknown) as IPythonExecutionService;
-
-        const stubExecutionFactory2 = ({
-            createActivatedEnvironment: () => Promise.resolve(stubExecutionService2),
-        } as unknown) as IPythonExecutionFactory;
-        server = new PythonTestServer(stubExecutionFactory2, debugLauncher);
-        await server.serverReady();
-        server.onDataReceived(({ data }) => {
-            eventData = data;
-            deferred.resolve();
-        });
-
-        client.on('connect', () => {
-            console.log('Socket connected, local port:', client.localPort);
-            client.write('{"not content length": "5"}');
-            client.end();
-        });
-        client.on('error', (error) => {
-            console.log('Socket connection error:', error);
-        });
-
-        server.sendCommand(options);
-        await deferred.promise;
-        assert.deepStrictEqual(eventData, '');
-    });
-
-    const testData = [
-        {
-            testName: 'fires discovery correctly on test payload',
-            payload: `Content-Length: 52
-Content-Type: application/json
-Request-uuid: UUID_HERE
-
-{"cwd": "path", "status": "success", "tests": "xyz"}`,
-            expectedResult: '{"cwd": "path", "status": "success", "tests": "xyz"}',
-        },
-        // Add more test data as needed
-    ];
-
-    testData.forEach(({ testName, payload, expectedResult }) => {
-        test(`test: ${testName}`, async () => {
-            // Your test logic here
-            let eventData: string | undefined;
-            const client = new net.Socket();
-
-            const options = {
-                command: { script: 'myscript', args: ['-foo', 'foo'] },
-                workspaceFolder: Uri.file('/foo/bar'),
-                cwd: '/foo/bar',
-                uuid: fakeUuid,
-            };
-            deferred = createDeferred();
-            mockProc = new MockChildProcess('', ['']);
-            const output = new Observable<Output<string>>(() => {
-                /* no op */
-            });
-            const stubExecutionService2 = ({
-                execObservable: () => {
-                    client.connect(server.getPort());
-                    return {
-                        proc: mockProc,
-                        out: output,
-                        dispose: () => {
-                            /* no-body */
-                        },
-                    };
-                },
-            } as unknown) as IPythonExecutionService;
-            const stubExecutionFactory2 = ({
-                createActivatedEnvironment: () => Promise.resolve(stubExecutionService2),
-            } as unknown) as IPythonExecutionFactory;
-
-            server = new PythonTestServer(stubExecutionFactory2, debugLauncher);
-            await server.serverReady();
-            const uuid = server.createUUID();
-            payload = payload.replace('UUID_HERE', uuid);
-            server.onDiscoveryDataReceived(({ data }) => {
-                eventData = data;
-                deferred.resolve();
-            });
-
-            client.on('connect', () => {
-                console.log('Socket connected, local port:', client.localPort);
-                client.write(payload);
-                client.end();
-            });
-            client.on('error', (error) => {
-                console.log('Socket connection error:', error);
-            });
-
-            server.sendCommand(options);
-            await deferred.promise;
-            assert.deepStrictEqual(eventData, expectedResult);
-        });
-    });
-
-    test('Calls run resolver if the result header is in the payload', async () => {
-        let eventData: string | undefined;
-        const client = new net.Socket();
-
-        deferred = createDeferred();
-        mockProc = new MockChildProcess('', ['']);
-        const output = new Observable<Output<string>>(() => {
-            /* no op */
-        });
-        const stubExecutionService2 = ({
-            execObservable: () => {
-                client.connect(server.getPort());
-                return {
-                    proc: mockProc,
-                    out: output,
-                    dispose: () => {
-                        /* no-body */
-                    },
-                };
-            },
-        } as unknown) as IPythonExecutionService;
-
-        const stubExecutionFactory2 = ({
-            createActivatedEnvironment: () => Promise.resolve(stubExecutionService2),
-        } as unknown) as IPythonExecutionFactory;
-        server = new PythonTestServer(stubExecutionFactory2, debugLauncher);
-        const options = {
-            command: { script: 'myscript', args: ['-foo', 'foo'] },
-            workspaceFolder: Uri.file('/foo/bar'),
-            cwd: '/foo/bar',
-            uuid: fakeUuid,
-        };
-
-        await server.serverReady();
         const uuid = server.createUUID();
+        const options = {
+            command: { script: 'myscript', args: ['-foo', 'foo'] },
+            workspaceFolder: Uri.file('/foo/bar'),
+            cwd: '/foo/bar',
+            uuid,
+        };
+        const payloadChunk = PAYLOAD_SINGLE_CHUNK(uuid);
+
+        await server.serverReady();
+
         server.onRunDataReceived(({ data }) => {
-            eventData = data;
+            eventData = eventData + data;
             deferred.resolve();
         });
-
-        const payload = `Content-Length: 87
-Content-Type: application/json
-Request-uuid: ${uuid}
-
-{"cwd": "path", "status": "success", "result": "xyz", "not_found": null, "error": null}`;
-
         client.on('connect', () => {
             console.log('Socket connected, local port:', client.localPort);
-            client.write(payload);
+            for (const line of payloadChunk.payload) {
+                client.write(line);
+            }
             client.end();
         });
         client.on('error', (error) => {
@@ -468,8 +108,459 @@ Request-uuid: ${uuid}
 
         server.sendCommand(options);
         await deferred.promise;
-        const expectedResult =
-            '{"cwd": "path", "status": "success", "result": "xyz", "not_found": null, "error": null}';
+        const expectedResult = payloadChunk.data;
         assert.deepStrictEqual(eventData, expectedResult);
     });
+    test('second payload', async () => {
+        let eventData = '';
+        const client = new net.Socket();
+
+        deferred = createDeferred();
+        mockProc = new MockChildProcess('', ['']);
+        const output2 = new Observable<Output<string>>(() => {
+            /* no op */
+        });
+        const stubExecutionService2 = ({
+            execObservable: () => {
+                client.connect(server.getPort());
+                return {
+                    proc: mockProc,
+                    out: output2,
+                    dispose: () => {
+                        /* no-body */
+                    },
+                };
+            },
+        } as unknown) as IPythonExecutionService;
+
+        const stubExecutionFactory2 = ({
+            createActivatedEnvironment: () => Promise.resolve(stubExecutionService2),
+        } as unknown) as IPythonExecutionFactory;
+        server = new PythonTestServer(stubExecutionFactory2, debugLauncher);
+        const uuid = server.createUUID();
+        const options = {
+            command: { script: 'myscript', args: ['-foo', 'foo'] },
+            workspaceFolder: Uri.file('/foo/bar'),
+            cwd: '/foo/bar',
+            uuid,
+        };
+        const payloadChunk = PAYLOAD_MULTI_CHUNK(uuid);
+
+        await server.serverReady();
+
+        server.onRunDataReceived(({ data }) => {
+            eventData = eventData + data;
+        });
+        client.on('connect', () => {
+            console.log('Socket connected, local port:', client.localPort);
+            for (const line of payloadChunk.payload) {
+                client.write(line);
+            }
+            client.end();
+        });
+        client.on('close', () => {
+            console.log('Socket connection exit:');
+            deferred.resolve();
+        });
+        client.on('error', (error) => {
+            console.log('Socket connection error:', error);
+        });
+
+        server.sendCommand(options);
+        await deferred.promise;
+        const expectedResult = payloadChunk.data;
+        assert.deepStrictEqual(eventData, expectedResult);
+    });
+
+    // test('sendCommand should add the port to the command being sent and add the correct extra spawn variables', async () => {
+    //     deferred2 = createDeferred();
+    //     execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
+    //     execFactory
+    //         .setup((x) => x.createActivatedEnvironment(typeMoq.It.isAny()))
+    //         .returns(() => {
+    //             deferred2.resolve();
+    //             return Promise.resolve(execService.object);
+    //         });
+    //     server = new PythonTestServer(execFactory.object, debugLauncher);
+    //     await server.serverReady();
+    //     server.sendCommand(BASE_TEST_COMMAND_OPTIONS, '56789');
+    //     // add in await and trigger
+    //     await deferred2.promise;
+    //     mockProc.trigger('close');
+
+    //     const port = server.getPort();
+    //     const expectedArgs = ['myscript', '--port', `${port}`, '--uuid', FAKE_UUID, '-foo', 'foo'];
+    //     execService.verify((x) => x.execObservable(expectedArgs, BASE_SPAWN_OPTIONS), typeMoq.Times.once());
+    // });
+
+    // test('sendCommand should write to an output channel if it is provided as an option', async () => {
+    //     const output2: string[] = [];
+    //     const outChannel = {
+    //         appendLine: (str: string) => {
+    //             output2.push(str);
+    //         },
+    //     } as OutputChannel;
+    //     const options = {
+    //         command: {
+    //             script: 'myscript',
+    //             args: ['-foo', 'foo'],
+    //         },
+    //         workspaceFolder: Uri.file('/foo/bar'),
+    //         cwd: '/foo/bar',
+    //         uuid: FAKE_UUID,
+    //         outChannel,
+    //     };
+    //     deferred = createDeferred();
+    //     execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
+    //     execFactory
+    //         .setup((x) => x.createActivatedEnvironment(typeMoq.It.isAny()))
+    //         .returns(() => {
+    //             deferred.resolve();
+    //             return Promise.resolve(execService.object);
+    //         });
+
+    //     server = new PythonTestServer(execFactory.object, debugLauncher);
+    //     await server.serverReady();
+
+    //     server.sendCommand(options);
+    //     // add in await and trigger
+    //     await deferred.promise;
+    //     mockProc.trigger('close');
+
+    //     const port = server.getPort();
+    //     const expected = ['python', 'myscript', '--port', `${port}`, '--uuid', FAKE_UUID, '-foo', 'foo'].join(' ');
+
+    //     assert.deepStrictEqual(output2, [expected]);
+    // });
+
+    // test('If script execution fails during sendCommand, an onDataReceived event should be fired with the "error" status', async () => {
+    //     let eventData: { status: string; errors: string[] } | undefined;
+    //     stubExecutionService = ({
+    //         execObservable: () => {
+    //             throw new Error('Failed to execute');
+    //         },
+    //     } as unknown) as IPythonExecutionService;
+    //     const options = {
+    //         command: { script: 'myscript', args: ['-foo', 'foo'] },
+    //         workspaceFolder: Uri.file('/foo/bar'),
+    //         cwd: '/foo/bar',
+    //         uuid: FAKE_UUID,
+    //     };
+
+    //     server = new PythonTestServer(stubExecutionFactory, debugLauncher);
+    //     await server.serverReady();
+
+    //     server.onDataReceived(({ data }) => {
+    //         eventData = JSON.parse(data);
+    //     });
+
+    //     await server.sendCommand(options);
+
+    //     assert.notEqual(eventData, undefined);
+    //     assert.deepStrictEqual(eventData?.status, 'error');
+    //     assert.deepStrictEqual(eventData?.errors, ['Failed to execute']);
+    // });
+
+    //     test('If the server receives malformed data, it should display a log message, and not fire an event', async () => {
+    //         deferred2 = createDeferred();
+    //         execFactory = typeMoq.Mock.ofType<IPythonExecutionFactory>();
+    //         execFactory
+    //             .setup((x) => x.createActivatedEnvironment(typeMoq.It.isAny()))
+    //             .returns(() => {
+    //                 deferred2.resolve();
+    //                 return Promise.resolve(execService.object);
+    //             });
+    //         server = new PythonTestServer(execFactory.object, debugLauncher);
+    //         await server.serverReady();
+    //         let eventData: string | undefined;
+    //         const client = new net.Socket();
+    //         const options = {
+    //             command: { script: 'myscript', args: ['-foo', 'foo'] },
+    //             workspaceFolder: Uri.file('/foo/bar'),
+    //             cwd: '/foo/bar',
+    //             uuid: FAKE_UUID,
+    //         };
+    //         mockProc = new MockChildProcess('', ['']);
+    //         const output2 = new Observable<Output<string>>(() => {
+    //             /* no op */
+    //         });
+    //         const stubExecutionService2 = ({
+    //             execObservable: () => {
+    //                 client.connect(server.getPort());
+    //                 return {
+    //                     proc: mockProc,
+    //                     out: output2,
+    //                     dispose: () => {
+    //                         /* no-body */
+    //                     },
+    //                 };
+    //             },
+    //         } as unknown) as IPythonExecutionService;
+
+    //         const stubExecutionFactory2 = ({
+    //             createActivatedEnvironment: () => Promise.resolve(stubExecutionService2),
+    //         } as unknown) as IPythonExecutionFactory;
+
+    //         deferred = createDeferred();
+    //         server = new PythonTestServer(stubExecutionFactory2, debugLauncher);
+    //         await server.serverReady();
+    //         server.onDataReceived(({ data }) => {
+    //             eventData = data;
+    //             deferred.resolve();
+    //         });
+
+    //         client.on('connect', () => {
+    //             console.log('Socket connected, local port:', client.localPort);
+    //             client.write('malformed data');
+    //             client.end();
+    //         });
+    //         client.on('error', (error) => {
+    //             console.log('Socket connection error:', error);
+    //         });
+
+    //         server.sendCommand(options);
+    //         // add in await and trigger
+    //         await deferred.promise;
+    //         mockProc.trigger('close');
+
+    //         assert.deepStrictEqual(eventData, '');
+    //     });
+
+    //     test('If the server doesnt recognize the UUID it should ignore it', async () => {
+    //         let eventData: string | undefined;
+    //         const client = new net.Socket();
+    //         const options = {
+    //             command: { script: 'myscript', args: ['-foo', 'foo'] },
+    //             workspaceFolder: Uri.file('/foo/bar'),
+    //             cwd: '/foo/bar',
+    //             uuid: FAKE_UUID,
+    //         };
+
+    //         deferred = createDeferred();
+    //         mockProc = new MockChildProcess('', ['']);
+    //         const output = new Observable<Output<string>>(() => {
+    //             /* no op */
+    //         });
+    //         const stubExecutionService2 = ({
+    //             execObservable: () => {
+    //                 client.connect(server.getPort());
+    //                 return {
+    //                     proc: mockProc,
+    //                     out: output,
+    //                     dispose: () => {
+    //                         /* no-body */
+    //                     },
+    //                 };
+    //             },
+    //         } as unknown) as IPythonExecutionService;
+
+    //         const stubExecutionFactory2 = ({
+    //             createActivatedEnvironment: () => Promise.resolve(stubExecutionService2),
+    //         } as unknown) as IPythonExecutionFactory;
+    //         server = new PythonTestServer(stubExecutionFactory2, debugLauncher);
+    //         await server.serverReady();
+    //         server.onDataReceived(({ data }) => {
+    //             eventData = data;
+    //             deferred.resolve();
+    //         });
+
+    //         client.on('connect', () => {
+    //             console.log('Socket connected, local port:', client.localPort);
+    //             client.write('{"Request-uuid": "unknown-uuid"}');
+    //             client.end();
+    //         });
+    //         client.on('error', (error) => {
+    //             console.log('Socket connection error:', error);
+    //         });
+
+    //         server.sendCommand(options);
+    //         await deferred.promise;
+    //         assert.deepStrictEqual(eventData, '');
+    //     });
+
+    //     // required to have "tests" or "results"
+    //     // the heading length not being equal and yes being equal
+    //     // multiple payloads
+    //     test('Error if payload does not have a content length header', async () => {
+    //         let eventData: string | undefined;
+    //         const client = new net.Socket();
+    //         const options = {
+    //             command: { script: 'myscript', args: ['-foo', 'foo'] },
+    //             workspaceFolder: Uri.file('/foo/bar'),
+    //             cwd: '/foo/bar',
+    //             uuid: FAKE_UUID,
+    //         };
+    //         deferred = createDeferred();
+    //         mockProc = new MockChildProcess('', ['']);
+    //         const output = new Observable<Output<string>>(() => {
+    //             /* no op */
+    //         });
+    //         const stubExecutionService2 = ({
+    //             execObservable: () => {
+    //                 client.connect(server.getPort());
+    //                 return {
+    //                     proc: mockProc,
+    //                     out: output,
+    //                     dispose: () => {
+    //                         /* no-body */
+    //                     },
+    //                 };
+    //             },
+    //         } as unknown) as IPythonExecutionService;
+
+    //         const stubExecutionFactory2 = ({
+    //             createActivatedEnvironment: () => Promise.resolve(stubExecutionService2),
+    //         } as unknown) as IPythonExecutionFactory;
+    //         server = new PythonTestServer(stubExecutionFactory2, debugLauncher);
+    //         await server.serverReady();
+    //         server.onDataReceived(({ data }) => {
+    //             eventData = data;
+    //             deferred.resolve();
+    //         });
+
+    //         client.on('connect', () => {
+    //             console.log('Socket connected, local port:', client.localPort);
+    //             client.write('{"not content length": "5"}');
+    //             client.end();
+    //         });
+    //         client.on('error', (error) => {
+    //             console.log('Socket connection error:', error);
+    //         });
+
+    //         server.sendCommand(options);
+    //         await deferred.promise;
+    //         assert.deepStrictEqual(eventData, '');
+    //     });
+
+    //     const testData = [
+    //         {
+    //             testName: 'fires discovery correctly on test payload',
+    //             payload: `Content-Length: 52
+    // Content-Type: application/json
+    // Request-uuid: UUID_HERE
+
+    // {"cwd": "path", "status": "success", "tests": "xyz"}`,
+    //             expectedResult: '{"cwd": "path", "status": "success", "tests": "xyz"}',
+    //         },
+    //         // Add more test data as needed
+    //     ];
+
+    //     testData.forEach(({ testName, payload, expectedResult }) => {
+    //         test(`test: ${testName}`, async () => {
+    //             // Your test logic here
+    //             let eventData: string | undefined;
+    //             const client = new net.Socket();
+
+    //             const options = {
+    //                 command: { script: 'myscript', args: ['-foo', 'foo'] },
+    //                 workspaceFolder: Uri.file('/foo/bar'),
+    //                 cwd: '/foo/bar',
+    //                 uuid: FAKE_UUID,
+    //             };
+    //             deferred = createDeferred();
+    //             mockProc = new MockChildProcess('', ['']);
+    //             const output = new Observable<Output<string>>(() => {
+    //                 /* no op */
+    //             });
+    //             const stubExecutionService2 = ({
+    //                 execObservable: () => {
+    //                     client.connect(server.getPort());
+    //                     return {
+    //                         proc: mockProc,
+    //                         out: output,
+    //                         dispose: () => {
+    //                             /* no-body */
+    //                         },
+    //                     };
+    //                 },
+    //             } as unknown) as IPythonExecutionService;
+    //             const stubExecutionFactory2 = ({
+    //                 createActivatedEnvironment: () => Promise.resolve(stubExecutionService2),
+    //             } as unknown) as IPythonExecutionFactory;
+
+    //             server = new PythonTestServer(stubExecutionFactory2, debugLauncher);
+    //             await server.serverReady();
+    //             const uuid = server.createUUID();
+    //             payload = payload.replace('UUID_HERE', uuid);
+    //             server.onDiscoveryDataReceived(({ data }) => {
+    //                 eventData = data;
+    //                 deferred.resolve();
+    //             });
+
+    //             client.on('connect', () => {
+    //                 console.log('Socket connected, local port:', client.localPort);
+    //                 client.write(payload);
+    //                 client.end();
+    //             });
+    //             client.on('error', (error) => {
+    //                 console.log('Socket connection error:', error);
+    //             });
+
+    //             server.sendCommand(options);
+    //             await deferred.promise;
+    //             assert.deepStrictEqual(eventData, expectedResult);
+    //         });
+    //     });
+
+    //     test('Calls run resolver if the result header is in the payload', async () => {
+    //         let eventData: string | undefined;
+    //         const client = new net.Socket();
+
+    //         deferred = createDeferred();
+    //         mockProc = new MockChildProcess('', ['']);
+    //         const output = new Observable<Output<string>>(() => {
+    //             /* no op */
+    //         });
+    //         const stubExecutionService2 = ({
+    //             execObservable: () => {
+    //                 client.connect(server.getPort());
+    //                 return {
+    //                     proc: mockProc,
+    //                     out: output,
+    //                     dispose: () => {
+    //                         /* no-body */
+    //                     },
+    //                 };
+    //             },
+    //         } as unknown) as IPythonExecutionService;
+
+    //         const stubExecutionFactory2 = ({
+    //             createActivatedEnvironment: () => Promise.resolve(stubExecutionService2),
+    //         } as unknown) as IPythonExecutionFactory;
+    //         server = new PythonTestServer(stubExecutionFactory2, debugLauncher);
+    //         const options = {
+    //             command: { script: 'myscript', args: ['-foo', 'foo'] },
+    //             workspaceFolder: Uri.file('/foo/bar'),
+    //             cwd: '/foo/bar',
+    //             uuid: FAKE_UUID,
+    //         };
+
+    //         await server.serverReady();
+    //         const uuid = server.createUUID();
+    //         server.onRunDataReceived(({ data }) => {
+    //             eventData = data;
+    //             deferred.resolve();
+    //         });
+
+    //         const payload = `Content-Length: 87
+    // Content-Type: application/json
+    // Request-uuid: ${uuid}
+
+    // {"cwd": "path", "status": "success", "result": "xyz", "not_found": null, "error": null}`;
+
+    //         client.on('connect', () => {
+    //             console.log('Socket connected, local port:', client.localPort);
+    //             client.write(payload);
+    //             client.end();
+    //         });
+    //         client.on('error', (error) => {
+    //             console.log('Socket connection error:', error);
+    //         });
+
+    //         server.sendCommand(options);
+    //         await deferred.promise;
+    //         const expectedResult =
+    //             '{"cwd": "path", "status": "success", "result": "xyz", "not_found": null, "error": null}';
+    //         assert.deepStrictEqual(eventData, expectedResult);
+    //     });
 });

--- a/src/test/testing/testController/utils.unit.test.ts
+++ b/src/test/testing/testController/utils.unit.test.ts
@@ -6,15 +6,15 @@ import {
     JSONRPC_CONTENT_LENGTH_HEADER,
     JSONRPC_CONTENT_TYPE_HEADER,
     JSONRPC_UUID_HEADER,
-    jsonRPCContent,
-    jsonRPCHeaders,
+    ExtractJsonRPCData,
+    parseJsonRPCHeadersAndData,
 } from '../../../client/testing/testController/common/utils';
 
 suite('Test Controller Utils: JSON RPC', () => {
     test('Empty raw data string', async () => {
         const rawDataString = '';
 
-        const output = jsonRPCHeaders(rawDataString);
+        const output = parseJsonRPCHeadersAndData(rawDataString);
         assert.deepStrictEqual(output.headers.size, 0);
         assert.deepStrictEqual(output.remainingRawData, '');
     });
@@ -22,20 +22,20 @@ suite('Test Controller Utils: JSON RPC', () => {
     test('Valid data empty JSON', async () => {
         const rawDataString = `${JSONRPC_CONTENT_LENGTH_HEADER}: 2\n${JSONRPC_CONTENT_TYPE_HEADER}: application/json\n${JSONRPC_UUID_HEADER}: 1234\n\n{}`;
 
-        const rpcHeaders = jsonRPCHeaders(rawDataString);
+        const rpcHeaders = parseJsonRPCHeadersAndData(rawDataString);
         assert.deepStrictEqual(rpcHeaders.headers.size, 3);
         assert.deepStrictEqual(rpcHeaders.remainingRawData, '{}');
-        const rpcContent = jsonRPCContent(rpcHeaders.headers, rpcHeaders.remainingRawData);
+        const rpcContent = ExtractJsonRPCData(rpcHeaders.headers.get('Content-Length'), rpcHeaders.remainingRawData);
         assert.deepStrictEqual(rpcContent.extractedJSON, '{}');
     });
 
     test('Valid data NO JSON', async () => {
         const rawDataString = `${JSONRPC_CONTENT_LENGTH_HEADER}: 0\n${JSONRPC_CONTENT_TYPE_HEADER}: application/json\n${JSONRPC_UUID_HEADER}: 1234\n\n`;
 
-        const rpcHeaders = jsonRPCHeaders(rawDataString);
+        const rpcHeaders = parseJsonRPCHeadersAndData(rawDataString);
         assert.deepStrictEqual(rpcHeaders.headers.size, 3);
         assert.deepStrictEqual(rpcHeaders.remainingRawData, '');
-        const rpcContent = jsonRPCContent(rpcHeaders.headers, rpcHeaders.remainingRawData);
+        const rpcContent = ExtractJsonRPCData(rpcHeaders.headers.get('Content-Length'), rpcHeaders.remainingRawData);
         assert.deepStrictEqual(rpcContent.extractedJSON, '');
     });
 
@@ -45,10 +45,10 @@ suite('Test Controller Utils: JSON RPC', () => {
             '{"jsonrpc": "2.0", "method": "initialize", "params": {"processId": 1234, "rootPath": "/home/user/project", "rootUri": "file:///home/user/project", "capabilities": {}}, "id": 0}';
         const rawDataString = `${JSONRPC_CONTENT_LENGTH_HEADER}: ${json.length}\n${JSONRPC_CONTENT_TYPE_HEADER}: application/json\n${JSONRPC_UUID_HEADER}: 1234\n\n${json}`;
 
-        const rpcHeaders = jsonRPCHeaders(rawDataString);
+        const rpcHeaders = parseJsonRPCHeadersAndData(rawDataString);
         assert.deepStrictEqual(rpcHeaders.headers.size, 3);
         assert.deepStrictEqual(rpcHeaders.remainingRawData, json);
-        const rpcContent = jsonRPCContent(rpcHeaders.headers, rpcHeaders.remainingRawData);
+        const rpcContent = ExtractJsonRPCData(rpcHeaders.headers.get('Content-Length'), rpcHeaders.remainingRawData);
         assert.deepStrictEqual(rpcContent.extractedJSON, json);
     });
 
@@ -58,9 +58,9 @@ suite('Test Controller Utils: JSON RPC', () => {
         const rawDataString = `${JSONRPC_CONTENT_LENGTH_HEADER}: ${json.length}\n${JSONRPC_CONTENT_TYPE_HEADER}: application/json\n${JSONRPC_UUID_HEADER}: 1234\n\n${json}`;
         const rawDataString2 = rawDataString + rawDataString;
 
-        const rpcHeaders = jsonRPCHeaders(rawDataString2);
+        const rpcHeaders = parseJsonRPCHeadersAndData(rawDataString2);
         assert.deepStrictEqual(rpcHeaders.headers.size, 3);
-        const rpcContent = jsonRPCContent(rpcHeaders.headers, rpcHeaders.remainingRawData);
+        const rpcContent = ExtractJsonRPCData(rpcHeaders.headers.get('Content-Length'), rpcHeaders.remainingRawData);
         assert.deepStrictEqual(rpcContent.extractedJSON, json);
         assert.deepStrictEqual(rpcContent.remainingRawData, rawDataString);
     });

--- a/src/testTestingRootWkspc/largeWorkspace/test_parameterized_subtest.py
+++ b/src/testTestingRootWkspc/largeWorkspace/test_parameterized_subtest.py
@@ -4,13 +4,13 @@ import pytest
 import unittest
 
 
-@pytest.mark.parametrize("num", range(0, 200))
+@pytest.mark.parametrize("num", range(0, 2000))
 def test_odd_even(num):
     return num % 2 == 0
 
 
 class NumbersTest(unittest.TestCase):
     def test_even(self):
-        for i in range(0, 200):
+        for i in range(0, 2000):
             with self.subTest(i=i):
                 self.assertEqual(i % 2, 0)

--- a/src/testTestingRootWkspc/largeWorkspace/test_parameterized_subtest.py
+++ b/src/testTestingRootWkspc/largeWorkspace/test_parameterized_subtest.py
@@ -4,13 +4,13 @@ import pytest
 import unittest
 
 
-@pytest.mark.parametrize("num", range(0, 200))
+@pytest.mark.parametrize("num", range(0, 20))
 def test_odd_even(num):
-    return num % 2 == 0
+    assert num % 2 == 0
 
 
 class NumbersTest(unittest.TestCase):
     def test_even(self):
-        for i in range(0, 200):
+        for i in range(0, 20):
             with self.subTest(i=i):
                 self.assertEqual(i % 2, 0)

--- a/src/testTestingRootWkspc/largeWorkspace/test_parameterized_subtest.py
+++ b/src/testTestingRootWkspc/largeWorkspace/test_parameterized_subtest.py
@@ -4,13 +4,13 @@ import pytest
 import unittest
 
 
-@pytest.mark.parametrize("num", range(0, 2000))
+@pytest.mark.parametrize("num", range(0, 200))
 def test_odd_even(num):
     return num % 2 == 0
 
 
 class NumbersTest(unittest.TestCase):
     def test_even(self):
-        for i in range(0, 2000):
+        for i in range(0, 200):
             with self.subTest(i=i):
                 self.assertEqual(i % 2, 0)


### PR DESCRIPTION
Some print statements were incorrectly merged which created noise for the test output log. The following is displaying on successful send attempts even though this information is not needed.

```
test_stderr.py Execution post sent successfully!
data sent {'/Users/eleanorboyd/testingFiles/from_users/symlink/test_stderr.py::test_passing': {'test': '/Users/eleanorboyd/testingFiles/from_users/symlink/test_stderr.py::test_passing', 'outcome': 'success', 'message': None, 'traceback': None, 'subtest': None}} end of data
.                                                         [100%]
```