### PR TITLE
Rename REPL to Terminal REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ The Python extension will automatically install the following extensions by defa
 
 These extensions are optional dependencies, meaning the Python extension will remain fully functional if they fail to be installed. Any or all of these extensions can be [disabled](https://code.visualstudio.com/docs/editor/extension-marketplace#_disable-an-extension) or [uninstalled](https://code.visualstudio.com/docs/editor/extension-marketplace#_uninstall-an-extension) at the expense of some features. Extensions installed through the marketplace are subject to the [Marketplace Terms of Use](https://cdn.vsassets.io/v/M146_20190123.39/_content/Microsoft-Visual-Studio-Marketplace-Terms-of-Use.pdf).
 
-## Extensibility 
+## Extensibility
 
-The Python extension provides pluggable access points for extensions that extend various feature areas to further improve your Python development experience. These extensions are all optional and depend on your project configuration and preferences. 
+The Python extension provides pluggable access points for extensions that extend various feature areas to further improve your Python development experience. These extensions are all optional and depend on your project configuration and preferences.
 
 - [Python formatters](https://code.visualstudio.com/docs/python/formatting#_choose-a-formatter)
 - [Python linters](https://code.visualstudio.com/docs/python/linting#_choose-a-linter)
 
-If you encounter issues with any of the listed extensions, please file an issue in its corresponding repo. 
+If you encounter issues with any of the listed extensions, please file an issue in its corresponding repo.
 
 ## Quick start
 
@@ -70,7 +70,7 @@ Open the Command Palette (Command+Shift+P on macOS and Ctrl+Shift+P on Windows/L
 | Command                               | Description                                                                                                                                                    |
 | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Python: Select Interpreter`          | Switch between Python interpreters, versions, and environments.                                                                                                |
-| `Python: Start REPL`                  | Start an interactive Python REPL using the selected interpreter in the VS Code terminal.                                                                       |
+| `Python: Start Terminal REPL`                  | Start an interactive Python REPL using the selected interpreter in the VS Code terminal.                                                                       |
 | `Python: Run Python File in Terminal` | Runs the active Python file in the VS Code terminal. You can also run a Python file by right-clicking on the file and selecting `Run Python File in Terminal`. |
 | `Python: Configure Tests`             | Select a test framework and configure it to display the Test Explorer.                                                                                         |
 

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,5 @@
 {
-    "python.command.python.startREPL.title": "Start REPL",
+    "python.command.python.startREPL.title": "Start Terminal REPL",
     "python.command.python.createEnvironment.title": "Create Environment...",
     "python.command.python.createNewFile.title": "New Python File",
     "python.command.python.createTerminal.title": "Create Terminal",


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-python/issues/23524

Renaming existing "Start REPL" command palette option into "Start Terminal REPL" as we discussed. /cc @luabud @cwebster-99 
