### PR TITLE
Add the proposed Port Attributes API for python testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "quickPickSortByLabel",
         "testObserver",
         "quickPickItemTooltip",
-        "saveEditor"
+        "saveEditor",
+        "portsAttributes"
     ],
     "author": {
         "name": "Microsoft Corporation"

--- a/src/client/testing/portAttributesProvider.ts
+++ b/src/client/testing/portAttributesProvider.ts
@@ -1,0 +1,27 @@
+/* eslint-disable class-methods-use-this */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {
+    CancellationToken,
+    Disposable,
+    PortAttributes,
+    PortAttributesProvider,
+    PortAutoForwardAction,
+    ProviderResult,
+    workspace,
+} from 'vscode';
+
+export class TestPortAttributesProvider implements PortAttributesProvider {
+    public providePortAttributes(
+        _attributes: { port: number; pid?: number; commandLine?: string },
+        _token: CancellationToken,
+    ): ProviderResult<PortAttributes> {
+        return new PortAttributes(PortAutoForwardAction.Ignore);
+    }
+}
+
+export function registerTestPortAttributesProvider(disposables: Disposable[]): void {
+    const provider = new TestPortAttributesProvider();
+    disposables.push(workspace.registerPortAttributesProvider({}, provider));
+}

--- a/src/client/testing/portAttributesProvider.ts
+++ b/src/client/testing/portAttributesProvider.ts
@@ -12,16 +12,39 @@ import {
     workspace,
 } from 'vscode';
 
-export class TestPortAttributesProvider implements PortAttributesProvider {
+class TestPortAttributesProvider implements PortAttributesProvider {
+    private knownPorts: number[] = [];
+
     public providePortAttributes(
-        _attributes: { port: number; pid?: number; commandLine?: string },
+        attributes: { port: number; pid?: number; commandLine?: string },
         _token: CancellationToken,
     ): ProviderResult<PortAttributes> {
-        return new PortAttributes(PortAutoForwardAction.Ignore);
+        if (this.knownPorts.includes(attributes.port)) {
+            return new PortAttributes(PortAutoForwardAction.Ignore);
+        }
+        return undefined;
+    }
+
+    public setPortAttribute(port: number): void {
+        this.knownPorts.push(port);
+    }
+
+    public resetPortAttribute(port: number): void {
+        this.knownPorts = this.knownPorts.filter((p) => p !== port);
     }
 }
 
+let provider: TestPortAttributesProvider | undefined;
+
 export function registerTestPortAttributesProvider(disposables: Disposable[]): void {
-    const provider = new TestPortAttributesProvider();
+    provider = new TestPortAttributesProvider();
     disposables.push(workspace.registerPortAttributesProvider({}, provider));
+}
+
+export function setPortAttribute(port: number): void {
+    provider?.setPortAttribute(port);
+}
+
+export function resetPortAttribute(port: number): void {
+    provider?.resetPortAttribute(port);
 }

--- a/src/client/testing/testController/common/server.ts
+++ b/src/client/testing/testController/common/server.ts
@@ -37,6 +37,8 @@ export class PythonTestServer implements ITestServer, Disposable {
 
     private ready: Promise<void>;
 
+    private port: number | undefined;
+
     private _onRunDataReceived: EventEmitter<DataReceivedEvent> = new EventEmitter<DataReceivedEvent>();
 
     private _onDiscoveryDataReceived: EventEmitter<DataReceivedEvent> = new EventEmitter<DataReceivedEvent>();
@@ -66,7 +68,8 @@ export class PythonTestServer implements ITestServer, Disposable {
         });
         this.ready = new Promise((resolve, _reject) => {
             this.server.listen(undefined, 'localhost', () => {
-                setPortAttribute(this.getPort());
+                this.port = (this.server.address() as net.AddressInfo).port;
+                setPortAttribute(this.port);
                 resolve();
             });
         });
@@ -134,7 +137,11 @@ export class PythonTestServer implements ITestServer, Disposable {
     }
 
     public getPort(): number {
-        return (this.server.address() as net.AddressInfo).port;
+        if (this.port) {
+            return this.port;
+        }
+        traceError('Attempted to access port but it is undefined for the python testing server.');
+        return 45454;
     }
 
     public createUUID(): string {

--- a/src/client/testing/testController/common/server.ts
+++ b/src/client/testing/testController/common/server.ts
@@ -26,6 +26,7 @@ import {
 } from './utils';
 import { createDeferred } from '../../../common/utils/async';
 import { EnvironmentVariables } from '../../../api/types';
+import { resetPortAttribute, setPortAttribute } from '../../portAttributesProvider';
 
 export class PythonTestServer implements ITestServer, Disposable {
     private _onDataReceived: EventEmitter<DataReceivedEvent> = new EventEmitter<DataReceivedEvent>();
@@ -65,6 +66,7 @@ export class PythonTestServer implements ITestServer, Disposable {
         });
         this.ready = new Promise((resolve, _reject) => {
             this.server.listen(undefined, 'localhost', () => {
+                setPortAttribute(this.getPort());
                 resolve();
             });
         });
@@ -72,7 +74,11 @@ export class PythonTestServer implements ITestServer, Disposable {
             traceLog(`Error starting test server: ${ex}`);
         });
         this.server.on('close', () => {
-            traceLog('Test server closed.');
+            if (this.getPort()) {
+                resetPortAttribute(this.getPort());
+                traceLog('Test server closed, port attributes reset');
+            }
+            traceLog('Test server closed port attributes reset skipped.');
         });
         this.server.on('listening', () => {
             traceLog('Test server listening.');

--- a/src/client/testing/testController/serviceRegistry.ts
+++ b/src/client/testing/testController/serviceRegistry.ts
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 import { IExtensionSingleActivationService } from '../../activation/types';
+import { IDisposableRegistry } from '../../common/types';
 import { IServiceManager } from '../../ioc/types';
 import { PYTEST_PROVIDER, UNITTEST_PROVIDER } from '../common/constants';
+import { registerTestPortAttributesProvider } from '../portAttributesProvider';
 import { TestDiscoveryHelper } from './common/discoveryHelper';
 import { ITestFrameworkController, ITestDiscoveryHelper, ITestsRunner, ITestController } from './common/types';
 import { PythonTestController } from './controller';
@@ -26,4 +28,6 @@ export function registerTestControllerTypes(serviceManager: IServiceManager): vo
     serviceManager.addSingleton<ITestsRunner>(ITestsRunner, UnittestRunner, UNITTEST_PROVIDER);
     serviceManager.addSingleton<ITestController>(ITestController, PythonTestController);
     serviceManager.addBinding(ITestController, IExtensionSingleActivationService);
+    const disposables = serviceManager.get<IDisposableRegistry>(IDisposableRegistry);
+    registerTestPortAttributesProvider(disposables);
 }

--- a/src/test/testing/serviceRegistry.unit.test.ts
+++ b/src/test/testing/serviceRegistry.unit.test.ts
@@ -34,9 +34,6 @@ suite('Testing_Service_Registry', () => {
     setup(() => {
         serviceManager = mock(ServiceManager);
     });
-    test('other', async () => {
-        assert.deepStrictEqual(1, 0);
-    });
     test('Ensure services are registered', async () => {
         registerTypes(instance(serviceManager));
 

--- a/src/test/testing/serviceRegistry.unit.test.ts
+++ b/src/test/testing/serviceRegistry.unit.test.ts
@@ -4,7 +4,6 @@
 'use strict';
 
 import { instance, mock, verify } from 'ts-mockito';
-import { assert } from 'chai';
 import { registerTypes } from '../../client/activation/serviceRegistry';
 import { IExtensionActivationService } from '../../client/activation/types';
 import { ServiceManager } from '../../client/ioc/serviceManager';

--- a/src/test/testing/serviceRegistry.unit.test.ts
+++ b/src/test/testing/serviceRegistry.unit.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { instance, mock, verify } from 'ts-mockito';
+import { assert } from 'chai';
+import { registerTypes } from '../../client/activation/serviceRegistry';
+import { IExtensionActivationService } from '../../client/activation/types';
+import { ServiceManager } from '../../client/ioc/serviceManager';
+import { IServiceManager } from '../../client/ioc/types';
+import { TestConfigSettingsService } from '../../client/testing/common/configSettingService';
+import { DebugLauncher } from '../../client/testing/common/debugLauncher';
+import { TestRunner } from '../../client/testing/common/runner';
+import { UnitTestSocketServer } from '../../client/testing/common/socketServer';
+import { TestsHelper } from '../../client/testing/common/testUtils';
+import {
+    ITestDebugLauncher,
+    ITestsHelper,
+    IUnitTestSocketServer,
+    ITestRunner,
+    ITestConfigurationService,
+    ITestConfigSettingsService,
+    ITestConfigurationManagerFactory,
+} from '../../client/testing/common/types';
+import { UnitTestConfigurationService } from '../../client/testing/configuration';
+import { TestConfigurationManagerFactory } from '../../client/testing/configurationFactory';
+import { TestingService, UnitTestManagementService } from '../../client/testing/main';
+import { ITestingService } from '../../client/testing/types';
+
+suite('Testing_Service_Registry', () => {
+    let serviceManager: IServiceManager;
+
+    setup(() => {
+        serviceManager = mock(ServiceManager);
+    });
+    test('other', async () => {
+        assert.deepStrictEqual(1, 0);
+    });
+    test('Ensure services are registered', async () => {
+        registerTypes(instance(serviceManager));
+
+        verify(serviceManager.addSingleton<ITestDebugLauncher>(ITestDebugLauncher, DebugLauncher)).once();
+        verify(serviceManager.add<ITestsHelper>(ITestsHelper, TestsHelper)).once();
+        verify(serviceManager.add<IUnitTestSocketServer>(IUnitTestSocketServer, UnitTestSocketServer)).once();
+        verify(serviceManager.add<ITestRunner>(ITestRunner, TestRunner)).once();
+        verify(
+            serviceManager.addSingleton<ITestConfigurationService>(
+                ITestConfigurationService,
+                UnitTestConfigurationService,
+            ),
+        ).once();
+        verify(serviceManager.addSingleton<ITestingService>(ITestingService, TestingService)).once();
+        verify(
+            serviceManager.addSingleton<ITestConfigSettingsService>(
+                ITestConfigSettingsService,
+                TestConfigSettingsService,
+            ),
+        ).once();
+        verify(
+            serviceManager.addSingleton<ITestConfigurationManagerFactory>(
+                ITestConfigurationManagerFactory,
+                TestConfigurationManagerFactory,
+            ),
+        ).once();
+        verify(
+            serviceManager.addSingleton<IExtensionActivationService>(
+                IExtensionActivationService,
+                UnitTestManagementService,
+            ),
+        ).once();
+    });
+});

--- a/types/vscode.proposed.portsAttributes.d.ts
+++ b/types/vscode.proposed.portsAttributes.d.ts
@@ -1,0 +1,105 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+    // https://github.com/microsoft/vscode/issues/115616 @alexr00
+
+    /**
+     * The action that should be taken when a port is discovered through automatic port forwarding discovery.
+     */
+    export enum PortAutoForwardAction {
+        /**
+         * Notify the user that the port is being forwarded. This is the default action.
+         */
+        Notify = 1,
+        /**
+         * Once the port is forwarded, open the user's web browser to the forwarded port.
+         */
+        OpenBrowser = 2,
+        /**
+         * Once the port is forwarded, open the preview browser to the forwarded port.
+         */
+        OpenPreview = 3,
+        /**
+         * Forward the port silently.
+         */
+        Silent = 4,
+        /**
+         * Do not forward the port.
+         */
+        Ignore = 5,
+    }
+
+    /**
+     * The attributes that a forwarded port can have.
+     */
+    export class PortAttributes {
+        /**
+         * The action to be taken when this port is detected for auto forwarding.
+         */
+        autoForwardAction: PortAutoForwardAction;
+
+        /**
+         * Creates a new PortAttributes object
+         * @param port the port number
+         * @param autoForwardAction the action to take when this port is detected
+         */
+        constructor(autoForwardAction: PortAutoForwardAction);
+    }
+
+    /**
+     * A provider of port attributes. Port attributes are used to determine what action should be taken when a port is discovered.
+     */
+    export interface PortAttributesProvider {
+        /**
+         * Provides attributes for the given port. For ports that your extension doesn't know about, simply
+         * return undefined. For example, if `providePortAttributes` is called with ports 3000 but your
+         * extension doesn't know anything about 3000 you should return undefined.
+         * @param port The port number of the port that attributes are being requested for.
+         * @param pid The pid of the process that is listening on the port. If the pid is unknown, undefined will be passed.
+         * @param commandLine The command line of the process that is listening on the port. If the command line is unknown, undefined will be passed.
+         * @param token A cancellation token that indicates the result is no longer needed.
+         */
+        providePortAttributes(
+            attributes: { port: number; pid?: number; commandLine?: string },
+            token: CancellationToken,
+        ): ProviderResult<PortAttributes>;
+    }
+
+    /**
+     * A selector that will be used to filter which {@link PortAttributesProvider} should be called for each port.
+     */
+    export interface PortAttributesSelector {
+        /**
+         * Specifying a port range will cause your provider to only be called for ports within the range.
+         * The start is inclusive and the end is exclusive.
+         */
+        portRange?: [number, number] | number;
+
+        /**
+         * Specifying a command pattern will cause your provider to only be called for processes whose command line matches the pattern.
+         */
+        commandPattern?: RegExp;
+    }
+
+    export namespace workspace {
+        /**
+         * If your extension listens on ports, consider registering a PortAttributesProvider to provide information
+         * about the ports. For example, a debug extension may know about debug ports in it's debuggee. By providing
+         * this information with a PortAttributesProvider the extension can tell the editor that these ports should be
+         * ignored, since they don't need to be user facing.
+         *
+         * The results of the PortAttributesProvider are merged with the user setting `remote.portsAttributes`. If the values conflict, the user setting takes precedence.
+         *
+         * @param portSelector It is best practice to specify a port selector to avoid unnecessary calls to your provider.
+         * If you don't specify a port selector your provider will be called for every port, which will result in slower port forwarding for the user.
+         * @param provider The {@link PortAttributesProvider PortAttributesProvider}.
+         */
+        export function registerPortAttributesProvider(
+            portSelector: PortAttributesSelector,
+            provider: PortAttributesProvider,
+        ): Disposable;
+    }
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python/issues/22021.

@alexr00, we are not able to provide a pattern for the extension like @paulacamargo25 was doing for debugpy and we are not able to define a port range. Is there something else I should be putting into the `PortAttributesSelector`?