### PR TITLE
add logging for when testing is already running and causes new runs to be canceled 

### DIFF
--- a/src/client/testing/testController/workspaceTestAdapter.ts
+++ b/src/client/testing/testController/workspaceTestAdapter.ts
@@ -47,6 +47,7 @@ export class WorkspaceTestAdapter {
         debugLauncher?: ITestDebugLauncher,
     ): Promise<void> {
         if (this.executing) {
+            traceError('Test execution already in progress, not starting a new one.');
             return this.executing.promise;
         }
 
@@ -119,6 +120,7 @@ export class WorkspaceTestAdapter {
 
         // Discovery is expensive. If it is already running, use the existing promise.
         if (this.discovering) {
+            traceError('Test discovery already in progress, not starting a new one.');
             return this.discovering.promise;
         }
 


### PR DESCRIPTION
This logging will provide greater visibility for users as the discovery or execution process immediately exits since the process interprets there is already a similar process is going. This can inform users or help spot bugs