### PR TITLE
remove new line chars from error text messages in testing rewrite

### DIFF
--- a/src/client/testing/testController/common/resultResolver.ts
+++ b/src/client/testing/testController/common/resultResolver.ts
@@ -153,7 +153,7 @@ export class PythonResultResolver implements ITestResultResolver {
                     }).join('\r\n');
                     const text = `${testItem.test} failed with error: ${
                         testItem.message ?? testItem.outcome
-                    }\r\n${traceback}\r\n`;
+                    }\r\n${traceback}`;
                     const message = new TestMessage(text);
 
                     const grabVSid = this.runIdToVSid.get(keyTemp);
@@ -173,7 +173,7 @@ export class PythonResultResolver implements ITestResultResolver {
                         removeEmptyEntries: true,
                     }).join('\r\n');
 
-                    const text = `${testItem.test} failed: ${testItem.message ?? testItem.outcome}\r\n${traceback}\r\n`;
+                    const text = `${testItem.test} failed: ${testItem.message ?? testItem.outcome}\r\n${traceback}`;
                     const message = new TestMessage(text);
 
                     // note that keyTemp is a runId for unittest library...
@@ -235,7 +235,7 @@ export class PythonResultResolver implements ITestResultResolver {
                             const traceback = data.traceback ?? '';
                             const text = `${data.subtest} failed: ${
                                 testItem.message ?? testItem.outcome
-                            }\r\n${traceback}\r\n`;
+                            }\r\n${traceback}`;
                             parentTestItem.children.add(subTestItem);
                             runInstance.started(subTestItem);
                             const message = new TestMessage(text);


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python/issues/21512 where 2 extra new lines were seen at the end of an error message popup. Removing these will restrict stop this from occurring. 