### PR TITLE
Fix Run Recent Command Caching Issue

### DIFF
--- a/pythonFiles/pythonrc.py
+++ b/pythonFiles/pythonrc.py
@@ -49,7 +49,7 @@ class ps1:
             exit_code = 1
         else:
             exit_code = 0
-
+        self.hooks.failure_flag = False
         # Guide following official VS Code doc for shell integration sequence:
         result = ""
         # For non-windows allow recent_command history.


### PR DESCRIPTION
Resolves: #22811

Fixing caching issue where users were experiencing cached success/failure decoration that were impacted when using `Terminal: Run Recent Command` on success/failure commands 