### PR TITLE
Remove `debugpy` from `requirements`

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,4 +13,3 @@ microvenv
 importlib_metadata
 packaging
 tomli
-debugpy


### PR DESCRIPTION
This is shipped in a separate extension.