### PR TITLE
Support providing conda exe in args

### DIFF
--- a/native_locator/Cargo.toml
+++ b/native_locator/Cargo.toml
@@ -11,3 +11,4 @@ serde = {version ="1.0.152", features = ["derive"]}
 serde_json = "1.0.93"
 serde_repr = "0.1.10"
 regex = "1.10.4"
+clap = { version = "4.5.4", features = ["derive"] }

--- a/native_locator/src/conda.rs
+++ b/native_locator/src/conda.rs
@@ -367,8 +367,11 @@ fn get_distinct_conda_envs(conda_bin: PathBuf) -> Vec<CondaEnv> {
     conda_envs
 }
 
-pub fn find_and_report() {
-    let conda_binary = find_conda_binary();
+pub fn find_and_report(conda_exe: Option<PathBuf>) {
+    let conda_binary = match conda_exe {
+        Some(_) => conda_exe,
+        None => find_conda_binary(),
+    };
     match conda_binary {
         Some(conda_binary) => {
             let params =

--- a/native_locator/src/main.rs
+++ b/native_locator/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+use clap::{arg, command, Parser};
 use std::time::SystemTime;
 
 mod common_python;
@@ -11,7 +12,15 @@ mod messaging;
 mod utils;
 mod windows_python;
 
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    #[arg(long)]
+    conda_exe: Option<std::path::PathBuf>,
+}
+
 fn main() {
+    let args = Args::parse();
     let now = SystemTime::now();
     logging::log_info("Starting Native Locator");
 
@@ -19,7 +28,7 @@ fn main() {
     common_python::find_and_report();
 
     // Finds conda binary and conda environments
-    conda::find_and_report();
+    conda::find_and_report(args.conda_exe);
 
     // Finds Windows Store, Known Path, and Registry pythons
     #[cfg(windows)]


### PR DESCRIPTION
Was easy to verify and test.
`cargo run` on my machine yields nothing (as conda isn't in path)

With this PR and `cargo run -- --codna-exe <path>`, things work as expected.
Will add tests later once we have that infra structure. 