### PR TITLE
Wait 0.5 second for shell integration event, otherwise fall back to sendtext.

### DIFF
--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -91,7 +91,7 @@ export class TerminalService implements ITerminalService, Disposable {
                         resolve(true);
                     },
                 );
-                const TIMEOUT_DURATION = 3000;
+                const TIMEOUT_DURATION = 500;
                 setTimeout(() => {
                     this.executeCommandListeners.add(shellIntegrationChangeEventListener);
                     resolve(true);


### PR DESCRIPTION
For some reason, it seems like shell integration may take awhile to get activated: https://github.com/microsoft/vscode-python/issues/24239 

Performance issue seemed to indicate exactly 3 second coming from the https://github.com/microsoft/vscode-python/pull/24078/files#diff-5290f3097d5f92e3495c8abfbe095dff83c3f8de3dcac08ab2d0304f71bb412fR93, so lets try reducing this to 0.5 second and let user fall back to sendText. We may need further investigate why onDidChangeTerminalShellIntegration may be taking awhile.