### PR TITLE
Jupyter API to get Env associated with Notebooks

### DIFF
--- a/pythonExtensionApi/src/main.ts
+++ b/pythonExtensionApi/src/main.ts
@@ -227,9 +227,9 @@ export type EnvironmentsChangeEvent = {
 
 export type ActiveEnvironmentPathChangeEvent = EnvironmentPath & {
     /**
-     * Workspace folder the environment changed for.
+     * Resource the environment changed for.
      */
-    readonly resource: WorkspaceFolder | undefined;
+    readonly resource: Resource | undefined;
 };
 
 /**

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -15,7 +15,11 @@ import { IConfigurationService, Resource } from './common/types';
 import { getDebugpyLauncherArgs } from './debugger/extension/adapter/remoteLaunchers';
 import { IInterpreterService } from './interpreter/contracts';
 import { IServiceContainer, IServiceManager } from './ioc/types';
-import { JupyterExtensionIntegration } from './jupyter/jupyterIntegration';
+import {
+    JupyterExtensionIntegration,
+    JupyterExtensionPythonEnvironments,
+    JupyterPythonEnvironmentApi,
+} from './jupyter/jupyterIntegration';
 import { traceError } from './logging';
 import { IDiscoveryAPI } from './pythonEnvironments/base/locator';
 import { buildEnvironmentApi } from './environmentApi';
@@ -33,11 +37,16 @@ export function buildApi(
     const configurationService = serviceContainer.get<IConfigurationService>(IConfigurationService);
     const interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
     serviceManager.addSingleton<JupyterExtensionIntegration>(JupyterExtensionIntegration, JupyterExtensionIntegration);
+    serviceManager.addSingleton<JupyterExtensionPythonEnvironments>(
+        JupyterExtensionPythonEnvironments,
+        JupyterExtensionPythonEnvironments,
+    );
     serviceManager.addSingleton<TensorboardExtensionIntegration>(
         TensorboardExtensionIntegration,
         TensorboardExtensionIntegration,
     );
     const jupyterIntegration = serviceContainer.get<JupyterExtensionIntegration>(JupyterExtensionIntegration);
+    const jupyterPythonEnvApi = serviceContainer.get<JupyterPythonEnvironmentApi>(JupyterExtensionPythonEnvironments);
     const tensorboardIntegration = serviceContainer.get<TensorboardExtensionIntegration>(
         TensorboardExtensionIntegration,
     );
@@ -146,7 +155,7 @@ export function buildApi(
             stop: (client: BaseLanguageClient): Promise<void> => client.stop(),
             getTelemetryReporter: () => getTelemetryReporter(),
         },
-        environments: buildEnvironmentApi(discoveryApi, serviceContainer),
+        environments: buildEnvironmentApi(discoveryApi, serviceContainer, jupyterPythonEnvApi),
     };
 
     // In test environment return the DI Container.

--- a/src/client/api/types.ts
+++ b/src/client/api/types.ts
@@ -227,9 +227,9 @@ export type EnvironmentsChangeEvent = {
 
 export type ActiveEnvironmentPathChangeEvent = EnvironmentPath & {
     /**
-     * Workspace folder the environment changed for.
+     * Resource the environment changed for.
      */
-    readonly resource: WorkspaceFolder | undefined;
+    readonly resource: Resource | undefined;
 };
 
 /**

--- a/src/client/jupyter/jupyterIntegration.ts
+++ b/src/client/jupyter/jupyterIntegration.ts
@@ -1,12 +1,12 @@
 /* eslint-disable comma-dangle */
 
-/* eslint-disable implicit-arrow-linebreak */
+/* eslint-disable implicit-arrow-linebreak, max-classes-per-file */
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 import { inject, injectable, named } from 'inversify';
 import { dirname } from 'path';
-import { Extension, Memento, Uri } from 'vscode';
+import { EventEmitter, Extension, Memento, Uri, workspace, Event } from 'vscode';
 import type { SemVer } from 'semver';
 import { IContextKeyManager, IWorkspaceService } from '../common/application/types';
 import { JUPYTER_EXTENSION_ID, PYLANCE_EXTENSION_ID } from '../common/constants';
@@ -23,6 +23,7 @@ import { PylanceApi } from '../activation/node/pylanceApi';
 import { ExtensionContextKey } from '../common/application/contextKeys';
 import { getDebugpyPath } from '../debugger/pythonDebugger';
 import type { Environment } from '../api/types';
+import { DisposableBase } from '../common/utils/resourceLifecycle';
 
 type PythonApiForJupyterExtension = {
     /**
@@ -169,4 +170,99 @@ export class JupyterExtensionIntegration {
             api.notebook!.registerJupyterPythonPathFunction(func);
         }
     }
+}
+
+export interface JupyterPythonEnvironmentApi {
+    /**
+     * This event is triggered when the environment associated with a Jupyter Notebook or Interactive Window changes.
+     * The Uri in the event is the Uri of the Notebook/IW.
+     */
+    onDidChangePythonEnvironment?: Event<Uri>;
+    /**
+     * Returns the EnvironmentPath to the Python environment associated with a Jupyter Notebook or Interactive Window.
+     * If the Uri is not associated with a Jupyter Notebook or Interactive Window, then this method returns undefined.
+     * @param uri
+     */
+    getPythonEnvironment?(
+        uri: Uri,
+    ):
+        | undefined
+        | {
+              /**
+               * The ID of the environment.
+               */
+              readonly id: string;
+              /**
+               * Path to environment folder or path to python executable that uniquely identifies an environment. Environments
+               * lacking a python executable are identified by environment folder paths, whereas other envs can be identified
+               * using python executable path.
+               */
+              readonly path: string;
+          };
+}
+
+@injectable()
+export class JupyterExtensionPythonEnvironments extends DisposableBase implements JupyterPythonEnvironmentApi {
+    private jupyterExtension?: JupyterPythonEnvironmentApi;
+
+    private readonly _onDidChangePythonEnvironment = this._register(new EventEmitter<Uri>());
+
+    public readonly onDidChangePythonEnvironment = this._onDidChangePythonEnvironment.event;
+
+    constructor(@inject(IExtensions) private readonly extensions: IExtensions) {
+        super();
+    }
+
+    public getPythonEnvironment(
+        uri: Uri,
+    ):
+        | undefined
+        | {
+              /**
+               * The ID of the environment.
+               */
+              readonly id: string;
+              /**
+               * Path to environment folder or path to python executable that uniquely identifies an environment. Environments
+               * lacking a python executable are identified by environment folder paths, whereas other envs can be identified
+               * using python executable path.
+               */
+              readonly path: string;
+          } {
+        if (!isJupyterResource(uri)) {
+            return undefined;
+        }
+        const api = this.getJupyterApi();
+        if (api?.getPythonEnvironment) {
+            return api.getPythonEnvironment(uri);
+        }
+        return undefined;
+    }
+
+    private getJupyterApi() {
+        if (!this.jupyterExtension) {
+            const api = this.extensions.getExtension<JupyterPythonEnvironmentApi>(JUPYTER_EXTENSION_ID)?.exports;
+            if (!api) {
+                return undefined;
+            }
+            this.jupyterExtension = api;
+            if (api.onDidChangePythonEnvironment) {
+                this._register(
+                    api.onDidChangePythonEnvironment(
+                        this._onDidChangePythonEnvironment.fire,
+                        this._onDidChangePythonEnvironment,
+                    ),
+                );
+            }
+        }
+        return this.jupyterExtension;
+    }
+}
+
+function isJupyterResource(resource: Uri): boolean {
+    // Jupyter extension only deals with Notebooks and Interactive Windows.
+    return (
+        resource.fsPath.endsWith('.ipynb') ||
+        workspace.notebookDocuments.some((item) => item.uri.toString() === resource.toString())
+    );
 }

--- a/src/test/api.functional.test.ts
+++ b/src/test/api.functional.test.ts
@@ -19,6 +19,8 @@ import { ServiceManager } from '../client/ioc/serviceManager';
 import { IServiceContainer, IServiceManager } from '../client/ioc/types';
 import { IDiscoveryAPI } from '../client/pythonEnvironments/base/locator';
 import * as pythonDebugger from '../client/debugger/pythonDebugger';
+import { JupyterExtensionPythonEnvironments, JupyterPythonEnvironmentApi } from '../client/jupyter/jupyterIntegration';
+import { EventEmitter, Uri } from 'vscode';
 
 suite('Extension API', () => {
     const debuggerPath = path.join(EXTENSION_ROOT_DIR, 'python_files', 'lib', 'python', 'debugpy');
@@ -49,6 +51,14 @@ suite('Extension API', () => {
             instance(environmentVariablesProvider),
         );
         when(serviceContainer.get<IInterpreterService>(IInterpreterService)).thenReturn(instance(interpreterService));
+        const onDidChangePythonEnvironment = new EventEmitter<Uri>();
+        const jupyterApi: JupyterPythonEnvironmentApi = {
+            onDidChangePythonEnvironment: onDidChangePythonEnvironment.event,
+            getPythonEnvironment: (_uri: Uri) => undefined,
+        };
+        when(serviceContainer.get<JupyterPythonEnvironmentApi>(JupyterExtensionPythonEnvironments)).thenReturn(
+            jupyterApi,
+        );
         when(serviceContainer.get<IDisposableRegistry>(IDisposableRegistry)).thenReturn([]);
         getDebugpyPathStub = sinon.stub(pythonDebugger, 'getDebugpyPath');
         getDebugpyPathStub.resolves(debuggerPath);


### PR DESCRIPTION
See https://github.com/microsoft/vscode-jupyter/issues/15987

Should also fix https://github.com/microsoft/vscode-jupyter/issues/16112
Should also avoid Pylance having to monitor notebook changes and then trying to figure out the Environment for a Notebook.

@rchiodo @heejaechang @debonte  Please can you let me know if this works
I.e. going forward (we can plan how we roll this out)
* Pylance can use just Python extension API to get Python environment for a Uri (the uri can be a Notebook or IW uri)
* If the kernel is changed, the event `onDidChangeActiveEnvironmentPath` will be triggered with the corresponding Uri
* If a kernel is changed to say a Non Python Kernel, then its triggered again, but the active interpreter for that Uri will be the same as the worksapce interpreter

I believe this should simplify things.
@karthiknadig  /cc