### PR TITLE
chore: use full names for CredScan false positives

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -3,6 +3,7 @@
     "suppressions": [
       {
         "file": [
+          "file:///mnt/vss/_work/1/a/extension/extension/.nox/install_python_libs/lib/python3.8/site-packages/setuptools/_distutils/command%5Cregister.py",
           "file:///mnt/vss/_work/1/b/extension/extension/.nox/install_python_libs/lib/python3.8/site-packages/setuptools/_distutils/command%5Cregister.py"
         ],
         "_justification": "These are not real passwords. For documentation purposes only."

--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -3,7 +3,7 @@
     "suppressions": [
       {
         "file": [
-          ".nox/install_python_libs/lib/python3.8/site-packages/setuptools/_distutils/command\\register.py"
+          "file:///mnt/vss/_work/1/b/extension/extension/.nox/install_python_libs/lib/python3.8/site-packages/setuptools/_distutils/command%5Cregister.py"
         ],
         "_justification": "These are not real passwords. For documentation purposes only."
       }


### PR DESCRIPTION
Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=269140&view=results 