### PR TITLE
fix subtest naming to parse on '('

### DIFF
--- a/src/client/testing/testController/common/resultResolver.ts
+++ b/src/client/testing/testController/common/resultResolver.ts
@@ -179,9 +179,11 @@ export class PythonResultResolver implements ITestResultResolver {
                         });
                     }
                 } else if (rawTestExecData.result[keyTemp].outcome === 'subtest-failure') {
-                    // split on " " since the subtest ID has the parent test ID in the first part of the ID.
-                    const parentTestCaseId = keyTemp.split(' ')[0];
-                    const subtestId = keyTemp.split(' ')[1];
+                    // split only on first " (" since the subtest ID has the parent test ID in the first part of the ID.
+                    const index = keyTemp.indexOf(' (');
+                    const parentTestCaseId = keyTemp.substring(0, index);
+                    // add one to index to remove the space from the start of the subtest ID
+                    const subtestId = keyTemp.substring(index + 1, keyTemp.length);
                     const parentTestItem = this.runIdToTestItem.get(parentTestCaseId);
                     const data = rawTestExecData.result[keyTemp];
                     // find the subtest's parent test item
@@ -190,7 +192,10 @@ export class PythonResultResolver implements ITestResultResolver {
                         if (subtestStats) {
                             subtestStats.failed += 1;
                         } else {
-                            this.subTestStats.set(parentTestCaseId, { failed: 1, passed: 0 });
+                            this.subTestStats.set(parentTestCaseId, {
+                                failed: 1,
+                                passed: 0,
+                            });
                             runInstance.appendOutput(fixLogLines(`${parentTestCaseId} [subtests]:\r\n`));
                             // clear since subtest items don't persist between runs
                             clearAllChildren(parentTestItem);
@@ -216,8 +221,8 @@ export class PythonResultResolver implements ITestResultResolver {
                         throw new Error('Parent test item not found');
                     }
                 } else if (rawTestExecData.result[keyTemp].outcome === 'subtest-success') {
-                    // split only on first " [" since the subtest ID has the parent test ID in the first part of the ID.
-                    const index = keyTemp.indexOf(' [');
+                    // split only on first " (" since the subtest ID has the parent test ID in the first part of the ID.
+                    const index = keyTemp.indexOf(' (');
                     const parentTestCaseId = keyTemp.substring(0, index);
                     // add one to index to remove the space from the start of the subtest ID
                     const subtestId = keyTemp.substring(index + 1, keyTemp.length);

--- a/src/test/testing/testController/resultResolver.unit.test.ts
+++ b/src/test/testing/testController/resultResolver.unit.test.ts
@@ -286,7 +286,6 @@ suite('Result Resolver tests', () => {
                 .setup((t) => t.createTestItem(typemoq.It.isAny(), typemoq.It.isAny()))
                 .callback((id: string) => {
                     generatedId = id;
-                    console.log('createTestItem function called with id:', id);
                 })
                 .returns(() => ({ id: 'id_this', label: 'label_this', uri: workspaceUri } as TestItem));
 
@@ -295,7 +294,7 @@ suite('Result Resolver tests', () => {
                 cwd: workspaceUri.fsPath,
                 status: 'success',
                 result: {
-                    'parentTest [subTest with spaces and [brackets]]': {
+                    'parentTest (i=subTest with spaces and (braces))': {
                         test: 'parentTest',
                         outcome: 'subtest-success', // failure, passed-unexpected, skipped, success, expected-failure, subtest-failure, subtest-succcess
                         message: 'message',
@@ -311,7 +310,7 @@ suite('Result Resolver tests', () => {
 
             // verify that the passed function was called for the single test item
             assert.ok(generatedId);
-            assert.strictEqual(generatedId, '[subTest with spaces and [brackets]]');
+            assert.strictEqual(generatedId, '(i=subTest with spaces and (braces))');
         });
         test('resolveExecution handles failed tests correctly', async () => {
             // test specific constants used expected values


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python/issues/21733