### PR TITLE
Add needs to CI coverage check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -461,6 +461,7 @@ jobs:
     name: Coverage
     # The value of runs-on is the OS of the current job (specified in the strategy matrix below) instead of being hardcoded.
     runs-on: ${{ matrix.os }}
+    needs: [lint, check-types, python-tests, tests, native-tests]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes #23052 

Added "needs" to the Coverage check, so it only runs if all the previous tests mentioned pass. 

![image](https://github.com/user-attachments/assets/9ba79542-5327-457a-b7cd-2e26d0f3ce7e)

We could also set `fail-fast` to `true` if we want to stop the workflow when any tests fail.

Please let me know if it needs any modifications.