### PR TITLE
Show PyPi link in requirements

### DIFF
--- a/src/client/activation/requirementsTxtLinkActivator.ts
+++ b/src/client/activation/requirementsTxtLinkActivator.ts
@@ -2,23 +2,24 @@ import { injectable } from 'inversify';
 import { Hover, languages, TextDocument, Position } from 'vscode';
 import { IExtensionSingleActivationService } from './types';
 
+const PYPI_PROJECT_URL = 'https://pypi.org/project';
 @injectable()
 export class RequirementsTxtLinkActivator implements IExtensionSingleActivationService {
     // eslint-disable-next-line class-methods-use-this
     public readonly supportedWorkspaceTypes = { untrustedWorkspace: true, virtualWorkspace: true };
+
     public async activate(): Promise<void> {
-        languages.registerHoverProvider(
-            [{ pattern: '**/*requirement*.txt' },{ pattern: '**/requirements/*.txt' }],
-            {
-                provideHover(document: TextDocument, position: Position) {
-                    // Regex to allow to find every possible pypi package (base regex from https://peps.python.org/pep-0508/#names)
-                    const regex = /^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*)($|=| |;|\[)/i
-                    const row = document.lineAt(position.line).text;
-                    const projectName = row.match(regex);
-                    return(projectName) ? new Hover(`https://pypi.org/project/${projectName[1]}/`) : null
-                },
+        languages.registerHoverProvider([{ pattern: '**/*requirement*.txt' }, { pattern: '**/requirements/*.txt' }], {
+            provideHover(document: TextDocument, position: Position) {
+                const link = RequirementsTxtLinkActivator.generatePyPiLink(document.lineAt(position.line).text);
+                return link ? new Hover(link) : null;
             },
-        );
+        });
+    }
+
+    public static generatePyPiLink(name: string): string | null {
+        // Regex to allow to find every possible pypi package (base regex from https://peps.python.org/pep-0508/#names)
+        const projectName = name.match(/^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*)($|=| |;|\[)/i);
+        return projectName ? `${PYPI_PROJECT_URL}/${projectName[1]}/` : null;
     }
 }
-

--- a/src/client/activation/requirementsTxtLinkActivator.ts
+++ b/src/client/activation/requirementsTxtLinkActivator.ts
@@ -1,0 +1,24 @@
+import { injectable } from 'inversify';
+import { Hover, languages, TextDocument, Position } from 'vscode';
+import { IExtensionSingleActivationService } from './types';
+
+@injectable()
+export class RequirementsTxtLinkActivator implements IExtensionSingleActivationService {
+    // eslint-disable-next-line class-methods-use-this
+    public readonly supportedWorkspaceTypes = { untrustedWorkspace: true, virtualWorkspace: true };
+    public async activate(): Promise<void> {
+        languages.registerHoverProvider(
+            [{ pattern: '**/*requirement*.txt' },{ pattern: '**/requirements/*.txt' }],
+            {
+                provideHover(document: TextDocument, position: Position) {
+                    // Regex to allow to find every possible pypi package (base regex from https://peps.python.org/pep-0508/#names)
+                    const regex = /^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*)($|=| |;|\[)/i
+                    const row = document.lineAt(position.line).text;
+                    const projectName = row.match(regex);
+                    return(projectName) ? new Hover(`https://pypi.org/project/${projectName[1]}/`) : null
+                },
+            },
+        );
+    }
+}
+

--- a/src/client/activation/requirementsTxtLinkActivator.ts
+++ b/src/client/activation/requirementsTxtLinkActivator.ts
@@ -12,7 +12,6 @@ export function generatePyPiLink(name: string): string | null {
 
 @injectable()
 export class RequirementsTxtLinkActivator implements IExtensionSingleActivationService {
-
     public readonly supportedWorkspaceTypes = { untrustedWorkspace: true, virtualWorkspace: true };
 
     // eslint-disable-next-line class-methods-use-this

--- a/src/client/activation/requirementsTxtLinkActivator.ts
+++ b/src/client/activation/requirementsTxtLinkActivator.ts
@@ -4,7 +4,7 @@ import { IExtensionSingleActivationService } from './types';
 
 const PYPI_PROJECT_URL = 'https://pypi.org/project';
 
-export function generatePyPiLink(name: string): string | null {
+export function generatePyPiLink(name: string): string | undefined {
     // Regex to allow to find every possible pypi package (base regex from https://peps.python.org/pep-0508/#names)
     const projectName = name.match(/^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*)($|=| |;|\[)/i);
     return projectName ? `${PYPI_PROJECT_URL}/${projectName[1]}/` : null;

--- a/src/client/activation/requirementsTxtLinkActivator.ts
+++ b/src/client/activation/requirementsTxtLinkActivator.ts
@@ -12,9 +12,10 @@ export function generatePyPiLink(name: string): string | null {
 
 @injectable()
 export class RequirementsTxtLinkActivator implements IExtensionSingleActivationService {
-    // eslint-disable-next-line class-methods-use-this
+
     public readonly supportedWorkspaceTypes = { untrustedWorkspace: true, virtualWorkspace: true };
 
+    // eslint-disable-next-line class-methods-use-this
     public async activate(): Promise<void> {
         languages.registerHoverProvider([{ pattern: '**/*requirement*.txt' }, { pattern: '**/requirements/*.txt' }], {
             provideHover(document: TextDocument, position: Position) {

--- a/src/client/activation/requirementsTxtLinkActivator.ts
+++ b/src/client/activation/requirementsTxtLinkActivator.ts
@@ -3,6 +3,13 @@ import { Hover, languages, TextDocument, Position } from 'vscode';
 import { IExtensionSingleActivationService } from './types';
 
 const PYPI_PROJECT_URL = 'https://pypi.org/project';
+
+export function generatePyPiLink(name: string): string | null {
+    // Regex to allow to find every possible pypi package (base regex from https://peps.python.org/pep-0508/#names)
+    const projectName = name.match(/^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*)($|=| |;|\[)/i);
+    return projectName ? `${PYPI_PROJECT_URL}/${projectName[1]}/` : null;
+}
+    
 @injectable()
 export class RequirementsTxtLinkActivator implements IExtensionSingleActivationService {
     // eslint-disable-next-line class-methods-use-this
@@ -11,15 +18,9 @@ export class RequirementsTxtLinkActivator implements IExtensionSingleActivationS
     public async activate(): Promise<void> {
         languages.registerHoverProvider([{ pattern: '**/*requirement*.txt' }, { pattern: '**/requirements/*.txt' }], {
             provideHover(document: TextDocument, position: Position) {
-                const link = RequirementsTxtLinkActivator.generatePyPiLink(document.lineAt(position.line).text);
+                const link = generatePyPiLink(document.lineAt(position.line).text);
                 return link ? new Hover(link) : null;
             },
         });
-    }
-
-    public static generatePyPiLink(name: string): string | null {
-        // Regex to allow to find every possible pypi package (base regex from https://peps.python.org/pep-0508/#names)
-        const projectName = name.match(/^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*)($|=| |;|\[)/i);
-        return projectName ? `${PYPI_PROJECT_URL}/${projectName[1]}/` : null;
     }
 }

--- a/src/client/activation/requirementsTxtLinkActivator.ts
+++ b/src/client/activation/requirementsTxtLinkActivator.ts
@@ -4,12 +4,12 @@ import { IExtensionSingleActivationService } from './types';
 
 const PYPI_PROJECT_URL = 'https://pypi.org/project';
 
-export function generatePyPiLink(name: string): string | undefined {
+export function generatePyPiLink(name: string): string | null {
     // Regex to allow to find every possible pypi package (base regex from https://peps.python.org/pep-0508/#names)
     const projectName = name.match(/^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*)($|=| |;|\[)/i);
     return projectName ? `${PYPI_PROJECT_URL}/${projectName[1]}/` : null;
 }
-    
+
 @injectable()
 export class RequirementsTxtLinkActivator implements IExtensionSingleActivationService {
     // eslint-disable-next-line class-methods-use-this

--- a/src/client/activation/serviceRegistry.ts
+++ b/src/client/activation/serviceRegistry.ts
@@ -15,6 +15,7 @@ import { LoadLanguageServerExtension } from './common/loadLanguageServerExtensio
 import { PartialModeStatusItem } from './partialModeStatus';
 import { ILanguageServerWatcher } from '../languageServer/types';
 import { LanguageServerWatcher } from '../languageServer/watcher';
+import { RequirementsTxtLinkActivator } from './requirementsTxtLinkActivator';
 
 export function registerTypes(serviceManager: IServiceManager): void {
     serviceManager.addSingleton<IExtensionActivationService>(IExtensionActivationService, PartialModeStatusItem);
@@ -34,4 +35,9 @@ export function registerTypes(serviceManager: IServiceManager): void {
 
     serviceManager.addSingleton<ILanguageServerWatcher>(ILanguageServerWatcher, LanguageServerWatcher);
     serviceManager.addBinding(ILanguageServerWatcher, IExtensionActivationService);
+
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        RequirementsTxtLinkActivator,
+    );
 }

--- a/src/test/activation/requirementsTxtLinkActivator.unit.test.ts
+++ b/src/test/activation/requirementsTxtLinkActivator.unit.test.ts
@@ -23,8 +23,7 @@ http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a88
  */
 
 suite('Link to PyPi in requiements test', () => {
-    test('Check if all possible project name are matched', () => {
-        const rows = [
+    [
             ['pytest', 'pytest'],
             ['pytest-cov', 'pytest-cov'],
             ['pytest_cov', 'pytest_cov'],
@@ -34,10 +33,9 @@ suite('Link to PyPi in requiements test', () => {
             ['requests [security] >= 2.8.1, == 2.8.* ; python_version < "2.7"', 'requests'],
             ['# a comment', null],
             ['', null],
-        ];
-
-        rows.forEach(([input, expected]) => {
-            expect(RequirementsTxtLinkActivator.generatePyPiLink(input)).equal(expected ? `https://pypi.org/project/${expected}/`: null);
+    ].forEach(([input, expected])=> {
+        test(`PyPI link case: "${input}"`, () => {
+            expect(generatePyPiLink(input)).equal(expected ? `https://pypi.org/project/${expected}/`: null);
         });
     });
 });

--- a/src/test/activation/requirementsTxtLinkActivator.unit.test.ts
+++ b/src/test/activation/requirementsTxtLinkActivator.unit.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect } from 'chai';
+import { RequirementsTxtLinkActivator } from '../../client/activation/requirementsTxtLinkActivator';
+
+/** *
+requests [security] >= 2.8.1, == 2.8.* ; python_version < "2.7"
+urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip
+
+# It is possible to refer to other requirement files or constraints files.
+-r other-requirements.txt
+-c constraints.txt
+
+# It is possible to refer to specific local distribution paths.
+./downloads/numpy-1.9.2-cp34-none-win32.whl
+
+# It is possible to refer to URLs.
+http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl
+
+ */
+
+suite('Link to PyPi in requiements test', () => {
+    test('Check if all possible project name are matched', () => {
+        const rows = [
+            ['pytest', 'pytest'],
+            ['pytest-cov', 'pytest-cov'],
+            ['pytest_cov', 'pytest_cov'],
+            ['pytest_cov[an_extra]', 'pytest_cov'],
+            ['pytest == 0.6.1', 'pytest'],
+            ['pytest== 0.6.1', 'pytest'],
+            ['requests [security] >= 2.8.1, == 2.8.* ; python_version < "2.7"', 'requests'],
+            ['# a comment', null],
+            ['', null],
+        ];
+
+        rows.forEach(([input, expected]) => {
+            expect(RequirementsTxtLinkActivator.generatePyPiLink(input)).equal(expected ? `https://pypi.org/project/${expected}/`: null);
+        });
+    });
+});

--- a/src/test/activation/requirementsTxtLinkActivator.unit.test.ts
+++ b/src/test/activation/requirementsTxtLinkActivator.unit.test.ts
@@ -6,36 +6,20 @@
 import { expect } from 'chai';
 import { generatePyPiLink } from '../../client/activation/requirementsTxtLinkActivator';
 
-/** *
-requests [security] >= 2.8.1, == 2.8.* ; python_version < "2.7"
-urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip
-
-# It is possible to refer to other requirement files or constraints files.
--r other-requirements.txt
--c constraints.txt
-
-# It is possible to refer to specific local distribution paths.
-./downloads/numpy-1.9.2-cp34-none-win32.whl
-
-# It is possible to refer to URLs.
-http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl
-
- */
-
 suite('Link to PyPi in requiements test', () => {
     [
-            ['pytest', 'pytest'],
-            ['pytest-cov', 'pytest-cov'],
-            ['pytest_cov', 'pytest_cov'],
-            ['pytest_cov[an_extra]', 'pytest_cov'],
-            ['pytest == 0.6.1', 'pytest'],
-            ['pytest== 0.6.1', 'pytest'],
-            ['requests [security] >= 2.8.1, == 2.8.* ; python_version < "2.7"', 'requests'],
-            ['# a comment', null],
-            ['', null],
-    ].forEach(([input, expected])=> {
+        ['pytest', 'pytest'],
+        ['pytest-cov', 'pytest-cov'],
+        ['pytest_cov', 'pytest_cov'],
+        ['pytest_cov[an_extra]', 'pytest_cov'],
+        ['pytest == 0.6.1', 'pytest'],
+        ['pytest== 0.6.1', 'pytest'],
+        ['requests [security] >= 2.8.1, == 2.8.* ; python_version < "2.7"', 'requests'],
+        ['# a comment', null],
+        ['', null],
+    ].forEach(([input, expected]) => {
         test(`PyPI link case: "${input}"`, () => {
-            expect(generatePyPiLink(input)).equal(expected ? `https://pypi.org/project/${expected}/`: null);
+            expect(generatePyPiLink(input!)).equal(expected ? `https://pypi.org/project/${expected}/` : null);
         });
     });
 });

--- a/src/test/activation/requirementsTxtLinkActivator.unit.test.ts
+++ b/src/test/activation/requirementsTxtLinkActivator.unit.test.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { expect } from 'chai';
-import { RequirementsTxtLinkActivator } from '../../client/activation/requirementsTxtLinkActivator';
+import { generatePyPiLink } from '../../client/activation/requirementsTxtLinkActivator';
 
 /** *
 requests [security] >= 2.8.1, == 2.8.* ; python_version < "2.7"

--- a/src/test/activation/serviceRegistry.unit.test.ts
+++ b/src/test/activation/serviceRegistry.unit.test.ts
@@ -14,6 +14,7 @@ import {
 import { ServiceManager } from '../../client/ioc/serviceManager';
 import { IServiceManager } from '../../client/ioc/types';
 import { LoadLanguageServerExtension } from '../../client/activation/common/loadLanguageServerExtension';
+import { RequirementsTxtLinkActivator } from '../../client/activation/requirementsTxtLinkActivator';
 
 suite('Unit Tests - Language Server Activation Service Registry', () => {
     let serviceManager: IServiceManager;
@@ -44,6 +45,12 @@ suite('Unit Tests - Language Server Activation Service Registry', () => {
             serviceManager.addSingleton<IExtensionSingleActivationService>(
                 IExtensionSingleActivationService,
                 LoadLanguageServerExtension,
+            ),
+        ).once();
+        verify(
+            serviceManager.addSingleton<IExtensionSingleActivationService>(
+                IExtensionSingleActivationService,
+                RequirementsTxtLinkActivator,
             ),
         ).once();
     });


### PR DESCRIPTION
Show PyPi link in requirements, see #14495.

Apart from the test to verify the register of `RequirementsTxtLinkActivator`, there are no other tests. This is my first contribution in TypeScript, if you have an example of a test that could be done, I'm interested :)