### PR TITLE
Bump Jedi to 0.19.1 for Python 3.12 support

### DIFF
--- a/pythonFiles/jedilsp_requirements/requirements.txt
+++ b/pythonFiles/jedilsp_requirements/requirements.txt
@@ -28,9 +28,9 @@ importlib-metadata==6.8.0 \
     --hash=sha256:3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb \
     --hash=sha256:dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743
     # via typeguard
-jedi==0.19.0 \
-    --hash=sha256:bcf9894f1753969cbac8022a8c2eaee06bfa3724e4192470aaffe7eb6272b0c4 \
-    --hash=sha256:cb8ce23fbccff0025e9386b5cf85e892f94c9b822378f8da49970471335ac64e
+jedi==0.19.1 \
+    --hash=sha256:cf0496f3651bc65d7174ac1b7d043eff454892c708a87d1b683e57b569927ffd \
+    --hash=sha256:e983c654fe5c02867aef4cdfce5a2fbb4a50adc0af145f70504238f18ef5e7e0
     # via jedi-language-server
 jedi-language-server==0.41.1 \
     --hash=sha256:3f15ca5cc28e728564f7d63583e171b418025582447ce023512e3f2b2d71ebae \


### PR DESCRIPTION
Follows from https://github.com/microsoft/vscode-python/issues/22011#issuecomment-1742682966