### PR TITLE
Handle white spaces for list along with dictionary

### DIFF
--- a/pythonFiles/normalizeSelection.py
+++ b/pythonFiles/normalizeSelection.py
@@ -119,7 +119,7 @@ def normalize_lines(selection):
 
         # Insert a newline between each top-level statement, and append a newline to the selection.
         source = "\n".join(statements) + "\n"
-        if selection[-2] == "}":
+        if selection[-2] == "}" or selection[-2] == "]":
             source = source[:-1]
     except Exception:
         # If there's a problem when parsing statements,


### PR DESCRIPTION
Legacy normalization script leaves unnecessary white spaces for dictionary as well as list. While there are multiple correct usage of it such as for after a function, for more intuitive REPL experience. We want to keep previous normalization style and white space format EXCEPT for dictionary and list case. 

Dictionary case is handled, but this is the PR to handle the elimination of extra white spaces for list as well.
Closes: #22208