### PR TITLE
Show warning and allow user to turn off smart send for deprecated Python code

### DIFF
--- a/package.json
+++ b/package.json
@@ -699,6 +699,12 @@
                     "scope": "resource",
                     "type": "array"
                 },
+                "python.REPL.EnableREPLSmartSend": {
+                    "default": true,
+                    "description": "%python.EnableREPLSmartSend.description%",
+                    "scope": "resource",
+                    "type": "boolean"
+                },
                 "python.testing.autoTestDiscoverOnSaveEnabled": {
                     "default": true,
                     "description": "%python.testing.autoTestDiscoverOnSaveEnabled.description%",

--- a/package.json
+++ b/package.json
@@ -699,7 +699,7 @@
                     "scope": "resource",
                     "type": "array"
                 },
-                "python.REPL.EnableREPLSmartSend": {
+                "python.REPL.EnableREPL SmartSend": {
                     "default": true,
                     "description": "%python.EnableREPLSmartSend.description%",
                     "scope": "resource",

--- a/package.json
+++ b/package.json
@@ -699,7 +699,7 @@
                     "scope": "resource",
                     "type": "array"
                 },
-                "python.REPL.EnableREPL SmartSend": {
+                "python.REPL.EnableREPLSmartSend": {
                     "default": true,
                     "description": "%python.EnableREPLSmartSend.description%",
                     "scope": "resource",

--- a/package.json
+++ b/package.json
@@ -699,7 +699,7 @@
                     "scope": "resource",
                     "type": "array"
                 },
-                "python.REPL.EnableREPLSmartSend": {
+                "python.REPL.enableREPLSmartSend": {
                     "default": true,
                     "description": "%python.EnableREPLSmartSend.description%",
                     "scope": "resource",

--- a/package.nls.json
+++ b/package.nls.json
@@ -58,6 +58,7 @@
     "python.missingPackage.severity.description": "Set severity of missing packages in requirements.txt or pyproject.toml",
     "python.pipenvPath.description": "Path to the pipenv executable to use for activation.",
     "python.poetryPath.description": "Path to the poetry executable.",
+    "python.EnableREPLSmartSend.description": "Toggle smart send for the Python REPL.",
     "python.tensorBoard.logDirectory.description": "Set this setting to your preferred TensorBoard log directory to skip log directory prompt when starting TensorBoard.",
     "python.tensorBoard.logDirectory.markdownDeprecationMessage": "Tensorboard support has been moved to the extension [Tensorboard extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.tensorboard). Instead use the setting `tensorBoard.logDirectory`.",
     "python.tensorBoard.logDirectory.deprecationMessage": "Tensorboard support has been moved to the extension Tensorboard extension. Instead use the setting `tensorBoard.logDirectory`.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -58,7 +58,7 @@
     "python.missingPackage.severity.description": "Set severity of missing packages in requirements.txt or pyproject.toml",
     "python.pipenvPath.description": "Path to the pipenv executable to use for activation.",
     "python.poetryPath.description": "Path to the poetry executable.",
-    "python.EnableREPLSmartSend.description": "Toggle smart send for the Python REPL.",
+    "python.EnableREPLSmartSend.description": "Toggle Smart Send for the Python REPL. Smart Send enables sending the smallest runnable block of code to the REPL on Shift+Enter and moves the cursor accordingly.",
     "python.tensorBoard.logDirectory.description": "Set this setting to your preferred TensorBoard log directory to skip log directory prompt when starting TensorBoard.",
     "python.tensorBoard.logDirectory.markdownDeprecationMessage": "Tensorboard support has been moved to the extension [Tensorboard extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.tensorboard). Instead use the setting `tensorBoard.logDirectory`.",
     "python.tensorBoard.logDirectory.deprecationMessage": "Tensorboard support has been moved to the extension Tensorboard extension. Instead use the setting `tensorBoard.logDirectory`.",

--- a/pythonFiles/normalizeSelection.py
+++ b/pythonFiles/normalizeSelection.py
@@ -290,9 +290,12 @@ if __name__ == "__main__":
         )
         normalized = result["normalized_smart_result"]
         which_line_next = result["which_line_next"]
-        data = json.dumps(
-            {"normalized": normalized, "nextBlockLineno": result["which_line_next"]}
-        )
+        if normalized == "deprecated":
+            data = json.dumps({"normalized": normalized})
+        else:
+            data = json.dumps(
+                {"normalized": normalized, "nextBlockLineno": result["which_line_next"]}
+            )
     else:
         normalized = normalize_lines(contents["code"])
         data = json.dumps({"normalized": normalized})

--- a/pythonFiles/normalizeSelection.py
+++ b/pythonFiles/normalizeSelection.py
@@ -289,7 +289,11 @@ if __name__ == "__main__":
     data = None
     which_line_next = 0
 
-    if empty_Highlight and contents.get("smartSendExperimentEnabled"):
+    if (
+        empty_Highlight
+        and contents.get("smartSendExperimentEnabled")
+        and contents.get("smartSendSettingsEnabled")
+    ):
         result = traverse_file(
             contents["wholeFileContent"],
             vscode_start_line,

--- a/pythonFiles/normalizeSelection.py
+++ b/pythonFiles/normalizeSelection.py
@@ -10,14 +10,14 @@ import sys
 import textwrap
 from typing import Iterable
 
-script_dir = pathlib.Path(
-    "User/anthonykim/Desktop/vscode-python/pythonFiles/lib/python"
-)
-sys.path.append(os.fspath(script_dir))
-import debugpy
+# script_dir = pathlib.Path(
+#     "User/anthonykim/Desktop/vscode-python/pythonFiles/lib/python"
+# )
+# sys.path.append(os.fspath(script_dir))
+# import debugpy
 
-debugpy.connect(5678)
-debugpy.breakpoint()
+# debugpy.connect(5678)
+# debugpy.breakpoint()
 
 
 def split_lines(source):
@@ -168,8 +168,11 @@ def traverse_file(wholeFileContent, start_line, end_line, was_highlighted):
     except Exception as old_python_code:
         # Handle case where user is attempting to run code where file contains deprecated Python code.
         # Somehow have to let typescript side know and show warning message. (TODO)
-        print(old_python_code)
-        return
+        # print(old_python_code)
+        return {
+            "normalized_smart_result": "deprecated",
+            "which_line_next": 0,
+        }
 
     smart_code = ""
     should_run_top_blocks = []

--- a/pythonFiles/normalizeSelection.py
+++ b/pythonFiles/normalizeSelection.py
@@ -3,21 +3,10 @@
 
 import ast
 import json
-import os
-import pathlib
 import re
 import sys
 import textwrap
 from typing import Iterable
-
-# script_dir = pathlib.Path(
-#     "User/anthonykim/Desktop/vscode-python/pythonFiles/lib/python"
-# )
-# sys.path.append(os.fspath(script_dir))
-# import debugpy
-
-# debugpy.connect(5678)
-# debugpy.breakpoint()
 
 
 def split_lines(source):
@@ -165,10 +154,9 @@ def traverse_file(wholeFileContent, start_line, end_line, was_highlighted):
 
     try:
         parsed_file_content = ast.parse(wholeFileContent)
-    except Exception as old_python_code:
+    except Exception:
         # Handle case where user is attempting to run code where file contains deprecated Python code.
-        # Somehow have to let typescript side know and show warning message. (TODO)
-        # print(old_python_code)
+        # Somehow have to let typescript side know and show warning message.
         return {
             "normalized_smart_result": "deprecated",
             "which_line_next": 0,

--- a/pythonFiles/normalizeSelection.py
+++ b/pythonFiles/normalizeSelection.py
@@ -156,7 +156,7 @@ def traverse_file(wholeFileContent, start_line, end_line, was_highlighted):
         parsed_file_content = ast.parse(wholeFileContent)
     except Exception:
         # Handle case where user is attempting to run code where file contains deprecated Python code.
-        # Somehow have to let typescript side know and show warning message.
+        # Let typescript side know and show warning message.
         return {
             "normalized_smart_result": "deprecated",
             "which_line_next": 0,

--- a/pythonFiles/normalizeSelection.py
+++ b/pythonFiles/normalizeSelection.py
@@ -3,10 +3,21 @@
 
 import ast
 import json
+import os
+import pathlib
 import re
 import sys
 import textwrap
 from typing import Iterable
+
+script_dir = pathlib.Path(
+    "User/anthonykim/Desktop/vscode-python/pythonFiles/lib/python"
+)
+sys.path.append(os.fspath(script_dir))
+import debugpy
+
+debugpy.connect(5678)
+debugpy.breakpoint()
 
 
 def split_lines(source):
@@ -150,8 +161,16 @@ def traverse_file(wholeFileContent, start_line, end_line, was_highlighted):
     or a multiline dictionary, or differently styled multi-line list comprehension, etc.
     Then call the normalize_lines function to normalize our smartly selected code block.
     """
+    parsed_file_content = None
 
-    parsed_file_content = ast.parse(wholeFileContent)
+    try:
+        parsed_file_content = ast.parse(wholeFileContent)
+    except Exception as old_python_code:
+        # Handle case where user is attempting to run code where file contains deprecated Python code.
+        # Somehow have to let typescript side know and show warning message. (TODO)
+        print(old_python_code)
+        return
+
     smart_code = ""
     should_run_top_blocks = []
 

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -72,6 +72,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     ];
     ['workbench.action.files.openFolder']: [];
     ['workbench.action.openWorkspace']: [];
+    ['workbench.action.openSettings']: [string];
     ['setContext']: [string, boolean] | ['python.vscode.channel', Channel];
     ['python.reloadVSCode']: [string];
     ['revealLine']: [{ lineNumber: number; at: 'top' | 'center' | 'bottom' }];

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -29,6 +29,7 @@ import {
     IInterpreterPathService,
     IInterpreterSettings,
     IPythonSettings,
+    IREPLSettings,
     ITensorBoardSettings,
     ITerminalSettings,
     Resource,
@@ -113,6 +114,8 @@ export class PythonSettings implements IPythonSettings {
     public terminal!: ITerminalSettings;
 
     public globalModuleInstallation = false;
+
+    public REPL!: IREPLSettings;
 
     public experiments!: IExperiments;
 
@@ -363,6 +366,7 @@ export class PythonSettings implements IPythonSettings {
                   activateEnvInCurrentTerminal: false,
               };
 
+        this.REPL = systemVariables.resolveAny(pythonSettings.get<IREPLSettings>('REPL'))!;
         const experiments = systemVariables.resolveAny(pythonSettings.get<IExperiments>('experiments'))!;
         if (this.experiments) {
             Object.assign<IExperiments, IExperiments>(this.experiments, experiments);

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -366,8 +366,8 @@ export class PythonSettings implements IPythonSettings {
                   activateEnvInCurrentTerminal: false,
               };
 
-        this.REPL = systemVariables.resolveAny(pythonSettings.get<IREPLSettings>('REPL'))!;
-        const experiments = systemVariables.resolveAny(pythonSettings.get<IExperiments>('experiments'))!;
+        this.REPL = pythonSettings.get<IREPLSettings>('REPL')!;
+        const experiments = pythonSettings.get<IExperiments>('experiments')!;
         if (this.experiments) {
             Object.assign<IExperiments, IExperiments>(this.experiments, experiments);
         } else {

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -178,6 +178,7 @@ export interface IPythonSettings {
     readonly languageServerIsDefault: boolean;
     readonly defaultInterpreterPath: string;
     readonly tensorBoard: ITensorBoardSettings | undefined;
+    readonly REPL: IREPLSettings;
     register(): void;
 }
 
@@ -195,6 +196,10 @@ export interface ITerminalSettings {
     readonly launchArgs: string[];
     readonly activateEnvironment: boolean;
     readonly activateEnvInCurrentTerminal: boolean;
+}
+
+export interface IREPLSettings {
+    readonly EnableREPLSmartSend: boolean;
 }
 
 export interface IExperiments {

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -199,7 +199,7 @@ export interface ITerminalSettings {
 }
 
 export interface IREPLSettings {
-    readonly EnableREPLSmartSend: boolean;
+    readonly enableREPLSmartSend: boolean;
 }
 
 export interface IExperiments {

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -4,6 +4,7 @@
 'use strict';
 
 import { l10n } from 'vscode';
+import { Commands } from '../constants';
 
 /* eslint-disable @typescript-eslint/no-namespace, no-shadow */
 
@@ -42,6 +43,9 @@ export namespace Diagnostics {
     export const pylanceDefaultMessage = l10n.t(
         "The Python extension now includes Pylance to improve completions, code navigation, overall performance and much more! You can learn more about the update and learn how to change your language server [here](https://aka.ms/new-python-bundle).\n\nRead Pylance's license [here](https://marketplace.visualstudio.com/items/ms-python.vscode-pylance/license).",
     );
+    export const invalidSmartSendMessage = l10n.t(`Python is unable to parse the code provided. Please
+    turn off Smart Send if you wish to always run line by line or explicitly select code
+    to force run. See [logs](command:${Commands.ViewOutput}) for more details`);
 }
 
 export namespace Common {
@@ -92,6 +96,9 @@ export namespace AttachProcess {
     export const refreshList = l10n.t('Refresh process list');
 }
 
+export namespace Repl {
+    export const disableSmartSend = l10n.t('Disable Smart Send');
+}
 export namespace Pylance {
     export const remindMeLater = l10n.t('Remind me later');
 

--- a/src/client/terminals/codeExecution/djangoShellCodeExecution.ts
+++ b/src/client/terminals/codeExecution/djangoShellCodeExecution.ts
@@ -36,6 +36,7 @@ export class DjangoShellCodeExecutionProvider extends TerminalCodeExecutionProvi
             disposableRegistry,
             platformService,
             interpreterService,
+            commandManager,
         );
         this.terminalTitle = 'Django Shell';
         disposableRegistry.push(new DjangoContextInitializer(documentManager, workspace, fileSystem, commandManager));

--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -98,7 +98,7 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
             const configuration = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
             if (configuration) {
                 const pythonSettings = configuration.getSettings(this.activeResourceService.getActiveResource());
-                smartSendSettingsEnabledVal = pythonSettings.REPL.EnableREPLSmartSend;
+                smartSendSettingsEnabledVal = pythonSettings.REPL.enableREPLSmartSend;
             }
 
             const input = JSON.stringify({

--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -105,10 +105,10 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
             const result = await normalizeOutput.promise;
             const object = JSON.parse(result);
 
-            if (activeEditor?.selection) {
-                const lineOffset = object.nextBlockLineno - activeEditor!.selection.start.line - 1;
-                await this.moveToNextBlock(lineOffset, activeEditor);
-            }
+            // if (activeEditor?.selection) {
+            //     const lineOffset = object.nextBlockLineno - activeEditor!.selection.start.line - 1;
+            //     await this.moveToNextBlock(lineOffset, activeEditor);
+            // }
 
             return parse(object.normalized);
         } catch (ex) {

--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -113,10 +113,10 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
             const result = await normalizeOutput.promise;
             const object = JSON.parse(result);
 
-            // if (activeEditor?.selection) {
-            //     const lineOffset = object.nextBlockLineno - activeEditor!.selection.start.line - 1;
-            //     await this.moveToNextBlock(lineOffset, activeEditor);
-            // }
+            if (activeEditor?.selection) {
+                const lineOffset = object.nextBlockLineno - activeEditor!.selection.start.line - 1;
+                await this.moveToNextBlock(lineOffset, activeEditor);
+            }
 
             return parse(object.normalized);
         } catch (ex) {

--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -117,7 +117,12 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
             const result = await normalizeOutput.promise;
             const object = JSON.parse(result);
 
-            if (activeEditor?.selection) {
+            if (
+                activeEditor?.selection &&
+                smartSendExperimentEnabledVal &&
+                smartSendSettingsEnabledVal &&
+                object.normalized !== 'deprecated'
+            ) {
                 const lineOffset = object.nextBlockLineno - activeEditor!.selection.start.line - 1;
                 await this.moveToNextBlock(lineOffset, activeEditor);
             }

--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -95,14 +95,12 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
             const emptyHighlightVal = activeEditor?.selection?.isEmpty ?? true;
             const smartSendExperimentEnabledVal = pythonSmartSendEnabled(this.serviceContainer);
             let smartSendSettingsEnabledVal = false;
-
             const configuration = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
             if (configuration) {
                 const pythonSettings = configuration.getSettings(this.activeResourceService.getActiveResource());
                 smartSendSettingsEnabledVal = pythonSettings.REPL.EnableREPLSmartSend;
             }
-            // const pythonSettings = configuration.getSettings(this.activeResourceService.getActiveResource());
-            // const smartSendSettingsEnabledVal = pythonSettings.REPL.EnableREPLSmartSend;
+
             const input = JSON.stringify({
                 code,
                 wholeFileContent,

--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -94,9 +94,15 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
             const endLineVal = activeEditor?.selection?.end.line ?? 0;
             const emptyHighlightVal = activeEditor?.selection?.isEmpty ?? true;
             const smartSendExperimentEnabledVal = pythonSmartSendEnabled(this.serviceContainer);
+            let smartSendSettingsEnabledVal = false;
+
             const configuration = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
-            const pythonSettings = configuration.getSettings(this.activeResourceService.getActiveResource());
-            const smartSendSettingsEnabledVal = pythonSettings.REPL.EnableREPLSmartSend;
+            if (configuration) {
+                const pythonSettings = configuration.getSettings(this.activeResourceService.getActiveResource());
+                smartSendSettingsEnabledVal = pythonSettings.REPL.EnableREPLSmartSend;
+            }
+            // const pythonSettings = configuration.getSettings(this.activeResourceService.getActiveResource());
+            // const smartSendSettingsEnabledVal = pythonSettings.REPL.EnableREPLSmartSend;
             const input = JSON.stringify({
                 code,
                 wholeFileContent,

--- a/src/client/terminals/codeExecution/repl.ts
+++ b/src/client/terminals/codeExecution/repl.ts
@@ -5,7 +5,7 @@
 
 import { inject, injectable } from 'inversify';
 import { Disposable } from 'vscode';
-import { IWorkspaceService } from '../../common/application/types';
+import { ICommandManager, IWorkspaceService } from '../../common/application/types';
 import { IPlatformService } from '../../common/platform/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IConfigurationService, IDisposableRegistry } from '../../common/types';
@@ -21,6 +21,7 @@ export class ReplProvider extends TerminalCodeExecutionProvider {
         @inject(IDisposableRegistry) disposableRegistry: Disposable[],
         @inject(IPlatformService) platformService: IPlatformService,
         @inject(IInterpreterService) interpreterService: IInterpreterService,
+        @inject(ICommandManager) commandManager: ICommandManager,
     ) {
         super(
             terminalServiceFactory,
@@ -29,6 +30,7 @@ export class ReplProvider extends TerminalCodeExecutionProvider {
             disposableRegistry,
             platformService,
             interpreterService,
+            commandManager,
         );
         this.terminalTitle = 'REPL';
     }

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -49,7 +49,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
             // If user is trying to smart send deprecated code show warning
             const selection = await showWarningMessage(
                 l10n.t(
-                    `You are attempting to run Smart Send on Python file with deprecated Python code, please
+                    `Python AST cannot parse invalid code provided in the current file, please
                     turn off Smart Send if you wish to always run line by line or explicitly select code
                     to force run. [logs](command:${Commands.ViewOutput}) for more details.`,
                 ),

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -51,7 +51,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
             const selection = await showWarningMessage(Diagnostics.invalidSmartSendMessage, Repl.disableSmartSend);
             traceInfo(`Selected file contains invalid Python or Deprecated Python 2 code`);
             if (selection === Repl.disableSmartSend) {
-                this.configurationService.updateSetting('REPL.EnableREPLSmartSend', false, resource);
+                this.configurationService.updateSetting('REPL.enableREPLSmartSend', false, resource);
             }
         } else {
             await this.getTerminalService(resource).sendText(code);

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -16,7 +16,7 @@ import { showWarningMessage } from '../../common/vscodeApis/windowApis';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { buildPythonExecInfo, PythonExecInfo } from '../../pythonEnvironments/exec';
 import { ICodeExecutionService } from '../../terminals/types';
-
+import * as vscode from 'vscode';
 @injectable()
 export class TerminalCodeExecutionProvider implements ICodeExecutionService {
     private hasRanOutsideCurrentDrive = false;
@@ -47,13 +47,17 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
         await this.initializeRepl(resource);
         if (code == 'deprecated') {
             // If user is trying to smart send deprecated code show warning
-            await showWarningMessage(
+            const selection = await showWarningMessage(
                 l10n.t(
                     `You are attempting to run Smart Send on Python file with deprecated Python code, please
                     turn off Smart Send if you wish to always run line by line or explicitly select code
                     to force run. [logs](command:${Commands.ViewOutput}) for more details.`,
                 ),
+                'Change Settings',
             );
+            if (selection === 'Change Settings') {
+                vscode.commands.executeCommand('workbench.action.openSettings', 'python.REPL.EnableREPLSmartSend');
+            }
         } else {
             await this.getTerminalService(resource).sendText(code);
         }

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -50,7 +50,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
             const selection = await showWarningMessage(
                 l10n.t(
                     `Python is unable to parse the code provided. Please
-                    turn off Smart Send if you wish to always run line by line or explicitly select code
+                    turn off Smart Send if you wish to run code line by line or explicitly select code
                     to force run. [logs](command:${Commands.ViewOutput}) for more details.`,
                 ),
                 'Switch to line-by-line',

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -45,6 +45,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
         if (!code || code.trim().length === 0) {
             return;
         }
+        await this.initializeRepl(resource);
         if (code == 'deprecated') {
             // If user is trying to smart send deprecated code show warning
             await showWarningMessage(
@@ -56,10 +57,8 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
                 Common.learnMore,
             );
         } else {
-            // await this.getTerminalService(resource).sendText(code);
+            await this.getTerminalService(resource).sendText(code);
         }
-        await this.getTerminalService(resource).sendText(code);
-        await this.initializeRepl(resource);
     }
     public async initializeRepl(resource: Resource) {
         const terminalService = this.getTerminalService(resource);

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -56,8 +56,9 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
                 Common.learnMore,
             );
         } else {
-            await this.getTerminalService(resource).sendText(code);
+            // await this.getTerminalService(resource).sendText(code);
         }
+        await this.getTerminalService(resource).sendText(code);
         await this.initializeRepl(resource);
     }
     public async initializeRepl(resource: Resource) {

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -12,7 +12,6 @@ import '../../common/extensions';
 import { IPlatformService } from '../../common/platform/types';
 import { ITerminalService, ITerminalServiceFactory } from '../../common/terminal/types';
 import { IConfigurationService, IDisposableRegistry, Resource } from '../../common/types';
-import { Common } from '../../common/utils/localize';
 import { showWarningMessage } from '../../common/vscodeApis/windowApis';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { buildPythonExecInfo, PythonExecInfo } from '../../pythonEnvironments/exec';
@@ -50,11 +49,10 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
             // If user is trying to smart send deprecated code show warning
             await showWarningMessage(
                 l10n.t(
-                    `You are attempting to run Smart Send on Python file with deprecated code, please
-                    turn off smart send if you wish to always run line by line or explicitly select code
-                    to force run [logs](command:${Commands.ViewOutput}) for more details.`,
+                    `You are attempting to run Smart Send on Python file with deprecated Python code, please
+                    turn off Smart Send if you wish to always run line by line or explicitly select code
+                    to force run. [logs](command:${Commands.ViewOutput}) for more details.`,
                 ),
-                Common.learnMore,
             );
         } else {
             await this.getTerminalService(resource).sendText(code);

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -14,6 +14,7 @@ import { ITerminalService, ITerminalServiceFactory } from '../../common/terminal
 import { IConfigurationService, IDisposableRegistry, Resource } from '../../common/types';
 import { showWarningMessage } from '../../common/vscodeApis/windowApis';
 import { IInterpreterService } from '../../interpreter/contracts';
+import { traceInfo } from '../../logging';
 import { buildPythonExecInfo, PythonExecInfo } from '../../pythonEnvironments/exec';
 import { ICodeExecutionService } from '../../terminals/types';
 @injectable()
@@ -55,6 +56,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
                 ),
                 'Switch to line-by-line',
             );
+            traceInfo(`Selected file contains invalid Python or Deprecated Python 2 code`);
             if (selection === 'Switch to line-by-line') {
                 // this.commandManager.executeCommand('workbench.action.openSettings', 'python.REPL.EnableREPLSmartSend');
                 this.configurationService.updateSetting('REPL.EnableREPLSmartSend', false, resource);

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -52,7 +52,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
                 l10n.t(
                     `Python is unable to parse the code provided. Please
                     turn off Smart Send if you wish to run code line by line or explicitly select code
-                    to force run. [Logs](command:${Commands.ViewOutput}) for more details.`,
+                    to force run. See [logs](command:${Commands.ViewOutput}) for more details.`,
                 ),
                 'Disable Smart Send',
             );

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -6,7 +6,7 @@
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { Disposable, l10n, Uri } from 'vscode';
-import { IWorkspaceService } from '../../common/application/types';
+import { ICommandManager, IWorkspaceService } from '../../common/application/types';
 import { Commands } from '../../common/constants';
 import '../../common/extensions';
 import { IPlatformService } from '../../common/platform/types';
@@ -16,7 +16,6 @@ import { showWarningMessage } from '../../common/vscodeApis/windowApis';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { buildPythonExecInfo, PythonExecInfo } from '../../pythonEnvironments/exec';
 import { ICodeExecutionService } from '../../terminals/types';
-import * as vscode from 'vscode';
 @injectable()
 export class TerminalCodeExecutionProvider implements ICodeExecutionService {
     private hasRanOutsideCurrentDrive = false;
@@ -29,6 +28,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
         @inject(IDisposableRegistry) protected readonly disposables: Disposable[],
         @inject(IPlatformService) protected readonly platformService: IPlatformService,
         @inject(IInterpreterService) protected readonly interpreterService: IInterpreterService,
+        @inject(ICommandManager) protected readonly commandManager: ICommandManager,
     ) {}
 
     public async executeFile(file: Uri, options?: { newTerminalPerFile: boolean }) {
@@ -56,7 +56,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
                 'Switch to line-by-line',
             );
             if (selection === 'Switch to line-by-line') {
-                vscode.commands.executeCommand('workbench.action.openSettings', 'python.REPL.EnableREPLSmartSend');
+                this.commandManager.executeCommand('workbench.action.openSettings', 'python.REPL.EnableREPLSmartSend');
             }
         } else {
             await this.getTerminalService(resource).sendText(code);

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -54,7 +54,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
                     turn off Smart Send if you wish to run code line by line or explicitly select code
                     to force run. [logs](command:${Commands.ViewOutput}) for more details.`,
                 ),
-                'Switch to line-by-line',
+                'Disable Smart Send',
             );
             traceInfo(`Selected file contains invalid Python or Deprecated Python 2 code`);
             if (selection === 'Switch to line-by-line') {

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -52,7 +52,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
                 l10n.t(
                     `Python is unable to parse the code provided. Please
                     turn off Smart Send if you wish to run code line by line or explicitly select code
-                    to force run. [logs](command:${Commands.ViewOutput}) for more details.`,
+                    to force run. [Logs](command:${Commands.ViewOutput}) for more details.`,
                 ),
                 'Disable Smart Send',
             );

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -57,7 +57,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
                 'Disable Smart Send',
             );
             traceInfo(`Selected file contains invalid Python or Deprecated Python 2 code`);
-            if (selection === 'Switch to line-by-line') {
+            if (selection === 'Disable Smart Send') {
                 // this.commandManager.executeCommand('workbench.action.openSettings', 'python.REPL.EnableREPLSmartSend');
                 this.configurationService.updateSetting('REPL.EnableREPLSmartSend', false, resource);
             }

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -49,13 +49,13 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
             // If user is trying to smart send deprecated code show warning
             const selection = await showWarningMessage(
                 l10n.t(
-                    `Python AST cannot parse invalid code provided in the current file, please
+                    `Python is unable to parse the code provided. Please
                     turn off Smart Send if you wish to always run line by line or explicitly select code
                     to force run. [logs](command:${Commands.ViewOutput}) for more details.`,
                 ),
-                'Change Settings',
+                'Switch to line-by-line',
             );
-            if (selection === 'Change Settings') {
+            if (selection === 'Switch to line-by-line') {
                 vscode.commands.executeCommand('workbench.action.openSettings', 'python.REPL.EnableREPLSmartSend');
             }
         } else {

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -56,7 +56,8 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
                 'Switch to line-by-line',
             );
             if (selection === 'Switch to line-by-line') {
-                this.commandManager.executeCommand('workbench.action.openSettings', 'python.REPL.EnableREPLSmartSend');
+                // this.commandManager.executeCommand('workbench.action.openSettings', 'python.REPL.EnableREPLSmartSend');
+                this.configurationService.updateSetting('REPL.EnableREPLSmartSend', false, resource);
             }
         } else {
             await this.getTerminalService(resource).sendText(code);

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -5,13 +5,13 @@
 
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import { Disposable, l10n, Uri } from 'vscode';
+import { Disposable, Uri } from 'vscode';
 import { ICommandManager, IWorkspaceService } from '../../common/application/types';
-import { Commands } from '../../common/constants';
 import '../../common/extensions';
 import { IPlatformService } from '../../common/platform/types';
 import { ITerminalService, ITerminalServiceFactory } from '../../common/terminal/types';
 import { IConfigurationService, IDisposableRegistry, Resource } from '../../common/types';
+import { Diagnostics, Repl } from '../../common/utils/localize';
 import { showWarningMessage } from '../../common/vscodeApis/windowApis';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { traceInfo } from '../../logging';
@@ -48,17 +48,9 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
         await this.initializeRepl(resource);
         if (code == 'deprecated') {
             // If user is trying to smart send deprecated code show warning
-            const selection = await showWarningMessage(
-                l10n.t(
-                    `Python is unable to parse the code provided. Please
-                    turn off Smart Send if you wish to run code line by line or explicitly select code
-                    to force run. See [logs](command:${Commands.ViewOutput}) for more details.`,
-                ),
-                'Disable Smart Send',
-            );
+            const selection = await showWarningMessage(Diagnostics.invalidSmartSendMessage, Repl.disableSmartSend);
             traceInfo(`Selected file contains invalid Python or Deprecated Python 2 code`);
-            if (selection === 'Disable Smart Send') {
-                // this.commandManager.executeCommand('workbench.action.openSettings', 'python.REPL.EnableREPLSmartSend');
+            if (selection === Repl.disableSmartSend) {
                 this.configurationService.updateSetting('REPL.EnableREPLSmartSend', false, resource);
             }
         } else {

--- a/src/test/pythonFiles/terminalExec/sample_invalid_smart_selection.py
+++ b/src/test/pythonFiles/terminalExec/sample_invalid_smart_selection.py
@@ -1,0 +1,10 @@
+def beliebig(x, y, *mehr):
+    print "x=", x, ", x=", y
+    print "mehr: ", mehr
+
+list = [
+1,
+2,
+3,
+]
+print("Above is invalid");print("deprecated");print("show warning")

--- a/src/test/terminals/codeExecution/smartSend.test.ts
+++ b/src/test/terminals/codeExecution/smartSend.test.ts
@@ -4,6 +4,7 @@ import { TextEditor, Selection, Position, TextDocument } from 'vscode';
 import * as fs from 'fs-extra';
 import { SemVer } from 'semver';
 import { assert, expect } from 'chai';
+import { when } from 'ts-mockito';
 import {
     // IActiveResourceService,
     IApplicationShell,
@@ -12,7 +13,12 @@ import {
 } from '../../../client/common/application/types';
 import { IProcessService, IProcessServiceFactory } from '../../../client/common/process/types';
 import { IInterpreterService } from '../../../client/interpreter/contracts';
-import { IConfigurationService, IExperimentService } from '../../../client/common/types';
+import {
+    IConfigurationService,
+    IExperimentService,
+    IPythonSettings,
+    IREPLSettings,
+} from '../../../client/common/types';
 import { CodeExecutionHelper } from '../../../client/terminals/codeExecution/helper';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { ICodeExecutionHelper } from '../../../client/terminals/types';
@@ -22,6 +28,7 @@ import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnviro
 import { PYTHON_PATH } from '../../common';
 import { Architecture } from '../../../client/common/utils/platform';
 import { ProcessService } from '../../../client/common/process/proc';
+import { PythonSettings } from '../../../client/common/configSettings';
 
 const TEST_FILES_PATH = path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'pythonFiles', 'terminalExec');
 
@@ -155,7 +162,28 @@ suite('REPL - Smart Send', () => {
         experimentService
             .setup((exp) => exp.inExperimentSync(TypeMoq.It.isValue(EnableREPLSmartSend.experiment)))
             .returns(() => true);
-
+        // const settings = TypeMoq.Mock.ofType<IREPLSettings>();
+        // configurationService.setup((c) => c.getSettings(TypeMoq.It.isAny())).returns(() => settings.);
+        configurationService
+            .setup((c) => c.getSettings(TypeMoq.It.isAny()))
+            .returns({
+                REPL: {
+                    EnableREPLSmartSend: true,
+                    REPLSmartSend: true,
+                },
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any);
+        // when(configurationService.getSettings()).thenReturn({
+        //     experiments: {
+        //         enabled: false,
+        //         optInto: [],
+        //         optOutFrom: [],
+        //     },
+        //     initialize: true,
+        //     venvPath: 'path',
+        //     pipenvPath: 'pipenv',
+        //     // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // } as any);
         const activeEditor = TypeMoq.Mock.ofType<TextEditor>();
         const firstIndexPosition = new Position(0, 0);
         const selection = TypeMoq.Mock.ofType<Selection>();

--- a/src/test/terminals/codeExecution/smartSend.test.ts
+++ b/src/test/terminals/codeExecution/smartSend.test.ts
@@ -108,7 +108,7 @@ suite('REPL - Smart Send', () => {
             .returns(() => activeResourceService.object);
         activeResourceService.setup((a) => a.getActiveResource()).returns(() => resource);
 
-        pythonSettings.setup((s) => s.REPL).returns(() => ({ EnableREPLSmartSend: true, REPLSmartSend: true }));
+        pythonSettings.setup((s) => s.REPL).returns(() => ({ enableREPLSmartSend: true, REPLSmartSend: true }));
 
         configurationService.setup((x) => x.getSettings(TypeMoq.It.isAny())).returns(() => pythonSettings.object);
 

--- a/src/test/terminals/codeExecution/smartSend.test.ts
+++ b/src/test/terminals/codeExecution/smartSend.test.ts
@@ -4,7 +4,6 @@ import { TextEditor, Selection, Position, TextDocument, Uri } from 'vscode';
 import * as fs from 'fs-extra';
 import { SemVer } from 'semver';
 import { assert, expect } from 'chai';
-// import { when } from 'ts-mockito';
 import {
     IActiveResourceService,
     IApplicationShell,
@@ -13,13 +12,7 @@ import {
 } from '../../../client/common/application/types';
 import { IProcessService, IProcessServiceFactory } from '../../../client/common/process/types';
 import { IInterpreterService } from '../../../client/interpreter/contracts';
-import {
-    IConfigurationService,
-    IExperimentService,
-    IPythonSettings,
-    // IPythonSettings,
-    // IREPLSettings,
-} from '../../../client/common/types';
+import { IConfigurationService, IExperimentService, IPythonSettings } from '../../../client/common/types';
 import { CodeExecutionHelper } from '../../../client/terminals/codeExecution/helper';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { ICodeExecutionHelper } from '../../../client/terminals/types';
@@ -29,7 +22,6 @@ import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnviro
 import { PYTHON_PATH } from '../../common';
 import { Architecture } from '../../../client/common/utils/platform';
 import { ProcessService } from '../../../client/common/process/proc';
-// import { PythonSettings } from '../../../client/common/configSettings';
 
 const TEST_FILES_PATH = path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'pythonFiles', 'terminalExec');
 
@@ -174,8 +166,7 @@ suite('REPL - Smart Send', () => {
         experimentService
             .setup((exp) => exp.inExperimentSync(TypeMoq.It.isValue(EnableREPLSmartSend.experiment)))
             .returns(() => true);
-        // const settings = TypeMoq.Mock.ofType<IPythonSettings>();
-        // configurationService.setup((c) => c.getSettings(TypeMoq.It.isAny())).returns(() => settings.object);
+
         configurationService
             .setup((c) => c.getSettings(TypeMoq.It.isAny()))
             .returns({
@@ -185,17 +176,7 @@ suite('REPL - Smart Send', () => {
                 },
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
             } as any);
-        // when(configurationService.getSettings()).thenReturn({
-        //     experiments: {
-        //         enabled: false,
-        //         optInto: [],
-        //         optOutFrom: [],
-        //     },
-        //     initialize: true,
-        //     venvPath: 'path',
-        //     pipenvPath: 'pipenv',
-        //     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        // } as any);
+
         const activeEditor = TypeMoq.Mock.ofType<TextEditor>();
         const firstIndexPosition = new Position(0, 0);
         const selection = TypeMoq.Mock.ofType<Selection>();

--- a/src/test/terminals/codeExecution/smartSend.test.ts
+++ b/src/test/terminals/codeExecution/smartSend.test.ts
@@ -4,7 +4,12 @@ import { TextEditor, Selection, Position, TextDocument } from 'vscode';
 import * as fs from 'fs-extra';
 import { SemVer } from 'semver';
 import { assert, expect } from 'chai';
-import { IApplicationShell, ICommandManager, IDocumentManager } from '../../../client/common/application/types';
+import {
+    IActiveResourceService,
+    IApplicationShell,
+    ICommandManager,
+    IDocumentManager,
+} from '../../../client/common/application/types';
 import { IProcessService, IProcessServiceFactory } from '../../../client/common/process/types';
 import { IInterpreterService } from '../../../client/interpreter/contracts';
 import { IConfigurationService, IExperimentService } from '../../../client/common/types';
@@ -35,6 +40,7 @@ suite('REPL - Smart Send', () => {
     let experimentService: TypeMoq.IMock<IExperimentService>;
 
     let processService: TypeMoq.IMock<IProcessService>;
+    let activeResourceService: TypeMoq.IMock<IActiveResourceService>;
 
     let document: TypeMoq.IMock<TextDocument>;
     const workingPython: PythonEnvironment = {
@@ -64,6 +70,7 @@ suite('REPL - Smart Send', () => {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         experimentService = TypeMoq.Mock.ofType<IExperimentService>();
         processService = TypeMoq.Mock.ofType<IProcessService>();
+        activeResourceService = TypeMoq.Mock.ofType<IActiveResourceService>();
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         processService.setup((x: any) => x.then).returns(() => undefined);

--- a/src/test/terminals/codeExecution/smartSend.test.ts
+++ b/src/test/terminals/codeExecution/smartSend.test.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs-extra';
 import { SemVer } from 'semver';
 import { assert, expect } from 'chai';
 import {
-    IActiveResourceService,
+    // IActiveResourceService,
     IApplicationShell,
     ICommandManager,
     IDocumentManager,
@@ -40,7 +40,7 @@ suite('REPL - Smart Send', () => {
     let experimentService: TypeMoq.IMock<IExperimentService>;
 
     let processService: TypeMoq.IMock<IProcessService>;
-    let activeResourceService: TypeMoq.IMock<IActiveResourceService>;
+    // let activeResourceService: TypeMoq.IMock<IActiveResourceService>;
 
     let document: TypeMoq.IMock<TextDocument>;
     const workingPython: PythonEnvironment = {
@@ -70,7 +70,7 @@ suite('REPL - Smart Send', () => {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         experimentService = TypeMoq.Mock.ofType<IExperimentService>();
         processService = TypeMoq.Mock.ofType<IProcessService>();
-        activeResourceService = TypeMoq.Mock.ofType<IActiveResourceService>();
+        // activeResourceService = TypeMoq.Mock.ofType<IActiveResourceService>();
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         processService.setup((x: any) => x.then).returns(() => undefined);

--- a/src/test/terminals/codeExecution/smartSend.test.ts
+++ b/src/test/terminals/codeExecution/smartSend.test.ts
@@ -4,7 +4,7 @@ import { TextEditor, Selection, Position, TextDocument } from 'vscode';
 import * as fs from 'fs-extra';
 import { SemVer } from 'semver';
 import { assert, expect } from 'chai';
-import { when } from 'ts-mockito';
+// import { when } from 'ts-mockito';
 import {
     // IActiveResourceService,
     IApplicationShell,
@@ -16,8 +16,8 @@ import { IInterpreterService } from '../../../client/interpreter/contracts';
 import {
     IConfigurationService,
     IExperimentService,
-    IPythonSettings,
-    IREPLSettings,
+    // IPythonSettings,
+    // IREPLSettings,
 } from '../../../client/common/types';
 import { CodeExecutionHelper } from '../../../client/terminals/codeExecution/helper';
 import { IServiceContainer } from '../../../client/ioc/types';
@@ -28,7 +28,7 @@ import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnviro
 import { PYTHON_PATH } from '../../common';
 import { Architecture } from '../../../client/common/utils/platform';
 import { ProcessService } from '../../../client/common/process/proc';
-import { PythonSettings } from '../../../client/common/configSettings';
+// import { PythonSettings } from '../../../client/common/configSettings';
 
 const TEST_FILES_PATH = path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'pythonFiles', 'terminalExec');
 

--- a/src/test/terminals/codeExecution/terminalCodeExec.unit.test.ts
+++ b/src/test/terminals/codeExecution/terminalCodeExec.unit.test.ts
@@ -84,6 +84,7 @@ suite('Terminal - Code Execution', () => {
                         disposables,
                         platform.object,
                         interpreterService.object,
+                        commandManager.object,
                     );
                     break;
                 }
@@ -95,6 +96,7 @@ suite('Terminal - Code Execution', () => {
                         disposables,
                         platform.object,
                         interpreterService.object,
+                        commandManager.object,
                     );
                     expectedTerminalTitle = 'REPL';
                     break;


### PR DESCRIPTION
Resolves: #22341 #22340

Showing warning message after detecting user is on Python file with deprecated Python code, and are attempting to run smart send via shift+enter action. Allow user to turn off this via workspace setting. 