### PR TITLE
remove EOT from testing communication

### DIFF
--- a/python_files/tests/pytestadapter/helpers.py
+++ b/python_files/tests/pytestadapter/helpers.py
@@ -85,9 +85,6 @@ def process_data_received(data: str) -> List[Dict[str, Any]]:
         else:
             json_messages.append(json_data["params"])
 
-    last_json = json_messages.pop(-1)
-    if "eot" not in last_json:
-        raise ValueError("Last JSON messages does not contain 'eot' as its last payload.")
     return json_messages  # return the list of json messages, only the params part without the EOT token
 
 

--- a/python_files/tests/pytestadapter/helpers.py
+++ b/python_files/tests/pytestadapter/helpers.py
@@ -71,7 +71,6 @@ def process_data_received(data: str) -> List[Dict[str, Any]]:
 
     This function also:
     - Checks that the jsonrpc value is 2.0
-    - Checks that the last JSON message contains the `eot` token.
     """
     json_messages = []
     remaining = data
@@ -85,7 +84,7 @@ def process_data_received(data: str) -> List[Dict[str, Any]]:
         else:
             json_messages.append(json_data["params"])
 
-    return json_messages  # return the list of json messages, only the params part without the EOT token
+    return json_messages  # return the list of json messages
 
 
 def parse_rpc_message(data: str) -> Tuple[Dict[str, str], str]:
@@ -93,7 +92,6 @@ def parse_rpc_message(data: str) -> Tuple[Dict[str, str], str]:
 
     A single rpc payload is in the format:
     content-length: #LEN# \r\ncontent-type: application/json\r\n\r\n{"jsonrpc": "2.0", "params": ENTIRE_DATA}
-    with EOT params: "params": {"command_type": "discovery", "eot": true}
 
     returns:
     json_data: A single rpc payload of JSON data from the server.

--- a/python_files/unittestadapter/discovery.py
+++ b/python_files/unittestadapter/discovery.py
@@ -16,7 +16,6 @@ from django_handler import django_discovery_runner  # noqa: E402
 # If I use from utils then there will be an import error in test_discovery.py.
 from unittestadapter.pvsc_utils import (  # noqa: E402
     DiscoveryPayloadDict,
-    EOTPayloadDict,
     VSCodeUnittestError,
     build_test_tree,
     parse_unittest_args,
@@ -129,7 +128,6 @@ if __name__ == "__main__":
             # collect args for Django discovery runner.
             args = argv[index + 1 :] or []
             django_discovery_runner(manage_py_path, args)
-            # eot payload sent within Django runner.
         except Exception as e:
             error_msg = f"Error configuring Django test runner: {e}"
             print(error_msg, file=sys.stderr)
@@ -139,6 +137,3 @@ if __name__ == "__main__":
         payload = discover_tests(start_dir, pattern, top_level_dir)
         # Post this discovery payload.
         send_post_request(payload, test_run_pipe)
-        # Post EOT token.
-        eot_payload: EOTPayloadDict = {"command_type": "discovery", "eot": True}
-        send_post_request(eot_payload, test_run_pipe)

--- a/python_files/unittestadapter/django_test_runner.py
+++ b/python_files/unittestadapter/django_test_runner.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING  # noqa: E402
 from execution import UnittestTestResult  # noqa: E402
 from pvsc_utils import (  # noqa: E402
     DiscoveryPayloadDict,
-    EOTPayloadDict,
     VSCodeUnittestError,
     build_test_tree,
     send_post_request,
@@ -64,9 +63,6 @@ class CustomDiscoveryTestRunner(DiscoverRunner):
 
             # Send discovery payload.
             send_post_request(payload, test_run_pipe)
-            # Send EOT token.
-            eot_payload: EOTPayloadDict = {"command_type": "discovery", "eot": True}
-            send_post_request(eot_payload, test_run_pipe)
             return 0  # Skip actual test execution, return 0 as no tests were run.
         except Exception as e:
             error_msg = (

--- a/python_files/unittestadapter/execution.py
+++ b/python_files/unittestadapter/execution.py
@@ -253,16 +253,8 @@ def run_tests(
     return payload
 
 
-def execute_eot_and_cleanup():
-    if __socket:
-        __socket.close()
-
-
 __socket = None
-__atexit_registered = False
-if not __atexit_registered:
-    atexit.register(execute_eot_and_cleanup)
-    __atexit_registered = True
+atexit.register(lambda: __socket.close() if __socket else None)
 
 
 def send_run_data(raw_data, test_run_pipe):

--- a/python_files/unittestadapter/execution.py
+++ b/python_files/unittestadapter/execution.py
@@ -17,16 +17,6 @@ path_var_name = "PATH" if "PATH" in os.environ else "Path"
 os.environ[path_var_name] = (
     sysconfig.get_paths()["scripts"] + os.pathsep + os.environ[path_var_name]
 )
-sys.path.append("/Users/eleanorboyd/vscode-python/.nox/install_python_libs/lib/python3.10")
-sys.path.append("/Users/eleanorboyd/vscode-python-debugger")
-sys.path.append("/Users/eleanorboyd/vscode-python-debugger/bundled")
-sys.path.append("/Users/eleanorboyd/vscode-python-debugger/bundled/libs")
-
-import debugpy  # noqa: E402
-
-debugpy.connect(5678)
-debugpy.breakpoint()  # noqa: E702
-
 
 script_dir = pathlib.Path(__file__).parent
 sys.path.append(os.fspath(script_dir))

--- a/python_files/unittestadapter/pvsc_utils.py
+++ b/python_files/unittestadapter/pvsc_utils.py
@@ -334,7 +334,6 @@ def send_post_request(
             __writer = socket_manager.PipeManager(test_run_pipe)
             __writer.connect()
         except Exception as error:
-            print("attempting to write", payload)
             error_msg = f"Error attempting to connect to extension named pipe {test_run_pipe}[vscode-unittest]: {error}"
             __writer = None
             raise VSCodeUnittestError(error_msg) from error

--- a/python_files/unittestadapter/pvsc_utils.py
+++ b/python_files/unittestadapter/pvsc_utils.py
@@ -314,7 +314,7 @@ atexit.register(lambda: __writer.close() if __writer else None)
 
 
 def send_post_request(
-    payload: Union[ExecutionPayloadDict, DiscoveryPayloadDict, EOTPayloadDict, CoveragePayloadDict],
+    payload: Union[ExecutionPayloadDict, DiscoveryPayloadDict, CoveragePayloadDict],
     test_run_pipe: Optional[str],
 ):
     """
@@ -341,6 +341,7 @@ def send_post_request(
             __writer = socket_manager.PipeManager(test_run_pipe)
             __writer.connect()
         except Exception as error:
+            print("attempting to write", payload)
             error_msg = f"Error attempting to connect to extension named pipe {test_run_pipe}[vscode-unittest]: {error}"
             __writer = None
             raise VSCodeUnittestError(error_msg) from error

--- a/python_files/unittestadapter/pvsc_utils.py
+++ b/python_files/unittestadapter/pvsc_utils.py
@@ -74,13 +74,6 @@ class ExecutionPayloadDict(TypedDict):
     error: NotRequired[str]
 
 
-class EOTPayloadDict(TypedDict):
-    """A dictionary that is used to send a end of transmission post request to the server."""
-
-    command_type: Literal["discovery", "execution"]
-    eot: bool
-
-
 class FileCoverageInfo(TypedDict):
     lines_covered: List[int]
     lines_missed: List[int]

--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -873,7 +873,7 @@ class PathEncoder(json.JSONEncoder):
 
 
 def send_post_request(
-    payload: ExecutionPayloadDict | DiscoveryPayloadDict | EOTPayloadDict | CoveragePayloadDict,
+    payload: ExecutionPayloadDict | DiscoveryPayloadDict | CoveragePayloadDict,
     cls_encoder=None,
 ):
     """

--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -455,10 +455,6 @@ def pytest_sessionfinish(session, exitstatus):
         )
         send_post_request(payload)
 
-    command_type = "discovery" if IS_DISCOVERY else "execution"
-    payload_eot: EOTPayloadDict = {"command_type": command_type, "eot": True}
-    send_post_request(payload_eot)
-
 
 def build_test_tree(session: pytest.Session) -> TestNode:
     """Builds a tree made up of testing nodes from the pytest session.
@@ -780,13 +776,6 @@ class CoveragePayloadDict(Dict):
     cwd: str
     result: dict[str, FileCoverageInfo] | None
     error: str | None  # Currently unused need to check
-
-
-class EOTPayloadDict(TypedDict):
-    """A dictionary that is used to send a end of transmission post request to the server."""
-
-    command_type: Literal["discovery", "execution"]
-    eot: bool
 
 
 def get_node_path(node: Any) -> pathlib.Path:

--- a/src/client/testing/testController/common/resultResolver.ts
+++ b/src/client/testing/testController/common/resultResolver.ts
@@ -20,19 +20,18 @@ import * as util from 'util';
 import {
     CoveragePayload,
     DiscoveredTestPayload,
-    EOTTestPayload,
+
     ExecutionTestPayload,
     ITestResultResolver,
 } from './types';
 import { TestProvider } from '../../types';
-import { traceError, traceVerbose } from '../../../logging';
+import { traceError } from '../../../logging';
 import { Testing } from '../../../common/utils/localize';
 import { clearAllChildren, createErrorTestItem, getTestCaseNodes } from './testItemUtilities';
 import { sendTelemetryEvent } from '../../../telemetry';
 import { EventName } from '../../../telemetry/constants';
 import { splitLines } from '../../../common/stringUtils';
 import { buildErrorNodeOptions, populateTestTree, splitTestNameWithRegex } from './utils';
-import { Deferred } from '../../../common/utils/async';
 
 export class PythonResultResolver implements ITestResultResolver {
     testController: TestController;
@@ -58,14 +57,8 @@ export class PythonResultResolver implements ITestResultResolver {
         this.vsIdToRunId = new Map<string, string>();
     }
 
-    public resolveDiscovery(
-        payload: DiscoveredTestPayload | EOTTestPayload,
-        deferredTillEOT: Deferred<void>,
-        token?: CancellationToken,
-    ): void {
-        if ('eot' in payload && payload.eot === true) {
-            deferredTillEOT.resolve();
-        } else if (!payload) {
+    public resolveDiscovery(payload: DiscoveredTestPayload, token?: CancellationToken): void {
+        if (!payload) {
             // No test data is available
         } else {
             this._resolveDiscovery(payload as DiscoveredTestPayload, token);

--- a/src/client/testing/testController/common/resultResolver.ts
+++ b/src/client/testing/testController/common/resultResolver.ts
@@ -17,15 +17,9 @@ import {
     Range,
 } from 'vscode';
 import * as util from 'util';
-import {
-    CoveragePayload,
-    DiscoveredTestPayload,
-
-    ExecutionTestPayload,
-    ITestResultResolver,
-} from './types';
+import { CoveragePayload, DiscoveredTestPayload, ExecutionTestPayload, ITestResultResolver } from './types';
 import { TestProvider } from '../../types';
-import { traceError } from '../../../logging';
+import { traceError, traceVerbose } from '../../../logging';
 import { Testing } from '../../../common/utils/localize';
 import { clearAllChildren, createErrorTestItem, getTestCaseNodes } from './testItemUtilities';
 import { sendTelemetryEvent } from '../../../telemetry';
@@ -110,16 +104,8 @@ export class PythonResultResolver implements ITestResultResolver {
         });
     }
 
-    public resolveExecution(
-        payload: ExecutionTestPayload | EOTTestPayload | CoveragePayload,
-        runInstance: TestRun,
-        deferredTillEOT: Deferred<void>,
-    ): void {
-        if ('eot' in payload && payload.eot === true) {
-            // eot sent once per connection
-            traceVerbose('EOT received, resolving deferredTillServerClose');
-            deferredTillEOT.resolve();
-        } else if ('coverage' in payload) {
+    public resolveExecution(payload: ExecutionTestPayload | CoveragePayload, runInstance: TestRun): void {
+        if ('coverage' in payload) {
             // coverage data is sent once per connection
             traceVerbose('Coverage data received.');
             this._resolveCoverage(payload as CoveragePayload, runInstance);

--- a/src/client/testing/testController/common/types.ts
+++ b/src/client/testing/testController/common/types.ts
@@ -197,16 +197,8 @@ export interface ITestResultResolver {
     vsIdToRunId: Map<string, string>;
     detailedCoverageMap: Map<string, FileCoverageDetail[]>;
 
-    resolveDiscovery(
-        payload: DiscoveredTestPayload | EOTTestPayload,
-        deferredTillEOT: Deferred<void>,
-        token?: CancellationToken,
-    ): void;
-    resolveExecution(
-        payload: ExecutionTestPayload | EOTTestPayload | CoveragePayload,
-        runInstance: TestRun,
-        deferredTillEOT: Deferred<void>,
-    ): void;
+    resolveDiscovery(payload: DiscoveredTestPayload, token?: CancellationToken): void;
+    resolveExecution(payload: ExecutionTestPayload | CoveragePayload, runInstance: TestRun): void;
     _resolveDiscovery(payload: DiscoveredTestPayload, token?: CancellationToken): void;
     _resolveExecution(payload: ExecutionTestPayload, runInstance: TestRun): void;
     _resolveCoverage(payload: CoveragePayload, runInstance: TestRun): void;

--- a/src/client/testing/testController/common/types.ts
+++ b/src/client/testing/testController/common/types.ts
@@ -16,7 +16,6 @@ import {
 import { ITestDebugLauncher, TestDiscoveryOptions } from '../../common/types';
 import { IPythonExecutionFactory } from '../../../common/process/types';
 import { EnvironmentVariables } from '../../../common/variables/types';
-import { Deferred } from '../../../common/utils/async';
 
 export type TestRunInstanceOptions = TestRunOptions & {
     exclude?: readonly TestItem[];
@@ -257,11 +256,6 @@ export type DiscoveredTestPayload = {
     tests?: DiscoveredTestNode;
     status: 'success' | 'error';
     error?: string[];
-};
-
-export type EOTTestPayload = {
-    commandType: 'discovery' | 'execution';
-    eot: boolean;
 };
 
 export type CoveragePayload = {

--- a/src/client/testing/testController/pytest/pytestDiscoveryAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestDiscoveryAdapter.ts
@@ -43,8 +43,6 @@ export class PytestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
         try {
             await this.runPytestDiscovery(uri, name, executionFactory);
         } finally {
-            // await deferredTillEOT.promise;
-            traceVerbose('deferredTill EOT resolved');
             dispose();
         }
         // this is only a placeholder to handle function overloading until rewrite is finished
@@ -141,7 +139,6 @@ export class PytestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
                 );
                 this.resultResolver?.resolveDiscovery(createDiscoveryErrorPayload(code, signal, cwd));
             }
-            // deferredTillEOT is resolved when all data sent on stdout and stderr is received, close event is only called when this occurs
             // due to the sync reading of the output.
             deferredTillExecClose?.resolve();
         });

--- a/src/client/testing/testController/pytest/pytestDiscoveryAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestDiscoveryAdapter.ts
@@ -9,14 +9,13 @@ import {
     SpawnOptions,
 } from '../../../common/process/types';
 import { IConfigurationService, ITestOutputChannel } from '../../../common/types';
-import { Deferred, createDeferred } from '../../../common/utils/async';
+import { Deferred } from '../../../common/utils/async';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
 import { traceError, traceInfo, traceVerbose, traceWarn } from '../../../logging';
-import { DiscoveredTestPayload, EOTTestPayload, ITestDiscoveryAdapter, ITestResultResolver } from '../common/types';
+import { DiscoveredTestPayload, ITestDiscoveryAdapter, ITestResultResolver } from '../common/types';
 import {
     MESSAGE_ON_TESTING_OUTPUT_MOVE,
     createDiscoveryErrorPayload,
-    createEOTPayload,
     createTestingDeferred,
     fixLogLinesNoTrailing,
     startDiscoveryNamedPipe,
@@ -37,16 +36,14 @@ export class PytestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
     ) {}
 
     async discoverTests(uri: Uri, executionFactory?: IPythonExecutionFactory): Promise<DiscoveredTestPayload> {
-        const deferredTillEOT: Deferred<void> = createDeferred<void>();
-
-        const { name, dispose } = await startDiscoveryNamedPipe((data: DiscoveredTestPayload | EOTTestPayload) => {
-            this.resultResolver?.resolveDiscovery(data, deferredTillEOT);
+        const { name, dispose } = await startDiscoveryNamedPipe((data: DiscoveredTestPayload) => {
+            this.resultResolver?.resolveDiscovery(data);
         });
 
         try {
-            await this.runPytestDiscovery(uri, name, deferredTillEOT, executionFactory);
+            await this.runPytestDiscovery(uri, name, executionFactory);
         } finally {
-            await deferredTillEOT.promise;
+            // await deferredTillEOT.promise;
             traceVerbose('deferredTill EOT resolved');
             dispose();
         }
@@ -58,7 +55,6 @@ export class PytestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
     async runPytestDiscovery(
         uri: Uri,
         discoveryPipeName: string,
-        deferredTillEOT: Deferred<void>,
         executionFactory?: IPythonExecutionFactory,
     ): Promise<void> {
         const relativePathToPytest = 'python_files';
@@ -143,8 +139,7 @@ export class PytestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
                 traceError(
                     `Subprocess exited unsuccessfully with exit code ${code} and signal ${signal} on workspace ${uri.fsPath}. Creating and sending error discovery payload`,
                 );
-                this.resultResolver?.resolveDiscovery(createDiscoveryErrorPayload(code, signal, cwd), deferredTillEOT);
-                this.resultResolver?.resolveDiscovery(createEOTPayload(false), deferredTillEOT);
+                this.resultResolver?.resolveDiscovery(createDiscoveryErrorPayload(code, signal, cwd));
             }
             // deferredTillEOT is resolved when all data sent on stdout and stderr is received, close event is only called when this occurs
             // due to the sync reading of the output.

--- a/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
@@ -36,8 +36,6 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
         executionFactory?: IPythonExecutionFactory,
         debugLauncher?: ITestDebugLauncher,
     ): Promise<ExecutionTestPayload> {
-        // deferredTillEOT awaits EOT message and deferredTillServerClose awaits named pipe server close
-        // const deferredTillEOT: Deferred<void> = utils.createTestingDeferred();
         const deferredTillServerClose: Deferred<void> = utils.createTestingDeferred();
 
         // create callback to handle data received on the named pipe
@@ -54,9 +52,8 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
             runInstance?.token, // token to cancel
         );
         runInstance?.token.onCancellationRequested(() => {
-            traceInfo(`Test run cancelled, resolving 'till EOT' deferred for ${uri.fsPath}.`);
+            traceInfo(`Test run cancelled, resolving 'TillServerClose' deferred for ${uri.fsPath}.`);
             // if canceled, stop listening for results
-            // deferredTillEOT.resolve();
             serverDispose(); // this will resolve deferredTillServerClose
 
             const executionPayload: ExecutionTestPayload = {
@@ -72,7 +69,6 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                 uri,
                 testIds,
                 name,
-                // deferredTillEOT,
                 serverDispose,
                 runInstance,
                 profileKind,
@@ -80,8 +76,6 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                 debugLauncher,
             );
         } finally {
-            // wait for to send EOT
-            // await deferredTillEOT.promise;
             await deferredTillServerClose.promise;
         }
 
@@ -99,7 +93,6 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
         uri: Uri,
         testIds: string[],
         resultNamedPipeName: string,
-        // deferredTillEOT: Deferred<void>,
         serverDispose: () => void,
         runInstance?: TestRun,
         profileKind?: TestRunProfileKind,
@@ -172,7 +165,6 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                 traceInfo(`Running DEBUG pytest with arguments: ${testArgs} for workspace ${uri.fsPath} \r\n`);
                 await debugLauncher!.launchDebugger(launchOptions, () => {
                     serverDispose(); // this will resolve deferredTillServerClose
-                    // deferredTillEOT?.resolve();
                 });
             } else {
                 // deferredTillExecClose is resolved when all stdout and stderr is read
@@ -232,14 +224,12 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                             this.resultResolver?.resolveExecution(
                                 utils.createExecutionErrorPayload(code, signal, testIds, cwd),
                                 runInstance,
-                                // deferredTillEOT,
                             );
                         }
                         // this doesn't work, it instead directs us to the noop one which is defined first
                         // potentially this is due to the server already being close, if this is the case?
                         serverDispose(); // this will resolve deferredTillServerClose
                     }
-                    // deferredTillEOT is resolved when all data sent on stdout and stderr is received, close event is only called when this occurs
                     // due to the sync reading of the output.
                     deferredTillExecClose.resolve();
                 });

--- a/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
@@ -7,13 +7,7 @@ import { ChildProcess } from 'child_process';
 import { IConfigurationService, ITestOutputChannel } from '../../../common/types';
 import { Deferred } from '../../../common/utils/async';
 import { traceError, traceInfo, traceVerbose } from '../../../logging';
-import {
-    CoveragePayload,
-    EOTTestPayload,
-    ExecutionTestPayload,
-    ITestExecutionAdapter,
-    ITestResultResolver,
-} from '../common/types';
+import { ExecutionTestPayload, ITestExecutionAdapter, ITestResultResolver } from '../common/types';
 import {
     ExecutionFactoryCreateWithEnvironmentOptions,
     IPythonExecutionFactory,
@@ -43,13 +37,13 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
         debugLauncher?: ITestDebugLauncher,
     ): Promise<ExecutionTestPayload> {
         // deferredTillEOT awaits EOT message and deferredTillServerClose awaits named pipe server close
-        const deferredTillEOT: Deferred<void> = utils.createTestingDeferred();
+        // const deferredTillEOT: Deferred<void> = utils.createTestingDeferred();
         const deferredTillServerClose: Deferred<void> = utils.createTestingDeferred();
 
         // create callback to handle data received on the named pipe
-        const dataReceivedCallback = (data: ExecutionTestPayload | EOTTestPayload | CoveragePayload) => {
+        const dataReceivedCallback = (data: ExecutionTestPayload) => {
             if (runInstance && !runInstance.token.isCancellationRequested) {
-                this.resultResolver?.resolveExecution(data, runInstance, deferredTillEOT);
+                this.resultResolver?.resolveExecution(data, runInstance);
             } else {
                 traceError(`No run instance found, cannot resolve execution, for workspace ${uri.fsPath}.`);
             }
@@ -62,7 +56,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
         runInstance?.token.onCancellationRequested(() => {
             traceInfo(`Test run cancelled, resolving 'till EOT' deferred for ${uri.fsPath}.`);
             // if canceled, stop listening for results
-            deferredTillEOT.resolve();
+            // deferredTillEOT.resolve();
             serverDispose(); // this will resolve deferredTillServerClose
 
             const executionPayload: ExecutionTestPayload = {
@@ -78,7 +72,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                 uri,
                 testIds,
                 name,
-                deferredTillEOT,
+                // deferredTillEOT,
                 serverDispose,
                 runInstance,
                 profileKind,
@@ -87,7 +81,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
             );
         } finally {
             // wait for to send EOT
-            await deferredTillEOT.promise;
+            // await deferredTillEOT.promise;
             await deferredTillServerClose.promise;
         }
 
@@ -105,7 +99,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
         uri: Uri,
         testIds: string[],
         resultNamedPipeName: string,
-        deferredTillEOT: Deferred<void>,
+        // deferredTillEOT: Deferred<void>,
         serverDispose: () => void,
         runInstance?: TestRun,
         profileKind?: TestRunProfileKind,
@@ -178,7 +172,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                 traceInfo(`Running DEBUG pytest with arguments: ${testArgs} for workspace ${uri.fsPath} \r\n`);
                 await debugLauncher!.launchDebugger(launchOptions, () => {
                     serverDispose(); // this will resolve deferredTillServerClose
-                    deferredTillEOT?.resolve();
+                    // deferredTillEOT?.resolve();
                 });
             } else {
                 // deferredTillExecClose is resolved when all stdout and stderr is read
@@ -238,12 +232,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                             this.resultResolver?.resolveExecution(
                                 utils.createExecutionErrorPayload(code, signal, testIds, cwd),
                                 runInstance,
-                                deferredTillEOT,
-                            );
-                            this.resultResolver?.resolveExecution(
-                                utils.createEOTPayload(true),
-                                runInstance,
-                                deferredTillEOT,
+                                // deferredTillEOT,
                             );
                         }
                         // this doesn't work, it instead directs us to the noop one which is defined first

--- a/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
+++ b/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
@@ -26,7 +26,7 @@ import {
     fixLogLinesNoTrailing,
     startDiscoveryNamedPipe,
 } from '../common/utils';
-import { traceError, traceInfo, traceLog, traceVerbose } from '../../../logging';
+import { traceError, traceInfo, traceLog } from '../../../logging';
 
 /**
  * Wrapper class for unittest test discovery. This is where we call `runTestCommand`.

--- a/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
+++ b/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
@@ -44,8 +44,6 @@ export class UnittestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
         const { unittestArgs } = settings.testing;
         const cwd = settings.testing.cwd && settings.testing.cwd.length > 0 ? settings.testing.cwd : uri.fsPath;
 
-        // const deferredTillEOT: Deferred<void> = createDeferred<void>();
-
         const { name, dispose } = await startDiscoveryNamedPipe((data: DiscoveredTestPayload) => {
             this.resultResolver?.resolveDiscovery(data);
         });
@@ -68,8 +66,6 @@ export class UnittestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
         try {
             await this.runDiscovery(uri, options, name, cwd, executionFactory);
         } finally {
-            // await deferredTillEOT.promise;
-            traceVerbose('deferredTill EOT resolved');
             dispose();
         }
         // placeholder until after the rewrite is adopted
@@ -83,7 +79,6 @@ export class UnittestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
         options: TestCommandOptions,
         testRunPipeName: string,
         cwd: string,
-        // deferredTillEOT: Deferred<void>,
         executionFactory?: IPythonExecutionFactory,
     ): Promise<void> {
         // get and edit env vars

--- a/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
+++ b/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
@@ -12,7 +12,7 @@ import {
     TestCommandOptions,
     TestDiscoveryCommand,
 } from '../common/types';
-import { Deferred, createDeferred } from '../../../common/utils/async';
+import { createDeferred } from '../../../common/utils/async';
 import { EnvironmentVariables, IEnvironmentVariablesProvider } from '../../../common/variables/types';
 import {
     ExecutionFactoryCreateWithEnvironmentOptions,

--- a/src/client/testing/testController/unittest/testExecutionAdapter.ts
+++ b/src/client/testing/testController/unittest/testExecutionAdapter.ts
@@ -8,7 +8,6 @@ import { IConfigurationService, ITestOutputChannel } from '../../../common/types
 import { Deferred, createDeferred } from '../../../common/utils/async';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
 import {
-    EOTTestPayload,
     ExecutionTestPayload,
     ITestExecutionAdapter,
     ITestResultResolver,
@@ -49,13 +48,12 @@ export class UnittestTestExecutionAdapter implements ITestExecutionAdapter {
         debugLauncher?: ITestDebugLauncher,
     ): Promise<ExecutionTestPayload> {
         // deferredTillEOT awaits EOT message and deferredTillServerClose awaits named pipe server close
-        const deferredTillEOT: Deferred<void> = utils.createTestingDeferred();
         const deferredTillServerClose: Deferred<void> = utils.createTestingDeferred();
 
         // create callback to handle data received on the named pipe
-        const dataReceivedCallback = (data: ExecutionTestPayload | EOTTestPayload) => {
+        const dataReceivedCallback = (data: ExecutionTestPayload) => {
             if (runInstance && !runInstance.token.isCancellationRequested) {
-                this.resultResolver?.resolveExecution(data, runInstance, deferredTillEOT);
+                this.resultResolver?.resolveExecution(data, runInstance);
             } else {
                 traceError(`No run instance found, cannot resolve execution, for workspace ${uri.fsPath}.`);
             }
@@ -68,7 +66,7 @@ export class UnittestTestExecutionAdapter implements ITestExecutionAdapter {
         runInstance?.token.onCancellationRequested(() => {
             console.log(`Test run cancelled, resolving 'till EOT' deferred for ${uri.fsPath}.`);
             // if canceled, stop listening for results
-            deferredTillEOT.resolve();
+            // deferredTillEOT.resolve();
             // if canceled, close the server, resolves the deferredTillAllServerClose
             deferredTillServerClose.resolve();
             serverDispose();
@@ -78,7 +76,6 @@ export class UnittestTestExecutionAdapter implements ITestExecutionAdapter {
                 uri,
                 testIds,
                 resultNamedPipeName,
-                deferredTillEOT,
                 serverDispose,
                 runInstance,
                 profileKind,
@@ -89,7 +86,7 @@ export class UnittestTestExecutionAdapter implements ITestExecutionAdapter {
             traceError(`Error in running unittest tests: ${error}`);
         } finally {
             // wait for EOT
-            await deferredTillEOT.promise;
+            // await deferredTillEOT.promise;
             await deferredTillServerClose.promise;
         }
         const executionPayload: ExecutionTestPayload = {
@@ -104,7 +101,7 @@ export class UnittestTestExecutionAdapter implements ITestExecutionAdapter {
         uri: Uri,
         testIds: string[],
         resultNamedPipeName: string,
-        deferredTillEOT: Deferred<void>,
+        // deferredTillEOT: Deferred<void>,
         serverDispose: () => void,
         runInstance?: TestRun,
         profileKind?: TestRunProfileKind,
@@ -181,7 +178,7 @@ export class UnittestTestExecutionAdapter implements ITestExecutionAdapter {
                 }
                 await debugLauncher.launchDebugger(launchOptions, () => {
                     serverDispose(); // this will resolve the deferredTillAllServerClose
-                    deferredTillEOT?.resolve();
+                    // deferredTillEOT?.resolve();
                 });
             } else {
                 // This means it is running the test
@@ -232,12 +229,6 @@ export class UnittestTestExecutionAdapter implements ITestExecutionAdapter {
                             this.resultResolver?.resolveExecution(
                                 utils.createExecutionErrorPayload(code, signal, testIds, cwd),
                                 runInstance,
-                                deferredTillEOT,
-                            );
-                            this.resultResolver?.resolveExecution(
-                                utils.createEOTPayload(true),
-                                runInstance,
-                                deferredTillEOT,
                             );
                         }
                         serverDispose();

--- a/src/test/testing/testController/payloadTestCases.ts
+++ b/src/test/testing/testController/payloadTestCases.ts
@@ -3,12 +3,6 @@ export interface DataWithPayloadChunks {
     data: string;
 }
 
-const EOT_PAYLOAD = `Content-Length: 42
-Content-Type: application/json
-Request-uuid: fake-u-u-i-d
-
-{"command_type": "execution", "eot": true}`;
-
 const SINGLE_UNITTEST_SUBTEST = {
     cwd: '/home/runner/work/vscode-python/vscode-python/path with spaces/src/testTestingRootWkspc/largeWorkspace',
     status: 'success',
@@ -84,7 +78,7 @@ export function PAYLOAD_SINGLE_CHUNK(uuid: string): DataWithPayloadChunks {
     const payload = createPayload(uuid, SINGLE_UNITTEST_SUBTEST);
 
     return {
-        payloadArray: [payload, EOT_PAYLOAD],
+        payloadArray: [payload],
         data: JSON.stringify(SINGLE_UNITTEST_SUBTEST.result),
     };
 }
@@ -99,7 +93,7 @@ export function PAYLOAD_MULTI_CHUNK(uuid: string): DataWithPayloadChunks {
         result += JSON.stringify(SINGLE_UNITTEST_SUBTEST.result);
     }
     return {
-        payloadArray: [payload, EOT_PAYLOAD],
+        payloadArray: [payload],
         data: result,
     };
 }
@@ -116,7 +110,6 @@ export function PAYLOAD_ONLY_HEADER_MULTI_CHUNK(uuid: string): DataWithPayloadCh
     const payload2 = val.substring(firstSpaceIndex);
     payloadArray.push(payload1);
     payloadArray.push(payload2);
-    payloadArray.push(EOT_PAYLOAD);
     return {
         payloadArray,
         data: result,
@@ -128,7 +121,6 @@ export function PAYLOAD_SPLIT_ACROSS_CHUNKS_ARRAY(uuid: string): DataWithPayload
     const payload = createPayload(uuid, SINGLE_PYTEST_PAYLOAD);
     const splitPayload = splitIntoRandomSubstrings(payload);
     const finalResult = JSON.stringify(SINGLE_PYTEST_PAYLOAD.result);
-    splitPayload.push(EOT_PAYLOAD);
     return {
         payloadArray: splitPayload,
         data: finalResult,
@@ -143,7 +135,6 @@ export function PAYLOAD_SPLIT_MULTI_CHUNK_ARRAY(uuid: string): DataWithPayloadCh
         JSON.stringify(SINGLE_PYTEST_PAYLOAD_TWO.result),
     );
 
-    splitPayload.push(EOT_PAYLOAD);
     return {
         payloadArray: splitPayload,
         data: finalResult,

--- a/src/test/testing/testController/pytest/pytestExecutionAdapter.unit.test.ts
+++ b/src/test/testing/testController/pytest/pytestExecutionAdapter.unit.test.ts
@@ -243,14 +243,15 @@ suite('pytest test execution adapter', () => {
     });
     test('Debug launched correctly for pytest', async () => {
         const deferred3 = createDeferred();
-        utilsWriteTestIdsFileStub.callsFake(() => {
-            deferred3.resolve();
-            return Promise.resolve('testIdPipe-mockName');
-        });
+        utilsWriteTestIdsFileStub.callsFake(() => Promise.resolve('testIdPipe-mockName'));
         debugLauncher
             .setup((dl) => dl.launchDebugger(typeMoq.It.isAny(), typeMoq.It.isAny()))
-            .returns(async () => {
+            .returns(async (_opts, callback) => {
                 traceInfo('stubs launch debugger');
+                if (typeof callback === 'function') {
+                    deferred3.resolve();
+                    callback();
+                }
             });
         const testRun = typeMoq.Mock.ofType<TestRun>();
         testRun
@@ -264,14 +265,7 @@ suite('pytest test execution adapter', () => {
         const uri = Uri.file(myTestPath);
         const outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
         adapter = new PytestTestExecutionAdapter(configService, outputChannel.object);
-        await adapter.runTests(
-            uri,
-            [],
-            TestRunProfileKind.Debug,
-            testRun.object,
-            execFactory.object,
-            debugLauncher.object,
-        );
+        adapter.runTests(uri, [], TestRunProfileKind.Debug, testRun.object, execFactory.object, debugLauncher.object);
         await deferred3.promise;
         debugLauncher.verify(
             (x) =>

--- a/src/test/testing/testController/pytest/pytestExecutionAdapter.unit.test.ts
+++ b/src/test/testing/testController/pytest/pytestExecutionAdapter.unit.test.ts
@@ -243,7 +243,6 @@ suite('pytest test execution adapter', () => {
     });
     test('Debug launched correctly for pytest', async () => {
         const deferred3 = createDeferred();
-        const deferredEOT = createDeferred();
         utilsWriteTestIdsFileStub.callsFake(() => {
             deferred3.resolve();
             return Promise.resolve('testIdPipe-mockName');
@@ -252,10 +251,7 @@ suite('pytest test execution adapter', () => {
             .setup((dl) => dl.launchDebugger(typeMoq.It.isAny(), typeMoq.It.isAny()))
             .returns(async () => {
                 traceInfo('stubs launch debugger');
-                deferredEOT.resolve();
             });
-        const utilsCreateEOTStub: sinon.SinonStub = sinon.stub(util, 'createTestingDeferred');
-        utilsCreateEOTStub.callsFake(() => deferredEOT);
         const testRun = typeMoq.Mock.ofType<TestRun>();
         testRun
             .setup((t) => t.token)

--- a/src/test/testing/testController/resultResolver.unit.test.ts
+++ b/src/test/testing/testController/resultResolver.unit.test.ts
@@ -14,7 +14,6 @@ import {
 import * as testItemUtilities from '../../../client/testing/testController/common/testItemUtilities';
 import * as ResultResolver from '../../../client/testing/testController/common/resultResolver';
 import * as util from '../../../client/testing/testController/common/utils';
-import { Deferred, createDeferred } from '../../../client/common/utils/async';
 import { traceLog } from '../../../client/logging';
 
 suite('Result Resolver tests', () => {
@@ -89,8 +88,7 @@ suite('Result Resolver tests', () => {
             const populateTestTreeStub = sinon.stub(util, 'populateTestTree').returns();
 
             // call resolve discovery
-            const deferredTillEOT: Deferred<void> = createDeferred<void>();
-            resultResolver.resolveDiscovery(payload, deferredTillEOT, cancelationToken);
+            resultResolver.resolveDiscovery(payload, cancelationToken);
 
             // assert the stub functions were called with the correct parameters
 
@@ -129,8 +127,7 @@ suite('Result Resolver tests', () => {
             const createErrorTestItemStub = sinon.stub(testItemUtilities, 'createErrorTestItem').returns(blankTestItem);
 
             // call resolve discovery
-            const deferredTillEOT: Deferred<void> = createDeferred<void>();
-            resultResolver.resolveDiscovery(payload, deferredTillEOT, cancelationToken);
+            resultResolver.resolveDiscovery(payload, cancelationToken);
 
             // assert the stub functions were called with the correct parameters
 
@@ -175,8 +172,7 @@ suite('Result Resolver tests', () => {
             // stub out functionality of populateTestTreeStub which is called in resolveDiscovery
             const populateTestTreeStub = sinon.stub(util, 'populateTestTree').returns();
             // call resolve discovery
-            const deferredTillEOT: Deferred<void> = createDeferred<void>();
-            resultResolver.resolveDiscovery(payload, deferredTillEOT, cancelationToken);
+            resultResolver.resolveDiscovery(payload, cancelationToken);
 
             // assert the stub functions were called with the correct parameters
 
@@ -239,10 +235,8 @@ suite('Result Resolver tests', () => {
             const deleteSpy = sinon.spy(testController.items, 'delete');
             const replaceSpy = sinon.spy(testController.items, 'replace');
             // call resolve discovery
-            let deferredTillEOT: Deferred<void> = createDeferred<void>();
-            resultResolver.resolveDiscovery(regPayload, deferredTillEOT, cancelationToken);
-            deferredTillEOT = createDeferred<void>();
-            resultResolver.resolveDiscovery(errorPayload, deferredTillEOT, cancelationToken);
+            resultResolver.resolveDiscovery(regPayload, cancelationToken);
+            resultResolver.resolveDiscovery(errorPayload, cancelationToken);
 
             // assert the stub functions were called with the correct parameters
 
@@ -375,8 +369,7 @@ suite('Result Resolver tests', () => {
             };
 
             // call resolveExecution
-            const deferredTillEOT: Deferred<void> = createDeferred<void>();
-            resultResolver.resolveExecution(successPayload, runInstance.object, deferredTillEOT);
+            resultResolver.resolveExecution(successPayload, runInstance.object);
 
             // verify that the passed function was called for the single test item
             assert.ok(generatedId);
@@ -416,8 +409,7 @@ suite('Result Resolver tests', () => {
             };
 
             // call resolveExecution
-            const deferredTillEOT: Deferred<void> = createDeferred<void>();
-            resultResolver.resolveExecution(successPayload, runInstance.object, deferredTillEOT);
+            resultResolver.resolveExecution(successPayload, runInstance.object);
 
             // verify that the passed function was called for the single test item
             runInstance.verify((r) => r.failed(typemoq.It.isAny(), typemoq.It.isAny()), typemoq.Times.once());
@@ -456,8 +448,7 @@ suite('Result Resolver tests', () => {
             };
 
             // call resolveExecution
-            const deferredTillEOT: Deferred<void> = createDeferred<void>();
-            resultResolver.resolveExecution(successPayload, runInstance.object, deferredTillEOT);
+            resultResolver.resolveExecution(successPayload, runInstance.object);
 
             // verify that the passed function was called for the single test item
             runInstance.verify((r) => r.skipped(typemoq.It.isAny()), typemoq.Times.once());
@@ -496,8 +487,7 @@ suite('Result Resolver tests', () => {
             };
 
             // call resolveExecution
-            const deferredTillEOT: Deferred<void> = createDeferred<void>();
-            resultResolver.resolveExecution(successPayload, runInstance.object, deferredTillEOT);
+            resultResolver.resolveExecution(successPayload, runInstance.object);
 
             // verify that the passed function was called for the single test item
             runInstance.verify((r) => r.errored(typemoq.It.isAny(), typemoq.It.isAny()), typemoq.Times.once());
@@ -536,8 +526,7 @@ suite('Result Resolver tests', () => {
             };
 
             // call resolveExecution
-            const deferredTillEOT: Deferred<void> = createDeferred<void>();
-            resultResolver.resolveExecution(successPayload, runInstance.object, deferredTillEOT);
+            resultResolver.resolveExecution(successPayload, runInstance.object);
 
             // verify that the passed function was called for the single test item
             runInstance.verify((r) => r.passed(typemoq.It.isAny()), typemoq.Times.once());
@@ -558,8 +547,7 @@ suite('Result Resolver tests', () => {
                 error: 'error',
             };
 
-            const deferredTillEOT: Deferred<void> = createDeferred<void>();
-            resultResolver.resolveExecution(errorPayload, runInstance.object, deferredTillEOT);
+            resultResolver.resolveExecution(errorPayload, runInstance.object);
 
             // verify that none of these functions are called
 

--- a/src/test/testing/testController/testCancellationRunAdapters.unit.test.ts
+++ b/src/test/testing/testController/testCancellationRunAdapters.unit.test.ts
@@ -111,15 +111,9 @@ suite('Execution Flow Run Adapters', () => {
             });
 
             // mock EOT token & ExecClose token
-            const deferredEOT = createDeferred();
             const deferredExecClose = createDeferred();
             const utilsCreateEOTStub: sinon.SinonStub = sinon.stub(util, 'createTestingDeferred');
-            utilsCreateEOTStub.callsFake(() => {
-                if (utilsCreateEOTStub.callCount === 1) {
-                    return deferredEOT;
-                }
-                return deferredExecClose;
-            });
+            utilsCreateEOTStub.callsFake(() => deferredExecClose);
 
             // define adapter and run tests
             const testAdapter = createAdapter(adapter, configService, typeMoq.Mock.ofType<ITestOutputChannel>().object);

--- a/src/test/testing/testController/testCancellationRunAdapters.unit.test.ts
+++ b/src/test/testing/testController/testCancellationRunAdapters.unit.test.ts
@@ -110,11 +110,6 @@ suite('Execution Flow Run Adapters', () => {
                 }
             });
 
-            // mock EOT token & ExecClose token
-            const deferredExecClose = createDeferred();
-            const utilsCreateEOTStub: sinon.SinonStub = sinon.stub(util, 'createTestingDeferred');
-            utilsCreateEOTStub.callsFake(() => deferredExecClose);
-
             // define adapter and run tests
             const testAdapter = createAdapter(adapter, configService, typeMoq.Mock.ofType<ITestOutputChannel>().object);
             await testAdapter.runTests(
@@ -183,17 +178,6 @@ suite('Execution Flow Run Adapters', () => {
                         'deferredTillServerCloseTester is undefined, should be defined from startRunResultNamedPipe',
                     );
                 }
-            });
-
-            // mock EOT token & ExecClose token
-            const deferredEOT = createDeferred();
-            const deferredExecClose = createDeferred();
-            const utilsCreateEOTStub: sinon.SinonStub = sinon.stub(util, 'createTestingDeferred');
-            utilsCreateEOTStub.callsFake(() => {
-                if (utilsCreateEOTStub.callCount === 1) {
-                    return deferredEOT;
-                }
-                return deferredExecClose;
             });
 
             // debugLauncher mocked

--- a/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
+++ b/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
@@ -242,14 +242,15 @@ suite('Unittest test execution adapter', () => {
     });
     test('Debug launched correctly for unittest', async () => {
         const deferred3 = createDeferred();
-        utilsWriteTestIdsFileStub.callsFake(() => {
-            deferred3.resolve();
-            return Promise.resolve('testIdPipe-mockName');
-        });
+        utilsWriteTestIdsFileStub.callsFake(() => Promise.resolve('testIdPipe-mockName'));
         debugLauncher
             .setup((dl) => dl.launchDebugger(typeMoq.It.isAny(), typeMoq.It.isAny()))
-            .returns(async () => {
+            .returns(async (_opts, callback) => {
                 traceInfo('stubs launch debugger');
+                if (typeof callback === 'function') {
+                    deferred3.resolve();
+                    callback();
+                }
             });
         const testRun = typeMoq.Mock.ofType<TestRun>();
         testRun
@@ -263,14 +264,7 @@ suite('Unittest test execution adapter', () => {
         const uri = Uri.file(myTestPath);
         const outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
         adapter = new UnittestTestExecutionAdapter(configService, outputChannel.object);
-        await adapter.runTests(
-            uri,
-            [],
-            TestRunProfileKind.Debug,
-            testRun.object,
-            execFactory.object,
-            debugLauncher.object,
-        );
+        adapter.runTests(uri, [], TestRunProfileKind.Debug, testRun.object, execFactory.object, debugLauncher.object);
         await deferred3.promise;
         debugLauncher.verify(
             (x) =>

--- a/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
+++ b/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
@@ -242,7 +242,6 @@ suite('Unittest test execution adapter', () => {
     });
     test('Debug launched correctly for unittest', async () => {
         const deferred3 = createDeferred();
-        const deferredEOT = createDeferred();
         utilsWriteTestIdsFileStub.callsFake(() => {
             deferred3.resolve();
             return Promise.resolve('testIdPipe-mockName');
@@ -251,10 +250,7 @@ suite('Unittest test execution adapter', () => {
             .setup((dl) => dl.launchDebugger(typeMoq.It.isAny(), typeMoq.It.isAny()))
             .returns(async () => {
                 traceInfo('stubs launch debugger');
-                deferredEOT.resolve();
             });
-        const utilsCreateEOTStub: sinon.SinonStub = sinon.stub(util, 'createTestingDeferred');
-        utilsCreateEOTStub.callsFake(() => deferredEOT);
         const testRun = typeMoq.Mock.ofType<TestRun>();
         testRun
             .setup((t) => t.token)


### PR DESCRIPTION
remove the need for the EOT in the communication design between the extension and the python subprocesses produced to run testing.