### PR TITLE
Handle when onDidEndTerminalShellExecution never fires

### DIFF
--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -105,25 +105,11 @@ export class TerminalService implements ITerminalService, Disposable {
          * Shell integration in zsh works, but not python
          *
          * 1. TODO: executeCommand never actually runs the command because the `python` command never finishes
-         * 2. onDidEndTerminalShellExecution never fires because because the `python` command never finishes
+         * 2. onDidEndTerminalShellExecution never fires because because the `python` command never finishes --> complete
          */
 
         if (terminal.shellIntegration) {
-            // TODO: Test myself for windows
-            const execution = terminal.shellIntegration.executeCommand(commandLine); // create return object, on that object it has a promise to executed command
-
-            // Before
-            // return await new Promise((resolve) => {
-            //     const listener = this.terminalManager.onDidEndTerminalShellExecution((e) => {
-            //         if (e.execution === execution) {
-            //             this.executeCommandListeners.delete(listener);
-            //             resolve({ execution, exitCode: e.exitCode });
-            //         }
-            //     });
-            //     if (listener) {
-            //         this.executeCommandListeners.add(listener);
-            //     }
-            // });
+            const execution = terminal.shellIntegration.executeCommand(commandLine);
 
             return {
                 execution,

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -105,11 +105,13 @@ export class TerminalService implements ITerminalService, Disposable {
          * Shell integration in zsh works, but not python
          *
          * 1. TODO: executeCommand never actually runs the command because the `python` command never finishes
-         * 2. onDidEndTerminalShellExecution never fires because because the `python` command never finishes --> complete
+         * 2. onDidEndTerminalShellExecution never fires because because the `python` command never finishes --> line of defense via only promising on exitCode.
          */
 
         if (terminal.shellIntegration) {
             const execution = terminal.shellIntegration.executeCommand(commandLine);
+
+            // To cover case #1, could we take any hint from execution (TerminalShellExecution) to know if executeCommand actually ran/sent anything?
 
             return {
                 execution,

--- a/src/client/common/terminal/types.ts
+++ b/src/client/common/terminal/types.ts
@@ -60,7 +60,7 @@ export interface ITerminalService extends IDisposable {
 
 export interface ITerminalExecutedCommand {
     execution: TerminalShellExecution;
-    exitCode: number | undefined;
+    exitCode: Promise<number | undefined>;
 }
 
 export const ITerminalServiceFactory = Symbol('ITerminalServiceFactory');


### PR DESCRIPTION
Related: https://github.com/microsoft/vscode-python/pull/24078
We should rather have exitCode as a promise instead of the entire object as a promise for case: 
- onDidEndTerminalShellExecution never fires because because the `python` command never finishes. 
@ The case of where shell integration is enabled in zsh/pwsh in Windows but not inside Python REPL so python command won't finish until user exit()



Cases we need to handle:

@ Shell integration in zsh/pwsh works, but not python for windows

1. executeCommand never actually runs the command because the `python` command never finishes
2. onDidEndTerminalShellExecution never fires because because the `python` command never finishes

This PR takes care of the second case scenario.
        