### PR TITLE
Skip setting `PYTHONUTF8` when activating terminals

### DIFF
--- a/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
@@ -394,7 +394,12 @@ function shouldPS1BeSet(type: PythonEnvType | undefined, env: EnvironmentVariabl
 }
 
 function shouldSkip(env: string) {
-    return ['_', 'SHLVL'].includes(env);
+    return [
+        '_',
+        'SHLVL',
+        // Even though this maybe returned, setting it can result in output encoding errors
+        'PYTHONUTF8'
+    ].includes(env);
 }
 
 function getPromptForEnv(interpreter: PythonEnvironment | undefined) {

--- a/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
+++ b/src/client/interpreter/activation/terminalEnvVarCollectionService.ts
@@ -397,8 +397,8 @@ function shouldSkip(env: string) {
     return [
         '_',
         'SHLVL',
-        // Even though this maybe returned, setting it can result in output encoding errors
-        'PYTHONUTF8'
+        // Even though this maybe returned, setting it can result in output encoding errors in terminal.
+        'PYTHONUTF8',
     ].includes(env);
 }
 


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/22205