### PR TITLE
Remove experimental flag for create env prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -483,9 +483,6 @@
                     "enum": [
                         "off",
                         "prompt"
-                    ],
-                    "tags": [
-                        "experimental"
                     ]
                 },
                 "python.condaPath": {


### PR DESCRIPTION
Remove experimental flag for `python.createEnvironment.trigger`. 