### PR TITLE
Add consoleTitle to launch.json properties schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -981,7 +981,7 @@
                             },
                             "consoleTitle": {
                                 "default": "Python Debug Console",
-                                "description": "Name for debug console or terminal"
+                                "description": "Display name of the debug console or terminal"
                             },
                             "cwd": {
                                 "default": "${workspaceFolder}",

--- a/package.json
+++ b/package.json
@@ -979,6 +979,10 @@
                                     "internalConsole"
                                 ]
                             },
+                            "consoleTitle": {
+                                "default": "Python Debug Console",
+                                "description": "Name for debug console or terminal"
+                            },
                             "cwd": {
                                 "default": "${workspaceFolder}",
                                 "description": "Absolute path to the working directory of the program being debugged. Default is the root directory of the file (leave empty).",


### PR DESCRIPTION
consoleTitle is effectively an undocumented feature. pydebug accepts the config key, but vscode will report a problem because it is missing from the schema. see [this debugpy issue](https://github.com/microsoft/debugpy/issues/1178) and [#13040](https://github.com/microsoft/vscode-python/issues/13040)

I used the phrase "console or terminal" because I noticed the name was represented on both integratedTerminal and internalConsole. I didn't test externalTerminal.