### PR TITLE
chore: use Linux pools for Alpine builds

### DIFF
--- a/build/azure-pipeline.pre-release.yml
+++ b/build/azure-pipeline.pre-release.yml
@@ -42,10 +42,10 @@ extends:
       - name: Linux
         packageArch: x64
         vsceTarget: linux-x64
-      - name: Alpine
+      - name: Linux
         packageArch: arm64
         vsceTarget: alpine-arm64
-      - name: Alpine
+      - name: Linux
         packageArch: x64
         vsceTarget: alpine-x64
       - name: MacOS


### PR DESCRIPTION
I noticed that the pre-release template already has checks for whether the vsceTarget is an Alpine one, and that the current builds are using ubuntu-latest images anyway. As a result, I believe that switching over the Alpine builds to use the 1ES Ubuntu images is the easiest approach to getting the build green.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=276275&view=results