### PR TITLE
Improve shell identifier on case-insensitive system

### DIFF
--- a/src/client/common/terminal/shellDetectors/baseShellDetector.ts
+++ b/src/client/common/terminal/shellDetectors/baseShellDetector.ts
@@ -63,7 +63,7 @@ export abstract class BaseShellDetector implements IShellDetector {
 export function identifyShellFromShellPath(shellPath: string): TerminalShellType {
     // Remove .exe extension so shells can be more consistently detected
     // on Windows (including Cygwin).
-    const basePath = shellPath.replace(/\.exe$/, '');
+    const basePath = shellPath.replace(/\.exe$/i, '');
 
     const shell = Array.from(detectableShells.keys()).reduce((matchedShell, shellToDetect) => {
         if (matchedShell === TerminalShellType.other) {

--- a/src/test/common/terminals/shellDetectors/shellDetectors.unit.test.ts
+++ b/src/test/common/terminals/shellDetectors/shellDetectors.unit.test.ts
@@ -41,6 +41,7 @@ suite('Shell Detectors', () => {
     shellPathsAndIdentification.set('/usr/bin/ksh', TerminalShellType.ksh);
     shellPathsAndIdentification.set('c:\\windows\\system32\\powershell.exe', TerminalShellType.powershell);
     shellPathsAndIdentification.set('c:\\windows\\system32\\pwsh.exe', TerminalShellType.powershellCore);
+    shellPathsAndIdentification.set('C:\\Program Files\\nu\\bin\\nu.EXE', TerminalShellType.nushell);
     shellPathsAndIdentification.set('/usr/microsoft/xxx/powershell/powershell', TerminalShellType.powershell);
     shellPathsAndIdentification.set('/usr/microsoft/xxx/powershell/pwsh', TerminalShellType.powershellCore);
     shellPathsAndIdentification.set('/usr/bin/fish', TerminalShellType.fish);


### PR DESCRIPTION
Use case-insensitive regex to remove `.exe`  extension.

See: https://github.com/microsoft/vscode-python/issues/22036#issuecomment-1786354934