### PR TITLE
user defined pytest tree

### DIFF
--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -386,7 +386,10 @@ def pytest_sessionfinish(session, exitstatus):
             }
             post_response(os.fsdecode(cwd), error_node)
         try:
-            session_node: TestNode | None = build_test_tree(session)
+            if hasattr(session, "tree"):
+                session_node = session.tree
+            else:
+                session_node: TestNode | None = build_test_tree(session)
             if not session_node:
                 raise VSCodePytestError(
                     "Something went wrong following pytest finish, \


### PR DESCRIPTION
If a user defines a tree in the pytest session, then it overwrites the default built tree: Allows a plugin to overwrite the default test hierarchy