### PR TITLE
account for inline chat widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -1161,7 +1161,7 @@
             {
                 "command": "python.execInREPLEnter",
                 "key": "enter",
-                "when": "!config.interactiveWindow.executeWithShiftEnter && activeEditor == 'workbench.editor.interactive'"
+                "when": "!config.interactiveWindow.executeWithShiftEnter && activeEditor == 'workbench.editor.interactive' && !inlineChatFocused"
             },
             {
                 "command": "python.refreshTensorBoard",


### PR DESCRIPTION
`enter` should apply to the inline chat widget if it is focused, not the parent code editor