### PR TITLE
Remove branch coverage and refactor coverage.py methods for accessing

### DIFF
--- a/python_files/tests/pytestadapter/test_coverage.py
+++ b/python_files/tests/pytestadapter/test_coverage.py
@@ -42,9 +42,3 @@ def test_simple_pytest_coverage():
     assert focal_function_coverage.get("lines_missed") is not None
     assert set(focal_function_coverage.get("lines_covered")) == {4, 5, 7, 9, 10, 11, 12, 13, 14, 17}
     assert set(focal_function_coverage.get("lines_missed")) == {18, 19, 6}
-    assert (
-        focal_function_coverage.get("executed_branches") > 0
-    ), "executed_branches are a number greater than 0."
-    assert (
-        focal_function_coverage.get("total_branches") > 0
-    ), "total_branches are a number greater than 0."

--- a/python_files/tests/unittestadapter/test_coverage.py
+++ b/python_files/tests/unittestadapter/test_coverage.py
@@ -49,9 +49,3 @@ def test_basic_coverage():
     assert focal_function_coverage.get("lines_missed") is not None
     assert set(focal_function_coverage.get("lines_covered")) == {4, 5, 7, 9, 10, 11, 12, 13, 14}
     assert set(focal_function_coverage.get("lines_missed")) == {6}
-    assert (
-        focal_function_coverage.get("executed_branches") > 0
-    ), "executed_branches are a number greater than 0."
-    assert (
-        focal_function_coverage.get("total_branches") > 0
-    ), "total_branches are a number greater than 0."

--- a/python_files/unittestadapter/execution.py
+++ b/python_files/unittestadapter/execution.py
@@ -383,7 +383,7 @@ if __name__ == "__main__":
         cov.save()
         cov.load()
         file_set: Set[str] = cov.get_data().measured_files()
-        file_coverage_map: dict[str, FileCoverageInfo] = {}
+        file_coverage_map: Dict[str, FileCoverageInfo] = {}
         for file in file_set:
             analysis = cov.analysis2(file)
             lines_executable = {int(line_no) for line_no in analysis[1]}

--- a/python_files/unittestadapter/execution.py
+++ b/python_files/unittestadapter/execution.py
@@ -10,7 +10,7 @@ import sysconfig
 import traceback
 import unittest
 from types import TracebackType
-from typing import Dict, List, Optional, Tuple, Type, Union
+from typing import Dict, List, Optional, Set, Tuple, Type, Union
 
 # Adds the scripts directory to the PATH as a workaround for enabling shell for test execution.
 path_var_name = "PATH" if "PATH" in os.environ else "Path"
@@ -382,7 +382,7 @@ if __name__ == "__main__":
         cov.stop()
         cov.save()
         cov.load()
-        file_set: set[str] = cov.get_data().measured_files()
+        file_set: Set[str] = cov.get_data().measured_files()
         file_coverage_map: dict[str, FileCoverageInfo] = {}
         for file in file_set:
             analysis = cov.analysis2(file)

--- a/python_files/unittestadapter/execution.py
+++ b/python_files/unittestadapter/execution.py
@@ -10,7 +10,7 @@ import sysconfig
 import traceback
 import unittest
 from types import TracebackType
-from typing import Dict, Iterator, List, Optional, Tuple, Type, Union
+from typing import Dict, List, Optional, Tuple, Type, Union
 
 # Adds the scripts directory to the PATH as a workaround for enabling shell for test execution.
 path_var_name = "PATH" if "PATH" in os.environ else "Path"
@@ -375,31 +375,26 @@ if __name__ == "__main__":
         )
 
     if is_coverage_run:
-        from coverage.plugin import FileReporter
-        from coverage.report_core import get_analysis_to_report
-        from coverage.results import Analysis
+        import coverage
 
         if not cov:
             raise VSCodeUnittestError("Coverage is enabled but cov is not set")
         cov.stop()
         cov.save()
-        analysis_iterator: Iterator[Tuple[FileReporter, Analysis]] = get_analysis_to_report(
-            cov, None
-        )
-
-        file_coverage_map: Dict[str, FileCoverageInfo] = {}
-        for fr, analysis in analysis_iterator:
-            file_str: str = fr.filename
-            executed_branches = analysis.numbers.n_executed_branches
-            total_branches = analysis.numbers.n_branches
-
+        cov.load()
+        file_set: set[str] = cov.get_data().measured_files()
+        file_coverage_map: dict[str, FileCoverageInfo] = {}
+        for file in file_set:
+            analysis = cov.analysis2(file)
+            lines_executable = {int(line_no) for line_no in analysis[1]}
+            lines_missed = {int(line_no) for line_no in analysis[3]}
+            lines_covered = lines_executable - lines_missed
             file_info: FileCoverageInfo = {
-                "lines_covered": list(analysis.executed),  # set
-                "lines_missed": list(analysis.missing),  # set
-                "executed_branches": executed_branches,  # int
-                "total_branches": total_branches,  # int
+                "lines_covered": list(lines_covered),  # list of int
+                "lines_missed": list(lines_missed),  # list of int
             }
-            file_coverage_map[file_str] = file_info
+            file_coverage_map[file] = file_info
+
         payload_cov: CoveragePayloadDict = CoveragePayloadDict(
             coverage=True,
             cwd=os.fspath(cwd),

--- a/python_files/unittestadapter/pvsc_utils.py
+++ b/python_files/unittestadapter/pvsc_utils.py
@@ -84,8 +84,6 @@ class EOTPayloadDict(TypedDict):
 class FileCoverageInfo(TypedDict):
     lines_covered: List[int]
     lines_missed: List[int]
-    executed_branches: int
-    total_branches: int
 
 
 class CoveragePayloadDict(Dict):

--- a/python_files/vscode_pytest/run_pytest_script.py
+++ b/python_files/vscode_pytest/run_pytest_script.py
@@ -45,8 +45,7 @@ if __name__ == "__main__":
                 coverage_enabled = True
                 break
         if not coverage_enabled:
-            print("Coverage is enabled, adding branch coverage as an argument.")
-            args = [*args, "--cov=.", "--cov-branch"]
+            args = [*args, "--cov=."]
 
     run_test_ids_pipe = os.environ.get("RUN_TEST_IDS_PIPE")
     if run_test_ids_pipe:

--- a/src/client/testing/testController/common/resultResolver.ts
+++ b/src/client/testing/testController/common/resultResolver.ts
@@ -133,11 +133,6 @@ export class PythonResultResolver implements ITestResultResolver {
         } else {
             this._resolveExecution(payload as ExecutionTestPayload, runInstance);
         }
-        if ('coverage' in payload) {
-            // coverage data is sent once per connection
-            traceVerbose('Coverage data received.');
-            this._resolveCoverage(payload as CoveragePayload, runInstance);
-        }
     }
 
     public _resolveCoverage(payload: CoveragePayload, runInstance: TestRun): void {
@@ -180,7 +175,7 @@ export class PythonResultResolver implements ITestResultResolver {
                 detailedCoverageArray.push(statementCoverage);
             }
 
-            this.detailedCoverageMap.set(fileNameStr, detailedCoverageArray);
+            this.detailedCoverageMap.set(uri.fsPath, detailedCoverageArray);
         }
     }
 

--- a/src/client/testing/testController/common/resultResolver.ts
+++ b/src/client/testing/testController/common/resultResolver.ts
@@ -149,22 +149,13 @@ export class PythonResultResolver implements ITestResultResolver {
             const fileCoverageMetrics = value;
             const linesCovered = fileCoverageMetrics.lines_covered ? fileCoverageMetrics.lines_covered : []; // undefined if no lines covered
             const linesMissed = fileCoverageMetrics.lines_missed ? fileCoverageMetrics.lines_missed : []; // undefined if no lines missed
-            const executedBranches = fileCoverageMetrics.executed_branches;
-            const totalBranches = fileCoverageMetrics.total_branches;
 
             const lineCoverageCount = new TestCoverageCount(
                 linesCovered.length,
                 linesCovered.length + linesMissed.length,
             );
             const uri = Uri.file(fileNameStr);
-            let fileCoverage: FileCoverage;
-            if (totalBranches === -1) {
-                // branch coverage was not enabled and should not be displayed
-                fileCoverage = new FileCoverage(uri, lineCoverageCount);
-            } else {
-                const branchCoverageCount = new TestCoverageCount(executedBranches, totalBranches);
-                fileCoverage = new FileCoverage(uri, lineCoverageCount, branchCoverageCount);
-            }
+            const fileCoverage = new FileCoverage(uri, lineCoverageCount);
             runInstance.addCoverage(fileCoverage);
 
             // create detailed coverage array for each file (only line coverage on detailed, not branch)

--- a/src/client/testing/testController/common/types.ts
+++ b/src/client/testing/testController/common/types.ts
@@ -279,10 +279,6 @@ export type FileCoverageMetrics = {
     lines_covered: number[];
     // eslint-disable-next-line camelcase
     lines_missed: number[];
-    // eslint-disable-next-line camelcase
-    executed_branches: number;
-    // eslint-disable-next-line camelcase
-    total_branches: number;
 };
 
 export type ExecutionTestPayload = {

--- a/src/test/testing/common/testingAdapter.test.ts
+++ b/src/test/testing/common/testingAdapter.test.ts
@@ -768,8 +768,6 @@ suite('End to End Tests: test adapters', () => {
             // since only one test was run, the other test in the same file will have missed coverage lines
             assert.strictEqual(simpleFileCov.lines_covered.length, 3, 'Expected 1 line to be covered in even.py');
             assert.strictEqual(simpleFileCov.lines_missed.length, 1, 'Expected 3 lines to be missed in even.py');
-            assert.strictEqual(simpleFileCov.executed_branches, 1, 'Expected 3 lines to be missed in even.py');
-            assert.strictEqual(simpleFileCov.total_branches, 2, 'Expected 3 lines to be missed in even.py');
             return Promise.resolve();
         };
 
@@ -823,8 +821,6 @@ suite('End to End Tests: test adapters', () => {
             // since only one test was run, the other test in the same file will have missed coverage lines
             assert.strictEqual(simpleFileCov.lines_covered.length, 3, 'Expected 1 line to be covered in even.py');
             assert.strictEqual(simpleFileCov.lines_missed.length, 1, 'Expected 3 lines to be missed in even.py');
-            assert.strictEqual(simpleFileCov.executed_branches, 1, 'Expected 3 lines to be missed in even.py');
-            assert.strictEqual(simpleFileCov.total_branches, 2, 'Expected 3 lines to be missed in even.py');
 
             return Promise.resolve();
         };


### PR DESCRIPTION
Removing branch coverage from the payload as the initial way it was being discovered / added was not documented / in the coverage.py API and therefore is not guaranteed to be stable. Removing for now with plans to add upstream and re-include in the extension here

coverage PR: https://github.com/microsoft/vscode-python/pull/24118