### PR TITLE
Allow pytest to use correct interpreter from getActiveInterpreter

### DIFF
--- a/src/client/testing/testController/common/types.ts
+++ b/src/client/testing/testController/common/types.ts
@@ -16,6 +16,7 @@ import {
 import { ITestDebugLauncher, TestDiscoveryOptions } from '../../common/types';
 import { IPythonExecutionFactory } from '../../../common/process/types';
 import { EnvironmentVariables } from '../../../common/variables/types';
+import { PythonEnvironment } from '../../../pythonEnvironments/info';
 
 export type TestRunInstanceOptions = TestRunOptions & {
     exclude?: readonly TestItem[];
@@ -206,7 +207,11 @@ export interface ITestResultResolver {
 export interface ITestDiscoveryAdapter {
     // ** first line old method signature, second line new method signature
     discoverTests(uri: Uri): Promise<DiscoveredTestPayload>;
-    discoverTests(uri: Uri, executionFactory: IPythonExecutionFactory): Promise<DiscoveredTestPayload>;
+    discoverTests(
+        uri: Uri,
+        executionFactory: IPythonExecutionFactory,
+        interpreter?: PythonEnvironment,
+    ): Promise<DiscoveredTestPayload>;
 }
 
 // interface for execution/runner adapter
@@ -220,6 +225,7 @@ export interface ITestExecutionAdapter {
         runInstance?: TestRun,
         executionFactory?: IPythonExecutionFactory,
         debugLauncher?: ITestDebugLauncher,
+        interpreter?: PythonEnvironment,
     ): Promise<ExecutionTestPayload>;
 }
 

--- a/src/client/testing/testController/controller.ts
+++ b/src/client/testing/testController/controller.ts
@@ -276,6 +276,7 @@ export class PythonTestController implements ITestController, IExtensionSingleAc
                                 this.testController,
                                 this.refreshCancellation.token,
                                 this.pythonExecFactory,
+                                await this.interpreterService.getActiveInterpreter(workspace.uri),
                             );
                         } else {
                             traceError('Unable to find test adapter for workspace.');
@@ -297,6 +298,7 @@ export class PythonTestController implements ITestController, IExtensionSingleAc
                                 this.testController,
                                 this.refreshCancellation.token,
                                 this.pythonExecFactory,
+                                await this.interpreterService.getActiveInterpreter(workspace.uri),
                             );
                         } else {
                             traceError('Unable to find test adapter for workspace.');
@@ -455,6 +457,7 @@ export class PythonTestController implements ITestController, IExtensionSingleAc
                                     request.profile?.kind,
                                     this.pythonExecFactory,
                                     this.debugLauncher,
+                                    await this.interpreterService.getActiveInterpreter(workspace.uri),
                                 );
                             }
                             return this.pytest.runTests(
@@ -483,6 +486,7 @@ export class PythonTestController implements ITestController, IExtensionSingleAc
                                     request.profile?.kind,
                                     this.pythonExecFactory,
                                     this.debugLauncher,
+                                    await this.interpreterService.getActiveInterpreter(workspace.uri),
                                 );
                             }
                             // below is old way of running unittest execution

--- a/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
@@ -19,6 +19,7 @@ import { PYTEST_PROVIDER } from '../../common/constants';
 import { EXTENSION_ROOT_DIR } from '../../../common/constants';
 import * as utils from '../common/utils';
 import { IEnvironmentVariablesProvider } from '../../../common/variables/types';
+import { PythonEnvironment } from '../../../pythonEnvironments/info';
 
 export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
     constructor(
@@ -35,6 +36,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
         runInstance?: TestRun,
         executionFactory?: IPythonExecutionFactory,
         debugLauncher?: ITestDebugLauncher,
+        interpreter?: PythonEnvironment,
     ): Promise<ExecutionTestPayload> {
         const deferredTillServerClose: Deferred<void> = utils.createTestingDeferred();
 
@@ -74,6 +76,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                 profileKind,
                 executionFactory,
                 debugLauncher,
+                interpreter,
             );
         } finally {
             await deferredTillServerClose.promise;
@@ -98,6 +101,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
         profileKind?: TestRunProfileKind,
         executionFactory?: IPythonExecutionFactory,
         debugLauncher?: ITestDebugLauncher,
+        interpreter?: PythonEnvironment,
     ): Promise<ExecutionTestPayload> {
         const relativePathToPytest = 'python_files';
         const fullPluginPath = path.join(EXTENSION_ROOT_DIR, relativePathToPytest);
@@ -122,6 +126,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
         const creationOptions: ExecutionFactoryCreateWithEnvironmentOptions = {
             allowEnvironmentFetchExceptions: false,
             resource: uri,
+            interpreter,
         };
         // need to check what will happen in the exec service is NOT defined and is null
         const execService = await executionFactory?.createActivatedEnvironment(creationOptions);

--- a/src/client/testing/testController/workspaceTestAdapter.ts
+++ b/src/client/testing/testController/workspaceTestAdapter.ts
@@ -14,6 +14,7 @@ import { ITestDiscoveryAdapter, ITestExecutionAdapter, ITestResultResolver } fro
 import { IPythonExecutionFactory } from '../../common/process/types';
 import { ITestDebugLauncher } from '../common/types';
 import { buildErrorNodeOptions } from './common/utils';
+import { PythonEnvironment } from '../../pythonEnvironments/info';
 
 /**
  * This class exposes a test-provider-agnostic way of discovering tests.
@@ -45,6 +46,7 @@ export class WorkspaceTestAdapter {
         profileKind?: boolean | TestRunProfileKind,
         executionFactory?: IPythonExecutionFactory,
         debugLauncher?: ITestDebugLauncher,
+        interpreter?: PythonEnvironment,
     ): Promise<void> {
         if (this.executing) {
             traceError('Test execution already in progress, not starting a new one.');
@@ -80,6 +82,7 @@ export class WorkspaceTestAdapter {
                     runInstance,
                     executionFactory,
                     debugLauncher,
+                    interpreter,
                 );
             } else {
                 await this.executionAdapter.runTests(this.workspaceUri, testCaseIds, profileKind);
@@ -115,6 +118,7 @@ export class WorkspaceTestAdapter {
         testController: TestController,
         token?: CancellationToken,
         executionFactory?: IPythonExecutionFactory,
+        interpreter?: PythonEnvironment,
     ): Promise<void> {
         sendTelemetryEvent(EventName.UNITTEST_DISCOVERING, undefined, { tool: this.testProvider });
 
@@ -130,7 +134,7 @@ export class WorkspaceTestAdapter {
         try {
             // ** execution factory only defined for new rewrite way
             if (executionFactory !== undefined) {
-                await this.discoveryAdapter.discoverTests(this.workspaceUri, executionFactory);
+                await this.discoveryAdapter.discoverTests(this.workspaceUri, executionFactory, interpreter);
             } else {
                 await this.discoveryAdapter.discoverTests(this.workspaceUri);
             }


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-python/issues/24122
Related: https://github.com/microsoft/vscode-python/issues/24190, https://github.com/microsoft/vscode-python/issues/24127 

I think the culprit was we were not passing in interpreter when we call createActivatedEnvironment.