### PR TITLE
Fix duplicated venv prompt 

### DIFF
--- a/src/client/terminals/envCollectionActivation/service.ts
+++ b/src/client/terminals/envCollectionActivation/service.ts
@@ -468,7 +468,7 @@ function getPromptForEnv(interpreter: PythonEnvironment | undefined, env: Enviro
             return undefined;
         }
         if (interpreter.type === PythonEnvType.Virtual && env.VIRTUAL_ENV_PROMPT) {
-            return `(${env.VIRTUAL_ENV_PROMPT}) `;
+            return `${env.VIRTUAL_ENV_PROMPT}`;
         }
         return `(${interpreter.envName}) `;
     }


### PR DESCRIPTION
Resolves: #23193 #23184

Resolve duplicated (.venv) prompt for users terminal.
Issue came from: #23080 