### PR TITLE
xdist fixes

### DIFF
--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -899,5 +899,13 @@ class DeferPlugin:
 
 
 def pytest_plugin_registered(plugin: object, manager: pytest.PytestPluginManager):
-    if manager.hasplugin("xdist") and not isinstance(plugin, DeferPlugin):
-        manager.register(DeferPlugin())
+    plugin_name = "vscode_xdist"
+    if (
+        # only register the plugin if xdist is enabled:
+        manager.hasplugin("xdist")
+        # prevent infinite recursion:
+        and not isinstance(plugin, DeferPlugin)
+        # prevent this plugin from being registered multiple times:
+        and not manager.hasplugin(plugin_name)
+    ):
+        manager.register(DeferPlugin(), name=plugin_name)

--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -891,7 +891,11 @@ class DeferPlugin:
     @pytest.hookimpl(hookwrapper=True)
     def pytest_xdist_auto_num_workers(self, config: pytest.Config) -> Generator[None, int, int]:
         """Determine how many workers to use based on how many tests were selected in the test explorer."""
-        return min((yield), len(config.option.file_or_dir))
+        result = min((yield), len(config.option.file_or_dir))
+        if result == 1:
+            # setting it to 0 disables xdist, no point using xdist if there's only 1 test
+            return 0
+        return result
 
 
 def pytest_plugin_registered(plugin: object, manager: pytest.PytestPluginManager):

--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -19,6 +19,7 @@ from typing import (
 )
 
 import pytest
+from pluggy import Result
 
 script_dir = pathlib.Path(__file__).parent.parent
 sys.path.append(os.fspath(script_dir))
@@ -889,13 +890,15 @@ def send_post_request(
 
 class DeferPlugin:
     @pytest.hookimpl(hookwrapper=True)
-    def pytest_xdist_auto_num_workers(self, config: pytest.Config) -> Generator[None, int, int]:
+    def pytest_xdist_auto_num_workers(
+        self, config: pytest.Config
+    ) -> Generator[None, Result[int], None]:
         """Determine how many workers to use based on how many tests were selected in the test explorer."""
-        result = min((yield), len(config.option.file_or_dir))
+        outcome = yield
+        result = min(outcome.get_result(), len(config.option.file_or_dir))
         if result == 1:
-            # setting it to 0 disables xdist, no point using xdist if there's only 1 test
-            return 0
-        return result
+            result = 0
+        outcome.force_result(result)
 
 
 def pytest_plugin_registered(plugin: object, manager: pytest.PytestPluginManager):


### PR DESCRIPTION
- Don't use xdist when only running one test. this makes it slightly faster when running one test, because instead of creating a single worker it just runs the test in the same process
- fix #23816
- fix issue where the plugin was being registered multiple times