### PR TITLE
Support pytest-rerunfailures plugin

### DIFF
--- a/python_files/tests/pytestadapter/.data/test_rerunfailures_plugin.py
+++ b/python_files/tests/pytestadapter/.data/test_rerunfailures_plugin.py
@@ -11,3 +11,11 @@ def test_flaky():  # test_marker--test_flaky
     os.environ["COUNT"] = "2"
     # this will fail on the first run, but pass on the second (1 passed, 1 rerun)
     assert count == "2"
+
+def test_flaky_no_marker():
+    # this test is flaky and will be run via the command line argument
+    # count is not set for first run, but set to 2 for the second run
+    count = os.environ.get("COUNT")
+    os.environ["COUNT"] = "2"
+    # this will fail on the first run, but pass on the second (1 passed, 1 rerun)
+    assert count == "2"

--- a/python_files/tests/pytestadapter/.data/test_rerunfailures_plugin.py
+++ b/python_files/tests/pytestadapter/.data/test_rerunfailures_plugin.py
@@ -1,0 +1,13 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import pytest
+import os
+
+@pytest.mark.flaky(reruns=2)
+def test_flaky():  # test_marker--test_flaky
+    # count is not set for first run, but set to 2 for the second run
+    count = os.environ.get("COUNT")
+    os.environ["COUNT"] = "2"
+    # this will fail on the first run, but pass on the second (1 passed, 1 rerun)
+    assert count == "2"

--- a/python_files/tests/pytestadapter/expected_execution_test_output.py
+++ b/python_files/tests/pytestadapter/expected_execution_test_output.py
@@ -749,3 +749,18 @@ rerunfailures_plugin_expected_execution_output = {
         "subtest": None,
     }
 }
+
+test_rerunfailures_plugin_path = TEST_DATA_PATH / "test_rerunfailures_plugin.py"
+rerunfailures_with_arg_expected_execution_output = {
+    get_absolute_test_id(
+        "test_rerunfailures_plugin.py::test_flaky_no_marker", test_rerunfailures_plugin_path
+    ): {
+        "test": get_absolute_test_id(
+            "test_rerunfailures_plugin.py::test_flaky_no_marker", test_rerunfailures_plugin_path
+        ),
+        "outcome": "success",
+        "message": None,
+        "traceback": None,
+        "subtest": None,
+    }
+}

--- a/python_files/tests/pytestadapter/expected_execution_test_output.py
+++ b/python_files/tests/pytestadapter/expected_execution_test_output.py
@@ -734,3 +734,18 @@ nested_describe_expected_execution_output = {
         "subtest": None,
     },
 }
+
+test_rerunfailures_plugin_path = TEST_DATA_PATH / "test_rerunfailures_plugin.py"
+rerunfailures_plugin_expected_execution_output = {
+    get_absolute_test_id(
+        "test_rerunfailures_plugin.py::test_flaky", test_rerunfailures_plugin_path
+    ): {
+        "test": get_absolute_test_id(
+            "test_rerunfailures_plugin.py::test_flaky", test_rerunfailures_plugin_path
+        ),
+        "outcome": "success",
+        "message": None,
+        "traceback": None,
+        "subtest": None,
+    }
+}

--- a/python_files/tests/pytestadapter/helpers.py
+++ b/python_files/tests/pytestadapter/helpers.py
@@ -331,6 +331,7 @@ def runner_with_cwd_env(
         os.mkfifo(pipe_name)
         #################
 
+        print("beginning run request")
         completed = threading.Event()
 
         result = []  # result is a string array to store the data during threading

--- a/python_files/tests/pytestadapter/test_discovery.py
+++ b/python_files/tests/pytestadapter/test_discovery.py
@@ -308,6 +308,7 @@ def test_config_sub_folder():
     session node is correctly updated to the common path.
     """
     folder_path = helpers.TEST_DATA_PATH / "config_sub_folder"
+    print("running test_config_sub_folder")
     actual = helpers.runner_with_cwd(
         [
             "--collect-only",

--- a/python_files/tests/pytestadapter/test_discovery.py
+++ b/python_files/tests/pytestadapter/test_discovery.py
@@ -247,10 +247,12 @@ def test_symlink_root_dir():
 
 
 def test_pytest_root_dir():
+
     """Test to test pytest discovery with the command line arg --rootdir specified to be a subfolder of the workspace root.
 
     Discovery should succeed and testids should be relative to workspace root.
     """
+    print("running test_pytest_root_dir")
     rd = f"--rootdir={helpers.TEST_DATA_PATH / 'root' / 'tests'}"
     actual = helpers.runner_with_cwd(
         [
@@ -279,6 +281,7 @@ def test_pytest_config_file():
 
     Discovery should succeed and testids should be relative to workspace root.
     """
+    print("running test_pytest_config_file")
     actual = helpers.runner_with_cwd(
         [
             "--collect-only",
@@ -301,6 +304,7 @@ def test_pytest_config_file():
         ), f"Tests tree does not match expected value. \n Expected: {json.dumps(expected_discovery_test_output.root_with_config_expected_output, indent=4)}. \n Actual: {json.dumps(actual_item.get('tests'), indent=4)}"
 
 
+@pytest.mark.timeout(60)
 def test_config_sub_folder():
     """Here the session node will be a subfolder of the workspace root and the test are in another subfolder.
 

--- a/python_files/tests/pytestadapter/test_discovery.py
+++ b/python_files/tests/pytestadapter/test_discovery.py
@@ -247,7 +247,6 @@ def test_symlink_root_dir():
 
 
 def test_pytest_root_dir():
-
     """Test to test pytest discovery with the command line arg --rootdir specified to be a subfolder of the workspace root.
 
     Discovery should succeed and testids should be relative to workspace root.

--- a/python_files/tests/pytestadapter/test_execution.py
+++ b/python_files/tests/pytestadapter/test_execution.py
@@ -194,6 +194,13 @@ def test_rootdir_specified():
             expected_execution_test_output.nested_describe_expected_execution_output,
             id="nested_describe_plugin",
         ),
+        pytest.param(
+            [
+                "test_rerunfailures_plugin.py::test_flaky",
+            ],
+            expected_execution_test_output.rerunfailures_plugin_expected_execution_output,
+            id="test_rerunfailures_plugin",
+        ),
     ],
 )
 def test_pytest_execution(test_ids, expected_const):

--- a/python_files/tests/pytestadapter/test_execution.py
+++ b/python_files/tests/pytestadapter/test_execution.py
@@ -65,6 +65,23 @@ def test_rootdir_specified():
         assert actual_result_dict == expected_const
 
 
+def test_rerunfailure_with_arg():
+    """Test pytest execution when a --rootdir is specified."""
+    args = ["--reruns=2", "test_rerunfailures_plugin.py::test_flaky_no_marker"]
+    actual = runner(args)
+    expected_const = expected_execution_test_output.rerunfailures_with_arg_expected_execution_output
+    assert actual
+    actual_list: List[Dict[str, Dict[str, Any]]] = actual
+    assert len(actual_list) == len(expected_const)
+    actual_result_dict = {}
+    if actual_list is not None:
+        for actual_item in actual_list:
+            assert all(item in actual_item for item in ("status", "cwd", "result"))
+            assert actual_item.get("status") == "success"
+            actual_result_dict.update(actual_item["result"])
+        assert actual_result_dict == expected_const
+
+
 @pytest.mark.parametrize(
     ("test_ids", "expected_const"),
     [

--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -96,6 +96,7 @@ def pytest_load_initial_conftests(early_config, parser, args):  # noqa: ARG001
     # set the reruns value, -1 if not set
     global FLAKY_MAX_RUNS
     FLAKY_MAX_RUNS = get_reruns_value(args)
+    print("Plugin info[vscode-pytest]: global FLAKY_MAX_RUNS set to: ", FLAKY_MAX_RUNS)
 
     # check if --rootdir is in the args
     for arg in args:
@@ -198,6 +199,7 @@ def pytest_exception_interact(node, call, report):
 
             # flaky_max_runs != -1 means test is flaky
             if flaky_max_runs != -1 and exec_count <= flaky_max_runs:
+                print("flaky test rerun: ", exec_count)
                 return
             elif flaky_max_runs != -1 and exec_count > flaky_max_runs:
                 print("Plugin info[vscode-pytest]: max reruns reached.")
@@ -709,6 +711,8 @@ def build_nested_folders(
     counter = 0
     max_iter = 100
     while iterator_path != session_node_path:
+        print("iterator_path: ", iterator_path)
+        print("session_node_path: ", session_node_path)
         curr_folder_name = iterator_path.name
         try:
             curr_folder_node: TestNode = created_files_folders_dict[os.fspath(iterator_path)]

--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -33,7 +33,6 @@ with contextlib.suppress(ImportError):
     USES_PYTEST_DESCRIBE = True
 
 
-
 class TestData(TypedDict):
     """A general class that all test objects inherit from."""
 

--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -33,16 +33,6 @@ with contextlib.suppress(ImportError):
     USES_PYTEST_DESCRIBE = True
 
 
-sys.path.append("/Users/eleanorboyd/vscode-python/.nox/install_python_libs/lib/python3.10")
-sys.path.append("/Users/eleanorboyd/vscode-python-debugger")
-sys.path.append("/Users/eleanorboyd/vscode-python-debugger/bundled")
-sys.path.append("/Users/eleanorboyd/vscode-python-debugger/bundled/libs")
-
-import debugpy  # noqa: E402
-
-debugpy.connect(5678)
-debugpy.breakpoint()  # noqa: E702
-
 
 class TestData(TypedDict):
     """A general class that all test objects inherit from."""


### PR DESCRIPTION
This is part of adding support for top pytest plugins. When using pytest-rerunfailures, only the final run should be sent as a payload to the extension for display.