### PR TITLE
Use `WorkspaceFolder.name` in addition to workspace folder's basename when resolving `${workspaceFolder:name}` syntax in settings

### DIFF
--- a/src/client/common/variables/systemVariables.ts
+++ b/src/client/common/variables/systemVariables.ts
@@ -132,6 +132,8 @@ export class SystemVariables extends AbstractSystemVariables {
                 const basename = Path.basename(folder.uri.fsPath);
                 ((this as any) as Record<string, string | undefined>)[`workspaceFolder:${basename}`] =
                     folder.uri.fsPath;
+                ((this as any) as Record<string, string | undefined>)[`workspaceFolder:${folder.name}`] =
+                    folder.uri.fsPath;
             });
         } catch {
             // This try...catch block is here to support pre-existing tests, ignore error.


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/22452