### PR TITLE
Fix execInREPL Enter to respect complete expression

### DIFF
--- a/src/client/repl/pythonServer.ts
+++ b/src/client/repl/pythonServer.ts
@@ -75,8 +75,8 @@ class PythonServerImpl implements Disposable {
     }
 
     public async checkValidCommand(code: string): Promise<boolean> {
-        const completeCode = await this.connection.sendRequest('check_valid_command', code);
-        if (completeCode === 'True') {
+        const completeCode: ExecutionResult = await this.connection.sendRequest('check_valid_command', code);
+        if (completeCode.output === 'True') {
             return new Promise((resolve) => resolve(true));
         }
         return new Promise((resolve) => resolve(false));


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-python/issues/23934
Updating to check filed of object, since structure/type has changed when I refactored code for native REPL.