### PR TITLE
Move tensorboard support into a separate extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1836,7 +1836,7 @@
                     "category": "Python",
                     "command": "python.launchTensorBoard",
                     "title": "%python.command.python.launchTensorBoard.title%",
-                    "when": "!virtualWorkspace && shellExecutionSupported"
+                    "when": "!virtualWorkspace && shellExecutionSupported && !python.tensorboardExtInstalled"
                 },
                 {
                     "category": "Python",
@@ -1844,7 +1844,7 @@
                     "enablement": "python.hasActiveTensorBoardSession",
                     "icon": "$(refresh)",
                     "title": "%python.command.python.refreshTensorBoard.title%",
-                    "when": "!virtualWorkspace && shellExecutionSupported"
+                    "when": "!virtualWorkspace && shellExecutionSupported && !python.tensorboardExtInstalled"
                 },
                 {
                     "category": "Python",

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -21,6 +21,7 @@ import { IDiscoveryAPI } from './pythonEnvironments/base/locator';
 import { buildEnvironmentApi } from './environmentApi';
 import { ApiForPylance } from './pylanceApi';
 import { getTelemetryReporter } from './telemetry';
+import { TensorboardExtensionIntegration } from './tensorBoard/tensorboardIntegration';
 
 export function buildApi(
     ready: Promise<void>,
@@ -31,7 +32,14 @@ export function buildApi(
     const configurationService = serviceContainer.get<IConfigurationService>(IConfigurationService);
     const interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
     serviceManager.addSingleton<JupyterExtensionIntegration>(JupyterExtensionIntegration, JupyterExtensionIntegration);
+    serviceManager.addSingleton<TensorboardExtensionIntegration>(
+        TensorboardExtensionIntegration,
+        TensorboardExtensionIntegration,
+    );
     const jupyterIntegration = serviceContainer.get<JupyterExtensionIntegration>(JupyterExtensionIntegration);
+    const tensorboardIntegration = serviceContainer.get<TensorboardExtensionIntegration>(
+        TensorboardExtensionIntegration,
+    );
     const outputChannel = serviceContainer.get<ILanguageServerOutputChannel>(ILanguageServerOutputChannel);
 
     const api: PythonExtension & {
@@ -39,6 +47,12 @@ export function buildApi(
          * Internal API just for Jupyter, hence don't include in the official types.
          */
         jupyter: {
+            registerHooks(): void;
+        };
+        /**
+         * Internal API just for Tensorboard, hence don't include in the official types.
+         */
+        tensorboard: {
             registerHooks(): void;
         };
     } & {
@@ -91,6 +105,9 @@ export function buildApi(
         }),
         jupyter: {
             registerHooks: () => jupyterIntegration.integrateWithJupyterExtension(),
+        },
+        tensorboard: {
+            registerHooks: () => tensorboardIntegration.integrateWithTensorboardExtension(),
         },
         debug: {
             async getRemoteLauncherCommand(

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -23,6 +23,7 @@ export const PYTHON_NOTEBOOKS = [
 export const PVSC_EXTENSION_ID = 'ms-python.python';
 export const PYLANCE_EXTENSION_ID = 'ms-python.vscode-pylance';
 export const JUPYTER_EXTENSION_ID = 'ms-toolsai.jupyter';
+export const TENSORBOARD_EXTENSION_ID = 'ms-toolsai.tensorboard';
 export const AppinsightsKey = '0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255';
 
 export type Channel = 'stable' | 'insiders';

--- a/src/client/tensorBoard/nbextensionCodeLensProvider.ts
+++ b/src/client/tensorBoard/nbextensionCodeLensProvider.ts
@@ -12,6 +12,7 @@ import { sendTelemetryEvent } from '../telemetry';
 import { EventName } from '../telemetry/constants';
 import { TensorBoardEntrypoint, TensorBoardEntrypointTrigger } from './constants';
 import { containsNotebookExtension } from './helpers';
+import { useNewTensorboardExtension } from './tensorboarExperiment';
 
 @injectable()
 export class TensorBoardNbextensionCodeLensProvider implements IExtensionSingleActivationService {
@@ -27,6 +28,9 @@ export class TensorBoardNbextensionCodeLensProvider implements IExtensionSingleA
     constructor(@inject(IDisposableRegistry) private disposables: IDisposableRegistry) {}
 
     public async activate(): Promise<void> {
+        if (useNewTensorboardExtension()) {
+            return;
+        }
         this.activateInternal().ignoreErrors();
     }
 

--- a/src/client/tensorBoard/serviceRegistry.ts
+++ b/src/client/tensorBoard/serviceRegistry.ts
@@ -10,6 +10,7 @@ import { TensorBoardPrompt } from './tensorBoardPrompt';
 import { TensorBoardSessionProvider } from './tensorBoardSessionProvider';
 import { TensorBoardNbextensionCodeLensProvider } from './nbextensionCodeLensProvider';
 import { TerminalWatcher } from './terminalWatcher';
+import { TensorboardDependencyChecker } from './tensorboardDependencyChecker';
 
 export function registerTypes(serviceManager: IServiceManager): void {
     serviceManager.addSingleton<TensorBoardSessionProvider>(TensorBoardSessionProvider, TensorBoardSessionProvider);
@@ -32,4 +33,5 @@ export function registerTypes(serviceManager: IServiceManager): void {
     );
     serviceManager.addBinding(TensorBoardNbextensionCodeLensProvider, IExtensionSingleActivationService);
     serviceManager.addSingleton(IExtensionSingleActivationService, TerminalWatcher);
+    serviceManager.addSingleton(TensorboardDependencyChecker, TensorboardDependencyChecker);
 }

--- a/src/client/tensorBoard/tensorBoardFileWatcher.ts
+++ b/src/client/tensorBoard/tensorBoardFileWatcher.ts
@@ -8,6 +8,7 @@ import { IWorkspaceService } from '../common/application/types';
 import { IDisposableRegistry } from '../common/types';
 import { TensorBoardEntrypointTrigger } from './constants';
 import { TensorBoardPrompt } from './tensorBoardPrompt';
+import { useNewTensorboardExtension } from './tensorboarExperiment';
 
 @injectable()
 export class TensorBoardFileWatcher implements IExtensionSingleActivationService {
@@ -24,6 +25,9 @@ export class TensorBoardFileWatcher implements IExtensionSingleActivationService
     ) {}
 
     public async activate(): Promise<void> {
+        if (useNewTensorboardExtension()) {
+            return;
+        }
         this.activateInternal().ignoreErrors();
     }
 

--- a/src/client/tensorBoard/tensorBoardImportCodeLensProvider.ts
+++ b/src/client/tensorBoard/tensorBoardImportCodeLensProvider.ts
@@ -12,6 +12,7 @@ import { sendTelemetryEvent } from '../telemetry';
 import { EventName } from '../telemetry/constants';
 import { TensorBoardEntrypoint, TensorBoardEntrypointTrigger } from './constants';
 import { containsTensorBoardImport } from './helpers';
+import { useNewTensorboardExtension } from './tensorboarExperiment';
 
 @injectable()
 export class TensorBoardImportCodeLensProvider implements IExtensionSingleActivationService {
@@ -27,6 +28,9 @@ export class TensorBoardImportCodeLensProvider implements IExtensionSingleActiva
     constructor(@inject(IDisposableRegistry) private disposables: IDisposableRegistry) {}
 
     public async activate(): Promise<void> {
+        if (useNewTensorboardExtension()) {
+            return;
+        }
         this.activateInternal().ignoreErrors();
     }
 

--- a/src/client/tensorBoard/tensorBoardPrompt.ts
+++ b/src/client/tensorBoard/tensorBoardPrompt.ts
@@ -84,7 +84,7 @@ export class TensorBoardPrompt {
         }
     }
 
-    private isPromptEnabled(): boolean {
+    public isPromptEnabled(): boolean {
         return this.state.value;
     }
 

--- a/src/client/tensorBoard/tensorBoardSession.ts
+++ b/src/client/tensorBoard/tensorBoardSession.ts
@@ -101,8 +101,8 @@ export class TensorBoardSession {
         private readonly multiStepFactory: IMultiStepInputFactory,
         private readonly configurationService: IConfigurationService,
     ) {
-        this.disposables.push(this.onDidChangeViewStateEventEmitter)
-        this.disposables.push(this.onDidDisposeEventEmitter)
+        this.disposables.push(this.onDidChangeViewStateEventEmitter);
+        this.disposables.push(this.onDidDisposeEventEmitter);
     }
 
     public get onDidDispose(): Event<TensorBoardSession> {

--- a/src/client/tensorBoard/tensorBoardSession.ts
+++ b/src/client/tensorBoard/tensorBoardSession.ts
@@ -100,7 +100,10 @@ export class TensorBoardSession {
         private readonly globalMemento: IPersistentState<ViewColumn>,
         private readonly multiStepFactory: IMultiStepInputFactory,
         private readonly configurationService: IConfigurationService,
-    ) {}
+    ) {
+        this.disposables.push(this.onDidChangeViewStateEventEmitter)
+        this.disposables.push(this.onDidDisposeEventEmitter)
+    }
 
     public get onDidDispose(): Event<TensorBoardSession> {
         return this.onDidDisposeEventEmitter.event;
@@ -189,10 +192,10 @@ export class TensorBoardSession {
     // to start a TensorBoard session. If the user has a torch import in
     // any of their open documents, also try to install the torch-tb-plugin
     // package, but don't block if installing that fails.
-    private async ensurePrerequisitesAreInstalled() {
+    public async ensurePrerequisitesAreInstalled(resource?: Uri): Promise<boolean> {
         traceVerbose('Ensuring TensorBoard package is installed into active interpreter');
         const interpreter =
-            (await this.interpreterService.getActiveInterpreter()) ||
+            (await this.interpreterService.getActiveInterpreter(resource)) ||
             (await this.commandManager.executeCommand('python.setInterpreter'));
         if (!interpreter) {
             return false;

--- a/src/client/tensorBoard/tensorBoardSessionProvider.ts
+++ b/src/client/tensorBoard/tensorBoardSessionProvider.ts
@@ -22,6 +22,7 @@ import { sendTelemetryEvent } from '../telemetry';
 import { EventName } from '../telemetry/constants';
 import { TensorBoardEntrypoint, TensorBoardEntrypointTrigger } from './constants';
 import { TensorBoardSession } from './tensorBoardSession';
+import { useNewTensorboardExtension } from './tensorboarExperiment';
 
 export const PREFERRED_VIEWGROUP = 'PythonTensorBoardWebviewPreferredViewGroup';
 
@@ -58,6 +59,10 @@ export class TensorBoardSessionProvider implements IExtensionSingleActivationSer
     }
 
     public async activate(): Promise<void> {
+        if (useNewTensorboardExtension()) {
+            return;
+        }
+
         this.disposables.push(
             this.commandManager.registerCommand(
                 Commands.LaunchTensorBoard,

--- a/src/client/tensorBoard/tensorBoardSessionProvider.ts
+++ b/src/client/tensorBoard/tensorBoardSessionProvider.ts
@@ -23,7 +23,7 @@ import { EventName } from '../telemetry/constants';
 import { TensorBoardEntrypoint, TensorBoardEntrypointTrigger } from './constants';
 import { TensorBoardSession } from './tensorBoardSession';
 
-const PREFERRED_VIEWGROUP = 'PythonTensorBoardWebviewPreferredViewGroup';
+export const PREFERRED_VIEWGROUP = 'PythonTensorBoardWebviewPreferredViewGroup';
 
 @injectable()
 export class TensorBoardSessionProvider implements IExtensionSingleActivationService {

--- a/src/client/tensorBoard/tensorBoardUsageTracker.ts
+++ b/src/client/tensorBoard/tensorBoardUsageTracker.ts
@@ -12,6 +12,7 @@ import { getDocumentLines } from '../telemetry/importTracker';
 import { TensorBoardEntrypointTrigger } from './constants';
 import { containsTensorBoardImport } from './helpers';
 import { TensorBoardPrompt } from './tensorBoardPrompt';
+import { useNewTensorboardExtension } from './tensorboarExperiment';
 
 const testExecution = isTestExecution();
 
@@ -28,6 +29,9 @@ export class TensorBoardUsageTracker implements IExtensionSingleActivationServic
     ) {}
 
     public async activate(): Promise<void> {
+        if (useNewTensorboardExtension()) {
+            return;
+        }
         if (testExecution) {
             await this.activateInternal();
         } else {

--- a/src/client/tensorBoard/tensorboarExperiment.ts
+++ b/src/client/tensorBoard/tensorboarExperiment.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { extensions } from 'vscode';
+
+export function useNewTensorboardExtension(): boolean {
+    return !!extensions.getExtension('ms-toolsai.tensorboard');
+}

--- a/src/client/tensorBoard/tensorboardDependencyChecker.ts
+++ b/src/client/tensorBoard/tensorboardDependencyChecker.ts
@@ -17,10 +17,9 @@ import { IInterpreterService } from '../interpreter/contracts';
 import { TensorBoardSession } from './tensorBoardSession';
 import { disposeAll } from '../common/utils/resourceLifecycle';
 import { PREFERRED_VIEWGROUP } from './tensorBoardSessionProvider';
-import { ITensorboardDependencyChecker } from './types';
 
 @injectable()
-export class TensorboardDependencyChecker implements ITensorboardDependencyChecker {
+export class TensorboardDependencyChecker {
     private preferredViewGroupMemento: IPersistentState<ViewColumn>;
 
     constructor(

--- a/src/client/tensorBoard/tensorboardDependencyChecker.ts
+++ b/src/client/tensorBoard/tensorboardDependencyChecker.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { inject, injectable } from 'inversify';
+import { Uri, ViewColumn } from 'vscode';
+import { IApplicationShell, ICommandManager, IWorkspaceService } from '../common/application/types';
+import { IPythonExecutionFactory } from '../common/process/types';
+import {
+    IInstaller,
+    IPersistentState,
+    IPersistentStateFactory,
+    IConfigurationService,
+    IDisposable,
+} from '../common/types';
+import { IMultiStepInputFactory } from '../common/utils/multiStepInput';
+import { IInterpreterService } from '../interpreter/contracts';
+import { TensorBoardSession } from './tensorBoardSession';
+import { disposeAll } from '../common/utils/resourceLifecycle';
+import { PREFERRED_VIEWGROUP } from './tensorBoardSessionProvider';
+import { ITensorboardDependencyChecker } from './types';
+
+@injectable()
+export class TensorboardDependencyChecker implements ITensorboardDependencyChecker {
+    private preferredViewGroupMemento: IPersistentState<ViewColumn>;
+
+    constructor(
+        @inject(IInstaller) private readonly installer: IInstaller,
+        @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
+        @inject(IApplicationShell) private readonly applicationShell: IApplicationShell,
+        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
+        @inject(ICommandManager) private readonly commandManager: ICommandManager,
+        @inject(IPythonExecutionFactory) private readonly pythonExecFactory: IPythonExecutionFactory,
+        @inject(IPersistentStateFactory) private stateFactory: IPersistentStateFactory,
+        @inject(IMultiStepInputFactory) private readonly multiStepFactory: IMultiStepInputFactory,
+        @inject(IConfigurationService) private readonly configurationService: IConfigurationService,
+    ) {
+        this.preferredViewGroupMemento = this.stateFactory.createGlobalPersistentState<ViewColumn>(
+            PREFERRED_VIEWGROUP,
+            ViewColumn.Active,
+        );
+    }
+
+    public async ensureDependenciesAreInstalled(resource?: Uri): Promise<boolean> {
+        const disposables: IDisposable[] = [];
+        const newSession = new TensorBoardSession(
+            this.installer,
+            this.interpreterService,
+            this.workspaceService,
+            this.pythonExecFactory,
+            this.commandManager,
+            disposables,
+            this.applicationShell,
+            this.preferredViewGroupMemento,
+            this.multiStepFactory,
+            this.configurationService,
+        );
+        const result = await newSession.ensurePrerequisitesAreInstalled(resource);
+        disposeAll(disposables);
+        return result;
+    }
+}

--- a/src/client/tensorBoard/tensorboardIntegration.ts
+++ b/src/client/tensorBoard/tensorboardIntegration.ts
@@ -14,9 +14,6 @@ import { PythonEnvironment } from '../pythonEnvironments/info';
 import { ITensorboardDependencyChecker } from './types';
 
 type PythonApiForTensorboardExtension = {
-    /**
-     * IEnvironmentActivationService
-     */
     getActivatedEnvironmentVariables(
         resource: Resource,
         interpreter?: PythonEnvironment,
@@ -48,7 +45,6 @@ export class TensorboardExtensionIntegration {
             this.workspaceService.onDidGrantWorkspaceTrust(() => this.registerApi(tensorboardExtensionApi));
             return undefined;
         }
-        // Forward python parts
         tensorboardExtensionApi.registerPythonApi({
             getActivatedEnvironmentVariables: async (
                 resource: Resource,

--- a/src/client/tensorBoard/tensorboardIntegration.ts
+++ b/src/client/tensorBoard/tensorboardIntegration.ts
@@ -1,0 +1,87 @@
+/* eslint-disable comma-dangle */
+
+/* eslint-disable implicit-arrow-linebreak */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { inject, injectable } from 'inversify';
+import { Extension, Uri } from 'vscode';
+import { IWorkspaceService } from '../common/application/types';
+import { TENSORBOARD_EXTENSION_ID } from '../common/constants';
+import { IExtensions, Resource } from '../common/types';
+import { IEnvironmentActivationService } from '../interpreter/activation/types';
+import { PythonEnvironment } from '../pythonEnvironments/info';
+import { ITensorboardDependencyChecker } from './types';
+
+type PythonApiForTensorboardExtension = {
+    /**
+     * IEnvironmentActivationService
+     */
+    getActivatedEnvironmentVariables(
+        resource: Resource,
+        interpreter?: PythonEnvironment,
+        allowExceptions?: boolean,
+    ): Promise<NodeJS.ProcessEnv | undefined>;
+    ensureDependenciesAreInstalled(resource?: Uri): Promise<boolean>;
+};
+
+type TensorboardExtensionApi = {
+    /**
+     * Registers python extension specific parts with the tensorboard extension
+     */
+    registerPythonApi(interpreterService: PythonApiForTensorboardExtension): void;
+};
+
+@injectable()
+export class TensorboardExtensionIntegration {
+    private tensorboardExtension: Extension<TensorboardExtensionApi> | undefined;
+
+    constructor(
+        @inject(IExtensions) private readonly extensions: IExtensions,
+        @inject(IEnvironmentActivationService) private readonly envActivation: IEnvironmentActivationService,
+        @inject(IWorkspaceService) private workspaceService: IWorkspaceService,
+        @inject(ITensorboardDependencyChecker) private readonly dependencyChcker: ITensorboardDependencyChecker,
+    ) {}
+
+    public registerApi(tensorboardExtensionApi: TensorboardExtensionApi): TensorboardExtensionApi | undefined {
+        if (!this.workspaceService.isTrusted) {
+            this.workspaceService.onDidGrantWorkspaceTrust(() => this.registerApi(tensorboardExtensionApi));
+            return undefined;
+        }
+        // Forward python parts
+        tensorboardExtensionApi.registerPythonApi({
+            getActivatedEnvironmentVariables: async (
+                resource: Resource,
+                interpreter?: PythonEnvironment,
+                allowExceptions?: boolean,
+            ) => this.envActivation.getActivatedEnvironmentVariables(resource, interpreter, allowExceptions),
+            ensureDependenciesAreInstalled: async (resource?: Uri): Promise<boolean> =>
+                this.dependencyChcker.ensureDependenciesAreInstalled(resource),
+        });
+        return undefined;
+    }
+
+    public async integrateWithTensorboardExtension(): Promise<void> {
+        const api = await this.getExtensionApi();
+        if (api) {
+            this.registerApi(api);
+        }
+    }
+
+    private async getExtensionApi(): Promise<TensorboardExtensionApi | undefined> {
+        if (!this.tensorboardExtension) {
+            const extension = this.extensions.getExtension<TensorboardExtensionApi>(TENSORBOARD_EXTENSION_ID);
+            if (!extension) {
+                return undefined;
+            }
+            await extension.activate();
+            if (extension.isActive) {
+                this.tensorboardExtension = extension;
+                return this.tensorboardExtension.exports;
+            }
+        } else {
+            return this.tensorboardExtension.exports;
+        }
+        return undefined;
+    }
+}

--- a/src/client/tensorBoard/terminalWatcher.ts
+++ b/src/client/tensorBoard/terminalWatcher.ts
@@ -4,6 +4,7 @@ import { IExtensionSingleActivationService } from '../activation/types';
 import { IDisposable, IDisposableRegistry } from '../common/types';
 import { sendTelemetryEvent } from '../telemetry';
 import { EventName } from '../telemetry/constants';
+import { useNewTensorboardExtension } from './tensorboarExperiment';
 
 // Every 5 min look, through active terminals to see if any are running `tensorboard`
 @injectable()
@@ -15,6 +16,9 @@ export class TerminalWatcher implements IExtensionSingleActivationService, IDisp
     constructor(@inject(IDisposableRegistry) private disposables: IDisposableRegistry) {}
 
     public async activate(): Promise<void> {
+        if (useNewTensorboardExtension()) {
+            return;
+        }
         const handle = setInterval(() => {
             // When user runs a command in VSCode terminal, the terminal's name
             // becomes the program that is currently running. Since tensorboard

--- a/src/client/tensorBoard/types.ts
+++ b/src/client/tensorBoard/types.ts
@@ -8,6 +8,7 @@ export interface ITensorBoardImportTracker {
     onDidImportTensorBoard: Event<void>;
 }
 
+export const ITensorboardDependencyChecker = Symbol('ITensorboardDependencyChecker');
 export interface ITensorboardDependencyChecker {
     ensureDependenciesAreInstalled(resource?: Uri): Promise<boolean>;
 }

--- a/src/client/tensorBoard/types.ts
+++ b/src/client/tensorBoard/types.ts
@@ -1,9 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Event } from 'vscode';
+import { Event, Uri } from 'vscode';
 
 export const ITensorBoardImportTracker = Symbol('ITensorBoardImportTracker');
 export interface ITensorBoardImportTracker {
     onDidImportTensorBoard: Event<void>;
+}
+
+export interface ITensorboardDependencyChecker {
+    ensureDependenciesAreInstalled(resource?: Uri): Promise<boolean>;
 }

--- a/src/test/tensorBoard/tensorBoardUsageTracker.unit.test.ts
+++ b/src/test/tensorBoard/tensorBoardUsageTracker.unit.test.ts
@@ -1,9 +1,11 @@
 import { assert } from 'chai';
 import * as sinon from 'sinon';
+import { anything, reset, when } from 'ts-mockito';
 import { TensorBoardUsageTracker } from '../../client/tensorBoard/tensorBoardUsageTracker';
 import { TensorBoardPrompt } from '../../client/tensorBoard/tensorBoardPrompt';
 import { MockDocumentManager } from '../mocks/mockDocumentManager';
 import { createTensorBoardPromptWithMocks } from './helpers';
+import { mockedVSCodeNamespaces } from '../vscode-mock';
 
 suite('TensorBoard usage tracker', () => {
     let documentManager: MockDocumentManager;
@@ -11,6 +13,11 @@ suite('TensorBoard usage tracker', () => {
     let prompt: TensorBoardPrompt;
     let showNativeTensorBoardPrompt: sinon.SinonSpy;
 
+    suiteSetup(() => {
+        reset(mockedVSCodeNamespaces.extensions);
+        when(mockedVSCodeNamespaces.extensions?.getExtension(anything())).thenReturn(undefined);
+    });
+    suiteTeardown(() => reset(mockedVSCodeNamespaces.extensions));
     setup(() => {
         documentManager = new MockDocumentManager();
         prompt = createTensorBoardPromptWithMocks();


### PR DESCRIPTION
* No need of experiments (if users install extension, then it works)
    * If tensorboard extension is installed the we rely on tensorboard extension to handle everything
    * For final deplayment we can decide whether to just remove this feature altogether or prompt users to install tensorboard extension or to go with an experiment, for now I wanted to keep this super simple (this shoudl not affect anyone as no one will have a tensorboard extension except us)
* Simple private API for tensorboard extension, untill Python ext exposes a stable API
    * API is similar to Jupyter, scoped to Tensorboard ext