### PR TITLE
Double quote value returned by `${command:python.interpreterPath}` if it contains spaces

### DIFF
--- a/src/client/interpreter/interpreterPathCommand.ts
+++ b/src/client/interpreter/interpreterPathCommand.ts
@@ -46,6 +46,8 @@ export class InterpreterPathCommand implements IExtensionSingleActivationService
             workspaceFolderUri = undefined;
         }
 
-        return (await this.interpreterService.getActiveInterpreter(workspaceFolderUri))?.path ?? 'python';
+        const interpreterPath =
+            (await this.interpreterService.getActiveInterpreter(workspaceFolderUri))?.path ?? 'python';
+        return interpreterPath.toCommandArgumentForPythonExt();
     }
 }

--- a/src/test/interpreters/interpreterPathCommand.unit.test.ts
+++ b/src/test/interpreters/interpreterPathCommand.unit.test.ts
@@ -64,6 +64,17 @@ suite('Interpreter Path Command', () => {
         expect(setting).to.equal('settingValue');
     });
 
+    test('If interpreter path contains spaces, double quote it before returning', async () => {
+        const args = ['command', 'folderPath'];
+        when(interpreterService.getActiveInterpreter(anything())).thenCall((arg) => {
+            assert.deepEqual(arg, Uri.file('folderPath'));
+
+            return Promise.resolve({ path: 'setting Value' }) as unknown;
+        });
+        const setting = await interpreterPathCommand._getSelectedInterpreterPath(args);
+        expect(setting).to.equal('"setting Value"');
+    });
+
     test('If neither of these exists, value of workspace folder is `undefined`', async () => {
         const args = ['command'];
 


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/23028