### PR TITLE
remove duration from native_finder_perf property list

### DIFF
--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -1762,7 +1762,6 @@ export interface IEventNamePropertyMapping {
         /**
          * Total duration to find envs using native locator.
          */
-        duration: number;
         breakdownLocators?: number;
         breakdownPath?: number;
         breakdownGlobalVirtualEnvs?: number;


### PR DESCRIPTION
It looks like duration is being classified as a property here preventing it from showing up in our data. I think the fix is removing it from the property list here. 