### PR TITLE
add hookwrappers to pytest plugin to ensure run

### DIFF
--- a/pythonFiles/vscode_pytest/__init__.py
+++ b/pythonFiles/vscode_pytest/__init__.py
@@ -183,6 +183,7 @@ class testRunResultDict(Dict[str, Dict[str, TestOutcome]]):
     tests: Dict[str, TestOutcome]
 
 
+@pytest.hookimpl(hookwrapper=True, trylast=True)
 def pytest_report_teststatus(report, config):
     """
     A pytest hook that is called when a test is called. It is called 3 times per test,
@@ -223,6 +224,7 @@ def pytest_report_teststatus(report, config):
                 "success",
                 collected_test if collected_test else None,
             )
+    yield
 
 
 ERROR_MESSAGE_CONST = {


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python/issues/22232. From [this discussion](https://github.com/pytest-dev/pytest/discussions/11509), learned that some pytest hooks are meant to be unique and only one will be called per run. If multiple plugins are at play then another plugin the user has might override our plugin. Added the hookwrapper so our is always run.