### PR TITLE
Remove unmatched parenthesis from error message

### DIFF
--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -152,7 +152,7 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
             return undefined;
         }
         if (activeEditor.document.languageId !== PYTHON_LANGUAGE) {
-            this.applicationShell.showErrorMessage(l10n.t('The active file is not a Python source file)'));
+            this.applicationShell.showErrorMessage(l10n.t('The active file is not a Python source file'));
             return undefined;
         }
         if (activeEditor.document.isDirty) {


### PR DESCRIPTION
Remove unmatched parenthesis from error message

closes: https://github.com/microsoft/vscode-python/issues/22253