### PR TITLE
Default PYTHONSTARTUP to opt out/off for Stable Release

### DIFF
--- a/package.json
+++ b/package.json
@@ -658,7 +658,7 @@
                     "type": "array"
                 },
                 "python.REPL.enableShellIntegration": {
-                    "default": true,
+                    "default": false,
                     "description": "%python.REPL.enableShellIntegration.description%",
                     "scope": "resource",
                     "type": "boolean"


### PR DESCRIPTION
From discussion in the original issue: https://github.com/microsoft/vscode-python/issues/23930#issuecomment-2362192346 
Making default to be false for September stable, perhaps we could turn it on to true for insiders AFTER once we ship out stable. 
/cc @Tyriar 