### PR TITLE
Fix `${command:python.interpreterPath}` in tasks.json in multiroot workspaces

### DIFF
--- a/src/client/debugger/extension/configuration/launch.json/interpreterPathCommand.ts
+++ b/src/client/debugger/extension/configuration/launch.json/interpreterPathCommand.ts
@@ -41,7 +41,7 @@ export class InterpreterPathCommand implements IExtensionSingleActivationService
 
         let workspaceFolderUri;
         try {
-            workspaceFolderUri = workspaceFolder ? Uri.parse(workspaceFolder) : undefined;
+            workspaceFolderUri = workspaceFolder ? Uri.file(workspaceFolder) : undefined;
         } catch (ex) {
             workspaceFolderUri = undefined;
         }

--- a/src/test/debugger/extension/configuration/launch.json/interpreterPathCommand.unit.test.ts
+++ b/src/test/debugger/extension/configuration/launch.json/interpreterPathCommand.unit.test.ts
@@ -45,7 +45,7 @@ suite('Interpreter Path Command', () => {
     test('If `workspaceFolder` property exists in `args`, it is used to retrieve setting from config', async () => {
         const args = { workspaceFolder: 'folderPath' };
         when(interpreterService.getActiveInterpreter(anything())).thenCall((arg) => {
-            assert.deepEqual(arg, Uri.parse('folderPath'));
+            assert.deepEqual(arg, Uri.file('folderPath'));
 
             return Promise.resolve({ path: 'settingValue' }) as unknown;
         });

--- a/src/test/debugger/extension/configuration/launch.json/interpreterPathCommand.unit.test.ts
+++ b/src/test/debugger/extension/configuration/launch.json/interpreterPathCommand.unit.test.ts
@@ -56,7 +56,7 @@ suite('Interpreter Path Command', () => {
     test('If `args[1]` is defined, it is used to retrieve setting from config', async () => {
         const args = ['command', 'folderPath'];
         when(interpreterService.getActiveInterpreter(anything())).thenCall((arg) => {
-            assert.deepEqual(arg, Uri.parse('folderPath'));
+            assert.deepEqual(arg, Uri.file('folderPath'));
 
             return Promise.resolve({ path: 'settingValue' }) as unknown;
         });

--- a/src/test/debugger/extension/configuration/launch.json/interpreterPathCommand.unit.test.ts
+++ b/src/test/debugger/extension/configuration/launch.json/interpreterPathCommand.unit.test.ts
@@ -73,14 +73,4 @@ suite('Interpreter Path Command', () => {
         const setting = await interpreterPathCommand._getSelectedInterpreterPath(args);
         expect(setting).to.equal('settingValue');
     });
-
-    test('If `args[1]` is not a valid uri', async () => {
-        const args = ['command', '${input:some_input}'];
-        when(interpreterService.getActiveInterpreter(anything())).thenCall((arg) => {
-            assert.deepEqual(arg, undefined);
-            return Promise.resolve({ path: 'settingValue' }) as unknown;
-        });
-        const setting = await interpreterPathCommand._getSelectedInterpreterPath(args);
-        expect(setting).to.equal('settingValue');
-    });
 });


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/21915