### PR TITLE
REPL Telemetry for Terminal REPL and Native REPL

### DIFF
--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -53,6 +53,7 @@ import { logAndNotifyOnLegacySettings } from './logging/settingLogs';
 import { DebuggerTypeName } from './debugger/constants';
 import { StopWatch } from './common/utils/stopWatch';
 import { registerReplCommands, registerReplExecuteOnEnter, registerStartNativeReplCommand } from './repl/replCommands';
+import { registerTriggerForTerminalREPL } from './terminals/codeExecution/terminalReplWatcher';
 
 export async function activateComponents(
     // `ext` is passed to any extra activation funcs.
@@ -108,6 +109,7 @@ export function activateFeatures(ext: ExtensionState, _components: Components): 
     );
     const executionHelper = ext.legacyIOC.serviceContainer.get<ICodeExecutionHelper>(ICodeExecutionHelper);
     const commandManager = ext.legacyIOC.serviceContainer.get<ICommandManager>(ICommandManager);
+    registerTriggerForTerminalREPL(ext.disposables);
     registerStartNativeReplCommand(ext.disposables, interpreterService);
     registerReplCommands(ext.disposables, interpreterService, executionHelper, commandManager);
     registerReplExecuteOnEnter(ext.disposables, interpreterService, commandManager);

--- a/src/client/providers/replProvider.ts
+++ b/src/client/providers/replProvider.ts
@@ -28,7 +28,7 @@ export class ReplProvider implements Disposable {
         this.disposables.push(disposable);
     }
 
-    @captureTelemetry(EventName.REPL)
+    @captureTelemetry(EventName.REPL, { replType: 'Terminal' })
     private async commandHandler() {
         const resource = this.activeResourceService.getActiveResource();
         const interpreterService = this.serviceContainer.get<IInterpreterService>(IInterpreterService);

--- a/src/client/repl/replCommands.ts
+++ b/src/client/repl/replCommands.ts
@@ -15,6 +15,8 @@ import {
     isMultiLineText,
 } from './replUtils';
 import { registerCommand } from '../common/vscodeApis/commandApis';
+import { sendTelemetryEvent } from '../telemetry';
+import { EventName } from '../telemetry/constants';
 
 /**
  * Register Start Native REPL command in the command palette
@@ -30,6 +32,7 @@ export async function registerStartNativeReplCommand(
 ): Promise<void> {
     disposables.push(
         registerCommand(Commands.Start_Native_REPL, async (uri: Uri) => {
+            sendTelemetryEvent(EventName.REPL, undefined, { replType: 'Native' });
             const interpreter = await getActiveInterpreter(uri, interpreterService);
             if (interpreter) {
                 if (interpreter) {
@@ -61,7 +64,7 @@ export async function registerReplCommands(
                 await executeInTerminal();
                 return;
             }
-
+            sendTelemetryEvent(EventName.REPL, undefined, { replType: 'Native' });
             const interpreter = await getActiveInterpreter(uri, interpreterService);
 
             if (interpreter) {

--- a/src/client/repl/replCommands.ts
+++ b/src/client/repl/replCommands.ts
@@ -64,7 +64,6 @@ export async function registerReplCommands(
                 await executeInTerminal();
                 return;
             }
-            sendTelemetryEvent(EventName.REPL, undefined, { replType: 'Native' });
             const interpreter = await getActiveInterpreter(uri, interpreterService);
 
             if (interpreter) {

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -2305,10 +2305,15 @@ export interface IEventNamePropertyMapping {
      */
     /* __GDPR__
        "repl" : {
-           "duration" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "karthiknadig" }
+           "duration" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "anthonykim1" }
        }
      */
-    [EventName.REPL]: never | undefined;
+    [EventName.REPL]: {
+        /**
+         * Whether the user launched the Terminal REPL or Native REPL
+         */
+        replType: 'Terminal' | 'Native';
+    };
     /**
      * Telemetry event sent if and when user configure tests command. This command can be trigerred from multiple places in the extension. (Command palette, prompt etc.)
      */

--- a/src/client/terminals/codeExecution/terminalReplWatcher.ts
+++ b/src/client/terminals/codeExecution/terminalReplWatcher.ts
@@ -4,10 +4,8 @@ import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 
 function checkREPLCommand(command: string): boolean {
-    const lower = command.toLowerCase();
-    // Cover cases for 'py', 'py -3' and 'py -3.x'.
-    const replCommandRegex = /^py(?:\s-3(?:\.\d)?)?$/;
-    return lower.startsWith('python') || replCommandRegex.test(command);
+    const lower = command.toLowerCase().trimStart();
+    return lower.startsWith('python ') || lower.startsWith('py ');
 }
 
 export function registerTriggerForTerminalREPL(disposables: Disposable[]): void {

--- a/src/client/terminals/codeExecution/terminalReplWatcher.ts
+++ b/src/client/terminals/codeExecution/terminalReplWatcher.ts
@@ -7,7 +7,7 @@ function checkREPLCommand(command: string): boolean {
     const lower = command.toLowerCase();
     // Cover cases for 'py', 'py -3' and 'py -3.x'.
     const replCommandRegex = /^py(?:\s-3(?:\.\d)?)?$/;
-    return lower.startsWith('python') || lower.startsWith('python3') || replCommandRegex.test(command);
+    return lower.startsWith('python') || replCommandRegex.test(command);
 }
 
 export function registerTriggerForTerminalREPL(disposables: Disposable[]): void {

--- a/src/client/terminals/codeExecution/terminalReplWatcher.ts
+++ b/src/client/terminals/codeExecution/terminalReplWatcher.ts
@@ -1,0 +1,21 @@
+import { Disposable, TerminalShellExecutionStartEvent } from 'vscode';
+import { onDidStartTerminalShellExecution } from '../../common/vscodeApis/windowApis';
+import { sendTelemetryEvent } from '../../telemetry';
+import { EventName } from '../../telemetry/constants';
+
+function checkREPLCommand(command: string): boolean {
+    const lower = command.toLowerCase();
+    // Cover cases for 'py', 'py -3' and 'py -3.x'.
+    const replCommandRegex = /^py(?:\s-3(?:\.\d)?)?$/;
+    return lower.startsWith('python') || lower.startsWith('python3') || replCommandRegex.test(command);
+}
+
+export function registerTriggerForTerminalREPL(disposables: Disposable[]): void {
+    disposables.push(
+        onDidStartTerminalShellExecution(async (e: TerminalShellExecutionStartEvent) => {
+            if (e.execution.commandLine.isTrusted && checkREPLCommand(e.execution.commandLine.value)) {
+                sendTelemetryEvent(EventName.REPL, undefined, { replType: 'Terminal' });
+            }
+        }),
+    );
+}


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-python/issues/23740 

Also organize Telemetry for Terminal REPL vs. Native REPL.
Now we can sort them out with new attribute 'replType' on the REPL Event.

With this PR:
- (EventName.REPL, { replType: 'Terminal' }) for when people launch Terminal REPL via Command Palette, Manually type Python in terminal (tried to account for all Python cases that will trigger REPL). 
- (EventName.REPL, { replType: 'Native' }) for when people launch Native REPL via Command Palette. 