### PR TITLE
Make `environments.known` API faster

### DIFF
--- a/src/client/environmentApi.ts
+++ b/src/client/environmentApi.ts
@@ -155,7 +155,7 @@ export function buildEnvironmentApi(
             if (e.old) {
                 if (e.new) {
                     const newEnv = convertEnvInfoAndGetReference(e.new);
-                    knownCache.updateEnv(convertEnvInfoAndGetReference(e.old), newEnv);
+                    knownCache.updateEnv(convertEnvInfo(e.old), newEnv);
                     traceVerbose('Python API env change detected', env.id, 'update');
                     onEnvironmentsChanged.fire({ type: 'update', env: newEnv });
                     reportInterpretersChanged([

--- a/src/client/environmentApi.ts
+++ b/src/client/environmentApi.ts
@@ -256,7 +256,8 @@ export function buildEnvironmentApi(
             return resolveEnvironment(path, discoveryApi);
         },
         get known(): Environment[] {
-            sendApiTelemetry('known');
+            // Do not send telemetry for "known", as this may be called 1000s of times so it can significant:
+            // sendApiTelemetry('known');
             return knownCache.envs;
         },
         async refreshEnvironments(options?: RefreshOptions) {

--- a/src/client/environmentApi.ts
+++ b/src/client/environmentApi.ts
@@ -127,7 +127,7 @@ export function buildEnvironmentApi(
         const knownEnvs = discoveryApi
             .getEnvs()
             .filter((e) => filterUsingVSCodeContext(e))
-            .map((e) => convertEnvInfoAndGetReference(e));
+            .map((e) => updateReference(e));
         return new EnvironmentKnownCache(knownEnvs);
     }
     function sendApiTelemetry(apiName: string, args?: unknown) {
@@ -154,7 +154,7 @@ export function buildEnvironmentApi(
             }
             if (e.old) {
                 if (e.new) {
-                    const newEnv = convertEnvInfoAndGetReference(e.new);
+                    const newEnv = updateReference(e.new);
                     knownCache.updateEnv(convertEnvInfo(e.old), newEnv);
                     traceVerbose('Python API env change detected', env.id, 'update');
                     onEnvironmentsChanged.fire({ type: 'update', env: newEnv });
@@ -165,7 +165,7 @@ export function buildEnvironmentApi(
                         },
                     ]);
                 } else {
-                    const oldEnv = convertEnvInfoAndGetReference(e.old);
+                    const oldEnv = updateReference(e.old);
                     knownCache.updateEnv(oldEnv, undefined);
                     traceVerbose('Python API env change detected', env.id, 'remove');
                     onEnvironmentsChanged.fire({ type: 'remove', env: oldEnv });
@@ -177,7 +177,7 @@ export function buildEnvironmentApi(
                     ]);
                 }
             } else if (e.new) {
-                const newEnv = convertEnvInfoAndGetReference(e.new);
+                const newEnv = updateReference(e.new);
                 knownCache.addEnv(newEnv);
                 traceVerbose('Python API env change detected', env.id, 'add');
                 onEnvironmentsChanged.fire({ type: 'add', env: newEnv });
@@ -370,7 +370,7 @@ export function convertEnvInfo(env: PythonEnvInfo): Environment {
     return convertedEnv as Environment;
 }
 
-function convertEnvInfoAndGetReference(env: PythonEnvInfo): Environment {
+function updateReference(env: PythonEnvInfo): Environment {
     return getEnvReference(convertEnvInfo(env));
 }
 

--- a/src/client/environmentApi.ts
+++ b/src/client/environmentApi.ts
@@ -33,7 +33,6 @@ import {
 } from './api/types';
 import { buildEnvironmentCreationApi } from './pythonEnvironments/creation/createEnvApi';
 import { EnvironmentKnownCache } from './environmentKnownCache';
-import { StopWatch } from './common/utils/stopWatch';
 
 type ActiveEnvironmentChangeEvent = {
     resource: WorkspaceFolder | undefined;

--- a/src/client/environmentKnownCache.ts
+++ b/src/client/environmentKnownCache.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Environment } from './api/types';
+
+/**
+ * Environment info cache using persistent storage to save and retrieve pre-cached env info.
+ */
+export class EnvironmentKnownCache {
+    private _envs: Environment[] = [];
+
+    constructor(envs: Environment[]) {
+        this._envs = envs;
+    }
+
+    public get envs(): Environment[] {
+        return this._envs;
+    }
+
+    public addEnv(env: Environment): void {
+        const found = this._envs.find((e) => env.id === e.id);
+        if (!found) {
+            this._envs.push(env);
+        }
+    }
+
+    public updateEnv(oldValue: Environment, newValue: Environment | undefined): void {
+        const index = this._envs.findIndex((e) => oldValue.id === e.id);
+        if (index !== -1) {
+            if (newValue === undefined) {
+                this._envs.splice(index, 1);
+            } else {
+                this._envs[index] = newValue;
+            }
+        }
+    }
+}

--- a/src/client/environmentKnownCache.ts
+++ b/src/client/environmentKnownCache.ts
@@ -4,7 +4,7 @@
 import { Environment } from './api/types';
 
 /**
- * Environment info cache using persistent storage to save and retrieve pre-cached env info.
+ * Workaround temp cache until types are consolidated.
  */
 export class EnvironmentKnownCache {
     private _envs: Environment[] = [];

--- a/src/test/api.functional.test.ts
+++ b/src/test/api.functional.test.ts
@@ -37,6 +37,7 @@ suite('Extension API', () => {
         interpreterService = mock(InterpreterService);
         environmentVariablesProvider = mock<IEnvironmentVariablesProvider>();
         discoverAPI = mock<IDiscoveryAPI>();
+        when(discoverAPI.getEnvs()).thenReturn([]);
 
         when(serviceContainer.get<IConfigurationService>(IConfigurationService)).thenReturn(
             instance(configurationService),

--- a/src/test/environmentApi.unit.test.ts
+++ b/src/test/environmentApi.unit.test.ts
@@ -74,8 +74,7 @@ suite('Python Environment API', () => {
         envVarsProvider = typemoq.Mock.ofType<IEnvironmentVariablesProvider>();
         extensions
             .setup((e) => e.determineExtensionFromCallStack())
-            .returns(() => Promise.resolve({ extensionId: 'id', displayName: 'displayName', apiName: 'apiName' }))
-            .verifiable(typemoq.Times.atLeastOnce());
+            .returns(() => Promise.resolve({ extensionId: 'id', displayName: 'displayName', apiName: 'apiName' }));
         interpreterPathService = typemoq.Mock.ofType<IInterpreterPathService>();
         configService = typemoq.Mock.ofType<IConfigurationService>();
         onDidChangeRefreshState = new EventEmitter();
@@ -100,8 +99,6 @@ suite('Python Environment API', () => {
     });
 
     teardown(() => {
-        // Verify each API method sends telemetry regarding who called the API.
-        extensions.verifyAll();
         sinon.restore();
     });
 

--- a/src/test/environmentApi.unit.test.ts
+++ b/src/test/environmentApi.unit.test.ts
@@ -94,6 +94,7 @@ suite('Python Environment API', () => {
 
         discoverAPI.setup((d) => d.onProgress).returns(() => onDidChangeRefreshState.event);
         discoverAPI.setup((d) => d.onChanged).returns(() => onDidChangeEnvironments.event);
+        discoverAPI.setup((d) => d.getEnvs()).returns(() => []);
 
         environmentApi = buildEnvironmentApi(discoverAPI.object, serviceContainer.object);
     });
@@ -325,6 +326,7 @@ suite('Python Environment API', () => {
             },
         ];
         discoverAPI.setup((d) => d.getEnvs()).returns(() => envs);
+        environmentApi = buildEnvironmentApi(discoverAPI.object, serviceContainer.object);
         const actual = environmentApi.known;
         const actualEnvs = actual?.map((a) => (a as EnvironmentReference).internal);
         assert.deepEqual(
@@ -409,10 +411,10 @@ suite('Python Environment API', () => {
         // Update events
         events = [];
         expectedEvents = [];
-        const updatedEnv = cloneDeep(envs[0]);
-        updatedEnv.arch = Architecture.x86;
-        onDidChangeEnvironments.fire({ old: envs[0], new: updatedEnv });
-        expectedEvents.push({ env: convertEnvInfo(updatedEnv), type: 'update' });
+        const updatedEnv0 = cloneDeep(envs[0]);
+        updatedEnv0.arch = Architecture.x86;
+        onDidChangeEnvironments.fire({ old: envs[0], new: updatedEnv0 });
+        expectedEvents.push({ env: convertEnvInfo(updatedEnv0), type: 'update' });
         eventValues = events.map((e) => ({ env: (e.env as EnvironmentReference).internal, type: e.type }));
         assert.deepEqual(eventValues, expectedEvents);
 
@@ -423,6 +425,11 @@ suite('Python Environment API', () => {
         expectedEvents.push({ env: convertEnvInfo(envs[2]), type: 'remove' });
         eventValues = events.map((e) => ({ env: (e.env as EnvironmentReference).internal, type: e.type }));
         assert.deepEqual(eventValues, expectedEvents);
+
+        const expectedEnvs = [convertEnvInfo(updatedEnv0), convertEnvInfo(envs[1])].sort();
+        const knownEnvs = environmentApi.known.map((e) => (e as EnvironmentReference).internal).sort();
+
+        assert.deepEqual(expectedEnvs, knownEnvs);
     });
 
     test('updateActiveEnvironmentPath: no resource', async () => {


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/22994 closes https://github.com/microsoft/vscode-python/issues/22993

Temporarily build our own known cache from which we return envs instead.