### PR TITLE
bump-dev-version-2023.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "python",
-    "version": "2023.22.0-rc",
+    "version": "2023.23.0-dev",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "python",
-            "version": "2023.22.0-rc",
+            "version": "2023.23.0-dev",
             "license": "MIT",
             "dependencies": {
                 "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "python",
     "displayName": "Python",
     "description": "IntelliSense (Pylance), Linting, Debugging (multi-threaded, remote), code formatting, refactoring, unit tests, and more.",
-    "version": "2023.22.0-rc",
+    "version": "2023.23.0-dev",
     "featureFlags": {
         "usingNewInterpreterStorage": true
     },


### PR DESCRIPTION
unfreezing main by switching version back to `-rc`, `2023.23.0-rc`