### PR TITLE
support yaml tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -260,7 +260,7 @@
             "type": "python",
             "request": "launch",
             "module": "pytest",
-            "args": ["${workspaceFolder}/pythonFiles/tests/pytestadapter"],
+            "args": ["${workspaceFolder}/pythonFiles/tests/pytestadapter", "-vv"],
             "justMyCode": true
         }
     ],

--- a/pythonFiles/tests/pytestadapter/.data/test_yaml.yaml
+++ b/pythonFiles/tests/pytestadapter/.data/test_yaml.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+- case: test_integer_type
+  main: |
+    reveal_type(123)
+  out: |
+    main:1: note: Revealed type is "Literal[123]?"

--- a/pythonFiles/tests/pytestadapter/expected_discovery_test_output.py
+++ b/pythonFiles/tests/pytestadapter/expected_discovery_test_output.py
@@ -886,6 +886,36 @@ root_with_config_expected_output = {
     ],
     "id_": os.fspath(tests_path),
 }
+
+TEST_YAML_PATH = TEST_DATA_PATH / "test_yaml.yaml"
+yaml_expected_output = {
+    "name": ".data",
+    "path": str(TEST_DATA_PATH),
+    "type_": "folder",
+    "children": [
+        {
+            "name": "test_yaml.yaml",
+            "path": str(TEST_YAML_PATH),
+            "type_": "file",
+            "id_": str(TEST_YAML_PATH),
+            "children": [
+                {
+                    "name": "test_integer_type",
+                    "path": str(TEST_YAML_PATH),
+                    "lineno": "6",
+                    "type_": "test",
+                    "id_": get_absolute_test_id(
+                        "test_yaml.yaml::test_integer_type", TEST_YAML_PATH
+                    ),
+                    "runID": get_absolute_test_id(
+                        "test_yaml.yaml::test_integer_type", TEST_YAML_PATH
+                    ),
+                }
+            ],
+        }
+    ],
+    "id_": str(TEST_DATA_PATH),
+}
 TEST_MULTI_CLASS_NEST_PATH = TEST_DATA_PATH / "test_multi_class_nest.py"
 
 nested_classes_expected_test_output = {

--- a/pythonFiles/tests/pytestadapter/expected_discovery_test_output.py
+++ b/pythonFiles/tests/pytestadapter/expected_discovery_test_output.py
@@ -916,6 +916,7 @@ yaml_expected_output = {
     ],
     "id_": str(TEST_DATA_PATH),
 }
+
 TEST_MULTI_CLASS_NEST_PATH = TEST_DATA_PATH / "test_multi_class_nest.py"
 
 nested_classes_expected_test_output = {

--- a/pythonFiles/tests/pytestadapter/expected_discovery_test_output.py
+++ b/pythonFiles/tests/pytestadapter/expected_discovery_test_output.py
@@ -902,7 +902,7 @@ yaml_expected_output = {
                 {
                     "name": "test_integer_type",
                     "path": str(TEST_YAML_PATH),
-                    "lineno": "6",
+                    "lineno": "1",  # Since the yaml test type is not in the pytest library (instead pytest-mypy-plugins), we will not support their line number but instead changing the default value to "1"  to prevent failure.
                     "type_": "test",
                     "id_": get_absolute_test_id(
                         "test_yaml.yaml::test_integer_type", TEST_YAML_PATH

--- a/pythonFiles/tests/pytestadapter/test_discovery.py
+++ b/pythonFiles/tests/pytestadapter/test_discovery.py
@@ -182,10 +182,14 @@ def test_pytest_collect(file, expected_const):
     file -- a string with the file or folder to run pytest discovery on.
     expected_const -- the expected output from running pytest discovery on the file.
     """
+    path_fs = TEST_DATA_PATH / file
+    print("PATH: EJFB", path_fs)
+    os.listdir(TEST_DATA_PATH)
+    assert path_fs.exists()
     actual = runner(
         [
             "--collect-only",
-            os.fspath(TEST_DATA_PATH / file),
+            os.fspath(path_fs),
         ]
     )
 
@@ -202,7 +206,8 @@ def test_pytest_collect(file, expected_const):
             assert actual_item.get("cwd") == os.fspath(TEST_DATA_PATH)
             assert actual_item.get("tests") == expected_const
         except AssertionError:
-            print(json.dumps(actual_item, indent=4))
+            print("assertion error occured, the actual item value is: \n")
+            print(json.dumps(actual_item, indent=4), "\n")
             raise
 
 

--- a/pythonFiles/tests/pytestadapter/test_discovery.py
+++ b/pythonFiles/tests/pytestadapter/test_discovery.py
@@ -123,6 +123,7 @@ def test_parameterized_error_collect():
 @pytest.mark.parametrize(
     "file, expected_const",
     [
+        ("test_yaml.yaml", expected_discovery_test_output.yaml_expected_output),
         (
             "test_multi_class_nest.py",
             expected_discovery_test_output.nested_classes_expected_test_output,

--- a/pythonFiles/tests/pytestadapter/test_discovery.py
+++ b/pythonFiles/tests/pytestadapter/test_discovery.py
@@ -192,9 +192,9 @@ def test_pytest_collect(file, expected_const):
     assert actual
     actual_list: List[Dict[str, Any]] = actual
     if actual_list is not None:
+        assert actual_list.pop(-1).get("eot")
+        actual_item = actual_list.pop(0)
         try:
-            assert actual_list.pop(-1).get("eot")
-            actual_item = actual_list.pop(0)
             assert all(
                 item in actual_item.keys() for item in ("status", "cwd", "error")
             )

--- a/pythonFiles/tests/pytestadapter/test_discovery.py
+++ b/pythonFiles/tests/pytestadapter/test_discovery.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+import json
 import os
 import shutil
 from typing import Any, Dict, List, Optional
@@ -191,12 +192,18 @@ def test_pytest_collect(file, expected_const):
     assert actual
     actual_list: List[Dict[str, Any]] = actual
     if actual_list is not None:
-        assert actual_list.pop(-1).get("eot")
-        actual_item = actual_list.pop(0)
-        assert all(item in actual_item.keys() for item in ("status", "cwd", "error"))
-        assert actual_item.get("status") == "success"
-        assert actual_item.get("cwd") == os.fspath(TEST_DATA_PATH)
-        assert actual_item.get("tests") == expected_const
+        try:
+            assert actual_list.pop(-1).get("eot")
+            actual_item = actual_list.pop(0)
+            assert all(
+                item in actual_item.keys() for item in ("status", "cwd", "error")
+            )
+            assert actual_item.get("status") == "success"
+            assert actual_item.get("cwd") == os.fspath(TEST_DATA_PATH)
+            assert actual_item.get("tests") == expected_const
+        except AssertionError:
+            print(json.dumps(actual_item, indent=4))
+            raise
 
 
 def test_pytest_root_dir():

--- a/pythonFiles/tests/pytestadapter/test_discovery.py
+++ b/pythonFiles/tests/pytestadapter/test_discovery.py
@@ -184,7 +184,7 @@ def test_pytest_collect(file, expected_const):
     """
     path_fs = TEST_DATA_PATH / file
     print("PATH: EJFB", path_fs)
-    os.listdir(TEST_DATA_PATH)
+    print("os diff list EJFB", os.listdir(TEST_DATA_PATH))
     assert path_fs.exists()
     actual = runner(
         [

--- a/pythonFiles/vscode_pytest/__init__.py
+++ b/pythonFiles/vscode_pytest/__init__.py
@@ -521,6 +521,10 @@ def create_test_node(
     test_case_loc: str = (
         str(test_case.location[1] + 1) if (test_case.location[1] is not None) else ""
     )
+    # This check is for yaml tests, which do not have a location but do have a starting_lineno.
+    if test_case_loc == "" and test_case.starting_lineno is not None:
+        test_case_loc = str(test_case.starting_lineno + 1)
+
     absolute_test_id = get_absolute_test_id(test_case.nodeid, get_node_path(test_case))
     return {
         "name": test_case.name,

--- a/pythonFiles/vscode_pytest/__init__.py
+++ b/pythonFiles/vscode_pytest/__init__.py
@@ -518,12 +518,10 @@ def create_test_node(
     Keyword arguments:
     test_case -- the pytest test case.
     """
+    # If test case has no location, set it to 1 as a default so test node is valid.
     test_case_loc: str = (
-        str(test_case.location[1] + 1) if (test_case.location[1] is not None) else ""
+        str(test_case.location[1] + 1) if (test_case.location[1] is not None) else "1"
     )
-    # This check is for yaml tests, which do not have a location but do have a starting_lineno.
-    if test_case_loc == "" and test_case.starting_lineno is not None:
-        test_case_loc = str(test_case.starting_lineno + 1)
 
     absolute_test_id = get_absolute_test_id(test_case.nodeid, get_node_path(test_case))
     return {

--- a/src/client/testing/testController/common/utils.ts
+++ b/src/client/testing/testController/common/utils.ts
@@ -255,6 +255,11 @@ export function populateTestTree(
                 const testItem = testController.createTestItem(child.id_, child.name, Uri.file(child.path));
                 testItem.tags = [RunTestTag, DebugTestTag];
 
+                // Check for a undefined value (here will be 0) and if found set lineno to 1 as a default.
+                if (Number(child.lineno) === 0) {
+                    traceError(`Test item ${child.name} does not have a line number.`);
+                    child.lineno = 1;
+                }
                 const range = new Range(
                     new Position(Number(child.lineno) - 1, 0),
                     new Position(Number(child.lineno), 0),


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python/issues/22668

`skip_test` selected since tests are in Python and only change to a `.ts` file is error handling.