### PR TITLE
Revert "Do not truncate whitespace for multi-line string" (#24096)

### DIFF
--- a/python_files/normalizeSelection.py
+++ b/python_files/normalizeSelection.py
@@ -26,10 +26,6 @@ def _get_statements(selection):
     This will remove empty newlines around and within the selection, dedent it,
     and split it using the result of `ast.parse()`.
     """
-    if '"""' in selection or "'''" in selection:
-        yield selection
-        return
-
     # Remove blank lines within the selection to prevent the REPL from thinking the block is finished.
     lines = (line for line in split_lines(selection) if line.strip() != "")
 

--- a/src/test/python_files/terminalExec/sample2_normalized_selection.py
+++ b/src/test/python_files/terminalExec/sample2_normalized_selection.py
@@ -1,15 +1,7 @@
 def add(x, y):
-    """
-
-    Adds x
-    to
-    y
-
-
-    """
+    """Adds x to y"""
     # Some comment
     return x + y
 
 v = add(1, 7)
 print(v)
-

--- a/src/test/python_files/terminalExec/sample2_raw.py
+++ b/src/test/python_files/terminalExec/sample2_raw.py
@@ -1,13 +1,7 @@
 def add(x, y):
-    """
-
-    Adds x
-    to
-    y
-
-
-    """
+    """Adds x to y"""
     # Some comment
+    
     return x + y
 
 v = add(1, 7)


### PR DESCRIPTION
Reverts microsoft/vscode-python#23977

Have to revert https://github.com/microsoft/vscode-python/pull/23977 with issue: https://github.com/microsoft/vscode-python/issues/23743 due to https://github.com/microsoft/vscode-python/issues/24069

Will revisit why https://github.com/microsoft/vscode-python/issues/23743 is breaking if contained inside other top level (in ast term) code block, and look into how to support
https://github.com/microsoft/vscode-python/issues/23743 without breaking.