### PR TITLE
add wrapper hook for pytest_runtest_protocol

### DIFF
--- a/pythonFiles/vscode_pytest/__init__.py
+++ b/pythonFiles/vscode_pytest/__init__.py
@@ -235,6 +235,7 @@ ERROR_MESSAGE_CONST = {
 }
 
 
+@pytest.hookimpl(hookwrapper=True, trylast=True)
 def pytest_runtest_protocol(item, nextitem):
     map_id_to_path[item.nodeid] = get_node_path(item)
     skipped = check_skipped_wrapper(item)
@@ -257,6 +258,7 @@ def pytest_runtest_protocol(item, nextitem):
                 "success",
                 collected_test if collected_test else None,
             )
+    yield
 
 
 def check_skipped_wrapper(item):


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python/issues/22232. From https://github.com/pytest-dev/pytest/discussions/11509, learned that some pytest hooks are meant to be unique and only one will be called per run. If multiple plugins are at play then another plugin the user has might override our plugin. Added the hookwrapper so our is always run. Same as https://github.com/microsoft/vscode-python/pull/22240