### PR TITLE
Bring back REPL shell integration decoration for Mac and Linux 

### DIFF
--- a/pythonFiles/pythonrc.py
+++ b/pythonFiles/pythonrc.py
@@ -1,55 +1,55 @@
-# import sys
+import sys
 
-# original_ps1 = ">>> "
-
-
-# class repl_hooks:
-#     def __init__(self):
-#         self.global_exit = None
-#         self.failure_flag = False
-#         self.original_excepthook = sys.excepthook
-#         self.original_displayhook = sys.displayhook
-#         sys.excepthook = self.my_excepthook
-#         sys.displayhook = self.my_displayhook
-
-#     def my_displayhook(self, value):
-#         if value is None:
-#             self.failure_flag = False
-
-#         self.original_displayhook(value)
-
-#     def my_excepthook(self, type, value, traceback):
-#         self.global_exit = value
-#         self.failure_flag = True
-
-#         self.original_excepthook(type, value, traceback)
+original_ps1 = ">>> "
 
 
-# class ps1:
-#     hooks = repl_hooks()
-#     sys.excepthook = hooks.my_excepthook
-#     sys.displayhook = hooks.my_displayhook
+class repl_hooks:
+    def __init__(self):
+        self.global_exit = None
+        self.failure_flag = False
+        self.original_excepthook = sys.excepthook
+        self.original_displayhook = sys.displayhook
+        sys.excepthook = self.my_excepthook
+        sys.displayhook = self.my_displayhook
 
-#     # str will get called for every prompt with exit code to show success/failure
-#     def __str__(self):
-#         exit_code = 0
-#         if self.hooks.failure_flag:
-#             exit_code = 1
-#         else:
-#             exit_code = 0
+    def my_displayhook(self, value):
+        if value is None:
+            self.failure_flag = False
 
-#         # Guide following official VS Code doc for shell integration sequence:
-#         # result = "{command_finished}{prompt_started}{prompt}{command_start}{command_executed}".format(
-#         #     command_finished="\x1b]633;D;" + str(exit_code) + "\x07",
-#         #     prompt_started="\x1b]633;A\x07",
-#         #     prompt=original_ps1,
-#         #     command_start="\x1b]633;B\x07",
-#         #     command_executed="\x1b]633;C\x07",
-#         # )
-#         result = f"{chr(27)}]633;D;{exit_code}{chr(7)}{chr(27)}]633;A{chr(7)}{original_ps1}{chr(27)}]633;B{chr(7)}{chr(27)}]633;C{chr(7)}"
+        self.original_displayhook(value)
 
-#         return result
+    def my_excepthook(self, type, value, traceback):
+        self.global_exit = value
+        self.failure_flag = True
+
+        self.original_excepthook(type, value, traceback)
 
 
-# if sys.platform != "win32":
-#     sys.ps1 = ps1()
+class ps1:
+    hooks = repl_hooks()
+    sys.excepthook = hooks.my_excepthook
+    sys.displayhook = hooks.my_displayhook
+
+    # str will get called for every prompt with exit code to show success/failure
+    def __str__(self):
+        exit_code = 0
+        if self.hooks.failure_flag:
+            exit_code = 1
+        else:
+            exit_code = 0
+
+        # Guide following official VS Code doc for shell integration sequence:
+        # result = "{command_finished}{prompt_started}{prompt}{command_start}{command_executed}".format(
+        #     command_finished="\x1b]633;D;" + str(exit_code) + "\x07",
+        #     prompt_started="\x1b]633;A\x07",
+        #     prompt=original_ps1,
+        #     command_start="\x1b]633;B\x07",
+        #     command_executed="\x1b]633;C\x07",
+        # )
+        result = f"{chr(27)}]633;D;{exit_code}{chr(7)}{chr(27)}]633;A{chr(7)}{original_ps1}{chr(27)}]633;B{chr(7)}{chr(27)}]633;C{chr(7)}"
+
+        return result
+
+
+if sys.platform != "win32":
+    sys.ps1 = ps1()

--- a/pythonFiles/tests/test_shell_integration.py
+++ b/pythonFiles/tests/test_shell_integration.py
@@ -1,48 +1,48 @@
-# import importlib
-# from unittest.mock import Mock
+import importlib
+from unittest.mock import Mock
 
-# import pythonrc
-
-
-# def test_decoration_success():
-#     importlib.reload(pythonrc)
-#     ps1 = pythonrc.ps1()
-
-#     ps1.hooks.failure_flag = False
-#     result = str(ps1)
-#     assert result == "\x1b]633;D;0\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07"
+import pythonrc
 
 
-# def test_decoration_failure():
-#     importlib.reload(pythonrc)
-#     ps1 = pythonrc.ps1()
+def test_decoration_success():
+    importlib.reload(pythonrc)
+    ps1 = pythonrc.ps1()
 
-#     ps1.hooks.failure_flag = True
-#     result = str(ps1)
-
-#     assert result == "\x1b]633;D;1\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07"
-
-
-# def test_displayhook_call():
-#     importlib.reload(pythonrc)
-#     pythonrc.ps1()
-#     mock_displayhook = Mock()
-
-#     hooks = pythonrc.repl_hooks()
-#     hooks.original_displayhook = mock_displayhook
-
-#     hooks.my_displayhook("mock_value")
-
-#     mock_displayhook.assert_called_once_with("mock_value")
+    ps1.hooks.failure_flag = False
+    result = str(ps1)
+    assert result == "\x1b]633;D;0\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07"
 
 
-# def test_excepthook_call():
-#     importlib.reload(pythonrc)
-#     pythonrc.ps1()
-#     mock_excepthook = Mock()
+def test_decoration_failure():
+    importlib.reload(pythonrc)
+    ps1 = pythonrc.ps1()
 
-#     hooks = pythonrc.repl_hooks()
-#     hooks.original_excepthook = mock_excepthook
+    ps1.hooks.failure_flag = True
+    result = str(ps1)
 
-#     hooks.my_excepthook("mock_type", "mock_value", "mock_traceback")
-#     mock_excepthook.assert_called_once_with("mock_type", "mock_value", "mock_traceback")
+    assert result == "\x1b]633;D;1\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07"
+
+
+def test_displayhook_call():
+    importlib.reload(pythonrc)
+    pythonrc.ps1()
+    mock_displayhook = Mock()
+
+    hooks = pythonrc.repl_hooks()
+    hooks.original_displayhook = mock_displayhook
+
+    hooks.my_displayhook("mock_value")
+
+    mock_displayhook.assert_called_once_with("mock_value")
+
+
+def test_excepthook_call():
+    importlib.reload(pythonrc)
+    pythonrc.ps1()
+    mock_excepthook = Mock()
+
+    hooks = pythonrc.repl_hooks()
+    hooks.original_excepthook = mock_excepthook
+
+    hooks.my_excepthook("mock_type", "mock_value", "mock_traceback")
+    mock_excepthook.assert_called_once_with("mock_type", "mock_value", "mock_traceback")


### PR DESCRIPTION
Bring back and enable shell integration decoration for Mac and Linux while fixing Windows pwsh problem.
Reverts: #22578 