### PR TITLE
White space after REPL prompt

### DIFF
--- a/pythonFiles/pythonrc.py
+++ b/pythonFiles/pythonrc.py
@@ -1,6 +1,6 @@
 import sys
 
-original_ps1 = ">>>"
+original_ps1 = ">>> "
 
 
 class repl_hooks:

--- a/pythonFiles/tests/test_shell_integration.py
+++ b/pythonFiles/tests/test_shell_integration.py
@@ -10,7 +10,7 @@ def test_decoration_success():
 
     ps1.hooks.failure_flag = False
     result = str(ps1)
-    assert result == "\x1b]633;D;00\x07\x1b]633;A\x07>>>\x1b]633;B\x07\x1b]633;C\x07"
+    assert result == "\x1b]633;D;00\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07"
 
 
 def test_decoration_failure():
@@ -20,7 +20,7 @@ def test_decoration_failure():
     ps1.hooks.failure_flag = True
     result = str(ps1)
 
-    assert result == "\x1b]633;D;10\x07\x1b]633;A\x07>>>\x1b]633;B\x07\x1b]633;C\x07"
+    assert result == "\x1b]633;D;10\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07"
 
 
 def test_displayhook_call():


### PR DESCRIPTION
There should be white space after new REPL prompt that I override for purpose of shell integration.
Resolves: #22548