### PR TITLE
fix regex split for subtest names

### DIFF
--- a/src/client/testing/testController/common/utils.ts
+++ b/src/client/testing/testController/common/utils.ts
@@ -328,18 +328,10 @@ export function createEOTPayload(executionBool: boolean): EOTTestPayload {
  * @returns A tuple where the first item is the parent test name and the second item is the subtest section or `testName` if no subtest section exists.
  */
 export function splitTestNameWithRegex(testName: string): [string, string] {
-    // The regex pattern has three main components:
-    // 1. ^(.*?): Matches the beginning of the string and captures everything until the last opening bracket or parenthesis. This captures the parent test name.
-    // 2. (?:...|...): A non-capturing group containing two patterns separated by an OR (|).
-    //    - \(([^)]+)\): Matches an opening parenthesis, captures everything inside it until the closing parenthesis. This captures the subtest inside parenthesis.
-    //    - \[([^]]+)\]: Matches an opening square bracket, captures everything inside it until the closing square bracket. This captures the subtest inside square brackets.
-    // 3. ?$: The question mark indicates the preceding non-capturing group is optional. The dollar sign matches the end of the string.
-    const regex = /^(.*?) ([\[(].*[\])])$/;
-    const match = testName.match(regex);
-    // const m2 = regex.exec(testName);
-    // console.log('m2', m2);
     // If a match is found, return the parent test name and the subtest (whichever was captured between parenthesis or square brackets).
     // Otherwise, return the entire testName for the parent and entire testName for the subtest.
+    const regex = /^(.*?) ([\[(].*[\])])$/;
+    const match = testName.match(regex);
     if (match) {
         return [match[1].trim(), match[2] || match[3] || testName];
     }

--- a/src/client/testing/testController/common/utils.ts
+++ b/src/client/testing/testController/common/utils.ts
@@ -320,3 +320,28 @@ export function createEOTPayload(executionBool: boolean): EOTTestPayload {
         eot: true,
     } as EOTTestPayload;
 }
+
+/**
+ * Splits a test name into its parent test name and subtest unique section.
+ *
+ * @param testName The full test name string.
+ * @returns A tuple where the first item is the parent test name and the second item is the subtest section or `testName` if no subtest section exists.
+ */
+export function splitTestNameWithRegex(testName: string): [string, string] {
+    // The regex pattern has three main components:
+    // 1. ^(.*?): Matches the beginning of the string and captures everything until the last opening bracket or parenthesis. This captures the parent test name.
+    // 2. (?:...|...): A non-capturing group containing two patterns separated by an OR (|).
+    //    - \(([^)]+)\): Matches an opening parenthesis, captures everything inside it until the closing parenthesis. This captures the subtest inside parenthesis.
+    //    - \[([^]]+)\]: Matches an opening square bracket, captures everything inside it until the closing square bracket. This captures the subtest inside square brackets.
+    // 3. ?$: The question mark indicates the preceding non-capturing group is optional. The dollar sign matches the end of the string.
+    const regex = /^(.*?) ([\[(].*[\])])$/;
+    const match = testName.match(regex);
+    // const m2 = regex.exec(testName);
+    // console.log('m2', m2);
+    // If a match is found, return the parent test name and the subtest (whichever was captured between parenthesis or square brackets).
+    // Otherwise, return the entire testName for the parent and entire testName for the subtest.
+    if (match) {
+        return [match[1].trim(), match[2] || match[3] || testName];
+    }
+    return [testName, testName];
+}

--- a/src/test/testing/testController/utils.unit.test.ts
+++ b/src/test/testing/testController/utils.unit.test.ts
@@ -8,6 +8,7 @@ import {
     JSONRPC_UUID_HEADER,
     ExtractJsonRPCData,
     parseJsonRPCHeadersAndData,
+    splitTestNameWithRegex,
 } from '../../../client/testing/testController/common/utils';
 
 suite('Test Controller Utils: JSON RPC', () => {
@@ -63,5 +64,60 @@ suite('Test Controller Utils: JSON RPC', () => {
         const rpcContent = ExtractJsonRPCData(rpcHeaders.headers.get('Content-Length'), rpcHeaders.remainingRawData);
         assert.deepStrictEqual(rpcContent.extractedJSON, json);
         assert.deepStrictEqual(rpcContent.remainingRawData, rawDataString);
+    });
+});
+
+suite('Test Controller Utils: Other', () => {
+    interface TestCase {
+        name: string;
+        input: string;
+        expectedParent: string;
+        expectedSubtest: string;
+    }
+
+    const testCases: Array<TestCase> = [
+        {
+            name: 'Single parameter, named',
+            input: 'test_package.ClassName.test_method (param=value)',
+            expectedParent: 'test_package.ClassName.test_method',
+            expectedSubtest: '(param=value)',
+        },
+        {
+            name: 'Single parameter, unnamed',
+            input: 'test_package.ClassName.test_method [value]',
+            expectedParent: 'test_package.ClassName.test_method',
+            expectedSubtest: '[value]',
+        },
+        {
+            name: 'Multiple parameters, named',
+            input: 'test_package.ClassName.test_method (param1=value1, param2=value2)',
+            expectedParent: 'test_package.ClassName.test_method',
+            expectedSubtest: '(param1=value1, param2=value2)',
+        },
+        {
+            name: 'Multiple parameters, unnamed',
+            input: 'test_package.ClassName.test_method [value1, value2]',
+            expectedParent: 'test_package.ClassName.test_method',
+            expectedSubtest: '[value1, value2]',
+        },
+        {
+            name: 'Names with special characters',
+            input: 'test_package.ClassName.test_method (param1=value/1, param2=value+2)',
+            expectedParent: 'test_package.ClassName.test_method',
+            expectedSubtest: '(param1=value/1, param2=value+2)',
+        },
+        {
+            name: 'Names with spaces',
+            input: 'test_package.ClassName.test_method ["a b c d"]',
+            expectedParent: 'test_package.ClassName.test_method',
+            expectedSubtest: '["a b c d"]',
+        },
+    ];
+
+    testCases.forEach((testCase) => {
+        test(`splitTestNameWithRegex: ${testCase.name}`, () => {
+            const splitResult = splitTestNameWithRegex(testCase.input);
+            assert.deepStrictEqual(splitResult, [testCase.expectedParent, testCase.expectedSubtest]);
+        });
     });
 });


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python/issues/21733. 



Handles both cases of subtest naming as described here by ChatGPT:

When you use self.subTest(i=i), you're explicitly naming the argument i. This causes subTest to use the key=value format for the sub-test's description. Therefore, the sub-test name becomes:

`test_subtests.NumbersTest2.test_even2 (i='h i')`

However, when you use self.subTest(i), you're passing a positional argument. In this case, subTest doesn't have a key for the argument, so it simply uses the value in square brackets:

`test_subtests.NumbersTest2.test_even2 [h i]`