### PR TITLE
Allow run recent command for REPL using shell integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
                 "@types/xml2js": "^0.4.2",
                 "@typescript-eslint/eslint-plugin": "^3.7.0",
                 "@typescript-eslint/parser": "^3.7.0",
-                "@vscode/test-electron": "^2.3.4",
+                "@vscode/test-electron": "^2.3.8",
                 "@vscode/vsce": "^2.18.0",
                 "bent": "^7.3.12",
                 "chai": "^4.1.2",
@@ -1875,9 +1875,9 @@
             }
         },
         "node_modules/@vscode/test-electron": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.4.tgz",
-            "integrity": "sha512-eWzIqXMhvlcoXfEFNWrVu/yYT5w6De+WZXR/bafUQhAp8+8GkQo95Oe14phwiRUPv8L+geAKl/QM2+PoT3YW3g==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.8.tgz",
+            "integrity": "sha512-b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==",
             "dev": true,
             "dependencies": {
                 "http-proxy-agent": "^4.0.1",
@@ -16764,9 +16764,9 @@
             }
         },
         "@vscode/test-electron": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.4.tgz",
-            "integrity": "sha512-eWzIqXMhvlcoXfEFNWrVu/yYT5w6De+WZXR/bafUQhAp8+8GkQo95Oe14phwiRUPv8L+geAKl/QM2+PoT3YW3g==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.8.tgz",
+            "integrity": "sha512-b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==",
             "dev": true,
             "requires": {
                 "http-proxy-agent": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1619,7 +1619,7 @@
         "@types/xml2js": "^0.4.2",
         "@typescript-eslint/eslint-plugin": "^3.7.0",
         "@typescript-eslint/parser": "^3.7.0",
-        "@vscode/test-electron": "^2.3.4",
+        "@vscode/test-electron": "^2.3.8",
         "@vscode/vsce": "^2.18.0",
         "bent": "^7.3.12",
         "chai": "^4.1.2",
@@ -1661,13 +1661,13 @@
         "typescript": "4.5.5",
         "uuid": "^8.3.2",
         "webpack": "^5.76.0",
-        "worker-loader": "^3.0.8",
         "webpack-bundle-analyzer": "^4.5.0",
         "webpack-cli": "^4.9.2",
         "webpack-fix-default-import-plugin": "^1.0.3",
         "webpack-merge": "^5.8.0",
         "webpack-node-externals": "^3.0.0",
         "webpack-require-from": "^1.8.6",
+        "worker-loader": "^3.0.8",
         "yargs": "^15.3.1"
     }
 }

--- a/pythonFiles/pythonrc.py
+++ b/pythonFiles/pythonrc.py
@@ -2,7 +2,9 @@ import sys
 
 import os
 
-sys.path.insert(0, os.getcwd())
+# sys.path.insert(0, os.getcwd())
+EXTENSION_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+os.path.join(EXTENSION_ROOT, "pythonFiles", "lib", "python")
 import readline
 
 original_ps1 = ">>> "

--- a/pythonFiles/pythonrc.py
+++ b/pythonFiles/pythonrc.py
@@ -1,4 +1,5 @@
 import sys
+import readline
 
 original_ps1 = ">>> "
 
@@ -25,6 +26,12 @@ class repl_hooks:
         self.original_excepthook(type, value, traceback)
 
 
+def get_last_command():
+    # Get the last history item
+    last_command = readline.get_history_item(readline.get_current_history_length())
+    return last_command
+
+
 class ps1:
     hooks = repl_hooks()
     sys.excepthook = hooks.my_excepthook
@@ -39,14 +46,15 @@ class ps1:
             exit_code = 0
 
         # Guide following official VS Code doc for shell integration sequence:
-        # result = "{command_finished}{prompt_started}{prompt}{command_start}{command_executed}".format(
-        #     command_finished="\x1b]633;D;" + str(exit_code) + "\x07",
-        #     prompt_started="\x1b]633;A\x07",
-        #     prompt=original_ps1,
-        #     command_start="\x1b]633;B\x07",
-        #     command_executed="\x1b]633;C\x07",
-        # )
-        result = f"{chr(27)}]633;D;{exit_code}{chr(7)}{chr(27)}]633;A{chr(7)}{original_ps1}{chr(27)}]633;B{chr(7)}{chr(27)}]633;C{chr(7)}"
+        result = "{command_finished}{prompt_started}{prompt}{command_start}{command_executed}{command_line}".format(
+            command_finished="\x1b]633;D;" + str(exit_code) + "\x07",
+            prompt_started="\x1b]633;A\x07",
+            prompt=original_ps1,
+            command_start="\x1b]633;B\x07",
+            command_executed="\x1b]633;C\x07",
+            command_line="\x1b]633;E;" + str(get_last_command()) + "\x07",
+        )
+        # result = f"{chr(27)}]633;D;{exit_code}{chr(7)}{chr(27)}]633;A{chr(7)}{original_ps1}{chr(27)}]633;B{chr(7)}{chr(27)}]633;C{chr(7)}"
 
         return result
 

--- a/pythonFiles/pythonrc.py
+++ b/pythonFiles/pythonrc.py
@@ -1,17 +1,7 @@
 import sys
 
-# import os
-
-# sys.path.insert(0, os.getcwd())
-# EXTENSION_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-# os.path.join(EXTENSION_ROOT, "pythonFiles", "lib", "python")
 if sys.platform != "win32":
     import readline
-
-# from pyreadline3 import Readline
-
-
-# readline = Readline()
 
 original_ps1 = ">>> "
 
@@ -43,8 +33,7 @@ def get_last_command():
     last_command = ""
     if sys.platform != "win32":
         last_command = readline.get_history_item(readline.get_current_history_length())
-    else:
-        last_command = ""
+
     return last_command
 
 

--- a/pythonFiles/pythonrc.py
+++ b/pythonFiles/pythonrc.py
@@ -1,4 +1,8 @@
 import sys
+
+import os
+
+sys.path.insert(0, os.getcwd())
 import readline
 
 original_ps1 = ">>> "

--- a/pythonFiles/pythonrc.py
+++ b/pythonFiles/pythonrc.py
@@ -5,7 +5,8 @@ import sys
 # sys.path.insert(0, os.getcwd())
 # EXTENSION_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # os.path.join(EXTENSION_ROOT, "pythonFiles", "lib", "python")
-import readline
+if sys.platform != "win32":
+    import readline
 
 # from pyreadline3 import Readline
 
@@ -39,7 +40,11 @@ class repl_hooks:
 
 def get_last_command():
     # Get the last history item
-    last_command = readline.get_history_item(readline.get_current_history_length())
+    last_command = ""
+    if sys.platform != "win32":
+        last_command = readline.get_history_item(readline.get_current_history_length())
+    else:
+        last_command = ""
     return last_command
 
 
@@ -57,14 +62,26 @@ class ps1:
             exit_code = 0
 
         # Guide following official VS Code doc for shell integration sequence:
-        result = "{command_finished}{prompt_started}{prompt}{command_start}{command_executed}{command_line}".format(
-            command_finished="\x1b]633;D;" + str(exit_code) + "\x07",
-            prompt_started="\x1b]633;A\x07",
-            prompt=original_ps1,
-            command_start="\x1b]633;B\x07",
-            command_executed="\x1b]633;C\x07",
-            command_line="\x1b]633;E;" + str(get_last_command()) + "\x07",
-        )
+        result = ""
+        # For non-windows allow recent_command history.
+        if sys.platform != "win32":
+            result = "{command_finished}{prompt_started}{prompt}{command_start}{command_executed}{command_line}".format(
+                command_finished="\x1b]633;D;" + str(exit_code) + "\x07",
+                prompt_started="\x1b]633;A\x07",
+                prompt=original_ps1,
+                command_start="\x1b]633;B\x07",
+                command_executed="\x1b]633;C\x07",
+                command_line="\x1b]633;E;" + str(get_last_command()) + "\x07",
+            )
+        else:
+            result = "{command_finished}{prompt_started}{prompt}{command_start}{command_executed}".format(
+                command_finished="\x1b]633;D;" + str(exit_code) + "\x07",
+                prompt_started="\x1b]633;A\x07",
+                prompt=original_ps1,
+                command_start="\x1b]633;B\x07",
+                command_executed="\x1b]633;C\x07",
+            )
+
         # result = f"{chr(27)}]633;D;{exit_code}{chr(7)}{chr(27)}]633;A{chr(7)}{original_ps1}{chr(27)}]633;B{chr(7)}{chr(27)}]633;C{chr(7)}"
 
         return result

--- a/pythonFiles/pythonrc.py
+++ b/pythonFiles/pythonrc.py
@@ -3,9 +3,13 @@ import sys
 import os
 
 # sys.path.insert(0, os.getcwd())
-EXTENSION_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-os.path.join(EXTENSION_ROOT, "pythonFiles", "lib", "python")
-import readline
+# EXTENSION_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# os.path.join(EXTENSION_ROOT, "pythonFiles", "lib", "python")
+# import readline
+
+from pyreadline3 import Readline
+
+readline = Readline()
 
 original_ps1 = ">>> "
 

--- a/pythonFiles/pythonrc.py
+++ b/pythonFiles/pythonrc.py
@@ -1,15 +1,16 @@
 import sys
 
-import os
+# import os
 
 # sys.path.insert(0, os.getcwd())
 # EXTENSION_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # os.path.join(EXTENSION_ROOT, "pythonFiles", "lib", "python")
-# import readline
+import readline
 
-from pyreadline3 import Readline
+# from pyreadline3 import Readline
 
-readline = Readline()
+
+# readline = Readline()
 
 original_ps1 = ">>> "
 

--- a/pythonFiles/tests/test_shell_integration.py
+++ b/pythonFiles/tests/test_shell_integration.py
@@ -10,7 +10,10 @@ def test_decoration_success():
 
     ps1.hooks.failure_flag = False
     result = str(ps1)
-    assert result == "\x1b]633;D;0\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07"
+    assert (
+        result
+        == "\x1b]633;D;0\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07\x1b]633;E;None\x07"
+    )
 
 
 def test_decoration_failure():
@@ -20,7 +23,10 @@ def test_decoration_failure():
     ps1.hooks.failure_flag = True
     result = str(ps1)
 
-    assert result == "\x1b]633;D;1\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07"
+    assert (
+        result
+        == "\x1b]633;D;1\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07\x1b]633;E;None\x07"
+    )
 
 
 def test_displayhook_call():

--- a/pythonFiles/tests/test_shell_integration.py
+++ b/pythonFiles/tests/test_shell_integration.py
@@ -1,6 +1,6 @@
 import importlib
+import sys
 from unittest.mock import Mock
-
 import pythonrc
 
 
@@ -10,10 +10,13 @@ def test_decoration_success():
 
     ps1.hooks.failure_flag = False
     result = str(ps1)
-    assert (
-        result
-        == "\x1b]633;D;0\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07\x1b]633;E;None\x07"
-    )
+    if sys.platform != "win32":
+        assert (
+            result
+            == "\x1b]633;D;0\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07\x1b]633;E;None\x07"
+        )
+    else:
+        pass
 
 
 def test_decoration_failure():
@@ -22,11 +25,13 @@ def test_decoration_failure():
 
     ps1.hooks.failure_flag = True
     result = str(ps1)
-
-    assert (
-        result
-        == "\x1b]633;D;1\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07\x1b]633;E;None\x07"
-    )
+    if sys.platform != "win32":
+        assert (
+            result
+            == "\x1b]633;D;1\x07\x1b]633;A\x07>>> \x1b]633;B\x07\x1b]633;C\x07\x1b]633;E;None\x07"
+        )
+    else:
+        pass
 
 
 def test_displayhook_call():


### PR DESCRIPTION
Resolves: #22647

Allow access to recent command "Terminal: Run recent command:" for Python REPL users. 
Due to GNU readline, Mac and Linux Users will now be able to see their REPL command history. 

Blocked on recent history support for Windows:
- Would have to go through VS Code to pick up the command or via native VS Code REPL.