### PR TITLE
Restore `pixi` functionality only when Pixi is available

### DIFF
--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -25,7 +25,7 @@ import {
 import { IInterpreterAutoSelectionService } from '../../interpreter/autoSelection/types';
 import { sleep } from '../utils/async';
 import { traceError } from '../../logging';
-import { getPixiEnvironmentFromInterpreter } from '../../pythonEnvironments/common/environmentManagers/pixi';
+import { getPixiEnvironmentFromInterpreter, Pixi } from '../../pythonEnvironments/common/environmentManagers/pixi';
 
 @injectable()
 export class PythonExecutionFactory implements IPythonExecutionFactory {
@@ -80,14 +80,16 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
         }
         const processService: IProcessService = await this.processServiceFactory.create(options.resource);
 
+        if (await Pixi.getPixi()) {
+            const pixiExecutionService = await this.createPixiExecutionService(pythonPath, processService);
+            if (pixiExecutionService) {
+                return pixiExecutionService;
+            }
+        }
+
         const condaExecutionService = await this.createCondaExecutionService(pythonPath, processService);
         if (condaExecutionService) {
             return condaExecutionService;
-        }
-
-        const pixiExecutionService = await this.createPixiExecutionService(pythonPath, processService);
-        if (pixiExecutionService) {
-            return pixiExecutionService;
         }
 
         const windowsStoreInterpreterCheck = this.pyenvs.isMicrosoftStoreInterpreter.bind(this.pyenvs);

--- a/src/client/common/terminal/environmentActivationProviders/pixiActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/pixiActivationProvider.ts
@@ -31,11 +31,11 @@ export class PixiActivationCommandProvider implements ITerminalActivationCommand
         return this.getActivationCommandsForInterpreter(interpreter.path, targetShell);
     }
 
-    public async getActivationCommandsForInterpreter(
+    public getActivationCommandsForInterpreter(
         pythonPath: string,
         targetShell: TerminalShellType,
     ): Promise<string[] | undefined> {
-        return await getPixiActivationCommands(pythonPath, targetShell);
+        return getPixiActivationCommands(pythonPath, targetShell);
     }
 }
 

--- a/src/client/common/terminal/environmentActivationProviders/pixiActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/pixiActivationProvider.ts
@@ -8,10 +8,7 @@ import { inject, injectable } from 'inversify';
 import { Uri } from 'vscode';
 import { IInterpreterService } from '../../../interpreter/contracts';
 import { ITerminalActivationCommandProvider, TerminalShellType } from '../types';
-import {
-    getPixiEnvironmentFromInterpreter,
-    isNonDefaultPixiEnvironmentName,
-} from '../../../pythonEnvironments/common/environmentManagers/pixi';
+import { getPixiActivationCommands } from '../../../pythonEnvironments/common/environmentManagers/pixi';
 
 @injectable()
 export class PixiActivationCommandProvider implements ITerminalActivationCommandProvider {
@@ -36,42 +33,9 @@ export class PixiActivationCommandProvider implements ITerminalActivationCommand
 
     public async getActivationCommandsForInterpreter(
         pythonPath: string,
-        _targetShell: TerminalShellType,
+        targetShell: TerminalShellType,
     ): Promise<string[] | undefined> {
-        const pixiEnv = await getPixiEnvironmentFromInterpreter(pythonPath);
-        if (!pixiEnv) {
-            return undefined;
-        }
-
-        const args = [
-            pixiEnv.pixi.command.toCommandArgumentForPythonExt(),
-            'shell',
-            '--manifest-path',
-            pixiEnv.manifestPath.toCommandArgumentForPythonExt(),
-        ];
-        if (isNonDefaultPixiEnvironmentName(pixiEnv.envName)) {
-            args.push('--environment');
-            args.push(pixiEnv.envName.toCommandArgumentForPythonExt());
-        }
-
-        // const pixiTargetShell = shellTypeToPixiShell(targetShell);
-        // if (pixiTargetShell) {
-        //     args.push('--shell');
-        //     args.push(pixiTargetShell);
-        // }
-
-        // const shellHookOutput = await exec(pixiEnv.pixi.command, args, {
-        //     throwOnStdErr: false,
-        // }).catch(traceError);
-        // if (!shellHookOutput) {
-        //     return undefined;
-        // }
-
-        // return splitLines(shellHookOutput.stdout, {
-        //     removeEmptyEntries: true,
-        //     trim: true,
-        // });
-        return [args.join(' ')];
+        return await getPixiActivationCommands(pythonPath, targetShell);
     }
 }
 

--- a/src/client/common/terminal/helper.ts
+++ b/src/client/common/terminal/helper.ts
@@ -22,6 +22,7 @@ import {
     TerminalActivationProviders,
     TerminalShellType,
 } from './types';
+import { isPixiEnvironment } from '../../pythonEnvironments/common/environmentManagers/pixi';
 
 @injectable()
 export class TerminalHelper implements ITerminalHelper {
@@ -142,6 +143,19 @@ export class TerminalHelper implements ITerminalHelper {
         providers: ITerminalActivationCommandProvider[],
     ): Promise<string[] | undefined> {
         const settings = this.configurationService.getSettings(resource);
+
+        const isPixiEnv = interpreter
+            ? interpreter.envType === EnvironmentType.Pixi
+            : await isPixiEnvironment(settings.pythonPath);
+        if (isPixiEnv) {
+            const activationCommands = interpreter
+                ? await this.pixi.getActivationCommandsForInterpreter(interpreter.path, terminalShellType)
+                : await this.pixi.getActivationCommands(resource, terminalShellType);
+
+            if (Array.isArray(activationCommands)) {
+                return activationCommands;
+            }
+        }
 
         const condaService = this.serviceContainer.get<IComponentAdapter>(IComponentAdapter);
         // If we have a conda environment, then use that.

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -54,6 +54,7 @@ import { StopWatch } from './common/utils/stopWatch';
 import { registerReplCommands, registerReplExecuteOnEnter, registerStartNativeReplCommand } from './repl/replCommands';
 import { registerTriggerForTerminalREPL } from './terminals/codeExecution/terminalReplWatcher';
 import { registerPythonStartup } from './terminals/pythonStartup';
+import { registerPixiFeatures } from './pythonEnvironments/common/environmentManagers/pixi';
 
 export async function activateComponents(
     // `ext` is passed to any extra activation funcs.
@@ -100,6 +101,7 @@ export function activateFeatures(ext: ExtensionState, _components: Components): 
         IInterpreterService,
     );
     const pathUtils = ext.legacyIOC.serviceContainer.get<IPathUtils>(IPathUtils);
+    registerPixiFeatures(ext.disposables);
     registerAllCreateEnvironmentFeatures(
         ext.disposables,
         interpreterQuickPick,

--- a/src/client/interpreter/activation/service.ts
+++ b/src/client/interpreter/activation/service.ts
@@ -39,6 +39,7 @@ import { StopWatch } from '../../common/utils/stopWatch';
 import { identifyShellFromShellPath } from '../../common/terminal/shellDetectors/baseShellDetector';
 import { getSearchPathEnvVarNames } from '../../common/utils/exec';
 import { cache } from '../../common/utils/decorators';
+import { getRunPixiPythonCommand } from '../../pythonEnvironments/common/environmentManagers/pixi';
 
 const ENVIRONMENT_PREFIX = 'e8b39361-0157-4923-80e1-22d70d46dee6';
 const CACHE_DURATION = 10 * 60 * 1000;
@@ -250,6 +251,11 @@ export class EnvironmentActivationService implements IEnvironmentActivationServi
                 });
                 if (pythonArgv) {
                     // Using environment prefix isn't needed as the marker script already takes care of it.
+                    command = [...pythonArgv, ...args].map((arg) => arg.toCommandArgumentForPythonExt()).join(' ');
+                }
+            } else if (interpreter?.envType === EnvironmentType.Pixi) {
+                const pythonArgv = await getRunPixiPythonCommand(interpreter.path);
+                if (pythonArgv) {
                     command = [...pythonArgv, ...args].map((arg) => arg.toCommandArgumentForPythonExt()).join(' ');
                 }
             }

--- a/src/client/pythonEnvironments/base/locators/lowLevel/pixiLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/lowLevel/pixiLocator.ts
@@ -6,17 +6,17 @@ import { asyncFilter } from '../../../../common/utils/arrayUtils';
 import { chain, iterable } from '../../../../common/utils/async';
 import { traceError, traceVerbose } from '../../../../logging';
 import { getCondaInterpreterPath } from '../../../common/environmentManagers/conda';
-import { Pixi } from '../../../common/environmentManagers/pixi';
 import { pathExists } from '../../../common/externalDependencies';
 import { PythonEnvKind } from '../../info';
 import { IPythonEnvsIterator, BasicEnvInfo } from '../../locator';
 import { FSWatcherKind, FSWatchingLocator } from './fsWatchingLocator';
+import { getPixi } from '../../../common/environmentManagers/pixi';
 
 /**
  * Returns all virtual environment locations to look for in a workspace.
  */
 async function getVirtualEnvDirs(root: string): Promise<string[]> {
-    const pixi = await Pixi.getPixi();
+    const pixi = await getPixi();
     const envDirs = (await pixi?.getEnvList(root)) ?? [];
     return asyncFilter(envDirs, pathExists);
 }

--- a/src/client/pythonEnvironments/common/environmentManagers/pixi.ts
+++ b/src/client/pythonEnvironments/common/environmentManagers/pixi.ts
@@ -5,12 +5,16 @@
 
 import * as path from 'path';
 import { readJSON } from 'fs-extra';
-import { OSType, getOSType, getUserHomeDir } from '../../../common/utils/platform';
-import { exec, getPythonSetting, onDidChangePythonSetting, pathExists, pathExistsSync } from '../externalDependencies';
+import which from 'which';
+import { getUserHomeDir } from '../../../common/utils/platform';
+import { exec, getPythonSetting, onDidChangePythonSetting, pathExists } from '../externalDependencies';
 import { cache } from '../../../common/utils/decorators';
-import { isTestExecution } from '../../../common/constants';
 import { traceVerbose, traceWarn } from '../../../logging';
 import { OUTPUT_MARKER_SCRIPT } from '../../../common/process/internal/scripts';
+import { isWindows } from '../../../common/platform/platformService';
+import { IDisposableRegistry } from '../../../common/types';
+import { getWorkspaceFolderPaths } from '../../../common/vscodeApis/workspaceApis';
+import { isTestExecution } from '../../../common/constants';
 
 export const PIXITOOLPATH_SETTING_KEY = 'pixiToolPath';
 
@@ -63,93 +67,77 @@ export async function isPixiEnvironment(interpreterPath: string): Promise<boolea
  */
 export function getPrefixFromInterpreterPath(interpreterPath: string): string {
     const interpreterDir = path.dirname(interpreterPath);
-    if (getOSType() === OSType.Windows) {
+    if (!interpreterDir.endsWith('bin') && !interpreterDir.endsWith('Scripts')) {
         return interpreterDir;
     }
     return path.dirname(interpreterDir);
+}
+
+async function findPixiOnPath(): Promise<readonly string[]> {
+    try {
+        return await which('pixi', { all: true });
+    } catch {}
+    return [];
+}
+
+async function getPixiTool(): Promise<Pixi | undefined> {
+    let pixi = getPythonSetting<string>(PIXITOOLPATH_SETTING_KEY);
+
+    if (!pixi || pixi === 'pixi' || !(await pathExists(pixi))) {
+        pixi = undefined;
+        const paths = await findPixiOnPath();
+        for (let p of paths) {
+            if (await pathExists(p)) {
+                pixi = p;
+                break;
+            }
+        }
+    }
+
+    if (!pixi) {
+        // Check the default installation location
+        const home = getUserHomeDir();
+        if (home) {
+            const pixiToolPath = path.join(home, '.pixi', 'bin', isWindows() ? 'pixi.exe' : 'pixi');
+            if (await pathExists(pixiToolPath)) {
+                pixi = pixiToolPath;
+            }
+        }
+    }
+
+    return pixi ? new Pixi(pixi) : undefined;
+}
+
+/**
+ * Locating pixi binary can be expensive, since it potentially involves spawning or
+ * trying to spawn processes; so we only do it once per session.
+ */
+let _pixi: Promise<Pixi | undefined> | undefined;
+
+/**
+ * Returns a Pixi instance corresponding to the binary which can be used to run commands for the cwd.
+ *
+ * Pixi commands can be slow and so can be bottleneck to overall discovery time. So trigger command
+ * execution as soon as possible. To do that we need to ensure the operations before the command are
+ * performed synchronously.
+ */
+export function getPixi() {
+    if (_pixi === undefined || isTestExecution()) {
+        _pixi = getPixiTool();
+    }
+    return _pixi;
 }
 
 /** Wraps the "pixi" utility, and exposes its functionality.
  */
 export class Pixi {
     /**
-     * Locating pixi binary can be expensive, since it potentially involves spawning or
-     * trying to spawn processes; so we only do it once per session.
-     */
-    private static pixiPromise: Promise<Pixi | undefined> | undefined;
-
-    /**
      * Creates a Pixi service corresponding to the corresponding "pixi" command.
      *
      * @param command - Command used to run pixi. This has the same meaning as the
      * first argument of spawn() - i.e. it can be a full path, or just a binary name.
      */
-    constructor(public readonly command: string) {
-        onDidChangePythonSetting(PIXITOOLPATH_SETTING_KEY, () => {
-            Pixi.pixiPromise = undefined;
-        });
-    }
-
-    /**
-     * Returns a Pixi instance corresponding to the binary which can be used to run commands for the cwd.
-     *
-     * Pixi commands can be slow and so can be bottleneck to overall discovery time. So trigger command
-     * execution as soon as possible. To do that we need to ensure the operations before the command are
-     * performed synchronously.
-     */
-    public static async getPixi(): Promise<Pixi | undefined> {
-        if (Pixi.pixiPromise === undefined || isTestExecution()) {
-            Pixi.pixiPromise = Pixi.locate();
-        }
-        return Pixi.pixiPromise;
-    }
-
-    private static async locate(): Promise<Pixi | undefined> {
-        // First thing this method awaits on should be pixi command execution, hence perform all operations
-        // before that synchronously.
-
-        traceVerbose(`Getting pixi`);
-        // Produce a list of candidate binaries to be probed by exec'ing them.
-        function* getCandidates() {
-            // Read the pixi location from the settings.
-            try {
-                const customPixiToolPath = getPythonSetting<string>(PIXITOOLPATH_SETTING_KEY);
-                if (customPixiToolPath && customPixiToolPath !== 'pixi') {
-                    // If user has specified a custom pixi path, use it first.
-                    yield customPixiToolPath;
-                }
-            } catch (ex) {
-                traceWarn(`Failed to get pixi setting`, ex);
-            }
-
-            // Check unqualified filename, in case it's on PATH.
-            yield 'pixi';
-
-            // Check the default installation location
-            const home = getUserHomeDir();
-            if (home) {
-                const defaultpixiToolPath = path.join(home, '.pixi', 'bin', 'pixi');
-                if (pathExistsSync(defaultpixiToolPath)) {
-                    yield defaultpixiToolPath;
-                }
-            }
-        }
-
-        // Probe the candidates, and pick the first one that exists and does what we need.
-        for (const pixiToolPath of getCandidates()) {
-            traceVerbose(`Probing pixi binary: ${pixiToolPath}`);
-            const pixi = new Pixi(pixiToolPath);
-            const pixiVersion = await pixi.getVersion();
-            if (pixiVersion !== undefined) {
-                traceVerbose(`Found pixi ${pixiVersion} via filesystem probing: ${pixiToolPath}`);
-                return pixi;
-            }
-        }
-
-        // Didn't find anything.
-        traceVerbose(`No pixi binary found`);
-        return undefined;
-    }
+    constructor(public readonly command: string) {}
 
     /**
      * Retrieves list of Python environments known to this pixi for the specified directory.
@@ -187,28 +175,6 @@ export class Pixi {
     }
 
     /**
-     * Runs `pixi --version` and returns the version part of the output.
-     */
-    @cache(30_000, true, 10_000)
-    public async getVersion(): Promise<string | undefined> {
-        try {
-            const versionOutput = await exec(this.command, ['--version'], {
-                throwOnStdErr: false,
-            });
-            if (!versionOutput || !versionOutput.stdout) {
-                return undefined;
-            }
-            const versionParts = versionOutput.stdout.split(' ');
-            if (versionParts.length < 2) {
-                return undefined;
-            }
-            return versionParts[1].trim();
-        } catch (error) {
-            return undefined;
-        }
-    }
-
-    /**
      * Returns the command line arguments to run `python` within a specific pixi environment.
      * @param manifestPath The path to the manifest file used by pixi.
      * @param envName The name of the environment in the pixi project
@@ -238,8 +204,13 @@ export class Pixi {
     // eslint-disable-next-line class-methods-use-this
     async getPixiEnvironmentMetadata(envDir: string): Promise<PixiEnvMetadata | undefined> {
         const pixiPath = path.join(envDir, 'conda-meta/pixi');
-        const result: PixiEnvMetadata | undefined = await readJSON(pixiPath).catch(traceVerbose);
-        return result;
+        try {
+            const result: PixiEnvMetadata | undefined = await readJSON(pixiPath);
+            return result;
+        } catch (e) {
+            traceVerbose(`Failed to get pixi environment metadata for ${envDir}`, e);
+        }
+        return undefined;
     }
 }
 
@@ -251,6 +222,12 @@ export type PixiEnvironmentInfo = {
     envName?: string;
 };
 
+function isPixiProjectDir(pixiProjectDir: string): boolean {
+    const paths = getWorkspaceFolderPaths().map((f) => path.normalize(f));
+    const normalized = path.normalize(pixiProjectDir);
+    return paths.some((p) => p === normalized);
+}
+
 /**
  * Given the location of an interpreter, try to deduce information about the environment in which it
  * resides.
@@ -260,16 +237,13 @@ export type PixiEnvironmentInfo = {
  */
 export async function getPixiEnvironmentFromInterpreter(
     interpreterPath: string,
-    pixi?: Pixi,
 ): Promise<PixiEnvironmentInfo | undefined> {
     if (!interpreterPath) {
         return undefined;
     }
 
     const prefix = getPrefixFromInterpreterPath(interpreterPath);
-
-    // Find the pixi executable for the project
-    pixi = pixi || (await Pixi.getPixi());
+    const pixi = await getPixi();
     if (!pixi) {
         traceVerbose(`could not find a pixi interpreter for the interpreter at ${interpreterPath}`);
         return undefined;
@@ -302,30 +276,42 @@ export async function getPixiEnvironmentFromInterpreter(
         envsDir = path.dirname(prefix);
         dotPixiDir = path.dirname(envsDir);
         pixiProjectDir = path.dirname(dotPixiDir);
+        if (!isPixiProjectDir(pixiProjectDir)) {
+            traceVerbose(`could not determine the pixi project directory for the interpreter at ${interpreterPath}`);
+            return undefined;
+        }
 
         // Invoke pixi to get information about the pixi project
         pixiInfo = await pixi.getPixiInfo(pixiProjectDir);
+
+        if (!pixiInfo || !pixiInfo.project_info) {
+            traceWarn(`failed to determine pixi project information for the interpreter at ${interpreterPath}`);
+            return undefined;
+        }
+
+        return {
+            interpreterPath,
+            pixi,
+            pixiVersion: pixiInfo.version,
+            manifestPath: pixiInfo.project_info.manifest_path,
+            envName,
+        };
     } catch (error) {
         traceWarn('Error processing paths or getting Pixi Info:', error);
     }
-
-    if (!pixiInfo || !pixiInfo.project_info) {
-        traceWarn(`failed to determine pixi project information for the interpreter at ${interpreterPath}`);
-        return undefined;
-    }
-
-    return {
-        interpreterPath,
-        pixi,
-        pixiVersion: pixiInfo.version,
-        manifestPath: pixiInfo.project_info.manifest_path,
-        envName,
-    };
 }
 
 /**
  * Returns true if the given environment name is *not* the default environment.
  */
 export function isNonDefaultPixiEnvironmentName(envName?: string): envName is string {
-    return envName !== undefined && envName !== 'default';
+    return envName !== 'default';
+}
+
+export function registerPixiFeatures(disposables: IDisposableRegistry): void {
+    disposables.push(
+        onDidChangePythonSetting(PIXITOOLPATH_SETTING_KEY, () => {
+            _pixi = getPixiTool();
+        }),
+    );
 }

--- a/src/client/pythonEnvironments/common/environmentManagers/pixi.ts
+++ b/src/client/pythonEnvironments/common/environmentManagers/pixi.ts
@@ -315,3 +315,27 @@ export function registerPixiFeatures(disposables: IDisposableRegistry): void {
         }),
     );
 }
+
+/**
+ * Returns the `pixi run` command
+ */
+export async function getRunPixiPythonCommand(pythonPath: string): Promise<string[] | undefined> {
+    const pixiEnv = await getPixiEnvironmentFromInterpreter(pythonPath);
+    if (!pixiEnv) {
+        return undefined;
+    }
+
+    const args = [
+        pixiEnv.pixi.command.toCommandArgumentForPythonExt(),
+        'run',
+        '--manifest-path',
+        pixiEnv.manifestPath.toCommandArgumentForPythonExt(),
+    ];
+    if (isNonDefaultPixiEnvironmentName(pixiEnv.envName)) {
+        args.push('--environment');
+        args.push(pixiEnv.envName.toCommandArgumentForPythonExt());
+    }
+
+    args.push('python');
+    return args;
+}

--- a/src/client/pythonEnvironments/common/environmentManagers/pixi.ts
+++ b/src/client/pythonEnvironments/common/environmentManagers/pixi.ts
@@ -144,7 +144,6 @@ export class Pixi {
                 traceVerbose(`Found pixi ${pixiVersion} via filesystem probing: ${pixiToolPath}`);
                 return pixi;
             }
-            traceVerbose(`Failed to find pixi: ${pixiToolPath}`);
         }
 
         // Didn't find anything.
@@ -205,7 +204,6 @@ export class Pixi {
             }
             return versionParts[1].trim();
         } catch (error) {
-            traceVerbose(`Failed to get pixi version`, error);
             return undefined;
         }
     }

--- a/src/client/pythonEnvironments/common/environmentManagers/pixi.ts
+++ b/src/client/pythonEnvironments/common/environmentManagers/pixi.ts
@@ -15,6 +15,7 @@ import { isWindows } from '../../../common/platform/platformService';
 import { IDisposableRegistry } from '../../../common/types';
 import { getWorkspaceFolderPaths } from '../../../common/vscodeApis/workspaceApis';
 import { isTestExecution } from '../../../common/constants';
+import { TerminalShellType } from '../../../common/terminal/types';
 
 export const PIXITOOLPATH_SETTING_KEY = 'pixiToolPath';
 
@@ -338,4 +339,44 @@ export async function getRunPixiPythonCommand(pythonPath: string): Promise<strin
 
     args.push('python');
     return args;
+}
+
+export async function getPixiActivationCommands(
+    pythonPath: string,
+    _targetShell?: TerminalShellType,
+): Promise<string[] | undefined> {
+    const pixiEnv = await getPixiEnvironmentFromInterpreter(pythonPath);
+    if (!pixiEnv) {
+        return undefined;
+    }
+
+    const args = [
+        pixiEnv.pixi.command.toCommandArgumentForPythonExt(),
+        'shell',
+        '--manifest-path',
+        pixiEnv.manifestPath.toCommandArgumentForPythonExt(),
+    ];
+    if (isNonDefaultPixiEnvironmentName(pixiEnv.envName)) {
+        args.push('--environment');
+        args.push(pixiEnv.envName.toCommandArgumentForPythonExt());
+    }
+
+    // const pixiTargetShell = shellTypeToPixiShell(targetShell);
+    // if (pixiTargetShell) {
+    //     args.push('--shell');
+    //     args.push(pixiTargetShell);
+    // }
+
+    // const shellHookOutput = await exec(pixiEnv.pixi.command, args, {
+    //     throwOnStdErr: false,
+    // }).catch(traceError);
+    // if (!shellHookOutput) {
+    //     return undefined;
+    // }
+
+    // return splitLines(shellHookOutput.stdout, {
+    //     removeEmptyEntries: true,
+    //     trim: true,
+    // });
+    return [args.join(' ')];
 }

--- a/src/test/common/process/pythonExecutionFactory.unit.test.ts
+++ b/src/test/common/process/pythonExecutionFactory.unit.test.ts
@@ -89,6 +89,7 @@ suite('Process - PythonExecutionFactory', () => {
             let autoSelection: IInterpreterAutoSelectionService;
             let interpreterPathExpHelper: IInterpreterPathService;
             let getPixiEnvironmentFromInterpreterStub: sinon.SinonStub;
+            let getPixiStub: sinon.SinonStub;
             const pythonPath = 'path/to/python';
             setup(() => {
                 sinon.stub(Conda, 'getConda').resolves(new Conda('conda'));
@@ -96,6 +97,9 @@ suite('Process - PythonExecutionFactory', () => {
 
                 getPixiEnvironmentFromInterpreterStub = sinon.stub(pixi, 'getPixiEnvironmentFromInterpreter');
                 getPixiEnvironmentFromInterpreterStub.resolves(undefined);
+
+                getPixiStub = sinon.stub(pixi, 'getPixi');
+                getPixiStub.resolves(undefined);
 
                 activationHelper = mock(EnvironmentActivationService);
                 processFactory = mock(ProcessServiceFactory);
@@ -141,6 +145,9 @@ suite('Process - PythonExecutionFactory', () => {
                 when(serviceContainer.get<IComponentAdapter>(IComponentAdapter)).thenReturn(instance(pyenvs));
                 when(serviceContainer.tryGet<IInterpreterService>(IInterpreterService)).thenReturn(
                     instance(interpreterService),
+                );
+                when(serviceContainer.get<IConfigurationService>(IConfigurationService)).thenReturn(
+                    instance(configService),
                 );
                 factory = new PythonExecutionFactory(
                     instance(serviceContainer),

--- a/src/test/common/terminals/helper.unit.test.ts
+++ b/src/test/common/terminals/helper.unit.test.ts
@@ -211,8 +211,8 @@ suite('Terminal Service helpers', () => {
                     const cmd = await helper.getEnvironmentActivationCommands(anything(), resource);
 
                     expect(cmd).to.equal(condaActivationCommands);
-                    verify(pythonSettings.pythonPath).once();
-                    verify(condaService.isCondaEnvironment(pythonPath)).once();
+                    verify(pythonSettings.pythonPath).atLeast(1);
+                    verify(condaService.isCondaEnvironment(pythonPath)).atLeast(1);
                     verify(condaActivationProvider.getActivationCommands(resource, anything())).once();
                 });
                 test('Activation command must return undefined if none of the proivders support the shell', async () => {
@@ -231,8 +231,8 @@ suite('Terminal Service helpers', () => {
                     );
 
                     expect(cmd).to.equal(undefined, 'Command must be undefined');
-                    verify(pythonSettings.pythonPath).once();
-                    verify(condaService.isCondaEnvironment(pythonPath)).once();
+                    verify(pythonSettings.pythonPath).atLeast(1);
+                    verify(condaService.isCondaEnvironment(pythonPath)).atLeast(1);
                     verify(bashActivationProvider.isShellSupported(anything())).atLeast(1);
                     verify(nushellActivationProvider.isShellSupported(anything())).atLeast(1);
                     verify(pyenvActivationProvider.isShellSupported(anything())).atLeast(1);
@@ -255,8 +255,8 @@ suite('Terminal Service helpers', () => {
                     const cmd = await helper.getEnvironmentActivationCommands(anything(), resource);
 
                     expect(cmd).to.deep.equal(expectCommand);
-                    verify(pythonSettings.pythonPath).once();
-                    verify(condaService.isCondaEnvironment(pythonPath)).once();
+                    verify(pythonSettings.pythonPath).atLeast(1);
+                    verify(condaService.isCondaEnvironment(pythonPath)).atLeast(1);
                     verify(bashActivationProvider.isShellSupported(anything())).atLeast(1);
                     verify(bashActivationProvider.getActivationCommands(resource, anything())).once();
                     verify(nushellActivationProvider.isShellSupported(anything())).atLeast(1);
@@ -287,7 +287,7 @@ suite('Terminal Service helpers', () => {
                     const cmd = await helper.getEnvironmentActivationCommands(anything(), resource);
 
                     expect(cmd).to.deep.equal(expectCommand);
-                    verify(pythonSettings.pythonPath).once();
+                    verify(pythonSettings.pythonPath).atLeast(1);
                     verify(condaService.isCondaEnvironment(pythonPath)).once();
                     verify(bashActivationProvider.isShellSupported(anything())).atLeast(1);
                     verify(bashActivationProvider.getActivationCommands(resource, anything())).never();
@@ -313,7 +313,7 @@ suite('Terminal Service helpers', () => {
                     const cmd = await helper.getEnvironmentActivationCommands(anything(), resource);
 
                     expect(cmd).to.deep.equal(expectCommand);
-                    verify(pythonSettings.pythonPath).once();
+                    verify(pythonSettings.pythonPath).atLeast(1);
                     verify(condaService.isCondaEnvironment(pythonPath)).once();
                     verify(bashActivationProvider.isShellSupported(anything())).atLeast(1);
                     verify(nushellActivationProvider.isShellSupported(anything())).atLeast(1);
@@ -340,7 +340,7 @@ suite('Terminal Service helpers', () => {
                     const cmd = await helper.getEnvironmentActivationCommands(anything(), resource);
 
                     expect(cmd).to.deep.equal(expectCommand);
-                    verify(pythonSettings.pythonPath).once();
+                    verify(pythonSettings.pythonPath).atLeast(1);
                     verify(condaService.isCondaEnvironment(pythonPath)).once();
                     verify(bashActivationProvider.getActivationCommands(resource, anything())).once();
                     verify(cmdActivationProvider.getActivationCommands(resource, anything())).once();
@@ -387,8 +387,13 @@ suite('Terminal Service helpers', () => {
                             );
 
                             expect(cmd).to.equal(undefined, 'Command must be undefined');
-                            verify(pythonSettings.pythonPath).times(interpreter ? 0 : 1);
-                            verify(condaService.isCondaEnvironment(pythonPath)).times(interpreter ? 0 : 1);
+                            if (interpreter) {
+                                verify(pythonSettings.pythonPath).never();
+                                verify(condaService.isCondaEnvironment(pythonPath)).never();
+                            } else {
+                                verify(pythonSettings.pythonPath).atLeast(1);
+                                verify(condaService.isCondaEnvironment(pythonPath)).atLeast(1);
+                            }
                             verify(bashActivationProvider.isShellSupported(shellToExpect)).atLeast(1);
                             verify(pyenvActivationProvider.isShellSupported(anything())).never();
                             verify(pipenvActivationProvider.isShellSupported(anything())).never();

--- a/src/test/pythonEnvironments/common/environmentManagers/pixi.unit.test.ts
+++ b/src/test/pythonEnvironments/common/environmentManagers/pixi.unit.test.ts
@@ -4,7 +4,7 @@ import * as sinon from 'sinon';
 import { ExecutionResult, ShellOptions } from '../../../../client/common/process/types';
 import * as externalDependencies from '../../../../client/pythonEnvironments/common/externalDependencies';
 import { TEST_LAYOUT_ROOT } from '../commonTestConstants';
-import { Pixi } from '../../../../client/pythonEnvironments/common/environmentManagers/pixi';
+import { getPixi } from '../../../../client/pythonEnvironments/common/environmentManagers/pixi';
 
 export type PixiCommand = { cmd: 'info --json' } | { cmd: '--version' } | { cmd: null };
 
@@ -119,7 +119,7 @@ suite('Pixi binary is located correctly', async () => {
         getPythonSetting.returns(pixiPath);
         // If `verify` is false, don’t verify that the command has been called with that path
         exec.callsFake(makeExecHandler(verify ? { pixiPath } : undefined));
-        const pixi = await Pixi.getPixi();
+        const pixi = await getPixi();
         expect(pixi?.command).to.equal(pixiPath);
     };
 
@@ -133,7 +133,7 @@ suite('Pixi binary is located correctly', async () => {
         exec.callsFake((_file: string, _args: string[], _options: ShellOptions) =>
             Promise.reject(new Error('Command failed')),
         );
-        const pixi = await Pixi.getPixi();
+        const pixi = await getPixi();
         expect(pixi?.command).to.equal(undefined);
     });
 });

--- a/src/test/pythonEnvironments/common/environmentManagers/pixi.unit.test.ts
+++ b/src/test/pythonEnvironments/common/environmentManagers/pixi.unit.test.ts
@@ -105,10 +105,12 @@ export function makeExecHandler(verify: VerifyOptions = {}) {
 suite('Pixi binary is located correctly', async () => {
     let exec: sinon.SinonStub;
     let getPythonSetting: sinon.SinonStub;
+    let pathExists: sinon.SinonStub;
 
     setup(() => {
         getPythonSetting = sinon.stub(externalDependencies, 'getPythonSetting');
         exec = sinon.stub(externalDependencies, 'exec');
+        pathExists = sinon.stub(externalDependencies, 'pathExists');
     });
 
     teardown(() => {
@@ -117,10 +119,16 @@ suite('Pixi binary is located correctly', async () => {
 
     const testPath = async (pixiPath: string, verify = true) => {
         getPythonSetting.returns(pixiPath);
+        pathExists.returns(pixiPath !== 'pixi');
         // If `verify` is false, don’t verify that the command has been called with that path
         exec.callsFake(makeExecHandler(verify ? { pixiPath } : undefined));
         const pixi = await getPixi();
-        expect(pixi?.command).to.equal(pixiPath);
+
+        if (pixiPath === 'pixi') {
+            expect(pixi).to.equal(undefined);
+        } else {
+            expect(pixi?.command).to.equal(pixiPath);
+        }
     };
 
     test('Return a Pixi instance in an empty directory', () => testPath('pixiPath', false));

--- a/src/test/testing/common/testingAdapter.test.ts
+++ b/src/test/testing/common/testingAdapter.test.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as os from 'os';
+import * as sinon from 'sinon';
 import { PytestTestDiscoveryAdapter } from '../../../client/testing/testController/pytest/pytestDiscoveryAdapter';
 import { ITestController, ITestResultResolver } from '../../../client/testing/testController/common/types';
 import { IPythonExecutionFactory } from '../../../client/common/process/types';
@@ -22,6 +23,7 @@ import { TestProvider } from '../../../client/testing/types';
 import { PYTEST_PROVIDER, UNITTEST_PROVIDER } from '../../../client/testing/common/constants';
 import { IEnvironmentVariablesProvider } from '../../../client/common/variables/types';
 import { createTypeMoq } from '../../mocks/helper';
+import * as pixi from '../../../client/pythonEnvironments/common/environmentManagers/pixi';
 
 suite('End to End Tests: test adapters', () => {
     let resultResolver: ITestResultResolver;
@@ -32,6 +34,7 @@ suite('End to End Tests: test adapters', () => {
     let workspaceUri: Uri;
     let testOutputChannel: typeMoq.IMock<ITestOutputChannel>;
     let testController: TestController;
+    let getPixiStub: sinon.SinonStub;
     const unittestProvider: TestProvider = UNITTEST_PROVIDER;
     const pytestProvider: TestProvider = PYTEST_PROVIDER;
     const rootPathSmallWorkspace = path.join(
@@ -104,6 +107,9 @@ suite('End to End Tests: test adapters', () => {
     });
 
     setup(async () => {
+        getPixiStub = sinon.stub(pixi, 'getPixi');
+        getPixiStub.resolves(undefined);
+
         // create objects that were injected
         configService = serviceContainer.get<IConfigurationService>(IConfigurationService);
         pythonExecFactory = serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
@@ -129,6 +135,9 @@ suite('End to End Tests: test adapters', () => {
             .returns(() => {
                 // Whatever you need to return
             });
+    });
+    teardown(() => {
+        sinon.restore();
     });
     suiteTeardown(async () => {
         // remove symlink


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-python/issues/24310
Fixes https://github.com/microsoft/vscode-python/issues/23901