### PR TITLE
Do not truncate whitespace for multi-line string

### DIFF
--- a/python_files/normalizeSelection.py
+++ b/python_files/normalizeSelection.py
@@ -30,16 +30,6 @@ def _get_statements(selection):
         yield selection
         return
 
-    # Check if the selection is a multiline string
-    try:
-        # Attempt to parse the selection as a string literal
-        literal = ast.literal_eval(selection)
-        if isinstance(literal, str):
-            yield selection
-            return
-    except (ValueError, SyntaxError):
-        pass
-
     # Remove blank lines within the selection to prevent the REPL from thinking the block is finished.
     lines = (line for line in split_lines(selection) if line.strip() != "")
 

--- a/python_files/normalizeSelection.py
+++ b/python_files/normalizeSelection.py
@@ -26,6 +26,20 @@ def _get_statements(selection):
     This will remove empty newlines around and within the selection, dedent it,
     and split it using the result of `ast.parse()`.
     """
+    if '"""' in selection or "'''" in selection:
+        yield selection
+        return
+
+    # Check if the selection is a multiline string
+    try:
+        # Attempt to parse the selection as a string literal
+        literal = ast.literal_eval(selection)
+        if isinstance(literal, str):
+            yield selection
+            return
+    except (ValueError, SyntaxError):
+        pass
+
     # Remove blank lines within the selection to prevent the REPL from thinking the block is finished.
     lines = (line for line in split_lines(selection) if line.strip() != "")
 

--- a/src/test/python_files/terminalExec/sample2_normalized.py
+++ b/src/test/python_files/terminalExec/sample2_normalized.py
@@ -1,12 +1,5 @@
 def add(x, y):
-    """
-
-    Adds x
-    to
-    y
-
-
-    """
+    """Adds x to y"""
     # Some comment
     return x + y
 

--- a/src/test/python_files/terminalExec/sample2_normalized.py
+++ b/src/test/python_files/terminalExec/sample2_normalized.py
@@ -1,8 +1,11 @@
 def add(x, y):
     """
+
     Adds x
     to
     y
+
+
     """
     # Some comment
 

--- a/src/test/python_files/terminalExec/sample2_normalized.py
+++ b/src/test/python_files/terminalExec/sample2_normalized.py
@@ -1,7 +1,13 @@
 def add(x, y):
-    """Adds x to y"""
+    """
+    Adds x
+    to
+    y
+    """
     # Some comment
+
     return x + y
+
 
 v = add(1, 7)
 print(v)

--- a/src/test/python_files/terminalExec/sample2_normalized.py
+++ b/src/test/python_files/terminalExec/sample2_normalized.py
@@ -8,7 +8,6 @@ def add(x, y):
 
     """
     # Some comment
-
     return x + y
 
 

--- a/src/test/python_files/terminalExec/sample2_normalized.py
+++ b/src/test/python_files/terminalExec/sample2_normalized.py
@@ -10,6 +10,5 @@ def add(x, y):
     # Some comment
     return x + y
 
-
 v = add(1, 7)
 print(v)

--- a/src/test/python_files/terminalExec/sample2_normalized_selection.py
+++ b/src/test/python_files/terminalExec/sample2_normalized_selection.py
@@ -1,5 +1,12 @@
 def add(x, y):
-    """Adds x to y"""
+    """
+
+    Adds x
+    to
+    y
+
+
+    """
     # Some comment
     return x + y
 

--- a/src/test/python_files/terminalExec/sample2_normalized_selection.py
+++ b/src/test/python_files/terminalExec/sample2_normalized_selection.py
@@ -12,3 +12,4 @@ def add(x, y):
 
 v = add(1, 7)
 print(v)
+

--- a/src/test/python_files/terminalExec/sample2_raw.py
+++ b/src/test/python_files/terminalExec/sample2_raw.py
@@ -1,8 +1,11 @@
 def add(x, y):
     """
+
     Adds x
     to
     y
+
+
     """
     # Some comment
 

--- a/src/test/python_files/terminalExec/sample2_raw.py
+++ b/src/test/python_files/terminalExec/sample2_raw.py
@@ -8,7 +8,6 @@ def add(x, y):
 
     """
     # Some comment
-
     return x + y
 
 

--- a/src/test/python_files/terminalExec/sample2_raw.py
+++ b/src/test/python_files/terminalExec/sample2_raw.py
@@ -10,6 +10,5 @@ def add(x, y):
     # Some comment
     return x + y
 
-
 v = add(1, 7)
 print(v)

--- a/src/test/python_files/terminalExec/sample2_raw.py
+++ b/src/test/python_files/terminalExec/sample2_raw.py
@@ -1,8 +1,13 @@
 def add(x, y):
-    """Adds x to y"""
+    """
+    Adds x
+    to
+    y
+    """
     # Some comment
-    
+
     return x + y
+
 
 v = add(1, 7)
 print(v)


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-python/issues/23743

It seems that when people have a multi line string such surrounded by """ quotes, the white spacing inside the quote is very much intentional, and so if we detect that they are in such code-block, we would rather not normalize/truncate the white spaces for that specific code block.