### PR TITLE
printEnvVariablesToFile.py overwrites itself if invoked without arguments

### DIFF
--- a/python_files/printEnvVariablesToFile.py
+++ b/python_files/printEnvVariablesToFile.py
@@ -4,7 +4,6 @@
 import os
 import sys
 
-
 # Prevent overwriting itself, since sys.argv[0] is the path to this file
 if len(sys.argv) > 1:
     # Last argument is the target file into which we'll write the env variables line by line.

--- a/python_files/printEnvVariablesToFile.py
+++ b/python_files/printEnvVariablesToFile.py
@@ -4,8 +4,13 @@
 import os
 import sys
 
-# Last argument is the target file into which we'll write the env variables line by line.
-output_file = sys.argv[-1]
+
+# Prevent overwriting itself, since sys.argv[0] is the path to this file
+if len(sys.argv) > 1:
+    # Last argument is the target file into which we'll write the env variables line by line.
+    output_file = sys.argv[-1]
+else:
+    raise ValueError("Missing output file argument")
 
 with open(output_file, "w") as outfile:  # noqa: PTH123
     for key, val in os.environ.items():


### PR DESCRIPTION
I saw the command in my terminal when launching the editor, was curious to see what it did, so I ran it again without arguments, expecting to get a `--help`-like message, instead it ended up overwriting itself.

This change changes the script's default behavior (default being the invocation without arguments) from overwriting itself to throwing an exception about a missing output file argument.