### PR TITLE
Refactor code to remove unused JSDoc types

### DIFF
--- a/pythonExtensionApi/src/main.ts
+++ b/pythonExtensionApi/src/main.ts
@@ -25,7 +25,6 @@ export interface PythonExtension {
 
         /**
          * Gets the path to the debugger package used by the extension.
-         * @returns {Promise<string>}
          */
         getDebuggerPackagePath(): Promise<string | undefined>;
     };

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -12,27 +12,14 @@ import { PythonEnvironment } from '../pythonEnvironments/info';
 export const IExtensionActivationManager = Symbol('IExtensionActivationManager');
 /**
  * Responsible for activation of extension.
- *
- * @export
- * @interface IExtensionActivationManager
- * @extends {IDisposable}
  */
 export interface IExtensionActivationManager extends IDisposable {
-    /**
-     * Method invoked when extension activates (invoked once).
-     *
-     * @returns {Promise<void>}
-     * @memberof IExtensionActivationManager
-     */
+    // Method invoked when extension activates (invoked once).
     activate(startupStopWatch: StopWatch): Promise<void>;
     /**
      * Method invoked when a workspace is loaded.
      * This is where we place initialization scripts for each workspace.
      * (e.g. if we need to run code for each workspace, then this is where that happens).
-     *
-     * @param {Resource} resource
-     * @returns {Promise<void>}
-     * @memberof IExtensionActivationManager
      */
     activateWorkspace(resource: Resource): Promise<void>;
 }
@@ -43,8 +30,6 @@ export const IExtensionActivationService = Symbol('IExtensionActivationService')
  * invoked for every workspace folder (in multi-root workspace folders) during the activation of the extension.
  * This is a great hook for extension activation code, i.e. you don't need to modify
  * the `extension.ts` file to invoke some code when extension gets activated.
- * @export
- * @interface IExtensionActivationService
  */
 export interface IExtensionActivationService {
     supportedWorkspaceTypes: { untrustedWorkspace: boolean; virtualWorkspace: boolean };
@@ -100,8 +85,6 @@ export interface ILanguageServerProxy extends IDisposable {
      * Sends a request to LS so as to load other extensions.
      * This is used as a plugin loader mechanism.
      * Anyone (such as intellicode) wanting to interact with LS, needs to send this request to LS.
-     * @param {{}} [args]
-     * @memberof ILanguageServerProxy
      */
     loadExtension(args?: unknown): void;
 }
@@ -110,9 +93,6 @@ export const ILanguageServerOutputChannel = Symbol('ILanguageServerOutputChannel
 export interface ILanguageServerOutputChannel {
     /**
      * Creates output channel if necessary and returns it
-     *
-     * @type {ILogOutputChannel}
-     * @memberof ILanguageServerOutputChannel
      */
     readonly channel: ILogOutputChannel;
 }
@@ -123,8 +103,6 @@ export const IExtensionSingleActivationService = Symbol('IExtensionSingleActivat
  * invoked during the activation of the extension.
  * This is a great hook for extension activation code, i.e. you don't need to modify
  * the `extension.ts` file to invoke some code when extension gets activated.
- * @export
- * @interface IExtensionSingleActivationService
  */
 export interface IExtensionSingleActivationService {
     supportedWorkspaceTypes: { untrustedWorkspace: boolean; virtualWorkspace: boolean };

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -80,7 +80,6 @@ export function buildApi(
              * @param {Resource} [resource] A resource for which the setting is asked for.
              * * When no resource is provided, the setting scoped to the first workspace folder is returned.
              * * If no folder is present, it returns the global setting.
-             * @returns {({ execCommand: string[] | undefined })}
              */
             getExecutionDetails(
                 resource?: Resource,

--- a/src/client/api/types.ts
+++ b/src/client/api/types.ts
@@ -25,7 +25,6 @@ export interface PythonExtension {
 
         /**
          * Gets the path to the debugger package used by the extension.
-         * @returns {Promise<string>}
          */
         getDebuggerPackagePath(): Promise<string | undefined>;
     };

--- a/src/client/application/diagnostics/base.ts
+++ b/src/client/application/diagnostics/base.ts
@@ -73,11 +73,6 @@ export abstract class BaseDiagnosticsService implements IDiagnosticsService, IDi
     /**
      * Returns a key used to keep track of whether a diagnostic was handled or not.
      * So as to prevent handling/displaying messages multiple times for the same diagnostic.
-     *
-     * @protected
-     * @param {IDiagnostic} diagnostic
-     * @returns {string}
-     * @memberof BaseDiagnosticsService
      */
     protected getDiagnosticsKey(diagnostic: IDiagnostic): string {
         if (diagnostic.scope === DiagnosticScope.Global) {

--- a/src/client/application/types.ts
+++ b/src/client/application/types.ts
@@ -11,8 +11,6 @@ export interface IApplicationDiagnostics {
     /**
      * Perform pre-extension activation health checks.
      * E.g. validate user environment, etc.
-     * @returns {Promise<void>}
-     * @memberof IApplicationDiagnostics
      */
     performPreStartupHealthCheck(resource: Resource): Promise<void>;
     register(): void;

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -14,7 +14,6 @@ export type CommandsWithoutArgs = keyof ICommandNameWithoutArgumentTypeMapping;
 /**
  * Mapping between commands and list or arguments.
  * These commands do NOT have any arguments.
- * @interface ICommandNameWithoutArgumentTypeMapping
  */
 interface ICommandNameWithoutArgumentTypeMapping {
     [Commands.InstallPythonOnMac]: [];
@@ -52,9 +51,6 @@ export type AllCommands = keyof ICommandNameArgumentTypeMapping;
 /**
  * Mapping between commands and list of arguments.
  * Used to provide strong typing for command & args.
- * @export
- * @interface ICommandNameArgumentTypeMapping
- * @extends {ICommandNameWithoutArgumentTypeMapping}
  */
 export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgumentTypeMapping {
     [Commands.Create_Environment]: [CreateEnvironmentOptions];

--- a/src/client/common/application/types.ts
+++ b/src/client/common/application/types.ts
@@ -818,9 +818,6 @@ export interface IWorkspaceService {
 
     /**
      * Generate a key that's unique to the workspace folder (could be fsPath).
-     * @param {(Uri | undefined)} resource
-     * @returns {string}
-     * @memberof IWorkspaceService
      */
     getWorkspaceFolderIdentifier(resource: Uri | undefined, defaultValue?: string): string;
     /**

--- a/src/client/common/cancellation.ts
+++ b/src/client/common/cancellation.ts
@@ -16,11 +16,6 @@ export class CancellationError extends Error {
 }
 /**
  * Create a promise that will either resolve with a default value or reject when the token is cancelled.
- *
- * @export
- * @template T
- * @param {({ defaultValue: T; token: CancellationToken; cancelAction: 'reject' | 'resolve' })} options
- * @returns {Promise<T>}
  */
 export function createPromiseFromCancellation<T>(options: {
     defaultValue: T;
@@ -50,10 +45,6 @@ export function createPromiseFromCancellation<T>(options: {
 
 /**
  * Create a single unified cancellation token that wraps multiple cancellation tokens.
- *
- * @export
- * @param {(...(CancellationToken | undefined)[])} tokens
- * @returns {CancellationToken}
  */
 export function wrapCancellationTokens(...tokens: (CancellationToken | undefined)[]): CancellationToken {
     const wrappedCancellantionToken = new CancellationTokenSource();
@@ -117,7 +108,6 @@ export namespace Cancellation {
 
     /**
      * isCanceled returns a boolean indicating if the cancel token has been canceled.
-     * @param cancelToken
      */
     export function isCanceled(cancelToken?: CancellationToken): boolean {
         return cancelToken ? cancelToken.isCancellationRequested : false;
@@ -125,7 +115,6 @@ export namespace Cancellation {
 
     /**
      * throws a CancellationError if the token is canceled.
-     * @param cancelToken
      */
     export function throwIfCanceled(cancelToken?: CancellationToken): void {
         if (isCanceled(cancelToken)) {

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -111,8 +111,6 @@ export function isTestExecution(): boolean {
 /**
  * Whether we're running unit tests (*.unit.test.ts).
  * These tests have a special meaning, they run fast.
- * @export
- * @returns {boolean}
  */
 export function isUnitTestExecution(): boolean {
     return process.env.VSC_PYTHON_UNIT_TEST === '1';

--- a/src/client/common/extensions.ts
+++ b/src/client/common/extensions.ts
@@ -28,7 +28,6 @@ declare interface String {
 /**
  * Appropriately formats a string so it can be used as an argument for a command in a shell.
  * E.g. if an argument contains a space, then it will be enclosed within double quotes.
- * @param {String} value.
  */
 String.prototype.toCommandArgumentForPythonExt = function (this: string): string {
     if (!this) {

--- a/src/client/common/installer/types.ts
+++ b/src/client/common/installer/types.ts
@@ -18,11 +18,6 @@ export interface IModuleInstaller {
      * If a cancellation token is provided, then a cancellable progress message is dispalyed.
      *  At this point, this method would resolve only after the module has been successfully installed.
      * If cancellation token is not provided, its not guaranteed that module installation has completed.
-     * @param {string} name
-     * @param {InterpreterUri} [resource]
-     * @param {CancellationToken} [cancel]
-     * @returns {Promise<void>}
-     * @memberof IModuleInstaller
      */
     installModule(
         productOrModuleName: Product | string,

--- a/src/client/common/terminal/shellDetector.ts
+++ b/src/client/common/terminal/shellDetector.ts
@@ -33,10 +33,6 @@ export class ShellDetector {
      * 3. Try to identify the type of the shell based on the user environment (OS).
      * 4. If all else fail, use defaults hardcoded (cmd for windows, bash for linux & mac).
      * More information here: https://github.com/microsoft/vscode/issues/74233#issuecomment-497527337
-     *
-     * @param {Terminal} [terminal]
-     * @returns {TerminalShellType}
-     * @memberof TerminalHelper
      */
     public identifyTerminalShell(terminal?: Terminal): TerminalShellType {
         let shell: TerminalShellType | undefined;

--- a/src/client/common/terminal/shellDetectors/settingsShellDetector.ts
+++ b/src/client/common/terminal/shellDetectors/settingsShellDetector.ts
@@ -13,10 +13,6 @@ import { BaseShellDetector } from './baseShellDetector';
 
 /**
  * Identifies the shell based on the user settings.
- *
- * @export
- * @class SettingsShellDetector
- * @extends {BaseShellDetector}
  */
 @injectable()
 export class SettingsShellDetector extends BaseShellDetector {

--- a/src/client/common/terminal/shellDetectors/terminalNameShellDetector.ts
+++ b/src/client/common/terminal/shellDetectors/terminalNameShellDetector.ts
@@ -11,10 +11,6 @@ import { BaseShellDetector } from './baseShellDetector';
 
 /**
  * Identifies the shell, based on the display name of the terminal.
- *
- * @export
- * @class TerminalNameShellDetector
- * @extends {BaseShellDetector}
  */
 @injectable()
 export class TerminalNameShellDetector extends BaseShellDetector {

--- a/src/client/common/terminal/shellDetectors/userEnvironmentShellDetector.ts
+++ b/src/client/common/terminal/shellDetectors/userEnvironmentShellDetector.ts
@@ -13,10 +13,6 @@ import { BaseShellDetector } from './baseShellDetector';
 
 /**
  * Identifies the shell based on the users environment (env variables).
- *
- * @export
- * @class UserEnvironmentShellDetector
- * @extends {BaseShellDetector}
  */
 @injectable()
 export class UserEnvironmentShellDetector extends BaseShellDetector {

--- a/src/client/common/terminal/shellDetectors/vscEnvironmentShellDetector.ts
+++ b/src/client/common/terminal/shellDetectors/vscEnvironmentShellDetector.ts
@@ -12,10 +12,6 @@ import { BaseShellDetector } from './baseShellDetector';
 
 /**
  * Identifies the shell, based on the VSC Environment API.
- *
- * @export
- * @class VSCEnvironmentShellDetector
- * @extends {BaseShellDetector}
  */
 export class VSCEnvironmentShellDetector extends BaseShellDetector {
     constructor(@inject(IApplicationEnvironment) private readonly appEnv: IApplicationEnvironment) {

--- a/src/client/common/terminal/syncTerminalService.ts
+++ b/src/client/common/terminal/syncTerminalService.ts
@@ -92,11 +92,6 @@ class ExecutionState implements Disposable {
  * - Send text to a terminal that executes our python file, passing in the original text as args
  * - The pthon file will execute the commands as a subprocess
  * - At the end of the execution a file is created to singal completion.
- *
- * @export
- * @class SynchronousTerminalService
- * @implements {ITerminalService}
- * @implements {Disposable}
  */
 export class SynchronousTerminalService implements ITerminalService, Disposable {
     private readonly disposables: Disposable[] = [];

--- a/src/client/common/terminal/types.ts
+++ b/src/client/common/terminal/types.ts
@@ -100,10 +100,6 @@ export interface ITerminalServiceFactory {
     /**
      * Gets a terminal service.
      * If one exists with the same information, that is returned else a new one is created.
-     *
-     * @param {TerminalCreationOptions}
-     * @returns {ITerminalService}
-     * @memberof ITerminalServiceFactory
      */
     getTerminalService(options: TerminalCreationOptions & { newTerminalPerFile?: boolean }): ITerminalService;
     createTerminalService(resource?: Uri, title?: string): ITerminalService;
@@ -132,11 +128,7 @@ export type TerminalActivationOptions = {
     resource?: Resource;
     preserveFocus?: boolean;
     interpreter?: PythonEnvironment;
-    /**
-     * When sending commands to the terminal, do not display the terminal.
-     *
-     * @type {boolean}
-     */
+    // When sending commands to the terminal, do not display the terminal.
     hideFromUser?: boolean;
 };
 export interface ITerminalActivator {
@@ -170,16 +162,10 @@ export const IShellDetector = Symbol('IShellDetector');
 /**
  * Used to identify a shell.
  * Each implemenetion will provide a unique way of identifying the shell.
- *
- * @export
- * @interface IShellDetector
  */
 export interface IShellDetector {
     /**
      * Classes with higher priorities will be used first when identifying the shell.
-     *
-     * @type {number}
-     * @memberof IShellDetector
      */
     readonly priority: number;
     identify(telemetryProperties: ShellIdentificationTelemetry, terminal?: Terminal): TerminalShellType | undefined;

--- a/src/client/common/utils/async.ts
+++ b/src/client/common/utils/async.ts
@@ -245,12 +245,6 @@ export async function flattenIterable<T>(iterableItem: AsyncIterable<T>): Promis
 
 /**
  * Wait for a condition to be fulfilled within a timeout.
- *
- * @export
- * @param {() => Promise<boolean>} condition
- * @param {number} timeoutMs
- * @param {string} errorMessage
- * @returns {Promise<void>}
  */
 export async function waitForCondition(
     condition: () => Promise<boolean>,

--- a/src/client/common/utils/cacheUtils.ts
+++ b/src/client/common/utils/cacheUtils.ts
@@ -5,11 +5,7 @@
 
 const globalCacheStore = new Map<string, { expiry: number; data: any }>();
 
-/**
- * Gets a cache store to be used to store return values of methods or any other.
- *
- * @returns
- */
+// Gets a cache store to be used to store return values of methods or any other.
 export function getGlobalCacheStore() {
     return globalCacheStore;
 }

--- a/src/client/common/utils/misc.ts
+++ b/src/client/common/utils/misc.ts
@@ -27,10 +27,6 @@ type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? nev
  * Checking whether something is a Resource (Uri/undefined).
  * Using `instanceof Uri` doesn't always work as the object is not an instance of Uri (at least not in tests).
  * That's why VSC too has a helper method `URI.isUri` (though not public).
- *
- * @export
- * @param {InterpreterUri} [resource]
- * @returns {resource is Resource}
  */
 export function isResource(resource?: InterpreterUri): resource is Resource {
     if (!resource) {
@@ -44,9 +40,6 @@ export function isResource(resource?: InterpreterUri): resource is Resource {
  * Checking whether something is a Uri.
  * Using `instanceof Uri` doesn't always work as the object is not an instance of Uri (at least not in tests).
  * That's why VSC too has a helper method `URI.isUri` (though not public).
- *
- * @param {InterpreterUri} [resource]
- * @returns {resource is Uri}
  */
 
 function isUri(resource?: Uri | any): resource is Uri {

--- a/src/client/debugger/extension/hooks/childProcessAttachHandler.ts
+++ b/src/client/debugger/extension/hooks/childProcessAttachHandler.ts
@@ -14,9 +14,6 @@ import { DebuggerTypeName } from '../../constants';
 /**
  * This class is responsible for automatically attaching the debugger to any
  * child processes launched. I.e. this is the class responsible for multi-proc debugging.
- * @export
- * @class ChildProcessAttachEventHandler
- * @implements {IDebugSessionEventHandlers}
  */
 @injectable()
 export class ChildProcessAttachEventHandler implements IDebugSessionEventHandlers {

--- a/src/client/debugger/extension/hooks/childProcessAttachService.ts
+++ b/src/client/debugger/extension/hooks/childProcessAttachService.ts
@@ -17,9 +17,6 @@ import { getWorkspaceFolders } from '../../../common/vscodeApis/workspaceApis';
 /**
  * This class is responsible for attaching the debugger to any
  * child processes launched. I.e. this is the class responsible for multi-proc debugging.
- * @export
- * @class ChildProcessAttachEventHandler
- * @implements {IChildProcessAttachService}
  */
 @injectable()
 export class ChildProcessAttachService implements IChildProcessAttachService {

--- a/src/client/deprecatedProposedApiTypes.ts
+++ b/src/client/deprecatedProposedApiTypes.ts
@@ -57,7 +57,6 @@ export interface DeprecatedProposedAPI {
          * @param {Resource} [resource] A resource for which the setting is asked for.
          * * When no resource is provided, the setting scoped to the first workspace folder is returned.
          * * If no folder is present, it returns the global setting.
-         * @returns {({ execCommand: string[] | undefined })}
          */
         getExecutionDetails(
             resource?: Resource,

--- a/src/client/interpreter/autoSelection/types.ts
+++ b/src/client/interpreter/autoSelection/types.ts
@@ -14,9 +14,6 @@ export const IInterpreterAutoSelectionProxyService = Symbol('IInterpreterAutoSel
  * However, the class that reads python Path, must first give preference to selected interpreter.
  * But all classes everywhere make use of python settings!
  * Solution - Use a proxy that does nothing first, but later the real instance is injected.
- *
- * @export
- * @interface IInterpreterAutoSelectionProxyService
  */
 export interface IInterpreterAutoSelectionProxyService {
     readonly onDidChangeAutoSelectedInterpreter: Event<void>;

--- a/src/client/pythonEnvironments/creation/common/createEnvTriggerUtils.ts
+++ b/src/client/pythonEnvironments/creation/common/createEnvTriggerUtils.ts
@@ -67,8 +67,7 @@ export async function isGlobalPythonSelected(workspace: WorkspaceFolder): Promis
 /**
  * Checks the setting `python.createEnvironment.trigger` to see if we should perform the checks
  * to prompt to create an environment.
- * @export
- * @returns : True if we should prompt to create an environment.
+ * Returns True if we should prompt to create an environment.
  */
 export function shouldPromptToCreateEnv(): boolean {
     const config = getConfiguration('python');

--- a/src/client/repl/nativeRepl.ts
+++ b/src/client/repl/nativeRepl.ts
@@ -109,7 +109,6 @@ export class NativeRepl implements Disposable {
 
     /**
      * Function that check if NotebookController for REPL exists, and returns it in Singleton manner.
-     * @returns NotebookController
      */
     public setReplController(): NotebookController {
         if (!this.replController) {
@@ -125,8 +124,6 @@ export class NativeRepl implements Disposable {
 
     /**
      * Function that checks if native REPL's text input box contains complete code.
-     * @param activeEditor
-     * @param pythonServer
      * @returns Promise<boolean> - True if complete/Valid code is present, False otherwise.
      */
     public async checkUserInputCompleteCode(activeEditor: TextEditor | undefined): Promise<boolean> {
@@ -147,7 +144,6 @@ export class NativeRepl implements Disposable {
 
     /**
      * Function that opens interactive repl, selects kernel, and send/execute code to the native repl.
-     * @param code
      */
     public async sendToNativeRepl(code?: string): Promise<void> {
         const notebookEditor = await openInteractiveREPL(this.replController, this.notebookDocument);

--- a/src/client/repl/replCommandHandler.ts
+++ b/src/client/repl/replCommandHandler.ts
@@ -16,9 +16,6 @@ import { PVSC_EXTENSION_ID } from '../common/constants';
 
 /**
  * Function that opens/show REPL using IW UI.
- * @param notebookController
- * @param notebookEditor
- * @returns notebookEditor
  */
 export async function openInteractiveREPL(
     notebookController: NotebookController,
@@ -46,10 +43,6 @@ export async function openInteractiveREPL(
 
 /**
  * Function that selects notebook Kernel.
- * @param notebookEditor
- * @param notebookControllerId
- * @param extensionId
- * @return Promise<void>
  */
 export async function selectNotebookKernel(
     notebookEditor: NotebookEditor,
@@ -65,9 +58,6 @@ export async function selectNotebookKernel(
 
 /**
  * Function that executes notebook cell given code.
- * @param notebookDocument
- * @param code
- * @return Promise<void>
  */
 export async function executeNotebookCell(notebookEditor: NotebookEditor, code: string): Promise<void> {
     const { notebook, replOptions } = notebookEditor;
@@ -83,8 +73,6 @@ export async function executeNotebookCell(notebookEditor: NotebookEditor, code: 
 /**
  * Function that adds cell to notebook.
  * This function will only get called when notebook document is defined.
- * @param code
- *
  */
 async function addCellToNotebook(notebookDocument: NotebookDocument, index: number, code: string): Promise<void> {
     const notebookCellData = new NotebookCellData(NotebookCellKind.Code, code as string, 'python');

--- a/src/client/repl/replCommands.ts
+++ b/src/client/repl/replCommands.ts
@@ -20,11 +20,6 @@ import { EventName } from '../telemetry/constants';
 
 /**
  * Register Start Native REPL command in the command palette
- *
- * @param disposables
- * @param interpreterService
- * @param commandManager
- * @returns Promise<void>
  */
 export async function registerStartNativeReplCommand(
     disposables: Disposable[],
@@ -46,9 +41,6 @@ export async function registerStartNativeReplCommand(
 
 /**
  * Registers REPL command for shift+enter if sendToNativeREPL setting is enabled.
- * @param disposables
- * @param interpreterService
- * @returns Promise<void>
  */
 export async function registerReplCommands(
     disposables: Disposable[],
@@ -88,8 +80,6 @@ export async function registerReplCommands(
 
 /**
  * Command triggered for 'Enter': Conditionally call interactive.execute OR insert \n in text input box.
- * @param disposables
- * @param interpreterService
  */
 export async function registerReplExecuteOnEnter(
     disposables: Disposable[],

--- a/src/client/repl/replUtils.ts
+++ b/src/client/repl/replUtils.ts
@@ -9,7 +9,6 @@ import { getMultiLineSelectionText, getSingleLineSelectionText } from '../termin
 
 /**
  * Function that executes selected code in the terminal.
- * @returns Promise<void>
  */
 export async function executeInTerminal(): Promise<void> {
     await commands.executeCommand(Commands.Exec_Selection_In_Terminal);
@@ -45,12 +44,7 @@ export function getSendToNativeREPLSetting(): boolean {
     return configuration.get<boolean>('REPL.sendToNativeREPL', false);
 }
 
-/**
- * Function that inserts new line in the given (input) text editor
- * @param activeEditor
- * @returns void
- */
-
+// Function that inserts new line in the given (input) text editor
 export function insertNewLineToREPLInput(activeEditor: TextEditor | undefined): void {
     if (activeEditor) {
         const position = activeEditor.selection.active;
@@ -70,9 +64,6 @@ export function isMultiLineText(textEditor: TextEditor): boolean {
 /**
  * Function that trigger interpreter warning if invalid interpreter.
  * Function will also return undefined or active interpreter
- * @parm uri
- * @param interpreterService
- * @returns Promise<PythonEnvironment | undefined>
  */
 export async function getActiveInterpreter(
     uri: Uri,
@@ -88,7 +79,6 @@ export async function getActiveInterpreter(
 
 /**
  * Function that will return ViewColumn for existing Native REPL that belongs to given  NotebookDocument.
- * @returns ViewColumn | undefined
  */
 export function getExistingReplViewColumn(notebookDocument: NotebookDocument): ViewColumn | undefined {
     const ourNotebookUri = notebookDocument.uri.toString();

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -24,7 +24,6 @@ import type { TestTool } from './types';
  * Checks whether telemetry is supported.
  * Its possible this function gets called within Debug Adapter, vscode isn't available in there.
  * Within DA, there's a completely different way to send telemetry.
- * @returns {boolean}
  */
 function isTelemetrySupported(): boolean {
     try {
@@ -42,7 +41,6 @@ let packageJSON: any;
 
 /**
  * Checks if the telemetry is disabled
- * @returns {boolean}
  */
 export function isTelemetryDisabled(): boolean {
     if (!packageJSON) {

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -452,12 +452,6 @@ export async function unzip(zipFile: string, targetFolder: string): Promise<void
 }
 /**
  * Wait for a condition to be fulfilled within a timeout.
- *
- * @export
- * @param {() => Promise<boolean>} condition
- * @param {number} timeoutMs
- * @param {string} errorMessage
- * @returns {Promise<void>}
  */
 export async function waitForCondition(
     condition: () => Promise<boolean>,

--- a/src/test/common/utils/decorators.unit.test.ts
+++ b/src/test/common/utils/decorators.unit.test.ts
@@ -89,9 +89,6 @@ suite('Common Utils - Decorators', function () {
          * await new Promise(resolve = setTimeout(resolve, 100))
          * console.log(currentTime - startTijme)
          * ```
-         *
-         * @param {number} actualDelay
-         * @param {number} expectedDelay
          */
         function assertElapsedTimeWithinRange(actualDelay: number, expectedDelay: number) {
             const difference = actualDelay - expectedDelay;

--- a/src/test/common/utils/decorators.unit.test.ts
+++ b/src/test/common/utils/decorators.unit.test.ts
@@ -72,8 +72,6 @@ suite('Common Utils - Decorators', function () {
          * This has an accuracy of around 2-20ms.
          * However we're dealing with tests that need accuracy of 1ms.
          * Use API that'll give us better accuracy when dealing with elapsed times.
-         *
-         * @returns {number}
          */
         function getHighPrecisionTime(): number {
             const currentTime = process.hrtime();

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -121,9 +121,6 @@ function activatePythonExtensionScript() {
 /**
  * Runner, invoked by VS Code.
  * More info https://code.visualstudio.com/api/working-with-extensions/testing-extension
- *
- * @export
- * @returns {Promise<void>}
  */
 export async function run(): Promise<void> {
     const options = configure();

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -44,8 +44,6 @@ process.on('unhandledRejection', (ex: any, _a) => {
 
 /**
  * Configure the test environment and return the optoins required to run moch tests.
- *
- * @returns {SetupOptions}
  */
 function configure(): SetupOptions {
     process.env.VSC_PYTHON_CI_TEST = '1';
@@ -103,7 +101,6 @@ function configure(): SetupOptions {
  * to complete.
  * That's when we know out PVSC extension specific code is ready for testing.
  * So, this code needs to run always for every test running in VS Code (what we call these `system test`) .
- * @returns
  */
 function activatePythonExtensionScript() {
     const ex = new Error('Failed to initialize Python extension for tests after 3 minutes');

--- a/src/test/mocks/vsc/arrays.ts
+++ b/src/test/mocks/vsc/arrays.ts
@@ -186,9 +186,6 @@ export function sortedDiff<T>(before: T[], after: T[], compare: (a: T, b: T) => 
 /**
  * Takes two *sorted* arrays and computes their delta (removed, added elements).
  * Finishes in `Math.min(before.length, after.length)` steps.
- * @param before
- * @param after
- * @param compare
  */
 export function delta<T>(before: T[], after: T[], compare: (a: T, b: T) => number): { removed: T[]; added: T[] } {
     const splices = sortedDiff(before, after, compare);

--- a/src/test/utils/interpreters.ts
+++ b/src/test/utils/interpreters.ts
@@ -9,10 +9,6 @@ import { EnvironmentType, PythonEnvironment } from '../../client/pythonEnvironme
 /**
  * Creates a PythonInterpreter object for testing purposes, with unique name, version and path.
  * If required a custom name, version and the like can be provided.
- *
- * @export
- * @param {Partial<PythonEnvironment>} [info]
- * @returns {PythonEnvironment}
  */
 export function createPythonInterpreter(info?: Partial<PythonEnvironment>): PythonEnvironment {
     const rnd = new Date().getTime().toString();


### PR DESCRIPTION
Fixes #24077

Removes redundant type annotations from JSDocs in TypeScript files where the type is already inferred by TypeScript.

For example:
![image](https://github.com/user-attachments/assets/9ee1f0b6-f36f-4f4f-81dc-5178d46808cb)

Here I removed JSDoc types but I still kept all the useful information. 
I tried to be on the liberal side to avoid removing any comments that provide useful context or clarify behavior. If I missed any or if more can be removed, I’m happy to go over it again.

Additionally, if this issue only applies to a specific folder or scope, please let me know so I can make the necessary adjustments.