### PR TITLE
Fix for issue with environment path and Jedi

### DIFF
--- a/src/client/activation/jedi/analysisOptions.ts
+++ b/src/client/activation/jedi/analysisOptions.ts
@@ -79,7 +79,7 @@ export class JediLanguageServerAnalysisOptions extends LanguageServerAnalysisOpt
             },
             workspace: {
                 extraPaths: distinctExtraPaths,
-                environmentPath: this.interpreter?.envPath,
+                environmentPath: this.interpreter?.path,
                 symbols: {
                     // 0 means remove limit on number of workspace symbols returned
                     maxSymbols: 0,

--- a/src/test/activation/jedi/jediAnalysisOptions.unit.test.ts
+++ b/src/test/activation/jedi/jediAnalysisOptions.unit.test.ts
@@ -92,7 +92,7 @@ suite('Jedi LSP - analysis Options', () => {
 
         const result = await analysisOptions.getAnalysisOptions();
 
-        expect(result.initializationOptions.workspace.environmentPath).to.deep.equal('.../.venv');
+        expect(result.initializationOptions.workspace.environmentPath).to.deep.equal('.../.venv/bin/python');
     });
 
     test('Without extraPaths provided and no workspace', async () => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-python/issues/22659
Fixes https://github.com/microsoft/vscode-python/issues/22672

Jedi checks if the environment path is a path to a file or directory. If it is a path, it uses it as is. If not it looks for a binary assuming it is a virtual environment. Conda environments are structured differently and it fails to find the binary, if we pass in the path to environment directory.

The fix here is to always pass the path to the binary.