### PR TITLE
If type identifier for an environment is not registered, infer type from locator

### DIFF
--- a/src/client/api/types.ts
+++ b/src/client/api/types.ts
@@ -268,6 +268,7 @@ export type KnownEnvironmentTools =
     | 'Venv'
     | 'VirtualEnvWrapper'
     | 'Pyenv'
+    | 'Hatch'
     | 'Unknown';
 
 /**

--- a/src/client/environmentApi.ts
+++ b/src/client/environmentApi.ts
@@ -338,6 +338,8 @@ function convertKind(kind: PythonEnvKind): EnvironmentTools | undefined {
             return 'Pipenv';
         case PythonEnvKind.Poetry:
             return 'Poetry';
+        case PythonEnvKind.Hatch:
+            return 'Hatch';
         case PythonEnvKind.VirtualEnvWrapper:
             return 'VirtualEnvWrapper';
         case PythonEnvKind.VirtualEnv:

--- a/src/client/interpreter/configuration/environmentTypeComparer.ts
+++ b/src/client/interpreter/configuration/environmentTypeComparer.ts
@@ -248,6 +248,7 @@ function getPrioritizedEnvironmentType(): EnvironmentType[] {
         EnvironmentType.Poetry,
         EnvironmentType.Pipenv,
         EnvironmentType.VirtualEnvWrapper,
+        EnvironmentType.Hatch,
         EnvironmentType.Venv,
         EnvironmentType.VirtualEnv,
         EnvironmentType.ActiveState,

--- a/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -74,6 +74,7 @@ export namespace EnvGroups {
     export const Pyenv = 'Pyenv';
     export const Venv = 'Venv';
     export const Poetry = 'Poetry';
+    export const Hatch = 'Hatch';
     export const VirtualEnvWrapper = 'VirtualEnvWrapper';
     export const ActiveState = 'ActiveState';
     export const Recommended = Common.recommended;

--- a/src/client/pythonEnvironments/base/locators/composite/envsResolver.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/envsResolver.ts
@@ -3,7 +3,7 @@
 
 import { cloneDeep } from 'lodash';
 import { Event, EventEmitter } from 'vscode';
-import { identifyEnvironment } from '../../../common/environmentIdentifier';
+import { hasIdentifierRegistered, identifyEnvironment } from '../../../common/environmentIdentifier';
 import { IEnvironmentInfoService } from '../../info/environmentInfoService';
 import { PythonEnvInfo, PythonEnvKind } from '../../info';
 import { getEnvPath, setEnvDisplayString } from '../../info/env';
@@ -156,6 +156,10 @@ async function setKind(env: BasicEnvInfo, environmentKinds: Map<string, PythonEn
     const { path } = getEnvPath(env.executablePath, env.envPath);
     let kind = environmentKinds.get(path);
     if (!kind) {
+        if (!hasIdentifierRegistered(env.kind)) {
+            // If identifier is not registered, skip setting env kind.
+            return;
+        }
         kind = await identifyEnvironment(path);
         environmentKinds.set(path, kind);
     }

--- a/src/client/pythonEnvironments/base/locators/composite/envsResolver.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/envsResolver.ts
@@ -3,7 +3,7 @@
 
 import { cloneDeep } from 'lodash';
 import { Event, EventEmitter } from 'vscode';
-import { hasIdentifierRegistered, identifyEnvironment } from '../../../common/environmentIdentifier';
+import { isIdentifierRegistered, identifyEnvironment } from '../../../common/environmentIdentifier';
 import { IEnvironmentInfoService } from '../../info/environmentInfoService';
 import { PythonEnvInfo, PythonEnvKind } from '../../info';
 import { getEnvPath, setEnvDisplayString } from '../../info/env';
@@ -156,7 +156,7 @@ async function setKind(env: BasicEnvInfo, environmentKinds: Map<string, PythonEn
     const { path } = getEnvPath(env.executablePath, env.envPath);
     let kind = environmentKinds.get(path);
     if (!kind) {
-        if (!hasIdentifierRegistered(env.kind)) {
+        if (!isIdentifierRegistered(env.kind)) {
             // If identifier is not registered, skip setting env kind.
             return;
         }

--- a/src/client/pythonEnvironments/common/environmentIdentifier.ts
+++ b/src/client/pythonEnvironments/common/environmentIdentifier.ts
@@ -40,7 +40,7 @@ function getIdentifiers(): Map<PythonEnvKind, (path: string) => Promise<boolean>
     return identifier;
 }
 
-export function hasIdentifierRegistered(kind: PythonEnvKind): boolean {
+export function isIdentifierRegistered(kind: PythonEnvKind): boolean {
     const identifiers = getIdentifiers();
     const identifier = identifiers.get(kind);
     if (identifier === notImplemented) {

--- a/src/client/pythonEnvironments/common/environmentIdentifier.ts
+++ b/src/client/pythonEnvironments/common/environmentIdentifier.ts
@@ -17,8 +17,9 @@ import {
 import { isMicrosoftStoreEnvironment } from './environmentManagers/microsoftStoreEnv';
 import { isActiveStateEnvironment } from './environmentManagers/activestate';
 
+const notImplemented = () => Promise.resolve(false);
+
 function getIdentifiers(): Map<PythonEnvKind, (path: string) => Promise<boolean>> {
-    const notImplemented = () => Promise.resolve(false);
     const defaultTrue = () => Promise.resolve(true);
     const identifier: Map<PythonEnvKind, (path: string) => Promise<boolean>> = new Map();
     Object.values(PythonEnvKind).forEach((k) => {
@@ -37,6 +38,15 @@ function getIdentifiers(): Map<PythonEnvKind, (path: string) => Promise<boolean>
     identifier.set(PythonEnvKind.Unknown, defaultTrue);
     identifier.set(PythonEnvKind.OtherGlobal, isGloballyInstalledEnv);
     return identifier;
+}
+
+export function hasIdentifierRegistered(kind: PythonEnvKind): boolean {
+    const identifiers = getIdentifiers();
+    const identifier = identifiers.get(kind);
+    if (identifier === notImplemented) {
+        return false;
+    }
+    return true;
 }
 
 /**

--- a/src/client/pythonEnvironments/info/index.ts
+++ b/src/client/pythonEnvironments/info/index.ts
@@ -19,6 +19,7 @@ export enum EnvironmentType {
     Venv = 'Venv',
     MicrosoftStore = 'MicrosoftStore',
     Poetry = 'Poetry',
+    Hatch = 'Hatch',
     VirtualEnvWrapper = 'VirtualEnvWrapper',
     ActiveState = 'ActiveState',
     Global = 'Global',
@@ -28,6 +29,7 @@ export enum EnvironmentType {
 export const virtualEnvTypes = [
     EnvironmentType.Poetry,
     EnvironmentType.Pipenv,
+    EnvironmentType.Hatch,
     EnvironmentType.Venv,
     EnvironmentType.VirtualEnvWrapper,
     EnvironmentType.Conda,
@@ -114,6 +116,9 @@ export function getEnvironmentTypeName(environmentType: EnvironmentType): string
         }
         case EnvironmentType.Poetry: {
             return 'Poetry';
+        }
+        case EnvironmentType.Hatch: {
+            return 'Hatch';
         }
         case EnvironmentType.VirtualEnvWrapper: {
             return 'virtualenvwrapper';

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -38,6 +38,7 @@ const convertedKinds = new Map(
         [PythonEnvKind.VirtualEnv]: EnvironmentType.VirtualEnv,
         [PythonEnvKind.Pipenv]: EnvironmentType.Pipenv,
         [PythonEnvKind.Poetry]: EnvironmentType.Poetry,
+        [PythonEnvKind.Hatch]: EnvironmentType.Hatch,
         [PythonEnvKind.Venv]: EnvironmentType.Venv,
         [PythonEnvKind.VirtualEnvWrapper]: EnvironmentType.VirtualEnvWrapper,
         [PythonEnvKind.ActiveState]: EnvironmentType.ActiveState,


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/22810

...so in case of Hatch, as an [explicit Hatch identifier is not available](https://github.com/microsoft/vscode-python/pull/22779#discussion_r1483341191), we infer an environment is Hatch if we get it from the Hatch locator: https://github.com/microsoft/vscode-python/pull/22779.