### PR TITLE
Respect `VIRTUAL_ENV_PROMPT` when calculating PS1

### DIFF
--- a/src/client/terminals/envCollectionActivation/service.ts
+++ b/src/client/terminals/envCollectionActivation/service.ts
@@ -338,6 +338,8 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
     }
 
     private async getPS1(shell: string, resource: Resource, env: EnvironmentVariables) {
+        // PS1 returned by shell is not predictable: #22078
+        // Hence calculate it ourselves where possible. Should no longer be needed once #22128 is available.
         const customShellType = identifyShellFromShellPath(shell);
         if (this.noPromptVariableShells.includes(customShellType)) {
             return env.PS1;

--- a/src/client/terminals/envCollectionActivation/service.ts
+++ b/src/client/terminals/envCollectionActivation/service.ts
@@ -347,7 +347,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
             const interpreter = await this.interpreterService.getActiveInterpreter(resource);
             const shouldSetPS1 = shouldPS1BeSet(interpreter?.type, env);
             if (shouldSetPS1) {
-                const prompt = getPromptForEnv(interpreter);
+                const prompt = getPromptForEnv(interpreter, env);
                 if (prompt) {
                     return prompt;
                 }
@@ -456,7 +456,7 @@ function shouldSkip(env: string) {
     ].includes(env);
 }
 
-function getPromptForEnv(interpreter: PythonEnvironment | undefined) {
+function getPromptForEnv(interpreter: PythonEnvironment | undefined, env: EnvironmentVariables) {
     if (!interpreter) {
         return undefined;
     }
@@ -464,6 +464,9 @@ function getPromptForEnv(interpreter: PythonEnvironment | undefined) {
         if (interpreter.envName === 'base') {
             // If conda base environment is selected, it can lead to "(base)" appearing twice if we return the env name.
             return undefined;
+        }
+        if (interpreter.type === PythonEnvType.Virtual && env.VIRTUAL_ENV_PROMPT) {
+            return `(${env.VIRTUAL_ENV_PROMPT}) `;
         }
         return `(${interpreter.envName}) `;
     }


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/22956

Because we calculate `PS1` ourselves due to a limitation: https://github.com/microsoft/vscode-python/pull/22078, this environment variable may not end up being respected as do not use `PS1`. This PR fixes it.