### PR TITLE
Fire telemetry when REPLs are launched via shift+enter

### DIFF
--- a/src/client/repl/nativeRepl.ts
+++ b/src/client/repl/nativeRepl.ts
@@ -17,6 +17,8 @@ import { PythonEnvironment } from '../pythonEnvironments/info';
 import { createPythonServer, PythonServer } from './pythonServer';
 import { executeNotebookCell, openInteractiveREPL, selectNotebookKernel } from './replCommandHandler';
 import { createReplController } from './replController';
+import { EventName } from '../telemetry/constants';
+import { sendTelemetryEvent } from '../telemetry';
 
 export class NativeRepl implements Disposable {
     // Adding ! since it will get initialized in create method, not the constructor.
@@ -159,6 +161,7 @@ let nativeRepl: NativeRepl | undefined; // In multi REPL scenario, hashmap of UR
  */
 export async function getNativeRepl(interpreter: PythonEnvironment, disposables: Disposable[]): Promise<NativeRepl> {
     if (!nativeRepl) {
+        sendTelemetryEvent(EventName.REPL, undefined, { replType: 'Native' });
         nativeRepl = await NativeRepl.create(interpreter);
         disposables.push(nativeRepl);
     }

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -17,6 +17,8 @@ import { IInterpreterService } from '../../interpreter/contracts';
 import { traceInfo } from '../../logging';
 import { buildPythonExecInfo, PythonExecInfo } from '../../pythonEnvironments/exec';
 import { ICodeExecutionService } from '../../terminals/types';
+import { EventName } from '../../telemetry/constants';
+import { sendTelemetryEvent } from '../../telemetry';
 
 @injectable()
 export class TerminalCodeExecutionProvider implements ICodeExecutionService {
@@ -67,7 +69,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
             await terminalService.show();
             return;
         }
-
+        sendTelemetryEvent(EventName.REPL, undefined, { replType: 'Terminal' });
         this.replActive = new Promise<boolean>(async (resolve) => {
             const replCommandArgs = await this.getExecutableInfo(resource);
             let listener: IDisposable;


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-python/issues/23740
In addition to : #23941 

Fire telemetry for when REPL is launched via shift+enter. 
/cc @cwebster-99 