### PR TITLE
REPL Smart Shift+Enter and Dynamic Smart Cursor Cherry Pick

### DIFF
--- a/src/client/terminals/codeExecution/codeExecutionManager.ts
+++ b/src/client/terminals/codeExecution/codeExecutionManager.ts
@@ -147,7 +147,8 @@ export class CodeExecutionManager implements ICodeExecutionManager {
         }
         const codeExecutionHelper = this.serviceContainer.get<ICodeExecutionHelper>(ICodeExecutionHelper);
         const codeToExecute = await codeExecutionHelper.getSelectedTextToExecute(activeEditor!);
-        const normalizedCode = await codeExecutionHelper.normalizeLines(codeToExecute!);
+        const wholeFileContent = activeEditor!.document.getText();
+        const normalizedCode = await codeExecutionHelper.normalizeLines(codeToExecute!, wholeFileContent);
         if (!normalizedCode || normalizedCode.trim().length === 0) {
             return;
         }

--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -33,7 +33,7 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
         this.interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
     }
 
-    public async normalizeLines(code: string, resource?: Uri): Promise<string> {
+    public async normalizeLines(code: string, wholeFileContent: string, resource?: Uri): Promise<string> {
         try {
             if (code.trim().length === 0) {
                 return '';
@@ -66,7 +66,7 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
 
             // The normalization script expects a serialized JSON object, with the selection under the "code" key.
             // We're using a JSON object so that we don't have to worry about encoding, or escaping non-ASCII characters.
-            const input = JSON.stringify({ code });
+            const input = JSON.stringify({ code, wholeFileContent });
             observable.proc?.stdin?.write(input);
             observable.proc?.stdin?.end();
 
@@ -110,6 +110,7 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
 
         const { selection } = textEditor;
         let code: string;
+        const wholeFileContent = textEditor.document.getText(); // This is a way to get the whole text content from the user
         if (selection.isEmpty) {
             code = textEditor.document.lineAt(selection.start.line).text;
         } else if (selection.isSingleLine) {

--- a/src/client/terminals/types.ts
+++ b/src/client/terminals/types.ts
@@ -15,7 +15,7 @@ export interface ICodeExecutionService {
 export const ICodeExecutionHelper = Symbol('ICodeExecutionHelper');
 
 export interface ICodeExecutionHelper {
-    normalizeLines(code: string): Promise<string>;
+    normalizeLines(code: string, wholeFileContent: string): Promise<string>;
     getFileToExecute(): Promise<Uri | undefined>;
     saveFileIfDirty(file: Uri): Promise<Resource>;
     getSelectedTextToExecute(textEditor: TextEditor): Promise<string | undefined>;


### PR DESCRIPTION
Cherry Picked REPL Smart selection + move to next line after rebasing:

Feature Request from: https://github.com/microsoft/vscode-python/issues/18105 https://github.com/microsoft/vscode-python/issues/21838
https://github.com/microsoft/vscode-python/discussions/19955 (For Execute line/selection and advance to next line, referred to as dynamic smart cursor hereby)
Open Issue: https://github.com/microsoft/vscode-python/issues/21778 https://github.com/microsoft/vscode-python/issues/21838

Steps in implementing REPL Smart Send (smart shift+enter to the REPL) and dynamic cursor move aka. Move to Next Line (next executable line of code to be more precise):

Figure out the workflow of where things start and run when user clicks on run selection/line
Send the content of selection & document to the Python Side from Typescript side.
Respect and follow previous logic/code for EXPLICIT selection (user has highlighting particular text they want to send to REPL), but otherwise, use newly created smart send code.
Receive content of document & selection in Python Side
Use AST (standard library) to figure out if selection if selection is part of, for example, dictionary, but look for nodes and how each relates to the top level. If some selection is, for example part of a dictionary, we should run the whole dictionary. Look at how to do this for all top level, so that we run the Minimum Viable Block possible. (For example, if user selects part of a dictionary to run in REPL, it will select and send only the dictionary not the whole class or file, etc)
Receive the commands to run in typescript side and send it to the REPL
After the user has ran shift+enter(non highlight, meaning there was no explicit highlight of text), thus the incurring of smart send, and we have processed the smart selection, figure out the "next" executable line of code in the currently opened Python file.
After figuring out the "next" line number, we will move user's cursor to that line number.
Notes:

To be shipped after dropping Python3.7 support, since end_lineno, which is critical in smart shift+enter logic, is only for Python version GREATER than 3.7
Code in regards to this feature(s) should be wrapped in standard experiment (not setting based experiment)
Respective Telemetry should also be attached
EXPLICIT (highlight) selection of the text, and shift+enter/run selection should respect user's selection and send AS IT IS. (When the user selects/highlight specifically what they want to send, we should respect user's selection and send the selection as they are selected)
Smart Shift+Enter should be shipped together with dynamic smart cursor movement for smoothest experience.
This way user could shift+enter line by line (or more accurately top block after another top block) as they shift+enter their code.
Be careful with line_no usage between vscode and python as vscode counts line number starting from 0 and python ast start as normal (starts from line 1)) So vscode_lineno + 1 = python_ast_lineno