### PR TITLE
Make `python_server.py` compatible to Python 3.7

### DIFF
--- a/python_files/python_server.py
+++ b/python_files/python_server.py
@@ -159,7 +159,10 @@ class CustomIO(io.TextIOWrapper):
 
 def get_headers():
     headers = {}
-    while line := STDIN.readline().strip():
+    while True:
+        line = STDIN.readline().strip()
+        if not line:
+            break
         name, value = line.split(":", 1)
         headers[name] = value.strip()
     return headers


### PR DESCRIPTION
```
2024-10-05 15:12:00.813 [error]   File "c:\Users\User\.vscode\extensions\ms-python.python-2024.16.0-win32-x64\python_files\python_server.py", line 162
    while line := STDIN.readline().strip():
                ^
SyntaxError: invalid syntax

2024-10-05 15:12:00.816 [error] Python server exited with code 1
2024-10-05 15:14:46.427 [error] Error getting response from REPL server: [k [Error]: Connection is closed.
	at pe (c:\Users\User\.vscode\extensions\ms-python.python-2024.16.0-win32-x64\out\client\extension.js:2:2053423)
	at Object.sendRequest (c:\Users\User\.vscode\extensions\ms-python.python-2024.16.0-win32-x64\out\client\extension.js:2:2055781)
	at g.executeCode (c:\Users\User\.vscode\extensions\ms-python.python-2024.16.0-win32-x64\out\client\extension.js:2:799948)
	at g.execute (c:\Users\User\.vscode\extensions\ms-python.python-2024.16.0-win32-x64\out\client\extension.js:2:799770)
	at u.value (c:\Users\User\.vscode\extensions\ms-python.python-2024.16.0-win32-x64\out\client\extension.js:2:829806)
	at i.executeHandler (c:\Users\User\.vscode\extensions\ms-python.python-2024.16.0-win32-x64\out\client\extension.js:2:805190)
	at bb.$executeCells (file:///c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:155:24084)
	at Zb.S (file:///c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:31:113896)
	at Zb.Q (file:///c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:31:113676)
	at Zb.M (file:///c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:31:112765)
	at Zb.L (file:///c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:31:111870)
	at gh.value (file:///c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:31:110667)
	at T.B (file:///c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:29:732)
	at T.fire (file:///c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:29:950)
	at no.fire (file:///c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:31:9399)
	at gh.value (file:///c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:174:13273)
	at T.B (file:///c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:29:732)
	at T.fire (file:///c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:29:950)
	at no.fire (file:///c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:31:9399)
	at MessagePortMain.<anonymous> (file:///c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:174:11562)
	at MessagePortMain.emit (node:events:519:28)
	at MessagePortMain._internalPort.emit (node:electron/js2c/utility_init:2:2619)] {
  code: 1
}
```