### PR TITLE
Calculate PS1 instead of using PS1 returned by shell

### DIFF
--- a/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
@@ -282,21 +282,24 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
     }
 
     private async getPS1(shell: string, resource: Resource, env: EnvironmentVariables) {
-        if (env.PS1) {
-            return env.PS1;
-        }
         const customShellType = identifyShellFromShellPath(shell);
         if (this.noPromptVariableShells.includes(customShellType)) {
-            return undefined;
+            return env.PS1;
         }
         if (this.platform.osType !== OSType.Windows) {
             // These shells are expected to set PS1 variable for terminal prompt for virtual/conda environments.
             const interpreter = await this.interpreterService.getActiveInterpreter(resource);
             const shouldSetPS1 = shouldPS1BeSet(interpreter?.type, env);
-            if (shouldSetPS1 && !env.PS1) {
-                // PS1 should be set but no PS1 was set.
-                return getPromptForEnv(interpreter);
+            if (shouldSetPS1) {
+                const prompt = getPromptForEnv(interpreter);
+                if (prompt) {
+                    return prompt;
+                }
             }
+        }
+        if (env.PS1) {
+            // Prefer PS1 set by env vars, as env.PS1 may or may not contain the full PS1: #22056.
+            return env.PS1;
         }
         return undefined;
     }
@@ -369,6 +372,10 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
 }
 
 function shouldPS1BeSet(type: PythonEnvType | undefined, env: EnvironmentVariables): boolean {
+    if (env.PS1) {
+        // Activated variables contain PS1, meaning it was supposed to be set.
+        return true;
+    }
     if (type === PythonEnvType.Virtual) {
         const promptDisabledVar = env.VIRTUAL_ENV_DISABLE_PROMPT;
         const isPromptDisabled = promptDisabledVar && promptDisabledVar !== undefined;

--- a/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
@@ -388,7 +388,7 @@ function shouldPS1BeSet(type: PythonEnvType | undefined, env: EnvironmentVariabl
         const isPromptEnabled = promptEnabledVar && promptEnabledVar !== '';
         return !!isPromptEnabled;
     }
-    return type !== undefined;
+    return false;
 }
 
 function shouldSkip(env: string) {

--- a/src/test/interpreters/activation/terminalEnvVarCollectionService.unit.test.ts
+++ b/src/test/interpreters/activation/terminalEnvVarCollectionService.unit.test.ts
@@ -191,7 +191,10 @@ suite('Terminal Environment Variable Collection Service', () => {
         verify(collection.replace('CONDA_PREFIX', 'prefix/to/conda', anything())).once();
     });
 
-    test('If activated variables contain PS1, prefix it using shell integration', async () => {
+    test('If activated variables contain PS1, prefix it using shell integration', async function () {
+        if (getOSType() === OSType.Windows) {
+            return this.skip();
+        }
         const envVars: NodeJS.ProcessEnv = {
             CONDA_PREFIX: 'prefix/to/conda',
             ...process.env,

--- a/src/test/interpreters/activation/terminalEnvVarCollectionService.unit.test.ts
+++ b/src/test/interpreters/activation/terminalEnvVarCollectionService.unit.test.ts
@@ -191,6 +191,7 @@ suite('Terminal Environment Variable Collection Service', () => {
         verify(collection.replace('CONDA_PREFIX', 'prefix/to/conda', anything())).once();
     });
 
+    // eslint-disable-next-line consistent-return
     test('If activated variables contain PS1, prefix it using shell integration', async function () {
         if (getOSType() === OSType.Windows) {
             return this.skip();

--- a/src/test/interpreters/activation/terminalEnvVarCollectionService.unit.test.ts
+++ b/src/test/interpreters/activation/terminalEnvVarCollectionService.unit.test.ts
@@ -192,20 +192,23 @@ suite('Terminal Environment Variable Collection Service', () => {
     });
 
     test('If activated variables contain PS1, prefix it using shell integration', async () => {
-        const envVars: NodeJS.ProcessEnv = { CONDA_PREFIX: 'prefix/to/conda', ...process.env, PS1: '(prompt)' };
+        const envVars: NodeJS.ProcessEnv = {
+            CONDA_PREFIX: 'prefix/to/conda',
+            ...process.env,
+            PS1: '(envName) extra prompt', // Should not use this
+        };
         when(
-            environmentActivationService.getActivatedEnvironmentVariables(
-                anything(),
-                undefined,
-                undefined,
-                customShell,
-            ),
+            environmentActivationService.getActivatedEnvironmentVariables(anything(), undefined, undefined, 'bash'),
         ).thenResolve(envVars);
+
+        when(interpreterService.getActiveInterpreter(anything())).thenResolve(({
+            envName: 'envName',
+        } as unknown) as PythonEnvironment);
 
         when(collection.replace(anything(), anything(), anything())).thenResolve();
         when(collection.delete(anything())).thenResolve();
         let opts: EnvironmentVariableMutatorOptions | undefined;
-        when(collection.prepend('PS1', '(prompt)', anything())).thenCall((_, _v, o) => {
+        when(collection.prepend('PS1', '(envName) ', anything())).thenCall((_, _v, o) => {
             opts = o;
         });
 


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/22056

`PS1` returned by shell is not predictable, it can be `(.venv) ` or already have the context of the terminal:
```
(venv) [\u@\h \W]\[\e[91m\]$(parse_git_branch)\[\e[00m\]$ 
```
Calculate it to be safe and not double prepend it.