### PR TITLE
Bug Fix: REPL reuse and do not overwrite Jupyter's IW title

### DIFF
--- a/src/client/repl/replCommands.ts
+++ b/src/client/repl/replCommands.ts
@@ -54,9 +54,8 @@ function getSendToNativeREPLSetting(): boolean {
     return configuration.get<boolean>('REPL.sendToNativeREPL', false);
 }
 
-window.onDidChangeVisibleTextEditors((editors) => {
-    const interactiveWindowIsOpen = editors.some((editor) => editor.document.uri.scheme === 'vscode-interactive-input');
-    if (!interactiveWindowIsOpen) {
+workspace.onDidCloseNotebookDocument((nb) => {
+    if (notebookDocument && nb.uri.toString() === notebookDocument.uri.toString()) {
         notebookEditor = undefined;
         notebookDocument = undefined;
     }


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-python/issues/23518

Should resolve issue where opening Python REPL -> opening Jupyter IW -> sending commands to REPL were happening instead of reusing existing Python REPL

Also seems to resolve issue where Python REPL was overwriting to Jupyter's IW title. 

Switching to watch onDidCloseNotebook event as suggested. 