### PR TITLE
Update action to use upload-artifact v4

### DIFF
--- a/.github/actions/build-vsix/action.yml
+++ b/.github/actions/build-vsix/action.yml
@@ -87,7 +87,7 @@ runs:
       shell: bash
 
     - name: Upload VSIX
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact_name }}
         path: ${{ inputs.vsix_name }}

--- a/.github/actions/smoke-tests/action.yml
+++ b/.github/actions/smoke-tests/action.yml
@@ -43,7 +43,7 @@ runs:
 
     # Bits from the VSIX are reused by smokeTest.ts to speed things up.
     - name: Download VSIX
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact_name }}
 


### PR DESCRIPTION
GitHub announced that v3 of actions/upload-artifact will be closing down and would start brownouts on November 14th. This small change moves to v4 of this action.

See:
https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/