### PR TITLE
Adding detail to create environment pip install prompt

### DIFF
--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -523,7 +523,7 @@ export namespace CreateEnv {
         export const createEnvironment = l10n.t('Create');
 
         export const globalPipInstallTriggerMessage = l10n.t(
-            'You may have installed Python packages into your global environment, which can cause conflicts between package versions. Would you like to create a virtual environment with these packages installed to isolate your dependencies?',
+            'You may have installed Python packages into your global environment, which can cause conflicts between package versions. Would you like to create a virtual environment with these packages to isolate your dependencies?',
         );
     }
 }

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -523,7 +523,7 @@ export namespace CreateEnv {
         export const createEnvironment = l10n.t('Create');
 
         export const globalPipInstallTriggerMessage = l10n.t(
-            'You may have installed Python packages into your global environment, which can cause conflicts between package versions. Would you like to create a virtual environment to isolate your dependencies?',
+            'You may have installed Python packages into your global environment, which can cause conflicts between package versions. Would you like to create a virtual environment with these packages installed to isolate your dependencies?',
         );
     }
 }


### PR DESCRIPTION
We discussed how it might not be clear to the user that this action will create a virtual environment in addition to running their last command to install packages into the newly created environment. Thoughts on adding this detail? 