### PR TITLE
Add `server_side_request` to `telemetry\pylance.ts`

### DIFF
--- a/src/client/telemetry/pylance.ts
+++ b/src/client/telemetry/pylance.ts
@@ -27,7 +27,8 @@
       "errorstack" : { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth" },
       "lsversion" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
       "method" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-      "modulehash" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+      "modulehash" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+      "resultLength" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true }
    }
 */
 /* __GDPR__
@@ -311,6 +312,15 @@
       "totaltime" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" },
       "typeevalcount" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" },
       "typeevaltime" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" }
+   }
+*/
+/* __GDPR__
+   "language_server/server_side_request" : {
+      "duration" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+      "lsversion" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+      "method" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+      "modulehash" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+      "resultLength" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true }
    }
 */
 /* __GDPR__


### PR DESCRIPTION
Added `language_server/server_side_request`. Also noticed that the `resultLength` measurement was missing from `language_server.request`.