### PR TITLE
Show name for conda environments created in the workspace

### DIFF
--- a/src/client/pythonEnvironments/base/info/env.ts
+++ b/src/client/pythonEnvironments/base/info/env.ts
@@ -179,8 +179,7 @@ function buildEnvDisplayString(env: PythonEnvInfo, getAllDetails = false): strin
     const envSuffixParts: string[] = [];
     if (env.name && env.name !== '') {
         envSuffixParts.push(`'${env.name}'`);
-    }
-    else if (env.location && env.location !== '') {
+    } else if (env.location && env.location !== '') {
         if (env.kind === PythonEnvKind.Conda) {
             const condaEnvName = path.basename(env.location);
             envSuffixParts.push(`'${condaEnvName}'`);

--- a/src/client/pythonEnvironments/base/info/env.ts
+++ b/src/client/pythonEnvironments/base/info/env.ts
@@ -180,6 +180,12 @@ function buildEnvDisplayString(env: PythonEnvInfo, getAllDetails = false): strin
     if (env.name && env.name !== '') {
         envSuffixParts.push(`'${env.name}'`);
     }
+    if (env.location && env.location !== '') {
+        if (env.kind === PythonEnvKind.Conda) {
+            const condaEnvName = path.basename(env.location);
+            envSuffixParts.push(`'${condaEnvName}'`);
+        }
+    }
     if (shouldDisplayKind) {
         const kindName = getKindDisplayName(env.kind);
         if (kindName !== '') {

--- a/src/client/pythonEnvironments/base/info/env.ts
+++ b/src/client/pythonEnvironments/base/info/env.ts
@@ -180,7 +180,7 @@ function buildEnvDisplayString(env: PythonEnvInfo, getAllDetails = false): strin
     if (env.name && env.name !== '') {
         envSuffixParts.push(`'${env.name}'`);
     }
-    if (env.location && env.location !== '') {
+    else if (env.location && env.location !== '') {
         if (env.kind === PythonEnvKind.Conda) {
             const condaEnvName = path.basename(env.location);
             envSuffixParts.push(`'${condaEnvName}'`);

--- a/src/test/pythonEnvironments/base/info/env.unit.test.ts
+++ b/src/test/pythonEnvironments/base/info/env.unit.test.ts
@@ -22,6 +22,9 @@ suite('Environment helpers', () => {
         version: parseVersionInfo('1.2.3')?.version,
         binDir: 'distroX/bin',
     };
+    const locationConda1 = 'x/y/z/conda1';
+    const locationConda2 = 'x/y/z/conda2';
+    const kindConda = PythonEnvKind.Conda;
     function getEnv(info: {
         version?: string;
         arch?: Architecture;
@@ -65,6 +68,10 @@ suite('Environment helpers', () => {
                 "Python 3.8.1 64-bit ('my-env')",
                 "Python 3.8.1 64-bit ('my-env')",
             ],
+            // conda env.name is empty.
+            [getEnv({ kind: kindConda }), 'Python', 'Python (conda)'],
+            [getEnv({ location: locationConda1, kind: kindConda }), "Python ('conda1')", "Python ('conda1': conda)"],
+            [getEnv({ location: locationConda2, kind: kindConda }), "Python ('conda2')", "Python ('conda2': conda)"],
         ];
         return tests;
     }


### PR DESCRIPTION
fixes #21770

![fix-update-conda-env-names](https://github.com/microsoft/vscode-python/assets/67870588/0b8906bc-232e-4880-afdf-5cc8adbf21bc)
