### PR TITLE
Fix) Python Shell Integration setting should have markdown description

### DIFF
--- a/package.json
+++ b/package.json
@@ -660,7 +660,7 @@
                 },
                 "python.terminal.shellIntegration.enabled": {
                     "default": false,
-                    "description": "%python.terminal.shellIntegration.enabled.description%",
+                    "markdownDescription": "%python.terminal.shellIntegration.enabled.description%",
                     "scope": "resource",
                     "type": "boolean",
                     "tags": [


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-python/issues/24186 
Related: https://github.com/microsoft/vscode-python/issues/23930