### PR TITLE
Changed order of options in Create Environment flow when .venv exists…

### DIFF
--- a/src/client/pythonEnvironments/creation/provider/venvUtils.ts
+++ b/src/client/pythonEnvironments/creation/provider/venvUtils.ts
@@ -292,10 +292,13 @@ export async function pickExistingVenvAction(
     if (workspaceFolder) {
         if (await hasVenv(workspaceFolder)) {
             const items: QuickPickItem[] = [
-                { label: CreateEnv.Venv.recreate, description: CreateEnv.Venv.recreateDescription },
                 {
                     label: CreateEnv.Venv.useExisting,
                     description: CreateEnv.Venv.useExistingDescription,
+                },
+                {
+                    label: CreateEnv.Venv.recreate,
+                    description: CreateEnv.Venv.recreateDescription,
                 },
             ];
 


### PR DESCRIPTION
closes https://github.com/microsoft/vscode-python/issues/22038