### PR TITLE
Change log level on pixi interpreter discovery to reduce confusion 

### DIFF
--- a/src/client/pythonEnvironments/common/environmentManagers/pixi.ts
+++ b/src/client/pythonEnvironments/common/environmentManagers/pixi.ts
@@ -273,7 +273,7 @@ export async function getPixiEnvironmentFromInterpreter(
     // Find the pixi executable for the project
     pixi = pixi || (await Pixi.getPixi());
     if (!pixi) {
-        traceWarn(`could not find a pixi interpreter for the interpreter at ${interpreterPath}`);
+        traceVerbose(`could not find a pixi interpreter for the interpreter at ${interpreterPath}`);
         return undefined;
     }
 


### PR DESCRIPTION
Reference: https://github.com/microsoft/vscode-python/issues/23773 and https://github.com/microsoft/vscode-python/issues/23773#issuecomment-2364779903 

It seems that pixi warnings may be confusing unnecessary confusion among folks who may not even intend to use pixi environment. Changing log level for clarity and further help diagnosing problems that may be unrelated to pixi. 