### PR TITLE
Fix shell integration decoration for windows pwsh

### DIFF
--- a/pythonFiles/pythonrc.py
+++ b/pythonFiles/pythonrc.py
@@ -46,7 +46,7 @@ class ps1:
         #     command_start="\x1b]633;B\x07",
         #     command_executed="\x1b]633;C\x07",
         # )
-        result = f"{chr(27)}]633;D;{exit_code}0{chr(7)}{chr(27)}]633;A{chr(7)}{original_ps1}{chr(27)}]633;B{chr(7)}{chr(27)}]633;C{chr(7)}"
+        result = f"{chr(27)}]633;D;{exit_code}{chr(7)}{chr(27)}]633;A{chr(7)}{original_ps1}{chr(27)}]633;B{chr(7)}{chr(27)}]633;C{chr(7)}"
 
         return result
 

--- a/pythonFiles/tests/test_shell_integration.py
+++ b/pythonFiles/tests/test_shell_integration.py
@@ -10,7 +10,7 @@ def test_decoration_success():
 
     ps1.hooks.failure_flag = False
     result = str(ps1)
-    assert result == "\x1b]633;D;00\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07"
+    assert result == "\x1b]633;D;0\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07"
 
 
 def test_decoration_failure():
@@ -20,7 +20,7 @@ def test_decoration_failure():
     ps1.hooks.failure_flag = True
     result = str(ps1)
 
-    assert result == "\x1b]633;D;10\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07"
+    assert result == "\x1b]633;D;1\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07"
 
 
 def test_displayhook_call():


### PR DESCRIPTION
Attempting to fix shell integration decoration glitch for windows pwsh when using Python REPL from VS Code.
Resolves: #22546 #22535