### PR TITLE
Bug: Fix python.execInREPL stealing shift+enter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1118,12 +1118,12 @@
             {
                 "command": "python.execInREPL",
                 "key": "shift+enter",
-                "when": "config.python.REPL.sendToNativeREPL && activeEditor != 'workbench.editor.interactive' && editorLangId == python && editorTextFocus && !jupyter.ownsSelection"
+                "when": "config.python.REPL.sendToNativeREPL && activeEditor != 'workbench.editor.interactive'&& editorLangId == python && editorTextFocus && !jupyter.ownsSelection"
             },
             {
                 "command": "python.execREPLShiftEnter",
                 "key": "shift+enter",
-                "when": "activeEditor == 'workbench.editor.interactive' && config.interactiveWindow.executeWithShiftEnter"
+                "when": "activeEditor == 'workbench.editor.interactive' && config.interactiveWindow.executeWithShiftEnter && editorLangId == python"
             },
             {
                 "command": "python.execInREPLEnter",

--- a/package.json
+++ b/package.json
@@ -1118,7 +1118,7 @@
             {
                 "command": "python.execInREPL",
                 "key": "shift+enter",
-                "when": "config.python.REPL.sendToNativeREPL && activeEditor != 'workbench.editor.interactive'"
+                "when": "config.python.REPL.sendToNativeREPL && activeEditor != 'workbench.editor.interactive' && editorLangId == python && editorTextFocus && !jupyter.ownsSelection"
             },
             {
                 "command": "python.execREPLShiftEnter",


### PR DESCRIPTION
Stop stealing shift+enter if editor is not focused and language is not python.
Resolves: https://github.com/microsoft/vscode-python/issues/23525