### PR TITLE
Specific arguments for test discovery and unexpected exit code 2

### DIFF
--- a/pythonFiles/testing_tools/adapter/pytest/_discovery.py
+++ b/pythonFiles/testing_tools/adapter/pytest/_discovery.py
@@ -23,7 +23,7 @@ def discover(
     if _plugin is None:
         _plugin = TestCollector()
 
-    pytestargs = _adjust_pytest_args(pytestargs)
+    pytestargs = _adjust_pytest_args(pytestargs) + ["--noconftest"]
     # We use this helper rather than "-pno:terminal" due to possible
     # platform-dependent issues.
     with util.hide_stdio() if hidestdio else util.noop_cm() as stdio:
@@ -32,7 +32,7 @@ def discover(
     if ec == 5:
         # No tests were discovered.
         pass
-    elif ec == 1:
+    elif ec == 1 or ec == 2:
         # Some tests where collected but with errors.
         pass
     elif ec != 0:


### PR DESCRIPTION
We have a rather large python repository with multiple submodules. Testing the complete suite is handled by Bazel, but we want users to be able to run individual tests locally in docker as well. So far, we've only been able to do this using the command line or PyCharm.

After fiddling around with VSCode for a day, I got a working setup which required two minor adjustments in `vscode-python`. 

###  Test discover phase only works with `--noconftest`, but this should not be passed during the actual tests.

When running `pytest --collect-only` we get an error saying `Defining 'pytest_plugins' in a non-top-level conftest is no longer supported:`. This error only happens during the discover phase or when we run all tests at once. Since in practise we always run tests per module, we want to pass the argument `--noconftest`. However, there is no separate config for pytest and the discover phase. 

In this PR I've hardcoded the intended argument. However, I would like to understand if it's possible to make this a custom configuration exclusively for the discover phase that can be set in `settings.json`. Happy to make the adjustments. 

### When `pytest --collect-only` fails with some errors, pytest exists with exit code is 2, not 1. 
Even though the [pytest docs](https://docs.pytest.org/en/7.1.x/reference/exit-codes.html) say that when `Tests were collected and run but some of the tests failed` the error code should be 1, we experience an exit code 2 (see below). The tests are collected just fine, and the errors can be safely ignored (at least for discovery). 

<details><summary>logs</summary>

```
!!!!!!!!!!!!!!!!!! Interrupted: 233 errors during collection !!!!!!!!!!!!!!!!!!!
================== 1559 tests collected, 233 errors in 29.28s ==================

Traceback (most recent call last):
  File "/root/.vscode-server/extensions/ms-python.python-2022.8.1/pythonFiles/testing_tools/run_adapter.py", line 22, in <module>
    main(tool, cmd, subargs, toolargs)
  File "/root/.vscode-server/extensions/ms-python.python-2022.8.1/pythonFiles/testing_tools/adapter/__main__.py", line 100, in main
    parents, result = run(toolargs, **subargs)
  File "/root/.vscode-server/extensions/ms-python.python-2022.8.1/pythonFiles/testing_tools/adapter/pytest/_discovery.py", line 47, in discover
    raise Exception("pytest discovery failed (exit code {})".format(ec))
Exception: pytest discovery failed (exit code 2)
```
</details>

I'd be happy to take some input on how to best proceed. The implementation is purely for illustrative reasons and I'm happy to adjust.


