### PR TITLE
incorrect print included for absolute path calculations

### DIFF
--- a/pythonFiles/vscode_pytest/__init__.py
+++ b/pythonFiles/vscode_pytest/__init__.py
@@ -126,7 +126,6 @@ def get_absolute_test_id(test_id: str, testPath: pathlib.Path) -> str:
     """
     split_id = test_id.split("::")[1:]
     absolute_test_id = "::".join([str(testPath), *split_id])
-    print("absolute path", absolute_test_id)
     return absolute_test_id
 
 


### PR DESCRIPTION
an additional print statement was left in the pytest plugin which unnecessarily printed all absolute paths calculated.