### PR TITLE
Revert arg map handler for test arguments

### DIFF
--- a/ThirdPartyNotices-Repository.txt
+++ b/ThirdPartyNotices-Repository.txt
@@ -17,7 +17,6 @@ Microsoft Python extension for Visual Studio Code incorporates third party mater
 11. vscode-cpptools (https://github.com/microsoft/vscode-cpptools)
 12. mocha (https://github.com/mochajs/mocha)
 13. get-pip (https://github.com/pypa/get-pip)
-14. vscode-js-debug (https://github.com/microsoft/vscode-js-debug)
 
 %%
 Go for Visual Studio Code NOTICES, INFORMATION, AND LICENSE BEGIN HERE
@@ -1033,31 +1032,3 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 =========================================
 END OF get-pip NOTICES, INFORMATION, AND LICENSE
-
-
-%% vscode-js-debug NOTICES, INFORMATION, AND LICENSE BEGIN HERE
-=========================================
-
-MIT License
-
-Copyright (c) Microsoft Corporation. All rights reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE
-=========================================
-END OF vscode-js-debug NOTICES, INFORMATION, AND LICENSE

--- a/src/client/testing/testController/common/utils.ts
+++ b/src/client/testing/testController/common/utils.ts
@@ -3,7 +3,7 @@
 import * as net from 'net';
 import * as path from 'path';
 import { CancellationToken, Position, TestController, TestItem, Uri, Range } from 'vscode';
-import { traceError, traceLog, traceVerbose } from '../../../logging';
+import { traceError, traceInfo, traceLog, traceVerbose } from '../../../logging';
 
 import { EnableTestAdapterRewrite } from '../../../common/experiments/groups';
 import { IExperimentService } from '../../../common/types';
@@ -351,103 +351,39 @@ export function splitTestNameWithRegex(testName: string): [string, string] {
 }
 
 /**
- * Converts an array of strings (with or without '=') into a map.
- * If a string contains '=', it is split into a key-value pair, with the portion
- * before the '=' as the key and the portion after the '=' as the value.
- * If no '=' is found in the string, the entire string becomes a key with a value of null.
- *
- * @param args - Readonly array of strings to be converted to a map.
- * @returns A map representation of the input strings.
+ * Takes a list of arguments and adds an key-value pair to the list if the key doesn't already exist. Searches each element
+ * in the array for the key to see if it is contained within the element.
+ * @param args list of arguments to search
+ * @param argToAdd argument to add if it doesn't already exist
+ * @returns the list of arguments with the key-value pair added if it didn't already exist
  */
-export const argsToMap = (args: ReadonlyArray<string>): { [key: string]: Array<string> | null | undefined } => {
-    const map: { [key: string]: Array<string> | null } = {};
+export function addValueIfKeyNotExist(args: string[], key: string, value: string | null): string[] {
     for (const arg of args) {
-        const delimiter = arg.indexOf('=');
-        if (delimiter === -1) {
-            // If no delimiter is found, the entire string becomes a key with a value of null.
-            map[arg] = null;
-        } else {
-            const key = arg.slice(0, delimiter);
-            const value = arg.slice(delimiter + 1);
-            if (map[key]) {
-                // add to the array
-                const arr = map[key] as string[];
-                arr.push(value);
-                map[key] = arr;
-            } else {
-                // create a new array
-                map[key] = [value];
-            }
+        if (arg.includes(key)) {
+            traceInfo(`arg: ${key} already exists in args, not adding.`);
+            return args;
         }
     }
-
-    return map;
-};
-
-/**
- * Converts a map into an array of strings.
- * Each key-value pair in the map is transformed into a string.
- * If the value is null, only the key is represented in the string.
- * If the value is defined (and not null), the string is in the format "key=value".
- * If a value is undefined, the key-value pair is skipped.
- *
- * @param map - The map to be converted to an array of strings.
- * @returns An array of strings representation of the input map.
- */
-export const mapToArgs = (map: { [key: string]: Array<string> | null | undefined }): string[] => {
-    const out: string[] = [];
-    for (const key of Object.keys(map)) {
-        const value = map[key];
-        if (value === undefined) {
-            // eslint-disable-next-line no-continue
-            continue;
-        }
-        if (value === null) {
-            out.push(key);
-        } else {
-            const values = Array.isArray(value) ? (value as string[]) : [value];
-            for (const v of values) {
-                out.push(`${key}=${v}`);
-            }
-        }
+    if (value) {
+        args.push(`${key}=${value}`);
+    } else {
+        args.push(`${key}`);
     }
-
-    return out;
-};
-
-/**
- * Adds an argument to the map only if it doesn't already exist.
- *
- * @param map - The map of arguments.
- * @param argKey - The argument key to be checked and added.
- * @param argValue - The value to set for the argument if it's not already in the map.
- * @returns The updated map.
- */
-export function addArgIfNotExist(
-    map: { [key: string]: Array<string> | null | undefined },
-    argKey: string,
-    argValue: string | null,
-): { [key: string]: Array<string> | null | undefined } {
-    // Only add the argument if it doesn't exist in the map.
-    if (map[argKey] === undefined) {
-        // if null then set to null, otherwise set to an array with the value
-        if (argValue === null) {
-            map[argKey] = null;
-        } else {
-            map[argKey] = [argValue];
-        }
-    }
-
-    return map;
+    return args;
 }
 
 /**
- * Checks if an argument key exists in the map.
- *
- * @param map - The map of arguments.
- * @param argKey - The argument key to be checked.
- * @returns True if the argument key exists in the map, false otherwise.
+ * Checks if a key exists in a list of arguments. Searches each element in the array
+ *  for the key to see if it is contained within the element.
+ * @param args list of arguments to search
+ * @param key string to search for
+ * @returns true if the key exists in the list of arguments, false otherwise
  */
-export function argKeyExists(map: { [key: string]: Array<string> | null | undefined }, argKey: string): boolean {
-    return map[argKey] !== undefined;
+export function argKeyExists(args: string[], key: string): boolean {
+    for (const arg of args) {
+        if (arg.includes(key)) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/test/testing/common/testingAdapter.test.ts
+++ b/src/test/testing/common/testingAdapter.test.ts
@@ -72,13 +72,17 @@ suite('End to End Tests: test adapters', () => {
         // create symlink for specific symlink test
         const target = rootPathSmallWorkspace;
         const dest = rootPathDiscoverySymlink;
-        fs.symlink(target, dest, 'dir', (err) => {
-            if (err) {
-                console.error(err);
-            } else {
-                console.log('Symlink created successfully for end to end tests.');
-            }
-        });
+        try {
+            fs.symlink(target, dest, 'dir', (err) => {
+                if (err) {
+                    console.error(err);
+                } else {
+                    console.log('Symlink created successfully for end to end tests.');
+                }
+            });
+        } catch (err) {
+            console.error(err);
+        }
     });
 
     setup(async () => {
@@ -117,13 +121,17 @@ suite('End to End Tests: test adapters', () => {
     suiteTeardown(async () => {
         // remove symlink
         const dest = rootPathDiscoverySymlink;
-        fs.unlink(dest, (err) => {
-            if (err) {
-                console.error(err);
-            } else {
-                console.log('Symlink removed successfully after tests.');
-            }
-        });
+        if (fs.existsSync(dest)) {
+            fs.unlink(dest, (err) => {
+                if (err) {
+                    console.error(err);
+                } else {
+                    console.log('Symlink removed successfully after tests.');
+                }
+            });
+        } else {
+            console.log('Symlink was not found to remove after tests, exiting successfully');
+        }
     });
     test('unittest discovery adapter small workspace', async () => {
         // result resolver and saved data for assertions
@@ -293,6 +301,7 @@ suite('End to End Tests: test adapters', () => {
             resultResolver,
             envVarsService,
         );
+        configService.getSettings(workspaceUri).testing.pytestArgs = [];
 
         await discoveryAdapter.discoverTests(workspaceUri, pythonExecFactory).finally(() => {
             // verification after discovery is complete
@@ -372,6 +381,7 @@ suite('End to End Tests: test adapters', () => {
 
         // set workspace to test workspace folder
         workspaceUri = Uri.parse(rootPathLargeWorkspace);
+        configService.getSettings(workspaceUri).testing.pytestArgs = [];
 
         await discoveryAdapter.discoverTests(workspaceUri, pythonExecFactory).finally(() => {
             // verification after discovery is complete
@@ -558,6 +568,7 @@ suite('End to End Tests: test adapters', () => {
         };
         // set workspace to test workspace folder
         workspaceUri = Uri.parse(rootPathSmallWorkspace);
+        configService.getSettings(workspaceUri).testing.pytestArgs = [];
 
         // run pytest execution
         const executionAdapter = new PytestTestExecutionAdapter(
@@ -648,6 +659,7 @@ suite('End to End Tests: test adapters', () => {
 
         // set workspace to test workspace folder
         workspaceUri = Uri.parse(rootPathLargeWorkspace);
+        configService.getSettings(workspaceUri).testing.pytestArgs = [];
 
         // generate list of test_ids
         const testIds: string[] = [];
@@ -728,6 +740,7 @@ suite('End to End Tests: test adapters', () => {
 
         // set workspace to test workspace folder
         workspaceUri = Uri.parse(rootPathDiscoveryErrorWorkspace);
+        configService.getSettings(workspaceUri).testing.unittestArgs = ['-s', '.', '-p', '*test*.py'];
 
         const discoveryAdapter = new UnittestTestDiscoveryAdapter(
             pythonTestServer,
@@ -799,6 +812,8 @@ suite('End to End Tests: test adapters', () => {
 
         // set workspace to test workspace folder
         workspaceUri = Uri.parse(rootPathDiscoveryErrorWorkspace);
+        configService.getSettings(workspaceUri).testing.pytestArgs = [];
+
         await discoveryAdapter.discoverTests(workspaceUri, pythonExecFactory).finally(() => {
             // verification after discovery is complete
             assert.ok(
@@ -860,6 +875,7 @@ suite('End to End Tests: test adapters', () => {
 
         // set workspace to test workspace folder
         workspaceUri = Uri.parse(rootPathErrorWorkspace);
+        configService.getSettings(workspaceUri).testing.unittestArgs = ['-s', '.', '-p', '*test*.py'];
 
         // run pytest execution
         const executionAdapter = new UnittestTestExecutionAdapter(
@@ -921,6 +937,7 @@ suite('End to End Tests: test adapters', () => {
 
         // set workspace to test workspace folder
         workspaceUri = Uri.parse(rootPathErrorWorkspace);
+        configService.getSettings(workspaceUri).testing.pytestArgs = [];
 
         // run pytest execution
         const executionAdapter = new PytestTestExecutionAdapter(

--- a/src/test/testing/testController/utils.unit.test.ts
+++ b/src/test/testing/testController/utils.unit.test.ts
@@ -9,10 +9,8 @@ import {
     ExtractJsonRPCData,
     parseJsonRPCHeadersAndData,
     splitTestNameWithRegex,
-    mapToArgs,
-    addArgIfNotExist,
     argKeyExists,
-    argsToMap,
+    addValueIfKeyNotExist,
 } from '../../../client/testing/testController/common/utils';
 
 suite('Test Controller Utils: JSON RPC', () => {
@@ -163,180 +161,42 @@ ${data}${secondPayload}`;
         });
     });
     suite('Test Controller Utils: Args Mapping', () => {
-        test('Converts map with mixed values to array of strings', async () => {
-            const inputMap = {
-                key1: ['value1'],
-                key2: null,
-                key3: undefined,
-                key4: ['value4'],
-            };
-            const expectedOutput = ['key1=value1', 'key2', 'key4=value4'];
+        suite('addValueIfKeyNotExist', () => {
+            test('should add key-value pair if key does not exist', () => {
+                const args = ['key1=value1', 'key2=value2'];
+                const result = addValueIfKeyNotExist(args, 'key3', 'value3');
+                assert.deepEqual(result, ['key1=value1', 'key2=value2', 'key3=value3']);
+            });
 
-            const result = mapToArgs(inputMap);
-
-            assert.deepStrictEqual(result, expectedOutput);
+            test('should not add key-value pair if key already exists', () => {
+                const args = ['key1=value1', 'key2=value2'];
+                const result = addValueIfKeyNotExist(args, 'key1', 'value3');
+                assert.deepEqual(result, ['key1=value1', 'key2=value2']);
+            });
+            test('should not add key-value pair if key exists as a solo element', () => {
+                const args = ['key1=value1', 'key2'];
+                const result = addValueIfKeyNotExist(args, 'key2', 'yellow');
+                assert.deepEqual(result, ['key1=value1', 'key2']);
+            });
+            test('add just key if value is null', () => {
+                const args = ['key1=value1', 'key2'];
+                const result = addValueIfKeyNotExist(args, 'key3', null);
+                assert.deepEqual(result, ['key1=value1', 'key2', 'key3']);
+            });
         });
 
-        test('Returns an empty array for an empty map', async () => {
-            const inputMap = {};
-            const expectedOutput: unknown[] = [];
+        suite('argKeyExists', () => {
+            test('should return true if key exists', () => {
+                const args = ['key1=value1', 'key2=value2'];
+                const result = argKeyExists(args, 'key1');
+                assert.deepEqual(result, true);
+            });
 
-            const result = mapToArgs(inputMap);
-
-            assert.deepStrictEqual(result, expectedOutput);
-        });
-
-        test('Skips undefined values', async () => {
-            const inputMap = {
-                key1: undefined,
-                key2: undefined,
-            };
-            const expectedOutput: unknown[] = [];
-
-            const result = mapToArgs(inputMap);
-
-            assert.deepStrictEqual(result, expectedOutput);
-        });
-
-        test('Handles null values correctly', async () => {
-            const inputMap = {
-                key1: null,
-                key2: null,
-            };
-            const expectedOutput = ['key1', 'key2'];
-
-            const result = mapToArgs(inputMap);
-
-            assert.deepStrictEqual(result, expectedOutput);
-        });
-        test('Handles mapToArgs for a key with multiple values', async () => {
-            const inputMap = {
-                key1: null,
-                key2: ['value1', 'value2'],
-            };
-            const expectedOutput = ['key1', 'key2=value1', 'key2=value2'];
-
-            const result = mapToArgs(inputMap);
-
-            assert.deepStrictEqual(result, expectedOutput);
-        });
-        test('Adds new argument if it does not exist', () => {
-            const map = {};
-            const argKey = 'newKey';
-            const argValue = 'newValue';
-
-            const updatedMap = addArgIfNotExist(map, argKey, argValue);
-
-            assert.deepStrictEqual(updatedMap, { [argKey]: [argValue] });
-        });
-
-        test('Does not overwrite existing argument', () => {
-            const map = { existingKey: ['existingValue'] };
-            const argKey = 'existingKey';
-            const argValue = 'newValue';
-
-            const updatedMap = addArgIfNotExist(map, argKey, argValue);
-
-            assert.deepStrictEqual(updatedMap, { [argKey]: ['existingValue'] });
-        });
-
-        test('Handles null value for new key', () => {
-            const map = {};
-            const argKey = 'nullKey';
-            const argValue = null;
-
-            const updatedMap = addArgIfNotExist(map, argKey, argValue);
-
-            assert.deepStrictEqual(updatedMap, { [argKey]: argValue });
-        });
-
-        test('Ignores addition if key exists with null value', () => {
-            const map = { nullKey: null };
-            const argKey = 'nullKey';
-            const argValue = 'newValue';
-
-            const updatedMap = addArgIfNotExist(map, argKey, argValue);
-
-            assert.deepStrictEqual(updatedMap, { [argKey]: null });
-        });
-
-        test('Complex test for argKeyExists with various key types', () => {
-            const map = {
-                stringKey: ['stringValue'],
-                nullKey: null,
-                // Note: not adding an 'undefinedKey' explicitly since it's not present and hence undefined by default
-            };
-
-            // Should return true for keys that are present, even with a null value
-            assert.strictEqual(
-                argKeyExists(map, 'stringKey'),
-                true,
-                "Failed to recognize 'stringKey' which has a string value.",
-            );
-            assert.strictEqual(
-                argKeyExists(map, 'nullKey'),
-                true,
-                "Failed to recognize 'nullKey' which has a null value.",
-            );
-
-            // Should return false for keys that are not present
-            assert.strictEqual(
-                argKeyExists(map, 'undefinedKey'),
-                false,
-                "Incorrectly recognized 'undefinedKey' as existing.",
-            );
-        });
-        test('Converts array of strings with "=" into a map', () => {
-            const args = ['key1=value1', 'key2=value2'];
-            const expectedMap = { key1: ['value1'], key2: ['value2'] };
-
-            const resultMap = argsToMap(args);
-
-            assert.deepStrictEqual(resultMap, expectedMap);
-        });
-        test('Handles argsToMap for multiple values for the same key', () => {
-            const args = ['key1=value1', 'key1=value2'];
-            const expectedMap = { key1: ['value1', 'value2'] };
-
-            const resultMap = argsToMap(args);
-
-            assert.deepStrictEqual(resultMap, expectedMap);
-        });
-
-        test('Assigns null to keys without "="', () => {
-            const args = ['key1', 'key2'];
-            const expectedMap = { key1: null, key2: null };
-
-            const resultMap = argsToMap(args);
-
-            assert.deepStrictEqual(resultMap, expectedMap);
-        });
-
-        test('Handles mixed keys with and without "="', () => {
-            const args = ['key1=value1', 'key2'];
-            const expectedMap = { key1: ['value1'], key2: null };
-
-            const resultMap = argsToMap(args);
-
-            assert.deepStrictEqual(resultMap, expectedMap);
-        });
-
-        test('Handles strings with multiple "=" characters', () => {
-            const args = ['key1=part1=part2'];
-            const expectedMap = { key1: ['part1=part2'] };
-
-            const resultMap = argsToMap(args);
-
-            assert.deepStrictEqual(resultMap, expectedMap);
-        });
-
-        test('Returns an empty map for an empty input array', () => {
-            const args: ReadonlyArray<string> = [];
-            const expectedMap = {};
-
-            const resultMap = argsToMap(args);
-
-            assert.deepStrictEqual(resultMap, expectedMap);
+            test('should return false if key does not exist', () => {
+                const args = ['key1=value1', 'key2=value2'];
+                const result = argKeyExists(args, 'key3');
+                assert.deepEqual(result, false);
+            });
         });
     });
 });


### PR DESCRIPTION
This reverts commit e3ff7988b9e1ed26598b7fb7ee4668dc0d327bff which
restores the original behavior without the argmap and instead keeps all
testing args as a list