### PR TITLE
Support powershell activation even if Powershell execution is disabled on the system

### DIFF
--- a/src/client/interpreter/activation/service.ts
+++ b/src/client/interpreter/activation/service.ts
@@ -329,7 +329,12 @@ export class EnvironmentActivationService implements IEnvironmentActivationServi
                     }
                     if (result.stderr) {
                         if (returnedEnv) {
-                            traceWarn('Got env variables but with errors', result.stderr);
+                            traceWarn('Got env variables but with errors', result.stderr, returnedEnv);
+                            if (result.stderr.includes('running scripts is disabled')) {
+                                throw new Error(
+                                    `Skipping returned result when powershell execution is disabled, stderr ${result.stderr} for ${command}`,
+                                );
+                            }
                         } else {
                             throw new Error(`StdErr from ShellExec, ${result.stderr} for ${command}`);
                         }


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/22252

Error out if stderr is related to Powershell execution being disabled on system, even though environment variables are returned in this case, we've observed they're not valid in this case.