### PR TITLE
include multiple pytest versions in PR check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -94,7 +94,7 @@ jobs:
         # macOS runners are expensive, and we assume that Ubuntu is enough to cover the Unix case.
         os: [ubuntu-latest, windows-latest]
         # Run the tests on the oldest and most recent versions of Python.
-        python: ['3.8', '3.x', '3.12-dev'] # run for 3 pytest versions, most recent stable, oldest version supported and pre-release
+        python: ['3.8', '3.x', '3.12'] # run for 3 pytest versions, most recent stable, oldest version supported and pre-release
         pytest-version: ['pytest', 'pytest@pre-release', 'pytest==6.2.0']
 
     steps:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -94,7 +94,7 @@ jobs:
         # macOS runners are expensive, and we assume that Ubuntu is enough to cover the Unix case.
         os: [ubuntu-latest, windows-latest]
         # Run the tests on the oldest and most recent versions of Python.
-        python: ['3.8', '3.x', '3.12'] # run for 3 pytest versions, most recent stable, oldest version supported and pre-release
+        python: ['3.8', '3.x'] # run for 3 pytest versions, most recent stable, oldest version supported and pre-release
         pytest-version: ['pytest', 'pytest@pre-release', 'pytest==6.2.0']
 
     steps:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -94,7 +94,8 @@ jobs:
         # macOS runners are expensive, and we assume that Ubuntu is enough to cover the Unix case.
         os: [ubuntu-latest, windows-latest]
         # Run the tests on the oldest and most recent versions of Python.
-        python: ['3.8', '3.x', '3.12-dev']
+        python: ['3.8', '3.x', '3.12-dev'] # run for 3 pytest versions, most recent stable, oldest version supported and pre-release
+        pytest-version: ['pytest', 'pytest@pre-release', 'pytest==6.2.0']
 
     steps:
       - name: Checkout
@@ -106,6 +107,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+
+      - name: Install specific pytest version
+        run: |
+          if [ "${{ matrix.pytest-version }}" = "pytest@pre-release" ]; then
+          python -m pip install --pre pytest
+          else
+          python -m pip install "${{ matrix.pytest-version }}"
+          fi
 
       - name: Install base Python requirements
         uses: brettcannon/pip-secure-install@v1

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -109,12 +109,14 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install specific pytest version
+        if: matrix.pytest-version == 'pytest@pre-release'
         run: |
-          if [ "${{ matrix.pytest-version }}" = "pytest@pre-release" ]; then
           python -m pip install --pre pytest
-          else
+
+      - name: Install specific pytest version
+        if: matrix.pytest-version != 'pytest@pre-release'
+        run: |
           python -m pip install "${{ matrix.pytest-version }}"
-          fi
 
       - name: Install base Python requirements
         uses: brettcannon/pip-secure-install@v1

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -118,6 +118,8 @@ jobs:
         run: |
           python -m pip install "${{ matrix.pytest-version }}"
 
+      - name: Install specific pytest version
+        run: python -m pytest --version
       - name: Install base Python requirements
         uses: brettcannon/pip-secure-install@v1
         with:


### PR DESCRIPTION
update PR check workflow to include testing Python tests against 3 versions of pytest: pre-release, stable release, and oldest supported version.