### PR TITLE
Enable experiments for all tests

### DIFF
--- a/src/test/initialize.ts
+++ b/src/test/initialize.ts
@@ -38,7 +38,7 @@ export async function initialize(): Promise<IExtensionTestApi> {
         // When running smoke tests, we won't have access to these.
         const configSettings = await import('../client/common/configSettings');
         // Dispose any cached python settings (used only in test env).
-        configSettings.PythonSettings.dispose();
+        // configSettings.PythonSettings.dispose();
     }
 
     return (api as any) as IExtensionTestApi;

--- a/src/test/initialize.ts
+++ b/src/test/initialize.ts
@@ -32,6 +32,8 @@ export async function initializePython() {
 export async function initialize(): Promise<IExtensionTestApi> {
     await initializePython();
     const api = await activateExtension();
+    const pythonConfig = vscode.workspace.getConfiguration('python');
+    await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
     if (!IS_SMOKE_TEST) {
         // When running smoke tests, we won't have access to these.
         const configSettings = await import('../client/common/configSettings');

--- a/src/test/initialize.ts
+++ b/src/test/initialize.ts
@@ -31,13 +31,11 @@ export async function initializePython() {
 
 export async function initialize(): Promise<IExtensionTestApi> {
     await initializePython();
-    // before extension start activating
+
     const pythonConfig = vscode.workspace.getConfiguration('python');
     await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
     await pythonConfig.update('experiments.optOutFrom', [], vscode.ConfigurationTarget.Global);
     const api = await activateExtension();
-    // const pythonConfig = vscode.workspace.getConfiguration('python');
-    // await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
     if (!IS_SMOKE_TEST) {
         // When running smoke tests, we won't have access to these.
         // const configSettings = await import('../client/common/configSettings');

--- a/src/test/initialize.ts
+++ b/src/test/initialize.ts
@@ -31,9 +31,13 @@ export async function initializePython() {
 
 export async function initialize(): Promise<IExtensionTestApi> {
     await initializePython();
-    const api = await activateExtension();
+    // before extension start activating
     const pythonConfig = vscode.workspace.getConfiguration('python');
     await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
+    await pythonConfig.update('experiments.optOutFrom', [], vscode.ConfigurationTarget.Global);
+    const api = await activateExtension();
+    // const pythonConfig = vscode.workspace.getConfiguration('python');
+    // await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
     if (!IS_SMOKE_TEST) {
         // When running smoke tests, we won't have access to these.
         // const configSettings = await import('../client/common/configSettings');

--- a/src/test/initialize.ts
+++ b/src/test/initialize.ts
@@ -38,9 +38,9 @@ export async function initialize(): Promise<IExtensionTestApi> {
     const api = await activateExtension();
     if (!IS_SMOKE_TEST) {
         // When running smoke tests, we won't have access to these.
-        // const configSettings = await import('../client/common/configSettings');
+        const configSettings = await import('../client/common/configSettings');
         // Dispose any cached python settings (used only in test env).
-        // configSettings.PythonSettings.dispose();
+        configSettings.PythonSettings.dispose();
     }
 
     return (api as any) as IExtensionTestApi;
@@ -58,9 +58,9 @@ export async function initializeTest(): Promise<any> {
     await closeActiveWindows();
     if (!IS_SMOKE_TEST) {
         // When running smoke tests, we won't have access to these.
-        // const configSettings = await import('../client/common/configSettings');
+        const configSettings = await import('../client/common/configSettings');
         // // Dispose any cached python settings (used only in test env).
-        // configSettings.PythonSettings.dispose();
+        configSettings.PythonSettings.dispose();
     }
 }
 export async function closeActiveWindows(): Promise<void> {

--- a/src/test/initialize.ts
+++ b/src/test/initialize.ts
@@ -56,9 +56,9 @@ export async function initializeTest(): Promise<any> {
     await closeActiveWindows();
     if (!IS_SMOKE_TEST) {
         // When running smoke tests, we won't have access to these.
-        const configSettings = await import('../client/common/configSettings');
-        // Dispose any cached python settings (used only in test env).
-        configSettings.PythonSettings.dispose();
+        // const configSettings = await import('../client/common/configSettings');
+        // // Dispose any cached python settings (used only in test env).
+        // configSettings.PythonSettings.dispose();
     }
 }
 export async function closeActiveWindows(): Promise<void> {

--- a/src/test/initialize.ts
+++ b/src/test/initialize.ts
@@ -59,7 +59,7 @@ export async function initializeTest(): Promise<any> {
     if (!IS_SMOKE_TEST) {
         // When running smoke tests, we won't have access to these.
         const configSettings = await import('../client/common/configSettings');
-        // // Dispose any cached python settings (used only in test env).
+        // Dispose any cached python settings (used only in test env).
         configSettings.PythonSettings.dispose();
     }
 }

--- a/src/test/initialize.ts
+++ b/src/test/initialize.ts
@@ -36,7 +36,7 @@ export async function initialize(): Promise<IExtensionTestApi> {
     await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
     if (!IS_SMOKE_TEST) {
         // When running smoke tests, we won't have access to these.
-        const configSettings = await import('../client/common/configSettings');
+        // const configSettings = await import('../client/common/configSettings');
         // Dispose any cached python settings (used only in test env).
         // configSettings.PythonSettings.dispose();
     }

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -3,7 +3,7 @@ import * as TypeMoq from 'typemoq';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { assert } from 'chai';
-import { mock, when } from 'ts-mockito';
+// import { mock, when } from 'ts-mockito';
 import * as tasClient from 'vscode-tas-client';
 import * as sinon from 'sinon';
 import { IS_SMOKE_TEST, EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants';
@@ -12,37 +12,37 @@ import { openFile, waitForCondition } from '../common';
 import { IExperimentService } from '../../client/common/types';
 import { EnableREPLSmartSend } from '../../client/common/experiments/groups';
 import { IServiceContainer } from '../../client/ioc/types';
-import { IWorkspaceService } from '../../client/common/application/types';
-import { WorkspaceService } from '../../client/common/application/workspace';
+// import { IWorkspaceService } from '../../client/common/application/types';
+// import { WorkspaceService } from '../../client/common/application/workspace';
 
 suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
-    let workspaceService: IWorkspaceService;
+    // let workspaceService: IWorkspaceService;
     let experimentService: TypeMoq.IMock<IExperimentService>;
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
 
-    function configureSettings(enabled: boolean, optInto: string[], optOutFrom: string[]) {
-        when(workspaceService.getConfiguration('python')).thenReturn({
-            get: (key: string) => {
-                if (key === 'experiments.enabled') {
-                    return enabled;
-                }
-                if (key === 'experiments.optInto') {
-                    return optInto;
-                }
-                if (key === 'experiments.optOutFrom') {
-                    return optOutFrom;
-                }
-                return undefined;
-            },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any);
-    }
+    // function configureSettings(enabled: boolean, optInto: string[], optOutFrom: string[]) {
+    //     when(workspaceService.getConfiguration('python')).thenReturn({
+    //         get: (key: string) => {
+    //             if (key === 'experiments.enabled') {
+    //                 return enabled;
+    //             }
+    //             if (key === 'experiments.optInto') {
+    //                 return optInto;
+    //             }
+    //             if (key === 'experiments.optOutFrom') {
+    //                 return optOutFrom;
+    //             }
+    //             return undefined;
+    //         },
+    //         // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    //     } as any);
+    // }
     teardown(() => {
         sinon.restore();
     });
     suiteSetup(async function () {
-        workspaceService = mock(WorkspaceService);
-        configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
+        // workspaceService = mock(WorkspaceService);
+        // configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
 
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         serviceContainer
@@ -66,8 +66,8 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
     test('Smart Send', async () => {
         const pythonConfig = vscode.workspace.getConfiguration('python');
         await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
-        workspaceService = mock(WorkspaceService);
-        configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
+        // workspaceService = mock(WorkspaceService);
+        // configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
 
         experimentService = TypeMoq.Mock.ofType<IExperimentService>();
         experimentService
@@ -79,7 +79,7 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
             .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
             .returns(() => experimentService.object);
 
-        configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
+        // configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
 
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         serviceContainer

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -133,7 +133,7 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
 
         const checkIfFileHasBeenCreated = () => fs.pathExists(outputFile);
         await waitForCondition(checkIfFileHasBeenCreated, 30_000, `"${outputFile}" file not created`);
-
+        console.log(experimentService.object.inExperimentSync(EnableREPLSmartSend.experiment));
         // Shift+enter two more times so we can track cursor movement with deletion of file
         await vscode.commands
             .executeCommand<void>('python.execSelectionInTerminal', textDocument.uri)

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -50,7 +50,7 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
             });
 
         const checkIfFileHasBeenCreated = () => fs.pathExists(outputFile);
-        await waitForCondition(checkIfFileHasBeenCreated, 30_000, `"${outputFile}" file not created`);
+        await waitForCondition(checkIfFileHasBeenCreated, 10_000, `"${outputFile}" file not created`);
 
         await vscode.commands
             .executeCommand<void>('python.execSelectionInTerminal', textDocument.uri)

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -1,14 +1,14 @@
 import * as vscode from 'vscode';
-import * as TypeMoq from 'typemoq';
+// import * as TypeMoq from 'typemoq';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { assert } from 'chai';
 import { IS_SMOKE_TEST, EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants';
 import { closeActiveWindows, initialize, initializeTest } from '../initialize';
 import { openFile, waitForCondition } from '../common';
-import { IExperimentService } from '../../client/common/types';
-import { EnableREPLSmartSend } from '../../client/common/experiments/groups';
-import { IServiceContainer } from '../../client/ioc/types';
+// import { IExperimentService } from '../../client/common/types';
+// import { EnableREPLSmartSend } from '../../client/common/experiments/groups';
+// import { IServiceContainer } from '../../client/ioc/types';
 
 suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
     // let experimentService: TypeMoq.IMock<IExperimentService>;

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -25,8 +25,8 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
             return this.skip();
         }
         await initialize();
-        const pythonConfig = vscode.workspace.getConfiguration('python');
-        await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
+        // const pythonConfig = vscode.workspace.getConfiguration('python');
+        // await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
         return undefined;
     });
 
@@ -35,8 +35,8 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
     teardown(closeActiveWindows);
 
     test('Smart Send', async () => {
-        const pythonConfig = vscode.workspace.getConfiguration('python');
-        await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
+        // const pythonConfig = vscode.workspace.getConfiguration('python');
+        // await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
 
         experimentService = TypeMoq.Mock.ofType<IExperimentService>();
         experimentService
@@ -72,7 +72,7 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
             'smart_send_smoke.txt',
         );
 
-        await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
+        // await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
         await fs.remove(outputFile);
 
         const textDocument = await openFile(file);

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -3,47 +3,18 @@ import * as TypeMoq from 'typemoq';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { assert } from 'chai';
-// import { mock, when } from 'ts-mockito';
-import * as tasClient from 'vscode-tas-client';
-import * as sinon from 'sinon';
 import { IS_SMOKE_TEST, EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants';
 import { closeActiveWindows, initialize, initializeTest } from '../initialize';
 import { openFile, waitForCondition } from '../common';
 import { IExperimentService } from '../../client/common/types';
 import { EnableREPLSmartSend } from '../../client/common/experiments/groups';
 import { IServiceContainer } from '../../client/ioc/types';
-// import { IWorkspaceService } from '../../client/common/application/types';
-// import { WorkspaceService } from '../../client/common/application/workspace';
 
 suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
-    // let workspaceService: IWorkspaceService;
     let experimentService: TypeMoq.IMock<IExperimentService>;
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
 
-    // function configureSettings(enabled: boolean, optInto: string[], optOutFrom: string[]) {
-    //     when(workspaceService.getConfiguration('python')).thenReturn({
-    //         get: (key: string) => {
-    //             if (key === 'experiments.enabled') {
-    //                 return enabled;
-    //             }
-    //             if (key === 'experiments.optInto') {
-    //                 return optInto;
-    //             }
-    //             if (key === 'experiments.optOutFrom') {
-    //                 return optOutFrom;
-    //             }
-    //             return undefined;
-    //         },
-    //         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    //     } as any);
-    // }
-    teardown(() => {
-        sinon.restore();
-    });
     suiteSetup(async function () {
-        // workspaceService = mock(WorkspaceService);
-        // configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
-
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         serviceContainer
             .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
@@ -66,20 +37,15 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
     test('Smart Send', async () => {
         const pythonConfig = vscode.workspace.getConfiguration('python');
         await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
-        // workspaceService = mock(WorkspaceService);
-        // configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
 
         experimentService = TypeMoq.Mock.ofType<IExperimentService>();
         experimentService
             .setup((exp) => exp.inExperimentSync(TypeMoq.It.isValue(EnableREPLSmartSend.experiment)))
             .returns(() => true);
-        sinon.stub(tasClient, 'getExperimentationService');
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         serviceContainer
             .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
             .returns(() => experimentService.object);
-
-        // configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
 
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         serviceContainer
@@ -124,7 +90,7 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
         const checkIfFileHasBeenCreated = () => fs.pathExists(outputFile);
         await waitForCondition(checkIfFileHasBeenCreated, 30_000, `"${outputFile}" file not created`);
         console.log(experimentService.object.inExperimentSync(EnableREPLSmartSend.experiment));
-        // Shift+enter two more times so we can track cursor movement with deletion of file
+
         await vscode.commands
             .executeCommand<void>('python.execSelectionInTerminal', textDocument.uri)
             .then(undefined, (err) => {

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -1,26 +1,13 @@
 import * as vscode from 'vscode';
-// import * as TypeMoq from 'typemoq';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { assert } from 'chai';
 import { IS_SMOKE_TEST, EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants';
 import { closeActiveWindows, initialize, initializeTest } from '../initialize';
 import { openFile, waitForCondition } from '../common';
-// import { IExperimentService } from '../../client/common/types';
-// import { EnableREPLSmartSend } from '../../client/common/experiments/groups';
-// import { IServiceContainer } from '../../client/ioc/types';
 
 suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
-    // let experimentService: TypeMoq.IMock<IExperimentService>;
-    // let serviceContainer: TypeMoq.IMock<IServiceContainer>;
-
     suiteSetup(async function () {
-        // serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
-        // serviceContainer
-        //     .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
-        //     .returns(() => experimentService.object);
-        // experimentService = TypeMoq.Mock.ofType<IExperimentService>();
-        // experimentService.setup((exp) => exp.inExperimentSync(TypeMoq.It.isAny())).returns(() => true);
         if (!IS_SMOKE_TEST) {
             return this.skip();
         }
@@ -34,25 +21,6 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
     teardown(closeActiveWindows);
 
     test('Smart Send', async () => {
-        // experimentService = TypeMoq.Mock.ofType<IExperimentService>();
-        // experimentService
-        //     .setup((exp) => exp.inExperimentSync(TypeMoq.It.isValue(EnableREPLSmartSend.experiment)))
-        //     .returns(() => true);
-        // serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
-        // serviceContainer
-        //     .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
-        //     .returns(() => experimentService.object);
-
-        // serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
-        // serviceContainer
-        //     .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
-        //     .returns(() => experimentService.object);
-        // experimentService = TypeMoq.Mock.ofType<IExperimentService>();
-
-        // experimentService
-        //     .setup((exp) => exp.inExperimentSync(TypeMoq.It.isValue(EnableREPLSmartSend.experiment)))
-        //     .returns(() => true);
-
         const file = path.join(
             EXTENSION_ROOT_DIR_FOR_TESTS,
             'src',
@@ -84,7 +52,6 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
 
         const checkIfFileHasBeenCreated = () => fs.pathExists(outputFile);
         await waitForCondition(checkIfFileHasBeenCreated, 30_000, `"${outputFile}" file not created`);
-        // console.log(experimentService.object.inExperimentSync(EnableREPLSmartSend.experiment));
 
         await vscode.commands
             .executeCommand<void>('python.execSelectionInTerminal', textDocument.uri)

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -2,14 +2,16 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { assert } from 'chai';
-import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants';
+import { EXTENSION_ROOT_DIR_FOR_TESTS, IS_SMOKE_TEST } from '../constants';
 import { closeActiveWindows, initialize, initializeTest } from '../initialize';
 import { openFile, waitForCondition } from '../common';
 
 suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
-    suiteSetup(async () => {
+    suiteSetup(async function () {
+        if (!IS_SMOKE_TEST) {
+            return this.skip();
+        }
         await initialize();
-
         return undefined;
     });
 

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -1,0 +1,166 @@
+import * as vscode from 'vscode';
+import * as TypeMoq from 'typemoq';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { assert } from 'chai';
+import { mock, when } from 'ts-mockito';
+import * as tasClient from 'vscode-tas-client';
+import * as sinon from 'sinon';
+import { IS_SMOKE_TEST, EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants';
+import { initialize } from '../initialize';
+import { openFile, waitForCondition } from '../common';
+import { IExperimentService } from '../../client/common/types';
+import { EnableREPLSmartSend } from '../../client/common/experiments/groups';
+import { IServiceContainer } from '../../client/ioc/types';
+import { IWorkspaceService } from '../../client/common/application/types';
+import { WorkspaceService } from '../../client/common/application/workspace';
+
+// const TEST_FILES_PATH = path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'pythonFiles', 'terminalExec');
+
+suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
+    // const extensionVersion = '1.2.3';
+    let workspaceService: IWorkspaceService;
+    let experimentService: TypeMoq.IMock<IExperimentService>;
+    let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+    // let appEnvironment: IApplicationEnvironment;
+    // "keybindings": [
+    //     {
+    //         "command": "python.execSelectionInTerminal",
+    //         "key": "shift+enter",
+    //         "when": "editorTextFocus && editorLangId == python && !findInputFocussed && !replaceInputFocussed && !jupyter.ownsSelection && !notebookEditorFocused"
+    //     },
+    // function configureApplicationEnvironment(channel: Channel, version: string, contributes?: Record<string, unknown>) {
+    //     when(appEnvironment.extensionChannel).thenReturn(channel);
+    //     when(appEnvironment.extensionName).thenReturn(PVSC_EXTENSION_ID_FOR_TESTS);
+    //     when(appEnvironment.packageJson).thenReturn({ version, contributes });
+    // }
+    function configureSettings(enabled: boolean, optInto: string[], optOutFrom: string[]) {
+        when(workspaceService.getConfiguration('python')).thenReturn({
+            get: (key: string) => {
+                if (key === 'experiments.enabled') {
+                    return enabled;
+                }
+                if (key === 'experiments.optInto') {
+                    return optInto;
+                }
+                if (key === 'experiments.optOutFrom') {
+                    return optOutFrom;
+                }
+                return undefined;
+            },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+    }
+    teardown(() => {
+        sinon.restore();
+    });
+    suiteSetup(async function () {
+        workspaceService = mock(WorkspaceService);
+        configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
+        // configureApplicationEnvironment('stable', extensionVersion);
+
+        serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        serviceContainer
+            .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
+            .returns(() => experimentService.object);
+        experimentService = TypeMoq.Mock.ofType<IExperimentService>();
+        experimentService.setup((exp) => exp.inExperimentSync(TypeMoq.It.isAny())).returns(() => true);
+        if (!IS_SMOKE_TEST) {
+            return this.skip();
+        }
+        await initialize();
+        return undefined;
+    });
+
+    // setup(initializeTest);
+    // suiteTeardown(closeActiveWindows);
+    // teardown(closeActiveWindows);
+
+    test('Smart Send', async () => {
+        workspaceService = mock(WorkspaceService);
+        configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
+        // configureApplicationEnvironment('stable', extensionVersion);
+        experimentService = TypeMoq.Mock.ofType<IExperimentService>();
+        experimentService
+            .setup((exp) => exp.inExperimentSync(TypeMoq.It.isValue(EnableREPLSmartSend.experiment)))
+            .returns(() => true);
+        sinon.stub(tasClient, 'getExperimentationService');
+        serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        serviceContainer
+            .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
+            .returns(() => experimentService.object);
+
+        configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
+
+        serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        serviceContainer
+            .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
+            .returns(() => experimentService.object);
+        experimentService = TypeMoq.Mock.ofType<IExperimentService>();
+
+        experimentService
+            .setup((exp) => exp.inExperimentSync(TypeMoq.It.isValue(EnableREPLSmartSend.experiment)))
+            .returns(() => true);
+
+        const file = path.join(
+            EXTENSION_ROOT_DIR_FOR_TESTS,
+            'src',
+            'testMultiRootWkspc',
+            'smokeTests',
+            'create_delete_file.py',
+        );
+        const outputFile = path.join(
+            EXTENSION_ROOT_DIR_FOR_TESTS,
+            'src',
+            'testMultiRootWkspc',
+            'smokeTests',
+            'smart_send_smoke.txt',
+        );
+
+        await fs.remove(outputFile);
+
+        const textDocument = await openFile(file);
+
+        if (vscode.window.activeTextEditor) {
+            const myPos = new vscode.Position(0, 0);
+            vscode.window.activeTextEditor!.selections = [new vscode.Selection(myPos, myPos)];
+        }
+        await vscode.commands
+            .executeCommand<void>('python.execSelectionInTerminal', textDocument.uri)
+            .then(undefined, (err) => {
+                assert.fail(`Something went wrong running the Python file in the terminal: ${err}`);
+            });
+
+        const checkIfFileHasBeenCreated = () => fs.pathExists(outputFile);
+        await waitForCondition(checkIfFileHasBeenCreated, 30_000, `"${outputFile}" file not created`);
+
+        // Shift+enter two more times so we can track cursor movement with deletion of file
+        await vscode.commands
+            .executeCommand<void>('python.execSelectionInTerminal', textDocument.uri)
+            .then(undefined, (err) => {
+                assert.fail(`Something went wrong running the Python file in the terminal: ${err}`);
+            });
+        await vscode.commands
+            .executeCommand<void>('python.execSelectionInTerminal', textDocument.uri)
+            .then(undefined, (err) => {
+                assert.fail(`Something went wrong running the Python file in the terminal: ${err}`);
+            });
+
+        async function waitThirtySeconds() {
+            return new Promise<void>((resolve) => {
+                setTimeout(() => {
+                    resolve();
+                }, 30000);
+            });
+        }
+
+        await waitThirtySeconds();
+
+        const deletedFile = !(await fs.pathExists(outputFile));
+        if (deletedFile) {
+            assert.ok(true, `"${outputFile}" file has been deleted`);
+        } else {
+            assert.fail(`"${outputFile}" file still exists`);
+        }
+    });
+});

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -7,7 +7,7 @@ import { mock, when } from 'ts-mockito';
 import * as tasClient from 'vscode-tas-client';
 import * as sinon from 'sinon';
 import { IS_SMOKE_TEST, EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants';
-import { initialize } from '../initialize';
+import { closeActiveWindows, initialize, initializeTest } from '../initialize';
 import { openFile, waitForCondition } from '../common';
 import { IExperimentService } from '../../client/common/types';
 import { EnableREPLSmartSend } from '../../client/common/experiments/groups';
@@ -74,9 +74,9 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
         return undefined;
     });
 
-    // setup(initializeTest);
-    // suiteTeardown(closeActiveWindows);
-    // teardown(closeActiveWindows);
+    setup(initializeTest);
+    suiteTeardown(closeActiveWindows);
+    teardown(closeActiveWindows);
 
     test('Smart Send', async () => {
         const pythonConfig = vscode.workspace.getConfiguration('python');
@@ -151,15 +151,15 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
                 assert.fail(`Something went wrong running the Python file in the terminal: ${err}`);
             });
 
-        async function waitThirtySeconds() {
+        async function wait() {
             return new Promise<void>((resolve) => {
                 setTimeout(() => {
                     resolve();
-                }, 30000);
+                }, 10000);
             });
         }
 
-        await waitThirtySeconds();
+        await wait();
 
         const deletedFile = !(await fs.pathExists(outputFile));
         if (deletedFile) {

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -48,7 +48,7 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
             });
 
         const checkIfFileHasBeenCreated = () => fs.pathExists(outputFile);
-        await waitForCondition(checkIfFileHasBeenCreated, 15_000, `"${outputFile}" file not created`);
+        await waitForCondition(checkIfFileHasBeenCreated, 20_000, `"${outputFile}" file not created`);
 
         await vscode.commands
             .executeCommand<void>('python.execSelectionInTerminal', textDocument.uri)

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -55,6 +55,11 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
             .then(undefined, (err) => {
                 assert.fail(`Something went wrong running the Python file in the terminal: ${err}`);
             });
+        await vscode.commands
+            .executeCommand<void>('python.execSelectionInTerminal', textDocument.uri)
+            .then(undefined, (err) => {
+                assert.fail(`Something went wrong running the Python file in the terminal: ${err}`);
+            });
 
         async function wait() {
             return new Promise<void>((resolve) => {

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -11,16 +11,16 @@ import { EnableREPLSmartSend } from '../../client/common/experiments/groups';
 import { IServiceContainer } from '../../client/ioc/types';
 
 suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
-    let experimentService: TypeMoq.IMock<IExperimentService>;
-    let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+    // let experimentService: TypeMoq.IMock<IExperimentService>;
+    // let serviceContainer: TypeMoq.IMock<IServiceContainer>;
 
     suiteSetup(async function () {
-        serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
-        serviceContainer
-            .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
-            .returns(() => experimentService.object);
-        experimentService = TypeMoq.Mock.ofType<IExperimentService>();
-        experimentService.setup((exp) => exp.inExperimentSync(TypeMoq.It.isAny())).returns(() => true);
+        // serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        // serviceContainer
+        //     .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
+        //     .returns(() => experimentService.object);
+        // experimentService = TypeMoq.Mock.ofType<IExperimentService>();
+        // experimentService.setup((exp) => exp.inExperimentSync(TypeMoq.It.isAny())).returns(() => true);
         if (!IS_SMOKE_TEST) {
             return this.skip();
         }
@@ -34,24 +34,24 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
     teardown(closeActiveWindows);
 
     test('Smart Send', async () => {
-        experimentService = TypeMoq.Mock.ofType<IExperimentService>();
-        experimentService
-            .setup((exp) => exp.inExperimentSync(TypeMoq.It.isValue(EnableREPLSmartSend.experiment)))
-            .returns(() => true);
-        serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
-        serviceContainer
-            .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
-            .returns(() => experimentService.object);
+        // experimentService = TypeMoq.Mock.ofType<IExperimentService>();
+        // experimentService
+        //     .setup((exp) => exp.inExperimentSync(TypeMoq.It.isValue(EnableREPLSmartSend.experiment)))
+        //     .returns(() => true);
+        // serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        // serviceContainer
+        //     .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
+        //     .returns(() => experimentService.object);
 
-        serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
-        serviceContainer
-            .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
-            .returns(() => experimentService.object);
-        experimentService = TypeMoq.Mock.ofType<IExperimentService>();
+        // serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        // serviceContainer
+        //     .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
+        //     .returns(() => experimentService.object);
+        // experimentService = TypeMoq.Mock.ofType<IExperimentService>();
 
-        experimentService
-            .setup((exp) => exp.inExperimentSync(TypeMoq.It.isValue(EnableREPLSmartSend.experiment)))
-            .returns(() => true);
+        // experimentService
+        //     .setup((exp) => exp.inExperimentSync(TypeMoq.It.isValue(EnableREPLSmartSend.experiment)))
+        //     .returns(() => true);
 
         const file = path.join(
             EXTENSION_ROOT_DIR_FOR_TESTS,
@@ -84,7 +84,7 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
 
         const checkIfFileHasBeenCreated = () => fs.pathExists(outputFile);
         await waitForCondition(checkIfFileHasBeenCreated, 30_000, `"${outputFile}" file not created`);
-        console.log(experimentService.object.inExperimentSync(EnableREPLSmartSend.experiment));
+        // console.log(experimentService.object.inExperimentSync(EnableREPLSmartSend.experiment));
 
         await vscode.commands
             .executeCommand<void>('python.execSelectionInTerminal', textDocument.uri)

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -3,7 +3,6 @@ import * as TypeMoq from 'typemoq';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { assert } from 'chai';
-import { mock, when } from 'ts-mockito';
 import * as tasClient from 'vscode-tas-client';
 import * as sinon from 'sinon';
 import { IS_SMOKE_TEST, EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants';
@@ -12,53 +11,16 @@ import { openFile, waitForCondition } from '../common';
 import { IExperimentService } from '../../client/common/types';
 import { EnableREPLSmartSend } from '../../client/common/experiments/groups';
 import { IServiceContainer } from '../../client/ioc/types';
-import { IWorkspaceService } from '../../client/common/application/types';
-import { WorkspaceService } from '../../client/common/application/workspace';
-
-// const TEST_FILES_PATH = path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'pythonFiles', 'terminalExec');
 
 suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
-    // const extensionVersion = '1.2.3';
-    let workspaceService: IWorkspaceService;
     let experimentService: TypeMoq.IMock<IExperimentService>;
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
-    // let appEnvironment: IApplicationEnvironment;
-    // "keybindings": [
-    //     {
-    //         "command": "python.execSelectionInTerminal",
-    //         "key": "shift+enter",
-    //         "when": "editorTextFocus && editorLangId == python && !findInputFocussed && !replaceInputFocussed && !jupyter.ownsSelection && !notebookEditorFocused"
-    //     },
-    // function configureApplicationEnvironment(channel: Channel, version: string, contributes?: Record<string, unknown>) {
-    //     when(appEnvironment.extensionChannel).thenReturn(channel);
-    //     when(appEnvironment.extensionName).thenReturn(PVSC_EXTENSION_ID_FOR_TESTS);
-    //     when(appEnvironment.packageJson).thenReturn({ version, contributes });
-    // }
-    function configureSettings(enabled: boolean, optInto: string[], optOutFrom: string[]) {
-        when(workspaceService.getConfiguration('python')).thenReturn({
-            get: (key: string) => {
-                if (key === 'experiments.enabled') {
-                    return enabled;
-                }
-                if (key === 'experiments.optInto') {
-                    return optInto;
-                }
-                if (key === 'experiments.optOutFrom') {
-                    return optOutFrom;
-                }
-                return undefined;
-            },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any);
-    }
+
     teardown(() => {
         sinon.restore();
     });
-    suiteSetup(async function () {
-        workspaceService = mock(WorkspaceService);
-        configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
-        // configureApplicationEnvironment('stable', extensionVersion);
 
+    suiteSetup(async function () {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         serviceContainer
             .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
@@ -81,9 +43,7 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
     test('Smart Send', async () => {
         const pythonConfig = vscode.workspace.getConfiguration('python');
         await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
-        workspaceService = mock(WorkspaceService);
-        configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
-        // configureApplicationEnvironment('stable', extensionVersion);
+
         experimentService = TypeMoq.Mock.ofType<IExperimentService>();
         experimentService
             .setup((exp) => exp.inExperimentSync(TypeMoq.It.isValue(EnableREPLSmartSend.experiment)))
@@ -93,8 +53,6 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
         serviceContainer
             .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
             .returns(() => experimentService.object);
-
-        configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
 
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         serviceContainer
@@ -120,7 +78,7 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
             'smokeTests',
             'smart_send_smoke.txt',
         );
-        // const pythonConfig = vscode.workspace.getConfiguration('python');
+
         await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
         await fs.remove(outputFile);
 

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -69,6 +69,8 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
             return this.skip();
         }
         await initialize();
+        const pythonConfig = vscode.workspace.getConfiguration('python');
+        await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
         return undefined;
     });
 
@@ -77,6 +79,8 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
     // teardown(closeActiveWindows);
 
     test('Smart Send', async () => {
+        const pythonConfig = vscode.workspace.getConfiguration('python');
+        await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
         workspaceService = mock(WorkspaceService);
         configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
         // configureApplicationEnvironment('stable', extensionVersion);
@@ -116,7 +120,8 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
             'smokeTests',
             'smart_send_smoke.txt',
         );
-
+        // const pythonConfig = vscode.workspace.getConfiguration('python');
+        await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
         await fs.remove(outputFile);
 
         const textDocument = await openFile(file);

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -2,15 +2,12 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { assert } from 'chai';
-import { IS_SMOKE_TEST, EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants';
+import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants';
 import { closeActiveWindows, initialize, initializeTest } from '../initialize';
 import { openFile, waitForCondition } from '../common';
 
 suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
-    suiteSetup(async function () {
-        if (!IS_SMOKE_TEST) {
-            return this.skip();
-        }
+    suiteSetup(async () => {
         await initialize();
 
         return undefined;
@@ -51,13 +48,8 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
             });
 
         const checkIfFileHasBeenCreated = () => fs.pathExists(outputFile);
-        await waitForCondition(checkIfFileHasBeenCreated, 30_000, `"${outputFile}" file not created`);
+        await waitForCondition(checkIfFileHasBeenCreated, 10_000, `"${outputFile}" file not created`);
 
-        await vscode.commands
-            .executeCommand<void>('python.execSelectionInTerminal', textDocument.uri)
-            .then(undefined, (err) => {
-                assert.fail(`Something went wrong running the Python file in the terminal: ${err}`);
-            });
         await vscode.commands
             .executeCommand<void>('python.execSelectionInTerminal', textDocument.uri)
             .then(undefined, (err) => {

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -15,25 +15,11 @@ import { IServiceContainer } from '../../client/ioc/types';
 import { IWorkspaceService } from '../../client/common/application/types';
 import { WorkspaceService } from '../../client/common/application/workspace';
 
-// const TEST_FILES_PATH = path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'pythonFiles', 'terminalExec');
-
 suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
-    // const extensionVersion = '1.2.3';
     let workspaceService: IWorkspaceService;
     let experimentService: TypeMoq.IMock<IExperimentService>;
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
-    // let appEnvironment: IApplicationEnvironment;
-    // "keybindings": [
-    //     {
-    //         "command": "python.execSelectionInTerminal",
-    //         "key": "shift+enter",
-    //         "when": "editorTextFocus && editorLangId == python && !findInputFocussed && !replaceInputFocussed && !jupyter.ownsSelection && !notebookEditorFocused"
-    //     },
-    // function configureApplicationEnvironment(channel: Channel, version: string, contributes?: Record<string, unknown>) {
-    //     when(appEnvironment.extensionChannel).thenReturn(channel);
-    //     when(appEnvironment.extensionName).thenReturn(PVSC_EXTENSION_ID_FOR_TESTS);
-    //     when(appEnvironment.packageJson).thenReturn({ version, contributes });
-    // }
+
     function configureSettings(enabled: boolean, optInto: string[], optOutFrom: string[]) {
         when(workspaceService.getConfiguration('python')).thenReturn({
             get: (key: string) => {
@@ -57,7 +43,6 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
     suiteSetup(async function () {
         workspaceService = mock(WorkspaceService);
         configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
-        // configureApplicationEnvironment('stable', extensionVersion);
 
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         serviceContainer
@@ -83,7 +68,7 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
         await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
         workspaceService = mock(WorkspaceService);
         configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
-        // configureApplicationEnvironment('stable', extensionVersion);
+
         experimentService = TypeMoq.Mock.ofType<IExperimentService>();
         experimentService
             .setup((exp) => exp.inExperimentSync(TypeMoq.It.isValue(EnableREPLSmartSend.experiment)))
@@ -120,7 +105,7 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
             'smokeTests',
             'smart_send_smoke.txt',
         );
-        // const pythonConfig = vscode.workspace.getConfiguration('python');
+
         await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
         await fs.remove(outputFile);
 

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -48,7 +48,7 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
             });
 
         const checkIfFileHasBeenCreated = () => fs.pathExists(outputFile);
-        await waitForCondition(checkIfFileHasBeenCreated, 20_000, `"${outputFile}" file not created`);
+        await waitForCondition(checkIfFileHasBeenCreated, 30_000, `"${outputFile}" file not created`);
 
         await vscode.commands
             .executeCommand<void>('python.execSelectionInTerminal', textDocument.uri)

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -25,8 +25,7 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
             return this.skip();
         }
         await initialize();
-        // const pythonConfig = vscode.workspace.getConfiguration('python');
-        // await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
+
         return undefined;
     });
 
@@ -35,9 +34,6 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
     teardown(closeActiveWindows);
 
     test('Smart Send', async () => {
-        // const pythonConfig = vscode.workspace.getConfiguration('python');
-        // await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
-
         experimentService = TypeMoq.Mock.ofType<IExperimentService>();
         experimentService
             .setup((exp) => exp.inExperimentSync(TypeMoq.It.isValue(EnableREPLSmartSend.experiment)))
@@ -72,7 +68,6 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
             'smart_send_smoke.txt',
         );
 
-        // await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
         await fs.remove(outputFile);
 
         const textDocument = await openFile(file);

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -3,6 +3,7 @@ import * as TypeMoq from 'typemoq';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { assert } from 'chai';
+import { mock, when } from 'ts-mockito';
 import * as tasClient from 'vscode-tas-client';
 import * as sinon from 'sinon';
 import { IS_SMOKE_TEST, EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants';
@@ -11,16 +12,53 @@ import { openFile, waitForCondition } from '../common';
 import { IExperimentService } from '../../client/common/types';
 import { EnableREPLSmartSend } from '../../client/common/experiments/groups';
 import { IServiceContainer } from '../../client/ioc/types';
+import { IWorkspaceService } from '../../client/common/application/types';
+import { WorkspaceService } from '../../client/common/application/workspace';
+
+// const TEST_FILES_PATH = path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'pythonFiles', 'terminalExec');
 
 suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
+    // const extensionVersion = '1.2.3';
+    let workspaceService: IWorkspaceService;
     let experimentService: TypeMoq.IMock<IExperimentService>;
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
-
+    // let appEnvironment: IApplicationEnvironment;
+    // "keybindings": [
+    //     {
+    //         "command": "python.execSelectionInTerminal",
+    //         "key": "shift+enter",
+    //         "when": "editorTextFocus && editorLangId == python && !findInputFocussed && !replaceInputFocussed && !jupyter.ownsSelection && !notebookEditorFocused"
+    //     },
+    // function configureApplicationEnvironment(channel: Channel, version: string, contributes?: Record<string, unknown>) {
+    //     when(appEnvironment.extensionChannel).thenReturn(channel);
+    //     when(appEnvironment.extensionName).thenReturn(PVSC_EXTENSION_ID_FOR_TESTS);
+    //     when(appEnvironment.packageJson).thenReturn({ version, contributes });
+    // }
+    function configureSettings(enabled: boolean, optInto: string[], optOutFrom: string[]) {
+        when(workspaceService.getConfiguration('python')).thenReturn({
+            get: (key: string) => {
+                if (key === 'experiments.enabled') {
+                    return enabled;
+                }
+                if (key === 'experiments.optInto') {
+                    return optInto;
+                }
+                if (key === 'experiments.optOutFrom') {
+                    return optOutFrom;
+                }
+                return undefined;
+            },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+    }
     teardown(() => {
         sinon.restore();
     });
-
     suiteSetup(async function () {
+        workspaceService = mock(WorkspaceService);
+        configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
+        // configureApplicationEnvironment('stable', extensionVersion);
+
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         serviceContainer
             .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
@@ -43,7 +81,9 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
     test('Smart Send', async () => {
         const pythonConfig = vscode.workspace.getConfiguration('python');
         await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
-
+        workspaceService = mock(WorkspaceService);
+        configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
+        // configureApplicationEnvironment('stable', extensionVersion);
         experimentService = TypeMoq.Mock.ofType<IExperimentService>();
         experimentService
             .setup((exp) => exp.inExperimentSync(TypeMoq.It.isValue(EnableREPLSmartSend.experiment)))
@@ -53,6 +93,8 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
         serviceContainer
             .setup((s) => s.get(TypeMoq.It.isValue(IExperimentService)))
             .returns(() => experimentService.object);
+
+        configureSettings(true, ['pythonREPLSmartSend', 'EnableREPLSmartSend'], []);
 
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         serviceContainer
@@ -78,7 +120,7 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
             'smokeTests',
             'smart_send_smoke.txt',
         );
-
+        // const pythonConfig = vscode.workspace.getConfiguration('python');
         await pythonConfig.update('experiments.optInto', ['All'], vscode.ConfigurationTarget.Global);
         await fs.remove(outputFile);
 

--- a/src/test/smoke/smartSend.smoke.test.ts
+++ b/src/test/smoke/smartSend.smoke.test.ts
@@ -48,7 +48,7 @@ suite('Smoke Test: Run Smart Selection and Advance Cursor', () => {
             });
 
         const checkIfFileHasBeenCreated = () => fs.pathExists(outputFile);
-        await waitForCondition(checkIfFileHasBeenCreated, 10_000, `"${outputFile}" file not created`);
+        await waitForCondition(checkIfFileHasBeenCreated, 15_000, `"${outputFile}" file not created`);
 
         await vscode.commands
             .executeCommand<void>('python.execSelectionInTerminal', textDocument.uri)


### PR DESCRIPTION
Closes: #22193

Enables to opt into experiments for tests such as single workspace, multi workspace, debugger, venv, etc. 