### PR TITLE
Allow pytest to use correct interpreter from getActiveInterpreter

### DIFF
--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -115,15 +115,14 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
                 pythonPath: options.interpreter ? options.interpreter.path : undefined,
             });
         }
-        // TODO: Try passing actual interpreter when calling this from Pytest
+
         const pythonPath = options.interpreter
             ? options.interpreter.path
-            : this.configService.getSettings(options.resource).pythonPath; // : this.configService.getSettings(options.resource).pythonPath; MIGHT BE A PROBLEM.
+            : this.configService.getSettings(options.resource).pythonPath;
         const processService: IProcessService = new ProcessService({ ...envVars });
         processService.on('exec', this.logger.logProcess.bind(this.logger));
         this.disposables.push(processService);
 
-        // TODO: Switch ordering on pixi and conda to see if that helps selecting right conda environment to run.   --> Looks like done?
         const condaExecutionService = await this.createCondaExecutionService(pythonPath, processService);
         if (condaExecutionService) {
             return condaExecutionService;

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -115,13 +115,15 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
                 pythonPath: options.interpreter ? options.interpreter.path : undefined,
             });
         }
+        // TODO: Try passing actual interpreter when calling this from Pytest
         const pythonPath = options.interpreter
             ? options.interpreter.path
-            : this.configService.getSettings(options.resource).pythonPath;
+            : this.configService.getSettings(options.resource).pythonPath; // : this.configService.getSettings(options.resource).pythonPath; MIGHT BE A PROBLEM.
         const processService: IProcessService = new ProcessService({ ...envVars });
         processService.on('exec', this.logger.logProcess.bind(this.logger));
         this.disposables.push(processService);
 
+        // TODO: Switch ordering on pixi and conda to see if that helps selecting right conda environment to run.   --> Looks like done?
         const condaExecutionService = await this.createCondaExecutionService(pythonPath, processService);
         if (condaExecutionService) {
             return condaExecutionService;

--- a/src/client/testing/testController/common/types.ts
+++ b/src/client/testing/testController/common/types.ts
@@ -17,6 +17,7 @@ import { ITestDebugLauncher, TestDiscoveryOptions } from '../../common/types';
 import { IPythonExecutionFactory } from '../../../common/process/types';
 import { EnvironmentVariables } from '../../../common/variables/types';
 import { Deferred } from '../../../common/utils/async';
+import { PythonEnvironment } from '../../../pythonEnvironments/info';
 
 export type TestRunInstanceOptions = TestRunOptions & {
     exclude?: readonly TestItem[];
@@ -215,7 +216,11 @@ export interface ITestResultResolver {
 export interface ITestDiscoveryAdapter {
     // ** first line old method signature, second line new method signature
     discoverTests(uri: Uri): Promise<DiscoveredTestPayload>;
-    discoverTests(uri: Uri, executionFactory: IPythonExecutionFactory): Promise<DiscoveredTestPayload>;
+    discoverTests(
+        uri: Uri,
+        executionFactory: IPythonExecutionFactory,
+        interpreter?: PythonEnvironment,
+    ): Promise<DiscoveredTestPayload>;
 }
 
 // interface for execution/runner adapter

--- a/src/client/testing/testController/controller.ts
+++ b/src/client/testing/testController/controller.ts
@@ -276,6 +276,7 @@ export class PythonTestController implements ITestController, IExtensionSingleAc
                                 this.testController,
                                 this.refreshCancellation.token,
                                 this.pythonExecFactory,
+                                await this.interpreterService.getActiveInterpreter(workspace.uri),
                             );
                         } else {
                             traceError('Unable to find test adapter for workspace.');
@@ -297,6 +298,7 @@ export class PythonTestController implements ITestController, IExtensionSingleAc
                                 this.testController,
                                 this.refreshCancellation.token,
                                 this.pythonExecFactory,
+                                await this.interpreterService.getActiveInterpreter(workspace.uri),
                             );
                         } else {
                             traceError('Unable to find test adapter for workspace.');

--- a/src/client/testing/testController/pytest/pytestDiscoveryAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestDiscoveryAdapter.ts
@@ -24,6 +24,7 @@ import {
     hasSymlinkParent,
 } from '../common/utils';
 import { IEnvironmentVariablesProvider } from '../../../common/variables/types';
+import { IInterpreterService } from '../../../interpreter/contracts';
 
 /**
  * Wrapper class for unittest test discovery. This is where we call `runTestCommand`. #this seems incorrectly copied
@@ -34,6 +35,7 @@ export class PytestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
         private readonly outputChannel: ITestOutputChannel,
         private readonly resultResolver?: ITestResultResolver,
         private readonly envVarsService?: IEnvironmentVariablesProvider,
+        private readonly interpreterService?: IInterpreterService,
     ) {}
 
     async discoverTests(uri: Uri, executionFactory?: IPythonExecutionFactory): Promise<DiscoveredTestPayload> {
@@ -102,11 +104,15 @@ export class PytestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
             env: mutableEnv,
         };
 
+        const interpreter = await this.interpreterService?.getActiveInterpreter();
+
         // Create the Python environment in which to execute the command.
         const creationOptions: ExecutionFactoryCreateWithEnvironmentOptions = {
             allowEnvironmentFetchExceptions: false,
             resource: uri,
+            interpreter,
         };
+
         const execService = await executionFactory?.createActivatedEnvironment(creationOptions);
         // delete UUID following entire discovery finishing.
         const execArgs = ['-m', 'pytest', '-p', 'vscode_pytest', '--collect-only'].concat(pytestArgs);

--- a/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
@@ -25,6 +25,7 @@ import { PYTEST_PROVIDER } from '../../common/constants';
 import { EXTENSION_ROOT_DIR } from '../../../common/constants';
 import * as utils from '../common/utils';
 import { IEnvironmentVariablesProvider } from '../../../common/variables/types';
+import { IInterpreterService } from '../../../interpreter/contracts';
 
 export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
     constructor(
@@ -32,6 +33,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
         private readonly outputChannel: ITestOutputChannel,
         private readonly resultResolver?: ITestResultResolver,
         private readonly envVarsService?: IEnvironmentVariablesProvider,
+        private readonly interpreterService?: IInterpreterService,
     ) {}
 
     async runTests(
@@ -131,10 +133,13 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
         }
         const debugBool = profileKind && profileKind === TestRunProfileKind.Debug;
 
+        const interpreter = await this.interpreterService?.getActiveInterpreter();
+
         // Create the Python environment in which to execute the command.
         const creationOptions: ExecutionFactoryCreateWithEnvironmentOptions = {
             allowEnvironmentFetchExceptions: false,
             resource: uri,
+            interpreter,
         };
         // need to check what will happen in the exec service is NOT defined and is null
         const execService = await executionFactory?.createActivatedEnvironment(creationOptions);

--- a/src/client/testing/testController/workspaceTestAdapter.ts
+++ b/src/client/testing/testController/workspaceTestAdapter.ts
@@ -14,6 +14,7 @@ import { ITestDiscoveryAdapter, ITestExecutionAdapter, ITestResultResolver } fro
 import { IPythonExecutionFactory } from '../../common/process/types';
 import { ITestDebugLauncher } from '../common/types';
 import { buildErrorNodeOptions } from './common/utils';
+import { PythonEnvironment } from '../../pythonEnvironments/info';
 
 /**
  * This class exposes a test-provider-agnostic way of discovering tests.
@@ -115,6 +116,7 @@ export class WorkspaceTestAdapter {
         testController: TestController,
         token?: CancellationToken,
         executionFactory?: IPythonExecutionFactory,
+        interpreter?: PythonEnvironment,
     ): Promise<void> {
         sendTelemetryEvent(EventName.UNITTEST_DISCOVERING, undefined, { tool: this.testProvider });
 
@@ -130,7 +132,7 @@ export class WorkspaceTestAdapter {
         try {
             // ** execution factory only defined for new rewrite way
             if (executionFactory !== undefined) {
-                await this.discoveryAdapter.discoverTests(this.workspaceUri, executionFactory);
+                await this.discoveryAdapter.discoverTests(this.workspaceUri, executionFactory, interpreter);
             } else {
                 await this.discoveryAdapter.discoverTests(this.workspaceUri);
             }

--- a/src/test/testing/common/testingAdapter.test.ts
+++ b/src/test/testing/common/testingAdapter.test.ts
@@ -22,10 +22,8 @@ import { TestProvider } from '../../../client/testing/types';
 import { PYTEST_PROVIDER, UNITTEST_PROVIDER } from '../../../client/testing/common/constants';
 import { IEnvironmentVariablesProvider } from '../../../client/common/variables/types';
 import { createTypeMoq } from '../../mocks/helper';
-import { IInterpreterService } from '../../../client/interpreter/contracts';
 
 suite('End to End Tests: test adapters', () => {
-    let interpreterService: IInterpreterService;
     let resultResolver: ITestResultResolver;
     let pythonExecFactory: IPythonExecutionFactory;
     let configService: IConfigurationService;
@@ -111,7 +109,6 @@ suite('End to End Tests: test adapters', () => {
         pythonExecFactory = serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
         testController = serviceContainer.get<TestController>(ITestController);
         envVarsService = serviceContainer.get<IEnvironmentVariablesProvider>(IEnvironmentVariablesProvider);
-        interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
         // create objects that were not injected
 
         testOutputChannel = createTypeMoq<ITestOutputChannel>();
@@ -273,7 +270,6 @@ suite('End to End Tests: test adapters', () => {
             testOutputChannel.object,
             resultResolver,
             envVarsService,
-            interpreterService,
         );
 
         await discoveryAdapter.discoverTests(workspaceUri, pythonExecFactory).finally(() => {
@@ -329,7 +325,6 @@ suite('End to End Tests: test adapters', () => {
             testOutputChannel.object,
             resultResolver,
             envVarsService,
-            interpreterService,
         );
         configService.getSettings(workspaceUri).testing.pytestArgs = [];
 
@@ -419,7 +414,6 @@ suite('End to End Tests: test adapters', () => {
             testOutputChannel.object,
             resultResolver,
             envVarsService,
-            interpreterService,
         );
         configService.getSettings(workspaceUri).testing.pytestArgs = [];
 
@@ -496,7 +490,6 @@ suite('End to End Tests: test adapters', () => {
             testOutputChannel.object,
             resultResolver,
             envVarsService,
-            interpreterService,
         );
 
         // set workspace to test workspace folder
@@ -1044,7 +1037,6 @@ suite('End to End Tests: test adapters', () => {
             testOutputChannel.object,
             resultResolver,
             envVarsService,
-            interpreterService,
         );
 
         // set workspace to test workspace folder

--- a/src/test/testing/common/testingAdapter.test.ts
+++ b/src/test/testing/common/testingAdapter.test.ts
@@ -22,8 +22,10 @@ import { TestProvider } from '../../../client/testing/types';
 import { PYTEST_PROVIDER, UNITTEST_PROVIDER } from '../../../client/testing/common/constants';
 import { IEnvironmentVariablesProvider } from '../../../client/common/variables/types';
 import { createTypeMoq } from '../../mocks/helper';
+import { IInterpreterService } from '../../../client/interpreter/contracts';
 
 suite('End to End Tests: test adapters', () => {
+    let interpreterService: IInterpreterService;
     let resultResolver: ITestResultResolver;
     let pythonExecFactory: IPythonExecutionFactory;
     let configService: IConfigurationService;
@@ -109,7 +111,7 @@ suite('End to End Tests: test adapters', () => {
         pythonExecFactory = serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
         testController = serviceContainer.get<TestController>(ITestController);
         envVarsService = serviceContainer.get<IEnvironmentVariablesProvider>(IEnvironmentVariablesProvider);
-
+        interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
         // create objects that were not injected
 
         testOutputChannel = createTypeMoq<ITestOutputChannel>();
@@ -271,6 +273,7 @@ suite('End to End Tests: test adapters', () => {
             testOutputChannel.object,
             resultResolver,
             envVarsService,
+            interpreterService,
         );
 
         await discoveryAdapter.discoverTests(workspaceUri, pythonExecFactory).finally(() => {
@@ -326,6 +329,7 @@ suite('End to End Tests: test adapters', () => {
             testOutputChannel.object,
             resultResolver,
             envVarsService,
+            interpreterService,
         );
         configService.getSettings(workspaceUri).testing.pytestArgs = [];
 
@@ -415,6 +419,7 @@ suite('End to End Tests: test adapters', () => {
             testOutputChannel.object,
             resultResolver,
             envVarsService,
+            interpreterService,
         );
         configService.getSettings(workspaceUri).testing.pytestArgs = [];
 
@@ -491,6 +496,7 @@ suite('End to End Tests: test adapters', () => {
             testOutputChannel.object,
             resultResolver,
             envVarsService,
+            interpreterService,
         );
 
         // set workspace to test workspace folder
@@ -1038,6 +1044,7 @@ suite('End to End Tests: test adapters', () => {
             testOutputChannel.object,
             resultResolver,
             envVarsService,
+            interpreterService,
         );
 
         // set workspace to test workspace folder

--- a/src/test/testing/testController/pytest/pytestDiscoveryAdapter.unit.test.ts
+++ b/src/test/testing/testController/pytest/pytestDiscoveryAdapter.unit.test.ts
@@ -20,7 +20,6 @@ import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
 import { MockChildProcess } from '../../../mocks/mockChildProcess';
 import { Deferred, createDeferred } from '../../../../client/common/utils/async';
 import * as util from '../../../../client/testing/testController/common/utils';
-import { IInterpreterService } from '../../../../client/interpreter/contracts';
 
 suite('pytest test discovery adapter', () => {
     let configService: IConfigurationService;
@@ -72,7 +71,6 @@ suite('pytest test discovery adapter', () => {
         execService = typeMoq.Mock.ofType<IPythonExecutionService>();
         execService.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
         outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
-        interpreterService = typeMoq.Mock.ofType<IInterpreterService>();
         const output = new Observable<Output<string>>(() => {
             /* no op */
         });

--- a/src/test/testing/testController/pytest/pytestDiscoveryAdapter.unit.test.ts
+++ b/src/test/testing/testController/pytest/pytestDiscoveryAdapter.unit.test.ts
@@ -20,6 +20,7 @@ import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
 import { MockChildProcess } from '../../../mocks/mockChildProcess';
 import { Deferred, createDeferred } from '../../../../client/common/utils/async';
 import * as util from '../../../../client/testing/testController/common/utils';
+import { IInterpreterService } from '../../../../client/interpreter/contracts';
 
 suite('pytest test discovery adapter', () => {
     let configService: IConfigurationService;
@@ -71,7 +72,7 @@ suite('pytest test discovery adapter', () => {
         execService = typeMoq.Mock.ofType<IPythonExecutionService>();
         execService.setup((p) => ((p as unknown) as any).then).returns(() => undefined);
         outputChannel = typeMoq.Mock.ofType<ITestOutputChannel>();
-
+        interpreterService = typeMoq.Mock.ofType<IInterpreterService>();
         const output = new Observable<Output<string>>(() => {
             /* no op */
         });


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-python/issues/24122
Related: https://github.com/microsoft/vscode-python/issues/24190, https://github.com/microsoft/vscode-python/issues/24127 

I think the culprit was we were not passing in interpreter when we call createActivatedEnvironment.
/cc @eleanorjboyd 