### PR TITLE
Unify Terminal REPL triggers 

### DIFF
--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -59,17 +59,6 @@ export class TerminalService implements ITerminalService, Disposable {
             this.terminal!.show(true);
         }
 
-        // use terminal shell integration
-        // window.onDidChangeTerminalShellIntegration(async ({ terminal, shellIntegration }) => {
-        //     // if (terminal.name === 'Python') {
-        //     const execution = shellIntegration.executeCommand(text);
-        //     window.onDidEndTerminalShellExecution((event) => {
-        //         if (event.execution === execution || event.execution === execution) {
-        //             console.log(`Command exited with code ${event.exitCode}`); // switches btw undefined 0,1,130
-        //             const temp = event.exitCode;
-        //         }
-        //     });
-        // });
         this.terminal!.sendText(text, true);
     }
     public async sendText(text: string): Promise<void> {

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -3,7 +3,7 @@
 
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import { CancellationToken, Disposable, Event, EventEmitter, Terminal, window } from 'vscode';
+import { CancellationToken, Disposable, Event, EventEmitter, Terminal } from 'vscode';
 import '../../common/extensions';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -60,17 +60,17 @@ export class TerminalService implements ITerminalService, Disposable {
         }
 
         // use terminal shell integration
-        window.onDidChangeTerminalShellIntegration(async ({ terminal, shellIntegration }) => {
-            // if (terminal.name === 'Python') {
-            const execution = shellIntegration.executeCommand(text);
-            window.onDidEndTerminalShellExecution((event) => {
-                if (event.execution === execution || event.execution === execution) {
-                    console.log(`Command exited with code ${event.exitCode}`); // switches btw undefined 0,1,130
-                    const temp = event.exitCode;
-                }
-            });
-        });
-        // this.terminal!.sendText(text, true); OG
+        // window.onDidChangeTerminalShellIntegration(async ({ terminal, shellIntegration }) => {
+        //     // if (terminal.name === 'Python') {
+        //     const execution = shellIntegration.executeCommand(text);
+        //     window.onDidEndTerminalShellExecution((event) => {
+        //         if (event.execution === execution || event.execution === execution) {
+        //             console.log(`Command exited with code ${event.exitCode}`); // switches btw undefined 0,1,130
+        //             const temp = event.exitCode;
+        //         }
+        //     });
+        // });
+        this.terminal!.sendText(text, true);
     }
     public async sendText(text: string): Promise<void> {
         await this.ensureTerminal();

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -62,13 +62,11 @@ export class TerminalService implements ITerminalService, Disposable {
         // use terminal shell integration
         window.onDidChangeTerminalShellIntegration(async ({ terminal, shellIntegration }) => {
             // if (terminal.name === 'Python') {
-            // const execution = shellIntegration.executeCommand(`print('hello world')`);
             const execution = shellIntegration.executeCommand(text);
             window.onDidEndTerminalShellExecution((event) => {
                 if (event.execution === execution || event.execution === execution) {
                     console.log(`Command exited with code ${event.exitCode}`); // switches btw undefined 0,1,130
                     const temp = event.exitCode;
-                    let temp2 = temp;
                 }
             });
         });

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -3,7 +3,7 @@
 
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import { CancellationToken, Disposable, Event, EventEmitter, Terminal } from 'vscode';
+import { CancellationToken, Disposable, Event, EventEmitter, Terminal, window } from 'vscode';
 import '../../common/extensions';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
@@ -58,7 +58,21 @@ export class TerminalService implements ITerminalService, Disposable {
         if (!this.options?.hideFromUser) {
             this.terminal!.show(true);
         }
-        this.terminal!.sendText(text, true);
+
+        // use terminal shell integration
+        window.onDidChangeTerminalShellIntegration(async ({ terminal, shellIntegration }) => {
+            // if (terminal.name === 'Python') {
+            // const execution = shellIntegration.executeCommand(`print('hello world')`);
+            const execution = shellIntegration.executeCommand(text);
+            window.onDidEndTerminalShellExecution((event) => {
+                if (event.execution === execution || event.execution === execution) {
+                    console.log(`Command exited with code ${event.exitCode}`); // switches btw undefined 0,1,130
+                    const temp = event.exitCode;
+                    let temp2 = temp;
+                }
+            });
+        });
+        // this.terminal!.sendText(text, true); OG
     }
     public async sendText(text: string): Promise<void> {
         await this.ensureTerminal();

--- a/src/client/providers/replProvider.ts
+++ b/src/client/providers/replProvider.ts
@@ -40,7 +40,7 @@ export class ReplProvider implements Disposable {
                 .then(noop, noop);
             return;
         }
-        const replProvider = this.serviceContainer.get<ICodeExecutionService>(ICodeExecutionService, 'repl');
+        const replProvider = this.serviceContainer.get<ICodeExecutionService>(ICodeExecutionService, 'standard');
         await replProvider.initializeRepl(resource);
     }
 }

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -17,7 +17,6 @@ import { IInterpreterService } from '../../interpreter/contracts';
 import { traceInfo } from '../../logging';
 import { buildPythonExecInfo, PythonExecInfo } from '../../pythonEnvironments/exec';
 import { ICodeExecutionService } from '../../terminals/types';
-// import TerminalShellIntegration proposed api
 
 @injectable()
 export class TerminalCodeExecutionProvider implements ICodeExecutionService {

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -5,7 +5,7 @@
 
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import { Disposable, Uri, window, ExtensionContext } from 'vscode';
+import { Disposable, Uri } from 'vscode';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../../common/application/types';
 import '../../common/extensions';
 import { IPlatformService } from '../../common/platform/types';

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -5,7 +5,7 @@
 
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import { Disposable, Uri } from 'vscode';
+import { Disposable, Uri, window } from 'vscode';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../../common/application/types';
 import '../../common/extensions';
 import { IPlatformService } from '../../common/platform/types';
@@ -17,6 +17,8 @@ import { IInterpreterService } from '../../interpreter/contracts';
 import { traceInfo } from '../../logging';
 import { buildPythonExecInfo, PythonExecInfo } from '../../pythonEnvironments/exec';
 import { ICodeExecutionService } from '../../terminals/types';
+// import TerminalShellIntegration proposed api
+
 @injectable()
 export class TerminalCodeExecutionProvider implements ICodeExecutionService {
     private hasRanOutsideCurrentDrive = false;
@@ -93,6 +95,22 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
                 }
                 resolve(true);
             });
+
+            // use terminal shell integration
+            const myTerm = window.createTerminal();
+            window.onDidChangeTerminalShellIntegration(async ({ terminal, shellIntegration }) => {
+                if (terminal.name === 'Python') {
+                    const execution = shellIntegration.executeCommand(`print('hello world')`);
+                    window.onDidEndTerminalShellExecution((event) => {
+                        if (event.execution === execution) {
+                            console.log(`Command exited with code ${event.exitCode}`); // I always get undefined
+                            const temp = event.exitCode;
+                            let temp2 = temp;
+                        }
+                    });
+                }
+            });
+
             terminalService.sendCommand(replCommandArgs.command, replCommandArgs.args);
         });
         this.disposables.push(

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -129,24 +129,24 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
             //         });
             //     }
             // });
-
+            // Very first replCommandArgs.command is the exsecutable info: @'/Users/anthonykim/.pyenv/versions/3.9.18/bin/python'
             await terminalService.sendCommand(replCommandArgs.command, replCommandArgs.args);
 
             // use terminal shell integration
-            window.onDidChangeTerminalShellIntegration(async ({ terminal, shellIntegration }) => {
-                // if (terminal.name === 'Python') {
-                // const execution = shellIntegration.executeCommand(`print('hello world')`);
-                const execution = shellIntegration.executeCommand(`print('hello world')`);
-                const wrongExecution = shellIntegration.executeCommand(`dqwkodkqokoqwdWRONG`);
-                window.onDidEndTerminalShellExecution((event) => {
-                    if (event.execution === execution || event.execution === wrongExecution) {
-                        console.log(`Command exited with code ${event.exitCode}`); // switches btw undefined 0,1,130
-                        const temp = event.exitCode;
-                        let temp2 = temp;
-                    }
-                });
-                // }
-            });
+            // window.onDidChangeTerminalShellIntegration(async ({ terminal, shellIntegration }) => {
+            //     // if (terminal.name === 'Python') {
+            //     // const execution = shellIntegration.executeCommand(`print('hello world')`);
+            //     const execution = shellIntegration.executeCommand(`print('hello world')`);
+            //     const wrongExecution = shellIntegration.executeCommand(`dqwkodkqokoqwdWRONG`);
+            //     window.onDidEndTerminalShellExecution((event) => {
+            //         if (event.execution === execution || event.execution === wrongExecution) {
+            //             console.log(`Command exited with code ${event.exitCode}`); // switches btw undefined 0,1,130
+            //             const temp = event.exitCode;
+            //             let temp2 = temp;
+            //         }
+            //     });
+            //     // }
+            // });
         });
         this.disposables.push(
             terminalService.onDidCloseTerminal(() => {

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -65,7 +65,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
     public async initializeRepl(resource: Resource) {
         const terminalService = this.getTerminalService(resource);
         if (this.replActive && (await this.replActive)) {
-            await terminalService.show();
+            await terminalService.show(); // in multi-file to REPL scenario, it just sends to same REPL.
             return;
         }
 

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -65,7 +65,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
     public async initializeRepl(resource: Resource) {
         const terminalService = this.getTerminalService(resource);
         if (this.replActive && (await this.replActive)) {
-            await terminalService.show(); // in multi-file to REPL scenario, it just sends to same REPL.
+            await terminalService.show();
             return;
         }
 
@@ -99,7 +99,6 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
                 resolve(true);
             });
 
-            // Very first replCommandArgs.command is the exsecutable info: @'/Users/anthonykim/.pyenv/versions/3.9.18/bin/python'
             await terminalService.sendCommand(replCommandArgs.command, replCommandArgs.args);
         });
         this.disposables.push(

--- a/src/test/providers/repl.unit.test.ts
+++ b/src/test/providers/repl.unit.test.ts
@@ -26,6 +26,7 @@ suite('REPL Provider', () => {
     let activeResourceService: TypeMoq.IMock<IActiveResourceService>;
     let replProvider: ReplProvider;
     let interpreterService: TypeMoq.IMock<IInterpreterService>;
+    const executionService = TypeMoq.Mock.ofType<ICodeExecutionService>();
     setup(() => {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         commandManager = TypeMoq.Mock.ofType<ICommandManager>();
@@ -35,9 +36,12 @@ suite('REPL Provider', () => {
         activeResourceService = TypeMoq.Mock.ofType<IActiveResourceService>();
         serviceContainer.setup((c) => c.get(ICommandManager)).returns(() => commandManager.object);
         serviceContainer.setup((c) => c.get(IWorkspaceService)).returns(() => workspace.object);
+        // serviceContainer
+        //     .setup((c) => c.get(ICodeExecutionService, TypeMoq.It.isValue('repl')))
+        //     .returns(() => codeExecutionService.object);
         serviceContainer
-            .setup((c) => c.get(ICodeExecutionService, TypeMoq.It.isValue('repl')))
-            .returns(() => codeExecutionService.object);
+            .setup((s) => s.get(TypeMoq.It.isValue(ICodeExecutionService), TypeMoq.It.isValue('standard')))
+            .returns(() => executionService.object);
         serviceContainer.setup((c) => c.get(IDocumentManager)).returns(() => documentManager.object);
         serviceContainer.setup((c) => c.get(IActiveResourceService)).returns(() => activeResourceService.object);
         interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
@@ -80,10 +84,6 @@ suite('REPL Provider', () => {
         const resource = Uri.parse('a');
         const disposable = TypeMoq.Mock.ofType<Disposable>();
         let commandHandler: undefined | (() => Promise<void>);
-        const executionService = TypeMoq.Mock.ofType<ICodeExecutionService>();
-        serviceContainer
-            .setup((s) => s.get(TypeMoq.It.isValue(ICodeExecutionService), TypeMoq.It.isValue('standard')))
-            .returns(() => executionService.object);
 
         commandManager
             .setup((c) =>

--- a/src/test/providers/repl.unit.test.ts
+++ b/src/test/providers/repl.unit.test.ts
@@ -98,7 +98,7 @@ suite('REPL Provider', () => {
         await commandHandler!.call(replProvider);
 
         serviceContainer.verify(
-            (c) => c.get(TypeMoq.It.isValue(ICodeExecutionService), TypeMoq.It.isValue('repl')),
+            (c) => c.get(TypeMoq.It.isValue(ICodeExecutionService), TypeMoq.It.isValue('Python')),
             TypeMoq.Times.once(),
         );
         codeExecutionService.verify((c) => c.initializeRepl(TypeMoq.It.isValue(resource)), TypeMoq.Times.once());

--- a/src/test/providers/repl.unit.test.ts
+++ b/src/test/providers/repl.unit.test.ts
@@ -26,7 +26,6 @@ suite('REPL Provider', () => {
     let activeResourceService: TypeMoq.IMock<IActiveResourceService>;
     let replProvider: ReplProvider;
     let interpreterService: TypeMoq.IMock<IInterpreterService>;
-    const executionService = TypeMoq.Mock.ofType<ICodeExecutionService>();
     setup(() => {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         commandManager = TypeMoq.Mock.ofType<ICommandManager>();
@@ -36,12 +35,9 @@ suite('REPL Provider', () => {
         activeResourceService = TypeMoq.Mock.ofType<IActiveResourceService>();
         serviceContainer.setup((c) => c.get(ICommandManager)).returns(() => commandManager.object);
         serviceContainer.setup((c) => c.get(IWorkspaceService)).returns(() => workspace.object);
-        // serviceContainer
-        //     .setup((c) => c.get(ICodeExecutionService, TypeMoq.It.isValue('repl')))
-        //     .returns(() => codeExecutionService.object);
         serviceContainer
             .setup((s) => s.get(TypeMoq.It.isValue(ICodeExecutionService), TypeMoq.It.isValue('standard')))
-            .returns(() => executionService.object);
+            .returns(() => codeExecutionService.object);
         serviceContainer.setup((c) => c.get(IDocumentManager)).returns(() => documentManager.object);
         serviceContainer.setup((c) => c.get(IActiveResourceService)).returns(() => activeResourceService.object);
         interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
@@ -103,7 +99,7 @@ suite('REPL Provider', () => {
         await commandHandler!.call(replProvider);
 
         serviceContainer.verify(
-            (c) => c.get(TypeMoq.It.isValue(ICodeExecutionService), TypeMoq.It.isAny()),
+            (c) => c.get(TypeMoq.It.isValue(ICodeExecutionService), TypeMoq.It.isValue('standard')),
             TypeMoq.Times.once(),
         );
         codeExecutionService.verify((c) => c.initializeRepl(TypeMoq.It.isValue(resource)), TypeMoq.Times.once());

--- a/src/test/providers/repl.unit.test.ts
+++ b/src/test/providers/repl.unit.test.ts
@@ -103,7 +103,7 @@ suite('REPL Provider', () => {
         await commandHandler!.call(replProvider);
 
         serviceContainer.verify(
-            (c) => c.get(TypeMoq.It.isValue(ICodeExecutionService), TypeMoq.It.isValue('standard')),
+            (c) => c.get(TypeMoq.It.isValue(ICodeExecutionService), TypeMoq.It.isAny()),
             TypeMoq.Times.once(),
         );
         codeExecutionService.verify((c) => c.initializeRepl(TypeMoq.It.isValue(resource)), TypeMoq.Times.once());

--- a/src/test/providers/repl.unit.test.ts
+++ b/src/test/providers/repl.unit.test.ts
@@ -98,7 +98,7 @@ suite('REPL Provider', () => {
         await commandHandler!.call(replProvider);
 
         serviceContainer.verify(
-            (c) => c.get(TypeMoq.It.isValue(ICodeExecutionService), TypeMoq.It.isValue('Python')),
+            (c) => c.get(TypeMoq.It.isValue(ICodeExecutionService), TypeMoq.It.isValue('standard')),
             TypeMoq.Times.once(),
         );
         codeExecutionService.verify((c) => c.initializeRepl(TypeMoq.It.isValue(resource)), TypeMoq.Times.once());

--- a/src/test/providers/repl.unit.test.ts
+++ b/src/test/providers/repl.unit.test.ts
@@ -80,6 +80,11 @@ suite('REPL Provider', () => {
         const resource = Uri.parse('a');
         const disposable = TypeMoq.Mock.ofType<Disposable>();
         let commandHandler: undefined | (() => Promise<void>);
+        const executionService = TypeMoq.Mock.ofType<ICodeExecutionService>();
+        serviceContainer
+            .setup((s) => s.get(TypeMoq.It.isValue(ICodeExecutionService), TypeMoq.It.isValue('standard')))
+            .returns(() => executionService.object);
+
         commandManager
             .setup((c) =>
                 c.registerCommand(TypeMoq.It.isValue(Commands.Start_REPL), TypeMoq.It.isAny(), TypeMoq.It.isAny()),


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-python/issues/22242

Attempting to keep instance of REPL. Did not end up using shell integration for this, but shell integration and exit code will come in handy when we have to keep track of 'opened' state of REPL instance for cases when user wants to enter 'exit()'