### PR TITLE
Prompt Native REPL in Terminal 

### DIFF
--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -101,6 +101,10 @@ export namespace AttachProcess {
 
 export namespace Repl {
     export const disableSmartSend = l10n.t('Disable Smart Send');
+    // TODO: get feedback on text message below:
+    export const terminalSuggestNativeReplPrompt = l10n.t(
+        'The Python extension now includes an editor based native Python REPL with Intellisense, syntax highlighting. Would you like to try this out?',
+    );
 }
 export namespace Pylance {
     export const remindMeLater = l10n.t('Remind me later');

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -111,7 +111,7 @@ export function activateFeatures(ext: ExtensionState, _components: Components): 
     );
     const executionHelper = ext.legacyIOC.serviceContainer.get<ICodeExecutionHelper>(ICodeExecutionHelper);
     const commandManager = ext.legacyIOC.serviceContainer.get<ICommandManager>(ICommandManager);
-    registerTriggerForTerminalREPL(commandManager, ext.disposables);
+    registerTriggerForTerminalREPL(commandManager, ext.context, ext.disposables);
     registerStartNativeReplCommand(ext.disposables, interpreterService);
     registerReplCommands(ext.disposables, interpreterService, executionHelper, commandManager);
     registerReplExecuteOnEnter(ext.disposables, interpreterService, commandManager);

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -111,7 +111,7 @@ export function activateFeatures(ext: ExtensionState, _components: Components): 
     );
     const executionHelper = ext.legacyIOC.serviceContainer.get<ICodeExecutionHelper>(ICodeExecutionHelper);
     const commandManager = ext.legacyIOC.serviceContainer.get<ICommandManager>(ICommandManager);
-    registerTriggerForTerminalREPL(ext.disposables);
+    registerTriggerForTerminalREPL(commandManager, ext.disposables);
     registerStartNativeReplCommand(ext.disposables, interpreterService);
     registerReplCommands(ext.disposables, interpreterService, executionHelper, commandManager);
     registerReplExecuteOnEnter(ext.disposables, interpreterService, commandManager);

--- a/src/client/terminals/codeExecution/terminalReplWatcher.ts
+++ b/src/client/terminals/codeExecution/terminalReplWatcher.ts
@@ -1,9 +1,14 @@
 import { Disposable, TerminalShellExecutionStartEvent } from 'vscode';
-import { onDidStartTerminalShellExecution } from '../../common/vscodeApis/windowApis';
+import { onDidStartTerminalShellExecution, showWarningMessage } from '../../common/vscodeApis/windowApis';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { ICommandManager } from '../../common/application/types';
 import { Commands } from '../../common/constants';
+import { Common, Repl } from '../../common/utils/localize';
+import { IExtensionContext } from '../../common/types';
+import { getGlobalStorage } from '../../common/persistentState';
+
+export const SUGGEST_NATIVE_REPL = 'suggestNativeRepl';
 
 export function checkREPLCommand(command: string): boolean {
     const lower = command.toLowerCase().trimStart();
@@ -12,19 +17,33 @@ export function checkREPLCommand(command: string): boolean {
 
 export async function registerTriggerForTerminalREPL(
     commandManager: ICommandManager,
+    context: IExtensionContext,
     disposables: Disposable[],
 ): Promise<void> {
     disposables.push(
         onDidStartTerminalShellExecution(async (e: TerminalShellExecutionStartEvent) => {
             if (e.execution.commandLine.isTrusted && checkREPLCommand(e.execution.commandLine.value)) {
                 sendTelemetryEvent(EventName.REPL, undefined, { replType: 'manualTerminal' });
-                // TODO: Prompt user to start Native REPL
 
-                // If yes, then launch native REPL
-                await commandManager.executeCommand(Commands.Start_Native_REPL, undefined);
+                // Plan:
+                // Global memento to disable show of prompt entirely - global memento
+                // workspace memento to track and only show suggest of native REPL once.
+                const globalSuggestNativeRepl = getGlobalStorage<boolean>(context, SUGGEST_NATIVE_REPL);
+                if (globalSuggestNativeRepl.get()) {
+                    // Prompt user to start Native REPL
+                    const selection = await showWarningMessage(
+                        Repl.terminalSuggestNativeReplPrompt,
+                        'Launch Native REPL',
+                        Common.doNotShowAgain,
+                    );
 
-                // TODO: Decide whether we want everytime, or once per workspace, or once per terminal
-                // How do I even track all terminal instances.
+                    if (selection === 'Launch Native REPL') {
+                        await commandManager.executeCommand(Commands.Start_Native_REPL, undefined);
+                    } else {
+                        // Update global suggest to disable Native REPL suggestion in future even after reload.
+                        await globalSuggestNativeRepl.set(false);
+                    }
+                }
             }
         }),
     );

--- a/src/client/terminals/codeExecution/terminalReplWatcher.ts
+++ b/src/client/terminals/codeExecution/terminalReplWatcher.ts
@@ -2,17 +2,29 @@ import { Disposable, TerminalShellExecutionStartEvent } from 'vscode';
 import { onDidStartTerminalShellExecution } from '../../common/vscodeApis/windowApis';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
+import { ICommandManager } from '../../common/application/types';
+import { Commands } from '../../common/constants';
 
-function checkREPLCommand(command: string): boolean {
+export function checkREPLCommand(command: string): boolean {
     const lower = command.toLowerCase().trimStart();
     return lower.startsWith('python') || lower.startsWith('py ');
 }
 
-export function registerTriggerForTerminalREPL(disposables: Disposable[]): void {
+export async function registerTriggerForTerminalREPL(
+    commandManager: ICommandManager,
+    disposables: Disposable[],
+): Promise<void> {
     disposables.push(
         onDidStartTerminalShellExecution(async (e: TerminalShellExecutionStartEvent) => {
             if (e.execution.commandLine.isTrusted && checkREPLCommand(e.execution.commandLine.value)) {
                 sendTelemetryEvent(EventName.REPL, undefined, { replType: 'manualTerminal' });
+                // TODO: Prompt user to start Native REPL
+
+                // If yes, then launch native REPL
+                await commandManager.executeCommand(Commands.Start_Native_REPL, undefined);
+
+                // TODO: Decide whether we want everytime, or once per workspace, or once per terminal
+                // How do I even track all terminal instances.
             }
         }),
     );


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-python/issues/24270 

Using two memento: global and workspace.
- Global is used so if user clicks on do not show again, native repl suggestion will not show up ever again even after reloading. 
- Workspace will be used so only single suggestion prompt shows up in the terminal (remains unaggressive) PER non-reloaded VS Code window instance. 


FYI) Problem exists with: user starting terminal Python REPL with 'Start Terminal REPL'. If they type exit, it still shows 'Python' and shift+enter will still send code to the shell which is now outside of Python shell. Bug: https://github.com/microsoft/vscode-python/issues/22547 

In future could also additionally leverage or alternatively use proposed Terminal Quick Fix API: https://github.com/microsoft/vscode/blob/3f3394a6e60850a7cd8578c5149bf34ab3157cf8/src/vscode-dts/vscode.proposed.terminalQuickFixProvider.d.ts 
