### PR TITLE
testing: improve performance of large test discovery

### DIFF
--- a/src/client/testing/testController/common/utils.ts
+++ b/src/client/testing/testController/common/utils.ts
@@ -142,7 +142,6 @@ export class ConcatBuffer {
     }
 }
 
-
 export function extractJsonPayload(rawData: ConcatBuffer, uuids: Array<string>): ExtractOutput {
     /**
      * Extracts JSON-RPC payload from the provided raw data.

--- a/src/test/testing/testController/utils.unit.test.ts
+++ b/src/test/testing/testController/utils.unit.test.ts
@@ -9,35 +9,73 @@ import {
     ExtractJsonRPCData,
     parseJsonRPCHeadersAndData,
     splitTestNameWithRegex,
+    ConcatBuffer,
 } from '../../../client/testing/testController/common/utils';
+
+const bufString = (s: string) => {
+    // chunk it to make sure processing is handled correctly
+    let chunks: Buffer[] = [];
+    for (let i = 0; i < s.length; ) {
+        const next = i + Math.floor(Math.random() * 5);
+        chunks.push(Buffer.from(s.slice(i, next)));
+        i = next;
+    }
+    return new ConcatBuffer(chunks);
+};
+
+suite('Test Controller Utils: ConcatBuffer', () => {
+    test('indexOf', () => {
+        const b = new ConcatBuffer([Buffer.from('abc'), Buffer.from('def')]);
+        assert.strictEqual(b.indexOf('a'.charCodeAt(0)), 0);
+        assert.strictEqual(b.indexOf('b'.charCodeAt(0)), 1);
+        assert.strictEqual(b.indexOf('c'.charCodeAt(0)), 2);
+        assert.strictEqual(b.indexOf('d'.charCodeAt(0)), 3);
+        assert.strictEqual(b.indexOf('e'.charCodeAt(0)), 4);
+        assert.strictEqual(b.indexOf('f'.charCodeAt(0)), 5);
+        assert.strictEqual(b.indexOf('g'.charCodeAt(0)), -1);
+    });
+
+    test('toString', () => {
+        const b = new ConcatBuffer([Buffer.from('abc'), Buffer.from('def')]);
+        assert.strictEqual(b.toString(), 'abcdef');
+    });
+
+    test('subarray', () => {
+        const b = new ConcatBuffer([Buffer.from('abc'), Buffer.from('def')]);
+        assert.strictEqual(b.subarray(0, 2).toString(), 'ab');
+        assert.strictEqual(b.subarray(4, 6).toString(), 'ef');
+        assert.strictEqual(b.subarray(2, 5).toString(), 'cde');
+        assert.strictEqual(b.subarray(0, 6).toString(), 'abcdef');
+    });
+});
 
 suite('Test Controller Utils: JSON RPC', () => {
     test('Empty raw data string', async () => {
         const rawDataString = '';
 
-        const output = parseJsonRPCHeadersAndData(rawDataString);
+        const output = parseJsonRPCHeadersAndData(bufString(rawDataString));
         assert.deepStrictEqual(output.headers.size, 0);
-        assert.deepStrictEqual(output.remainingRawData, '');
+        assert.deepStrictEqual(output.remainingRawData.toString(), '');
     });
 
     test('Valid data empty JSON', async () => {
         const rawDataString = `${JSONRPC_CONTENT_LENGTH_HEADER}: 2\n${JSONRPC_CONTENT_TYPE_HEADER}: application/json\n${JSONRPC_UUID_HEADER}: 1234\n\n{}`;
 
-        const rpcHeaders = parseJsonRPCHeadersAndData(rawDataString);
+        const rpcHeaders = parseJsonRPCHeadersAndData(bufString(rawDataString));
         assert.deepStrictEqual(rpcHeaders.headers.size, 3);
-        assert.deepStrictEqual(rpcHeaders.remainingRawData, '{}');
+        assert.deepStrictEqual(rpcHeaders.remainingRawData.toString(), '{}');
         const rpcContent = ExtractJsonRPCData(rpcHeaders.headers.get('Content-Length'), rpcHeaders.remainingRawData);
-        assert.deepStrictEqual(rpcContent.extractedJSON, '{}');
+        assert.deepStrictEqual(rpcContent.extractedJSON.toString(), '{}');
     });
 
     test('Valid data NO JSON', async () => {
         const rawDataString = `${JSONRPC_CONTENT_LENGTH_HEADER}: 0\n${JSONRPC_CONTENT_TYPE_HEADER}: application/json\n${JSONRPC_UUID_HEADER}: 1234\n\n`;
 
-        const rpcHeaders = parseJsonRPCHeadersAndData(rawDataString);
+        const rpcHeaders = parseJsonRPCHeadersAndData(bufString(rawDataString));
         assert.deepStrictEqual(rpcHeaders.headers.size, 3);
-        assert.deepStrictEqual(rpcHeaders.remainingRawData, '');
+        assert.deepStrictEqual(rpcHeaders.remainingRawData.toString(), '');
         const rpcContent = ExtractJsonRPCData(rpcHeaders.headers.get('Content-Length'), rpcHeaders.remainingRawData);
-        assert.deepStrictEqual(rpcContent.extractedJSON, '');
+        assert.deepStrictEqual(rpcContent.extractedJSON.toString(), '');
     });
 
     test('Valid data with full JSON', async () => {
@@ -46,11 +84,11 @@ suite('Test Controller Utils: JSON RPC', () => {
             '{"jsonrpc": "2.0", "method": "initialize", "params": {"processId": 1234, "rootPath": "/home/user/project", "rootUri": "file:///home/user/project", "capabilities": {}}, "id": 0}';
         const rawDataString = `${JSONRPC_CONTENT_LENGTH_HEADER}: ${json.length}\n${JSONRPC_CONTENT_TYPE_HEADER}: application/json\n${JSONRPC_UUID_HEADER}: 1234\n\n${json}`;
 
-        const rpcHeaders = parseJsonRPCHeadersAndData(rawDataString);
+        const rpcHeaders = parseJsonRPCHeadersAndData(bufString(rawDataString));
         assert.deepStrictEqual(rpcHeaders.headers.size, 3);
-        assert.deepStrictEqual(rpcHeaders.remainingRawData, json);
+        assert.deepStrictEqual(rpcHeaders.remainingRawData.toString(), json);
         const rpcContent = ExtractJsonRPCData(rpcHeaders.headers.get('Content-Length'), rpcHeaders.remainingRawData);
-        assert.deepStrictEqual(rpcContent.extractedJSON, json);
+        assert.deepStrictEqual(rpcContent.extractedJSON.toString(), json);
     });
 
     test('Valid data with multiple JSON', async () => {
@@ -59,11 +97,11 @@ suite('Test Controller Utils: JSON RPC', () => {
         const rawDataString = `${JSONRPC_CONTENT_LENGTH_HEADER}: ${json.length}\n${JSONRPC_CONTENT_TYPE_HEADER}: application/json\n${JSONRPC_UUID_HEADER}: 1234\n\n${json}`;
         const rawDataString2 = rawDataString + rawDataString;
 
-        const rpcHeaders = parseJsonRPCHeadersAndData(rawDataString2);
+        const rpcHeaders = parseJsonRPCHeadersAndData(bufString(rawDataString2));
         assert.deepStrictEqual(rpcHeaders.headers.size, 3);
         const rpcContent = ExtractJsonRPCData(rpcHeaders.headers.get('Content-Length'), rpcHeaders.remainingRawData);
-        assert.deepStrictEqual(rpcContent.extractedJSON, json);
-        assert.deepStrictEqual(rpcContent.remainingRawData, rawDataString);
+        assert.deepStrictEqual(rpcContent.extractedJSON.toString(), json);
+        assert.deepStrictEqual(rpcContent.remainingRawData.toString(), rawDataString);
     });
 
     test('Valid constant', async () => {
@@ -79,29 +117,29 @@ Request-uuid: 496c86b1-608f-4886-9436-ec00538e144c
 
 ${data}${secondPayload}`;
 
-        const rpcHeaders = parseJsonRPCHeadersAndData(payload);
+        const rpcHeaders = parseJsonRPCHeadersAndData(bufString(payload));
         assert.deepStrictEqual(rpcHeaders.headers.size, 3);
         const rpcContent = ExtractJsonRPCData(rpcHeaders.headers.get('Content-Length'), rpcHeaders.remainingRawData);
-        assert.deepStrictEqual(rpcContent.extractedJSON, data);
-        assert.deepStrictEqual(rpcContent.remainingRawData, secondPayload);
+        assert.deepStrictEqual(rpcContent.extractedJSON.toString(), data);
+        assert.deepStrictEqual(rpcContent.remainingRawData.toString(), secondPayload);
     });
     test('Valid content length as only header with carriage return', async () => {
         const payload = `Content-Length: 7
         `;
 
-        const rpcHeaders = parseJsonRPCHeadersAndData(payload);
+        const rpcHeaders = parseJsonRPCHeadersAndData(bufString(payload));
         assert.deepStrictEqual(rpcHeaders.headers.size, 1);
         const rpcContent = ExtractJsonRPCData(rpcHeaders.headers.get('Content-Length'), rpcHeaders.remainingRawData);
-        assert.deepStrictEqual(rpcContent.extractedJSON, '');
-        assert.deepStrictEqual(rpcContent.remainingRawData, '');
+        assert.deepStrictEqual(rpcContent.extractedJSON.toString(), '');
+        assert.deepStrictEqual(rpcContent.remainingRawData.toString(), '');
     });
     test('Valid content length header with no value', async () => {
         const payload = `Content-Length:`;
 
-        const rpcHeaders = parseJsonRPCHeadersAndData(payload);
+        const rpcHeaders = parseJsonRPCHeadersAndData(bufString(payload));
         const rpcContent = ExtractJsonRPCData(rpcHeaders.headers.get('Content-Length'), rpcHeaders.remainingRawData);
-        assert.deepStrictEqual(rpcContent.extractedJSON, '');
-        assert.deepStrictEqual(rpcContent.remainingRawData, '');
+        assert.deepStrictEqual(rpcContent.extractedJSON.toString(), '');
+        assert.deepStrictEqual(rpcContent.remainingRawData.toString(), '');
     });
 
     suite('Test Controller Utils: Other', () => {

--- a/src/test/testing/testController/utils.unit.test.ts
+++ b/src/test/testing/testController/utils.unit.test.ts
@@ -14,7 +14,7 @@ import {
 
 const bufString = (s: string) => {
     // chunk it to make sure processing is handled correctly
-    let chunks: Buffer[] = [];
+    const chunks: Buffer[] = [];
     for (let i = 0; i < s.length; ) {
         const next = i + Math.floor(Math.random() * 5);
         chunks.push(Buffer.from(s.slice(i, next)));


### PR DESCRIPTION
Avoids expensive string conversions and (to a lesser degree) buffer concatenations. Reduces time in the extension host in the lsprotocol repo from 17s -> 950ms for me.

Original profile:
[vscode-profile-2023-11-02-16-35-20.cpuprofile](https://github.com/microsoft/vscode-python/files/13245853/vscode-profile-2023-11-02-16-35-20.cpuprofile)

Profile with these changes:
[vscode-profile-2023-11-02-17-27-45.cpuprofile](https://github.com/microsoft/vscode-python/files/13245854/vscode-profile-2023-11-02-17-27-45.cpuprofile)
