### PR TITLE
Remove variableProvider suite.only from limiting other tests

### DIFF
--- a/src/test/repl/variableProvider.test.ts
+++ b/src/test/repl/variableProvider.test.ts
@@ -8,7 +8,7 @@ import { IVariableDescription } from '../../client/repl/variables/types';
 import { VariablesProvider } from '../../client/repl/variables/variablesProvider';
 import { VariableRequester } from '../../client/repl/variables/variableRequester';
 
-suite.only('ReplVariablesProvider', () => {
+suite('ReplVariablesProvider', () => {
     let provider: VariablesProvider;
     let varRequester: TypeMoq.IMock<VariableRequester>;
     let notebook: TypeMoq.IMock<NotebookDocument>;


### PR DESCRIPTION
Related: 

https://github.com/microsoft/vscode-python/pull/24094/files#diff-0f06d935b3fbdcc3b6bb01c3987d454c6eb0c3cb0eebbd7c2a58456b0442c4a1R11 seems to be only limiting itself to be ran as a test and no other. 
/cc @amunger 