### PR TITLE
Set Insiders target population as VS Code Insiders for ExP 

### DIFF
--- a/src/client/common/experiments/service.ts
+++ b/src/client/common/experiments/service.ts
@@ -5,7 +5,7 @@
 
 import { inject, injectable } from 'inversify';
 import { l10n } from 'vscode';
-import { getExperimentationService, IExperimentationService } from 'vscode-tas-client';
+import { getExperimentationService, IExperimentationService, TargetPopulation } from 'vscode-tas-client';
 import { traceLog } from '../../logging';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
@@ -16,16 +16,6 @@ import { ExperimentationTelemetry } from './telemetry';
 
 const EXP_MEMENTO_KEY = 'VSCode.ABExp.FeatureData';
 const EXP_CONFIG_ID = 'vscode';
-
-/**
- * We're defining a custom TargetPopulation specific for the Python extension.
- * This is done so the exp framework is able to differentiate between
- * VS Code insiders/public users and Python extension insiders (pre-release)/public users.
- */
-export enum TargetPopulation {
-    Insiders = 'python-insider',
-    Public = 'python-public',
-}
 
 @injectable()
 export class ExperimentService implements IExperimentService {
@@ -73,8 +63,8 @@ export class ExperimentService implements IExperimentService {
         }
 
         let targetPopulation: TargetPopulation;
-
-        if (this.appEnvironment.extensionChannel === 'insiders') {
+        // if running in VS Code Insiders, use the Insiders target population
+        if (this.appEnvironment.channel === 'insiders') {
             targetPopulation = TargetPopulation.Insiders;
         } else {
             targetPopulation = TargetPopulation.Public;

--- a/src/test/common/experiments/service.unit.test.ts
+++ b/src/test/common/experiments/service.unit.test.ts
@@ -11,11 +11,12 @@ import { Disposable } from 'vscode-jsonrpc';
 // sinon can not create a stub if we just point to the exported module
 import * as tasClient from 'vscode-tas-client/vscode-tas-client/VSCodeTasClient';
 import * as expService from 'vscode-tas-client';
+import { TargetPopulation } from 'vscode-tas-client';
 import { ApplicationEnvironment } from '../../../client/common/application/applicationEnvironment';
 import { IApplicationEnvironment, IWorkspaceService } from '../../../client/common/application/types';
 import { WorkspaceService } from '../../../client/common/application/workspace';
 import { Channel } from '../../../client/common/constants';
-import { ExperimentService, TargetPopulation } from '../../../client/common/experiments/service';
+import { ExperimentService } from '../../../client/common/experiments/service';
 import { PersistentState } from '../../../client/common/persistentState';
 import { IPersistentStateFactory } from '../../../client/common/types';
 import { registerLogger } from '../../../client/logging';
@@ -74,13 +75,13 @@ suite('Experimentation service', () => {
     }
 
     function configureApplicationEnvironment(channel: Channel, version: string, contributes?: Record<string, unknown>) {
-        when(appEnvironment.extensionChannel).thenReturn(channel);
+        when(appEnvironment.channel).thenReturn(channel);
         when(appEnvironment.extensionName).thenReturn(PVSC_EXTENSION_ID_FOR_TESTS);
         when(appEnvironment.packageJson).thenReturn({ version, contributes });
     }
 
     suite('Initialization', () => {
-        test('Users with a release version of the extension should be in the Public target population', () => {
+        test('Users with VS Code stable version should be in the Public target population', () => {
             const getExperimentationServiceStub = sinon.stub(tasClient, 'getExperimentationService');
             configureSettings(true, [], []);
             configureApplicationEnvironment('stable', extensionVersion);
@@ -99,7 +100,7 @@ suite('Experimentation service', () => {
             );
         });
 
-        test('Users with an Insiders version of the extension should be the Insiders target population', () => {
+        test('Users with VS Code Insiders version should be the Insiders target population', () => {
             const getExperimentationServiceStub = sinon.stub(tasClient, 'getExperimentationService');
 
             configureSettings(true, [], []);


### PR DESCRIPTION
To avoid confusion with the overlap between traffic filters from VS Code core and the Python extension with ExP, we are removing the `python-insider` and `python-public` values as acceptable values for Target Population, and instead are assigning VS Code insiders as `insider` and stable as `public`. 
  