### PR TITLE
do not use shell integration for Python subshell if Python setting is disabled

### DIFF
--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -101,7 +101,7 @@ export class TerminalService implements ITerminalService, Disposable {
             });
             await promise;
         }
-        //breaking test
+
         const config = getConfiguration('python');
         const pythonrcSetting = config.get<boolean>('terminal.shellIntegration.enabled');
         if (isPythonShell && !pythonrcSetting) {

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -101,7 +101,7 @@ export class TerminalService implements ITerminalService, Disposable {
             });
             await promise;
         }
-
+        //breaking test
         const config = getConfiguration('python');
         const pythonrcSetting = config.get<boolean>('terminal.shellIntegration.enabled');
         if (isPythonShell && !pythonrcSetting) {

--- a/src/client/common/terminal/syncTerminalService.ts
+++ b/src/client/common/terminal/syncTerminalService.ts
@@ -145,8 +145,8 @@ export class SynchronousTerminalService implements ITerminalService, Disposable 
     public sendText(text: string): Promise<void> {
         return this.terminalService.sendText(text);
     }
-    public executeCommand(commandLine: string): Promise<TerminalShellExecution | undefined> {
-        return this.terminalService.executeCommand(commandLine);
+    public executeCommand(commandLine: string, isPythonShell: boolean): Promise<TerminalShellExecution | undefined> {
+        return this.terminalService.executeCommand(commandLine, isPythonShell);
     }
     public show(preserveFocus?: boolean | undefined): Promise<void> {
         return this.terminalService.show(preserveFocus);

--- a/src/client/common/terminal/types.ts
+++ b/src/client/common/terminal/types.ts
@@ -54,7 +54,7 @@ export interface ITerminalService extends IDisposable {
     ): Promise<void>;
     /** @deprecated */
     sendText(text: string): Promise<void>;
-    executeCommand(commandLine: string): Promise<TerminalShellExecution | undefined>;
+    executeCommand(commandLine: string, isPythonShell: boolean): Promise<TerminalShellExecution | undefined>;
     show(preserveFocus?: boolean): Promise<void>;
 }
 

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -59,7 +59,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
                 this.configurationService.updateSetting('REPL.enableREPLSmartSend', false, resource);
             }
         } else {
-            await this.getTerminalService(resource).executeCommand(code);
+            await this.getTerminalService(resource).executeCommand(code, true);
         }
     }
 

--- a/src/test/common/terminals/service.unit.test.ts
+++ b/src/test/common/terminals/service.unit.test.ts
@@ -204,13 +204,20 @@ suite('Terminal Service', () => {
         terminalHelper.setup((h) => h.identifyTerminalShell(TypeMoq.It.isAny())).returns(() => TerminalShellType.bash);
         terminalManager.setup((t) => t.createTerminal(TypeMoq.It.isAny())).returns(() => terminal.object);
 
-        await service.sendText(textToSend);
+        service.ensureTerminal();
+        service.executeCommand(textToSend, true);
 
-        terminal.verify((t) => t.show(TypeMoq.It.isValue(true)), TypeMoq.Times.exactly(2));
+        terminal.verify((t) => t.show(TypeMoq.It.isValue(true)), TypeMoq.Times.exactly(1));
         terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.exactly(1));
     });
 
     // Ensure executeCommand is called when Python shell integration and terminal shell integration are both enabled
+    test('Ensure executeCommand is called when Python shell integration and terminal shell integration are both enabled', async () => {
+        pythonConfig
+            .setup((p) => p.get('terminal.shellIntegration.enabled'))
+            .returns(() => true)
+            .verifiable(TypeMoq.Times.once());
+    });
 
     test('Ensure terminal is not shown if `hideFromUser` option is set to `true`', async () => {
         terminalHelper

--- a/src/test/common/terminals/service.unit.test.ts
+++ b/src/test/common/terminals/service.unit.test.ts
@@ -190,6 +190,25 @@ suite('Terminal Service', () => {
     });
 
     // Ensure sendText is called when Python shell integration is disabled.
+    test('Ensure text is sent to terminal and it is shown when Python shell integration is disabled', async () => {
+        pythonConfig
+            .setup((p) => p.get('terminal.shellIntegration.enabled'))
+            .returns(() => false)
+            .verifiable(TypeMoq.Times.once());
+
+        terminalHelper
+            .setup((helper) => helper.getEnvironmentActivationCommands(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(undefined));
+        service = new TerminalService(mockServiceContainer.object);
+        const textToSend = 'Some Text';
+        terminalHelper.setup((h) => h.identifyTerminalShell(TypeMoq.It.isAny())).returns(() => TerminalShellType.bash);
+        terminalManager.setup((t) => t.createTerminal(TypeMoq.It.isAny())).returns(() => terminal.object);
+
+        await service.sendText(textToSend);
+
+        terminal.verify((t) => t.show(TypeMoq.It.isValue(true)), TypeMoq.Times.exactly(2));
+        terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.exactly(1));
+    });
 
     // Ensure executeCommand is called when Python shell integration and terminal shell integration are both enabled
 

--- a/src/test/common/terminals/service.unit.test.ts
+++ b/src/test/common/terminals/service.unit.test.ts
@@ -189,8 +189,7 @@ suite('Terminal Service', () => {
         terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.exactly(1));
     });
 
-    // Ensure sendText is called when Python shell integration are disabled.
-    test('Ensure text is sent to terminal and it is shown when Python shell integration is disabled', async () => {
+    test('Ensure sendText is used when Python shell integration is disabled', async () => {
         pythonConfig
             .setup((p) => p.get('terminal.shellIntegration.enabled'))
             .returns(() => false)
@@ -211,7 +210,6 @@ suite('Terminal Service', () => {
         terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.exactly(1));
     });
 
-    // Ensure sendText is called when terminal.shellIntegration is enabled but Python shell integration is disabled
     test('Ensure sendText is called when terminal.shellIntegration enabled but Python shell integration disabled', async () => {
         pythonConfig
             .setup((p) => p.get('terminal.shellIntegration.enabled'))
@@ -233,8 +231,7 @@ suite('Terminal Service', () => {
         terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.exactly(1));
     });
 
-    // Ensure executeCommand is called when Python shell integration and terminal shell integration are both enabled
-    test('Ensure sendText is not called when Python shell integration and terminal shell integration are both enabled', async () => {
+    test('Ensure sendText is NOT called when Python shell integration and terminal shell integration are both enabled', async () => {
         pythonConfig
             .setup((p) => p.get('terminal.shellIntegration.enabled'))
             .returns(() => true)

--- a/src/test/common/terminals/service.unit.test.ts
+++ b/src/test/common/terminals/service.unit.test.ts
@@ -189,6 +189,10 @@ suite('Terminal Service', () => {
         terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.exactly(1));
     });
 
+    // Ensure sendText is called when Python shell integration is disabled.
+
+    // Ensure executeCommand is called when Python shell integration and terminal shell integration are both enabled
+
     test('Ensure terminal is not shown if `hideFromUser` option is set to `true`', async () => {
         terminalHelper
             .setup((helper) => helper.getEnvironmentActivationCommands(TypeMoq.It.isAny(), TypeMoq.It.isAny()))

--- a/src/test/common/terminals/service.unit.test.ts
+++ b/src/test/common/terminals/service.unit.test.ts
@@ -3,6 +3,7 @@
 
 import { expect } from 'chai';
 import * as path from 'path';
+import * as sinon from 'sinon';
 import * as TypeMoq from 'typemoq';
 import {
     Disposable,
@@ -22,6 +23,7 @@ import { IDisposableRegistry } from '../../../client/common/types';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { ITerminalAutoActivation } from '../../../client/terminals/types';
 import { createPythonInterpreter } from '../../utils/interpreters';
+import * as workspaceApis from '../../../client/common/vscodeApis/workspaceApis';
 
 suite('Terminal Service', () => {
     let service: TerminalService;
@@ -37,6 +39,9 @@ suite('Terminal Service', () => {
     let terminalShellIntegration: TypeMoq.IMock<TerminalShellIntegration>;
     let onDidEndTerminalShellExecutionEmitter: EventEmitter<TerminalShellExecutionEndEvent>;
     let event: TerminalShellExecutionEndEvent;
+    let getConfigurationStub: sinon.SinonStub;
+    let pythonConfig: TypeMoq.IMock<WorkspaceConfiguration>;
+    let editorConfig: TypeMoq.IMock<WorkspaceConfiguration>;
 
     setup(() => {
         terminal = TypeMoq.Mock.ofType<VSCodeTerminal>();
@@ -88,12 +93,22 @@ suite('Terminal Service', () => {
         mockServiceContainer.setup((c) => c.get(IWorkspaceService)).returns(() => workspaceService.object);
         mockServiceContainer.setup((c) => c.get(ITerminalActivator)).returns(() => terminalActivator.object);
         mockServiceContainer.setup((c) => c.get(ITerminalAutoActivation)).returns(() => terminalAutoActivator.object);
+        getConfigurationStub = sinon.stub(workspaceApis, 'getConfiguration');
+        pythonConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
+        editorConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
+        getConfigurationStub.callsFake((section: string) => {
+            if (section === 'python') {
+                return pythonConfig.object;
+            }
+            return editorConfig.object;
+        });
     });
     teardown(() => {
         if (service) {
             service.dispose();
         }
         disposables.filter((item) => !!item).forEach((item) => item.dispose());
+        sinon.restore();
     });
 
     test('Ensure terminal is disposed', async () => {
@@ -103,6 +118,7 @@ suite('Terminal Service', () => {
         const os: string = 'windows';
         service = new TerminalService(mockServiceContainer.object);
         const shellPath = 'powershell.exe';
+        // TODO: switch over legacy Terminal code to use workspace getConfiguration from workspaceApis instead of directly from vscode.workspace
         workspaceService
             .setup((w) => w.getConfiguration(TypeMoq.It.isValue('terminal.integrated.shell')))
             .returns(() => {
@@ -110,6 +126,7 @@ suite('Terminal Service', () => {
                 workspaceConfig.setup((c) => c.get(os)).returns(() => shellPath);
                 return workspaceConfig.object;
             });
+        pythonConfig.setup((p) => p.get('terminal.shellIntegration.enabled')).returns(() => false);
 
         platformService.setup((p) => p.isWindows).returns(() => os === 'windows');
         platformService.setup((p) => p.isLinux).returns(() => os === 'linux');
@@ -134,6 +151,7 @@ suite('Terminal Service', () => {
     });
 
     test('Ensure command is sent to terminal and it is shown', async () => {
+        pythonConfig.setup((p) => p.get('terminal.shellIntegration.enabled')).returns(() => false);
         terminalHelper
             .setup((helper) => helper.getEnvironmentActivationCommands(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => Promise.resolve(undefined));

--- a/src/test/terminals/codeExecution/terminalCodeExec.unit.test.ts
+++ b/src/test/terminals/codeExecution/terminalCodeExec.unit.test.ts
@@ -643,10 +643,10 @@ suite('Terminal - Code Execution', () => {
                 terminalSettings.setup((t) => t.launchArgs).returns(() => terminalArgs);
 
                 await executor.execute('cmd1');
-                terminalService.verify(async (t) => t.executeCommand('cmd1', false), TypeMoq.Times.once());
+                terminalService.verify(async (t) => t.executeCommand('cmd1', true), TypeMoq.Times.once());
 
                 await executor.execute('cmd2');
-                terminalService.verify(async (t) => t.executeCommand('cmd2', false), TypeMoq.Times.once());
+                terminalService.verify(async (t) => t.executeCommand('cmd2', true), TypeMoq.Times.once());
             });
 
             test('Ensure code is sent to the same terminal for a particular resource', async () => {
@@ -668,10 +668,10 @@ suite('Terminal - Code Execution', () => {
                 terminalSettings.setup((t) => t.launchArgs).returns(() => terminalArgs);
 
                 await executor.execute('cmd1', resource);
-                terminalService.verify(async (t) => t.executeCommand('cmd1', false), TypeMoq.Times.once());
+                terminalService.verify(async (t) => t.executeCommand('cmd1', true), TypeMoq.Times.once());
 
                 await executor.execute('cmd2', resource);
-                terminalService.verify(async (t) => t.executeCommand('cmd2', false), TypeMoq.Times.once());
+                terminalService.verify(async (t) => t.executeCommand('cmd2', true), TypeMoq.Times.once());
             });
         });
     });

--- a/src/test/terminals/codeExecution/terminalCodeExec.unit.test.ts
+++ b/src/test/terminals/codeExecution/terminalCodeExec.unit.test.ts
@@ -643,10 +643,10 @@ suite('Terminal - Code Execution', () => {
                 terminalSettings.setup((t) => t.launchArgs).returns(() => terminalArgs);
 
                 await executor.execute('cmd1');
-                terminalService.verify(async (t) => t.executeCommand('cmd1'), TypeMoq.Times.once());
+                terminalService.verify(async (t) => t.executeCommand('cmd1', false), TypeMoq.Times.once());
 
                 await executor.execute('cmd2');
-                terminalService.verify(async (t) => t.executeCommand('cmd2'), TypeMoq.Times.once());
+                terminalService.verify(async (t) => t.executeCommand('cmd2', false), TypeMoq.Times.once());
             });
 
             test('Ensure code is sent to the same terminal for a particular resource', async () => {
@@ -668,10 +668,10 @@ suite('Terminal - Code Execution', () => {
                 terminalSettings.setup((t) => t.launchArgs).returns(() => terminalArgs);
 
                 await executor.execute('cmd1', resource);
-                terminalService.verify(async (t) => t.executeCommand('cmd1'), TypeMoq.Times.once());
+                terminalService.verify(async (t) => t.executeCommand('cmd1', false), TypeMoq.Times.once());
 
                 await executor.execute('cmd2', resource);
-                terminalService.verify(async (t) => t.executeCommand('cmd2'), TypeMoq.Times.once());
+                terminalService.verify(async (t) => t.executeCommand('cmd2', false), TypeMoq.Times.once());
             });
         });
     });


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-python/issues/24422

If the user has explicitly set their Python shell integration setting to false, 
then do not use shell integration inside the sub-shell (Python Terminal REPL in this case), 
regardless of upper shell integration status (Terminal shell integration setting in vscode).

We should still be safe from manual installation of shell integration with the setting disabled(https://code.visualstudio.com/docs/terminal/shell-integration#_manual-installation) 
since we are still reading the value of terminal.shellIntegration, and looking at Python's shell integration setting first to begin with. 

