### PR TITLE
Resolve test suite execution import errors due to path ordering

### DIFF
--- a/python_files/unittestadapter/execution.py
+++ b/python_files/unittestadapter/execution.py
@@ -171,6 +171,11 @@ def run_tests(
     locals: Optional[bool] = None,
 ) -> PayloadDict:
     cwd = os.path.abspath(start_dir)
+    if "/" in start_dir:  #  is a subdir
+        parent_dir = os.path.dirname(start_dir)
+        sys.path.insert(0, parent_dir)
+    else:
+        sys.path.insert(0, cwd)
     status = TestExecutionStatus.error
     error = None
     payload: PayloadDict = {"cwd": cwd, "status": status, "result": None}


### PR DESCRIPTION
- This has already been discussed and resolved for tests discovery in this [PR](https://github.com/microsoft/vscode-python/pull/22454)
- I have now run into the same issue for executing the test suite and have applied the same fix in this PR
- Tested and working

[Issue](https://github.com/microsoft/vscode-python/issues/23098) for this current PR

[Original Issue](https://github.com/microsoft/vscode-python/issues/22453)
[Original PR](https://github.com/microsoft/vscode-python/pull/22454)