### PR TITLE
remove asserts from catchable code for testing

### DIFF
--- a/src/test/testing/common/testingAdapter.test.ts
+++ b/src/test/testing/common/testingAdapter.test.ts
@@ -653,17 +653,21 @@ suite('End to End Tests: test adapters', () => {
                     if (data.error === undefined) {
                         // Dereference a NULL pointer
                         const indexOfTest = JSON.stringify(data).search('Dereference a NULL pointer');
-                        assert.notDeepEqual(indexOfTest, -1, 'Expected test to have a null pointer');
-                    } else {
-                        assert.ok(data.error, "Expected errors in 'error' field");
+                        if (indexOfTest === -1) {
+                            failureOccurred = true;
+                            failureMsg = 'Expected test to have a null pointer';
+                        }
+                    } else if (data.error.length === 0) {
+                        failureOccurred = true;
+                        failureMsg = "Expected errors in 'error' field";
                     }
                 } else {
                     const indexOfTest = JSON.stringify(data.tests).search('error');
-                    assert.notDeepEqual(
-                        indexOfTest,
-                        -1,
-                        'If payload status is not error then the individual tests should be marked as errors. This should occur on windows machines.',
-                    );
+                    if (indexOfTest === -1) {
+                        failureOccurred = true;
+                        failureMsg =
+                            'If payload status is not error then the individual tests should be marked as errors. This should occur on windows machines.';
+                    }
                 }
             } catch (err) {
                 failureMsg = err ? (err as Error).toString() : '';
@@ -705,22 +709,32 @@ suite('End to End Tests: test adapters', () => {
                     if (data.error === undefined) {
                         // Dereference a NULL pointer
                         const indexOfTest = JSON.stringify(data).search('Dereference a NULL pointer');
-                        assert.notDeepEqual(indexOfTest, -1, 'Expected test to have a null pointer');
-                    } else {
-                        assert.ok(data.error, "Expected errors in 'error' field");
+                        if (indexOfTest === -1) {
+                            failureOccurred = true;
+                            failureMsg = 'Expected test to have a null pointer';
+                        }
+                    } else if (data.error.length === 0) {
+                        failureOccurred = true;
+                        failureMsg = "Expected errors in 'error' field";
                     }
                 } else {
                     const indexOfTest = JSON.stringify(data.result).search('error');
-                    assert.notDeepEqual(
-                        indexOfTest,
-                        -1,
-                        'If payload status is not error then the individual tests should be marked as errors. This should occur on windows machines.',
-                    );
+                    if (indexOfTest === -1) {
+                        failureOccurred = true;
+                        failureMsg =
+                            'If payload status is not error then the individual tests should be marked as errors. This should occur on windows machines.';
+                    }
                 }
-                assert.ok(data.result, 'Expected results to be present');
+                if (data.result === undefined) {
+                    failureOccurred = true;
+                    failureMsg = 'Expected results to be present';
+                }
                 // make sure the testID is found in the results
                 const indexOfTest = JSON.stringify(data).search('test_seg_fault.TestSegmentationFault.test_segfault');
-                assert.notDeepEqual(indexOfTest, -1, 'Expected testId to be present');
+                if (indexOfTest === -1) {
+                    failureOccurred = true;
+                    failureMsg = 'Expected testId to be present';
+                }
             } catch (err) {
                 failureMsg = err ? (err as Error).toString() : '';
                 failureOccurred = true;

--- a/src/test/testing/common/testingPayloadsEot.test.ts
+++ b/src/test/testing/common/testingPayloadsEot.test.ts
@@ -165,13 +165,20 @@ suite('EOT tests', () => {
                 mockProc.emit('close', 0, null);
                 client.end();
             });
-
+            let errorBool = false;
+            let errorMessage = '';
             resultResolver = new PythonResultResolver(testController, PYTEST_PROVIDER, workspaceUri);
             resultResolver._resolveExecution = async (payload, _token?) => {
                 // the payloads that get to the _resolveExecution are all data and should be successful.
                 actualCollectedResult = actualCollectedResult + JSON.stringify(payload.result);
-                assert.strictEqual(payload.status, 'success', "Expected status to be 'success'");
-                assert.ok(payload.result, 'Expected results to be present');
+                if (payload.status !== 'success') {
+                    errorBool = true;
+                    errorMessage = "Expected status to be 'success'";
+                }
+                if (!payload.result) {
+                    errorBool = true;
+                    errorMessage = 'Expected results to be present';
+                }
 
                 return Promise.resolve();
             };
@@ -208,6 +215,7 @@ suite('EOT tests', () => {
                         actualCollectedResult,
                         "Expected collected result to match 'data'",
                     );
+                    assert.strictEqual(errorBool, false, errorMessage);
                 });
         });
     });

--- a/src/test/testing/testController/server.unit.test.ts
+++ b/src/test/testing/testController/server.unit.test.ts
@@ -117,13 +117,15 @@ suite('Python Test Server, DataWithPayloadChunks', () => {
             const dataWithPayloadChunks = testCaseDataObj;
 
             await server.serverReady();
-
+            let errorOccur = false;
+            let errorMessage = '';
             server.onRunDataReceived(({ data }) => {
                 try {
                     const resultData = JSON.parse(data).result;
                     eventData = eventData + JSON.stringify(resultData);
                 } catch (e) {
-                    assert(false, 'Error parsing data');
+                    errorOccur = true;
+                    errorMessage = 'Error parsing data';
                 }
                 deferred.resolve();
             });
@@ -143,6 +145,7 @@ suite('Python Test Server, DataWithPayloadChunks', () => {
             await deferred.promise;
             const expectedResult = dataWithPayloadChunks.data;
             assert.deepStrictEqual(eventData, expectedResult);
+            assert.deepStrictEqual(errorOccur, false, errorMessage);
         });
     });
 });

--- a/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
+++ b/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
@@ -31,12 +31,16 @@ suite('Unittest test execution adapter', () => {
 
     test('runTests should send the run command to the test server', async () => {
         let options: TestCommandOptions | undefined;
-
+        let errorBool = false;
+        let errorMessage = '';
         const stubTestServer = ({
             sendCommand(opt: TestCommandOptions, runTestIdPort?: string): Promise<void> {
                 delete opt.outChannel;
                 options = opt;
-                assert(runTestIdPort !== undefined);
+                if (runTestIdPort === undefined) {
+                    errorBool = true;
+                    errorMessage = 'runTestIdPort is undefined';
+                }
                 return Promise.resolve();
             },
             onRunDataReceived: () => {
@@ -60,6 +64,7 @@ suite('Unittest test execution adapter', () => {
                 testIds,
             };
             assert.deepStrictEqual(options, expectedOptions);
+            assert.equal(errorBool, false, errorMessage);
         });
     });
     test('runTests should respect settings.testing.cwd when present', async () => {
@@ -69,12 +74,16 @@ suite('Unittest test execution adapter', () => {
             }),
         } as unknown) as IConfigurationService;
         let options: TestCommandOptions | undefined;
-
+        let errorBool = false;
+        let errorMessage = '';
         const stubTestServer = ({
             sendCommand(opt: TestCommandOptions, runTestIdPort?: string): Promise<void> {
                 delete opt.outChannel;
                 options = opt;
-                assert(runTestIdPort !== undefined);
+                if (runTestIdPort === undefined) {
+                    errorBool = true;
+                    errorMessage = 'runTestIdPort is undefined';
+                }
                 return Promise.resolve();
             },
             onRunDataReceived: () => {
@@ -99,6 +108,7 @@ suite('Unittest test execution adapter', () => {
                 testIds,
             };
             assert.deepStrictEqual(options, expectedOptions);
+            assert.equal(errorBool, false, errorMessage);
         });
     });
 });


### PR DESCRIPTION
some asserts were inside functions / mocking and with this then the extension code catches the exception and doesn't error out as the test. Bring the asserts out of the functions into the test so the asserts work as expected.