### PR TITLE
ruff 0.8.0 fixes

### DIFF
--- a/python_files/create_conda.py
+++ b/python_files/create_conda.py
@@ -6,7 +6,8 @@ import os
 import pathlib
 import subprocess
 import sys
-from typing import Optional, Sequence, Union
+from collections.abc import Sequence
+from typing import Optional, Union
 
 CONDA_ENV_NAME = ".conda"
 CWD = pathlib.Path.cwd()

--- a/python_files/create_microvenv.py
+++ b/python_files/create_microvenv.py
@@ -6,7 +6,8 @@ import os
 import pathlib
 import subprocess
 import sys
-from typing import Optional, Sequence
+from collections.abc import Sequence
+from typing import Optional
 
 VENV_NAME = ".venv"
 LIB_ROOT = pathlib.Path(__file__).parent / "lib" / "python"

--- a/python_files/create_venv.py
+++ b/python_files/create_venv.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import urllib.request as url_lib
 from collections.abc import Sequence
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 VENV_NAME = ".venv"
 CWD = pathlib.Path.cwd()
@@ -108,7 +108,7 @@ def get_venv_path(name: str) -> str:
         return os.fspath(CWD / name / "bin" / "python")
 
 
-def install_requirements(venv_path: str, requirements: List[str]) -> None:
+def install_requirements(venv_path: str, requirements: list[str]) -> None:
     if not requirements:
         return
 
@@ -121,7 +121,7 @@ def install_requirements(venv_path: str, requirements: List[str]) -> None:
     print("CREATE_VENV.PIP_INSTALLED_REQUIREMENTS")
 
 
-def install_toml(venv_path: str, extras: List[str]) -> None:
+def install_toml(venv_path: str, extras: list[str]) -> None:
     args = "." if len(extras) == 0 else f".[{','.join(extras)}]"
     run_process(
         [venv_path, "-m", "pip", "install", "-e", args],
@@ -172,7 +172,7 @@ def install_pip(name: str):
     )
 
 
-def get_requirements_from_args(args: argparse.Namespace) -> List[str]:
+def get_requirements_from_args(args: argparse.Namespace) -> list[str]:
     requirements = []
     if args.stdin:
         data = json.loads(sys.stdin.read())

--- a/python_files/create_venv.py
+++ b/python_files/create_venv.py
@@ -9,7 +9,8 @@ import pathlib
 import subprocess
 import sys
 import urllib.request as url_lib
-from typing import List, Optional, Sequence, Union
+from collections.abc import Sequence
+from typing import List, Optional, Union
 
 VENV_NAME = ".venv"
 CWD = pathlib.Path.cwd()

--- a/python_files/installed_check.py
+++ b/python_files/installed_check.py
@@ -7,7 +7,7 @@ import os
 import pathlib
 import sys
 from collections.abc import Sequence
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 LIB_ROOT = pathlib.Path(__file__).parent / "lib" / "python"
 sys.path.insert(0, os.fspath(LIB_ROOT))
@@ -44,7 +44,7 @@ def parse_requirements(line: str) -> Optional[Requirement]:
     return None
 
 
-def process_requirements(req_file: pathlib.Path) -> List[Dict[str, Union[str, int]]]:
+def process_requirements(req_file: pathlib.Path) -> list[dict[str, Union[str, int]]]:
     diagnostics = []
     for n, line in enumerate(req_file.read_text(encoding="utf-8").splitlines()):
         if line.startswith(("#", "-", " ")) or line == "":
@@ -70,7 +70,7 @@ def process_requirements(req_file: pathlib.Path) -> List[Dict[str, Union[str, in
     return diagnostics
 
 
-def get_pos(lines: List[str], text: str) -> Tuple[int, int, int, int]:
+def get_pos(lines: list[str], text: str) -> tuple[int, int, int, int]:
     for n, line in enumerate(lines):
         index = line.find(text)
         if index >= 0:
@@ -78,7 +78,7 @@ def get_pos(lines: List[str], text: str) -> Tuple[int, int, int, int]:
     return (0, 0, 0, 0)
 
 
-def process_pyproject(req_file: pathlib.Path) -> List[Dict[str, Union[str, int]]]:
+def process_pyproject(req_file: pathlib.Path) -> list[dict[str, Union[str, int]]]:
     diagnostics = []
     try:
         raw_text = req_file.read_text(encoding="utf-8")
@@ -110,7 +110,7 @@ def process_pyproject(req_file: pathlib.Path) -> List[Dict[str, Union[str, int]]
     return diagnostics
 
 
-def get_diagnostics(req_file: pathlib.Path) -> List[Dict[str, Union[str, int]]]:
+def get_diagnostics(req_file: pathlib.Path) -> list[dict[str, Union[str, int]]]:
     diagnostics = []
     if not req_file.exists():
         return diagnostics

--- a/python_files/installed_check.py
+++ b/python_files/installed_check.py
@@ -6,7 +6,8 @@ import json
 import os
 import pathlib
 import sys
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from collections.abc import Sequence
+from typing import Dict, List, Optional, Tuple, Union
 
 LIB_ROOT = pathlib.Path(__file__).parent / "lib" / "python"
 sys.path.insert(0, os.fspath(LIB_ROOT))

--- a/python_files/normalizeSelection.py
+++ b/python_files/normalizeSelection.py
@@ -6,7 +6,7 @@ import json
 import re
 import sys
 import textwrap
-from typing import Iterable
+from collections.abc import Iterable
 
 attach_bracket_paste = sys.version_info >= (3, 13)
 

--- a/python_files/python_server.py
+++ b/python_files/python_server.py
@@ -5,7 +5,7 @@ import json
 import sys
 import traceback
 import uuid
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 STDIN = sys.stdin
 STDOUT = sys.stdout
@@ -38,7 +38,7 @@ def send_response(
     )
 
 
-def send_request(params: Optional[Union[List, Dict]] = None):
+def send_request(params: Optional[Union[list, dict]] = None):
     request_id = uuid.uuid4().hex
     if params is None:
         send_message(id=request_id, method="input")

--- a/python_files/testing_tools/process_json_util.py
+++ b/python_files/testing_tools/process_json_util.py
@@ -2,12 +2,11 @@
 # Licensed under the MIT License.
 import io
 import json
-from typing import Dict, List
 
 CONTENT_LENGTH: str = "Content-Length:"
 
 
-def process_rpc_json(data: str) -> Dict[str, List[str]]:
+def process_rpc_json(data: str) -> dict[str, list[str]]:
     """Process the JSON data which comes from the server."""
     str_stream: io.StringIO = io.StringIO(data)
 

--- a/python_files/tests/pytestadapter/helpers.py
+++ b/python_files/tests/pytestadapter/helpers.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 import threading
 import uuid
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 if sys.platform == "win32":
     from namedpipe import NPopen
@@ -63,7 +63,7 @@ def create_symlink(root: pathlib.Path, target_ext: str, destination_ext: str):
         print("destination unlinked", destination)
 
 
-def process_data_received(data: str) -> List[Dict[str, Any]]:
+def process_data_received(data: str) -> list[dict[str, Any]]:
     """Process the all JSON data which comes from the server.
 
     After listen is finished, this function will be called.
@@ -87,7 +87,7 @@ def process_data_received(data: str) -> List[Dict[str, Any]]:
     return json_messages  # return the list of json messages
 
 
-def parse_rpc_message(data: str) -> Tuple[Dict[str, str], str]:
+def parse_rpc_message(data: str) -> tuple[dict[str, str], str]:
     """Process the JSON data which comes from the server.
 
     A single rpc payload is in the format:
@@ -128,7 +128,7 @@ def parse_rpc_message(data: str) -> Tuple[Dict[str, str], str]:
             print("json decode error")
 
 
-def _listen_on_fifo(pipe_name: str, result: List[str], completed: threading.Event):
+def _listen_on_fifo(pipe_name: str, result: list[str], completed: threading.Event):
     # Open the FIFO for reading
     fifo_path = pathlib.Path(pipe_name)
     with fifo_path.open() as fifo:
@@ -144,7 +144,7 @@ def _listen_on_fifo(pipe_name: str, result: List[str], completed: threading.Even
             result.append(data)
 
 
-def _listen_on_pipe_new(listener, result: List[str], completed: threading.Event):
+def _listen_on_pipe_new(listener, result: list[str], completed: threading.Event):
     """Listen on the named pipe or Unix domain socket for JSON data from the server.
 
     Created as a separate function for clarity in threading context.
@@ -197,24 +197,24 @@ def _listen_on_pipe_new(listener, result: List[str], completed: threading.Event)
         result.append("".join(all_data))
 
 
-def _run_test_code(proc_args: List[str], proc_env, proc_cwd: str, completed: threading.Event):
+def _run_test_code(proc_args: list[str], proc_env, proc_cwd: str, completed: threading.Event):
     result = subprocess.run(proc_args, env=proc_env, cwd=proc_cwd)
     completed.set()
     return result
 
 
-def runner(args: List[str]) -> Optional[List[Dict[str, Any]]]:
+def runner(args: list[str]) -> Optional[list[dict[str, Any]]]:
     """Run a subprocess and a named-pipe to listen for messages at the same time with threading."""
     print("\n Running python test subprocess with cwd set to: ", TEST_DATA_PATH)
     return runner_with_cwd(args, TEST_DATA_PATH)
 
 
-def runner_with_cwd(args: List[str], path: pathlib.Path) -> Optional[List[Dict[str, Any]]]:
+def runner_with_cwd(args: list[str], path: pathlib.Path) -> Optional[list[dict[str, Any]]]:
     """Run a subprocess and a named-pipe to listen for messages at the same time with threading."""
     return runner_with_cwd_env(args, path, {})
 
 
-def split_array_at_item(arr: List[str], item: str) -> Tuple[List[str], List[str]]:
+def split_array_at_item(arr: list[str], item: str) -> tuple[list[str], list[str]]:
     """
     Splits an array into two subarrays at the specified item.
 
@@ -235,14 +235,14 @@ def split_array_at_item(arr: List[str], item: str) -> Tuple[List[str], List[str]
 
 
 def runner_with_cwd_env(
-    args: List[str], path: pathlib.Path, env_add: Dict[str, str]
-) -> Optional[List[Dict[str, Any]]]:
+    args: list[str], path: pathlib.Path, env_add: dict[str, str]
+) -> Optional[list[dict[str, Any]]]:
     """
     Run a subprocess and a named-pipe to listen for messages at the same time with threading.
 
     Includes environment variables to add to the test environment.
     """
-    process_args: List[str]
+    process_args: list[str]
     pipe_name: str
     if "MANAGE_PY_PATH" in env_add:
         # If we are running Django, generate a unittest-specific pipe name.

--- a/python_files/tests/pytestadapter/test_discovery.py
+++ b/python_files/tests/pytestadapter/test_discovery.py
@@ -3,7 +3,7 @@
 import json
 import os
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import pytest
 
@@ -25,10 +25,10 @@ def test_import_error():
     """
     file_path = helpers.TEST_DATA_PATH / "error_pytest_import.txt"
     with helpers.text_to_python_file(file_path) as p:
-        actual: Optional[List[Dict[str, Any]]] = helpers.runner(["--collect-only", os.fspath(p)])
+        actual: Optional[list[dict[str, Any]]] = helpers.runner(["--collect-only", os.fspath(p)])
 
     assert actual
-    actual_list: List[Dict[str, Any]] = actual
+    actual_list: list[dict[str, Any]] = actual
     if actual_list is not None:
         for actual_item in actual_list:
             assert all(item in actual_item for item in ("status", "cwd", "error"))
@@ -64,7 +64,7 @@ def test_syntax_error(tmp_path):  # noqa: ARG001
         actual = helpers.runner(["--collect-only", os.fspath(p)])
 
     assert actual
-    actual_list: List[Dict[str, Any]] = actual
+    actual_list: list[dict[str, Any]] = actual
     if actual_list is not None:
         for actual_item in actual_list:
             assert all(item in actual_item for item in ("status", "cwd", "error"))
@@ -89,7 +89,7 @@ def test_parameterized_error_collect():
     file_path_str = "error_parametrize_discovery.py"
     actual = helpers.runner(["--collect-only", file_path_str])
     assert actual
-    actual_list: List[Dict[str, Any]] = actual
+    actual_list: list[dict[str, Any]] = actual
     if actual_list is not None:
         for actual_item in actual_list:
             assert all(item in actual_item for item in ("status", "cwd", "error"))
@@ -191,7 +191,7 @@ def test_pytest_collect(file, expected_const):
     )
 
     assert actual
-    actual_list: List[Dict[str, Any]] = actual
+    actual_list: list[dict[str, Any]] = actual
     if actual_list is not None:
         actual_item = actual_list.pop(0)
         assert all(item in actual_item for item in ("status", "cwd", "error"))
@@ -227,7 +227,7 @@ def test_symlink_root_dir():
         )
         expected = expected_discovery_test_output.symlink_expected_discovery_output
         assert actual
-        actual_list: List[Dict[str, Any]] = actual
+        actual_list: list[dict[str, Any]] = actual
         if actual_list is not None:
             actual_item = actual_list.pop(0)
             try:
@@ -260,7 +260,7 @@ def test_pytest_root_dir():
         helpers.TEST_DATA_PATH / "root",
     )
     assert actual
-    actual_list: List[Dict[str, Any]] = actual
+    actual_list: list[dict[str, Any]] = actual
     if actual_list is not None:
         actual_item = actual_list.pop(0)
 
@@ -287,7 +287,7 @@ def test_pytest_config_file():
         helpers.TEST_DATA_PATH / "root",
     )
     assert actual
-    actual_list: List[Dict[str, Any]] = actual
+    actual_list: list[dict[str, Any]] = actual
     if actual_list is not None:
         actual_item = actual_list.pop(0)
 
@@ -319,7 +319,7 @@ def test_config_sub_folder():
     )
 
     assert actual
-    actual_list: List[Dict[str, Any]] = actual
+    actual_list: list[dict[str, Any]] = actual
     if actual_list is not None:
         actual_item = actual_list.pop(0)
         assert all(item in actual_item for item in ("status", "cwd", "error"))

--- a/python_files/tests/pytestadapter/test_execution.py
+++ b/python_files/tests/pytestadapter/test_execution.py
@@ -4,7 +4,7 @@ import json
 import os
 import pathlib
 import sys
-from typing import Any, Dict, List
+from typing import Any
 
 import pytest
 
@@ -33,7 +33,7 @@ def test_config_file():
     actual = runner_with_cwd(args, new_cwd)
     expected_const = expected_execution_test_output.config_file_pytest_expected_execution_output
     assert actual
-    actual_list: List[Dict[str, Any]] = actual
+    actual_list: list[dict[str, Any]] = actual
     assert len(actual_list) == len(expected_const)
     actual_result_dict = {}
     if actual_list is not None:
@@ -53,7 +53,7 @@ def test_rootdir_specified():
     actual = runner_with_cwd(args, new_cwd)
     expected_const = expected_execution_test_output.config_file_pytest_expected_execution_output
     assert actual
-    actual_list: List[Dict[str, Dict[str, Any]]] = actual
+    actual_list: list[dict[str, dict[str, Any]]] = actual
     assert len(actual_list) == len(expected_const)
     actual_result_dict = {}
     if actual_list is not None:
@@ -207,7 +207,7 @@ def test_pytest_execution(test_ids, expected_const):
     args = test_ids
     actual = runner(args)
     assert actual
-    actual_list: List[Dict[str, Dict[str, Any]]] = actual
+    actual_list: list[dict[str, dict[str, Any]]] = actual
     assert len(actual_list) == len(expected_const)
     actual_result_dict = {}
     if actual_list is not None:
@@ -248,7 +248,7 @@ def test_symlink_run():
 
         expected_const = expected_execution_test_output.symlink_run_expected_execution_output
         assert actual
-        actual_list: List[Dict[str, Any]] = actual
+        actual_list: list[dict[str, Any]] = actual
         if actual_list is not None:
             actual_item = actual_list.pop(0)
             try:

--- a/python_files/tests/test_installed_check.py
+++ b/python_files/tests/test_installed_check.py
@@ -7,7 +7,7 @@ import os
 import pathlib
 import subprocess
 import sys
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 import pytest
 
@@ -31,7 +31,7 @@ def generate_file(base_file: pathlib.Path):
 
 def run_on_file(
     file_path: pathlib.Path, severity: Optional[str] = None
-) -> List[Dict[str, Union[str, int]]]:
+) -> list[dict[str, Union[str, int]]]:
     env = os.environ.copy()
     if severity:
         env["VSCODE_MISSING_PGK_SEVERITY"] = severity

--- a/python_files/tests/unittestadapter/test_discovery.py
+++ b/python_files/tests/unittestadapter/test_discovery.py
@@ -4,7 +4,7 @@
 import os
 import pathlib
 import sys
-from typing import Any, Dict, List
+from typing import Any
 
 import pytest
 
@@ -70,7 +70,7 @@ TEST_DATA_PATH = pathlib.Path(__file__).parent / ".data"
         ),
     ],
 )
-def test_parse_unittest_args(args: List[str], expected: List[str]) -> None:
+def test_parse_unittest_args(args: list[str], expected: list[str]) -> None:
     """The parse_unittest_args function should return values for the start_dir, pattern, and top_level_dir arguments when passed as command-line options, and ignore unrecognized arguments."""
     actual = parse_unittest_args(args)
 
@@ -309,7 +309,7 @@ def test_simple_django_collect():
     )
 
     assert actual
-    actual_list: List[Dict[str, Any]] = actual
+    actual_list: list[dict[str, Any]] = actual
     assert actual_list is not None
     if actual_list is not None:
         actual_item = actual_list.pop(0)

--- a/python_files/tests/unittestadapter/test_execution.py
+++ b/python_files/tests/unittestadapter/test_execution.py
@@ -4,7 +4,7 @@
 import os
 import pathlib
 import sys
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from unittest.mock import patch
 
 import pytest
@@ -67,11 +67,11 @@ def test_single_ids_run(mock_send_run_data):
     test_actual = args[0]  # first argument is the result
 
     assert test_actual
-    actual_result: Optional[Dict[str, Dict[str, Optional[str]]]] = actual["result"]
+    actual_result: Optional[dict[str, dict[str, Optional[str]]]] = actual["result"]
     if actual_result is None:
         raise AssertionError("actual_result is None")
     else:
-        if not isinstance(actual_result, Dict):
+        if not isinstance(actual_result, dict):
             raise AssertionError("actual_result is not a Dict")
         assert len(actual_result) == 1
         assert id_ in actual_result
@@ -322,7 +322,7 @@ def test_basic_run_django():
         {"MANAGE_PY_PATH": manage_py_path},
     )
     assert actual
-    actual_list: List[Dict[str, Dict[str, Any]]] = actual
+    actual_list: list[dict[str, dict[str, Any]]] = actual
     actual_result_dict = {}
     assert len(actual_list) == 3
     for actual_item in actual_list:

--- a/python_files/unittestadapter/discovery.py
+++ b/python_files/unittestadapter/discovery.py
@@ -6,7 +6,7 @@ import pathlib
 import sys
 import traceback
 import unittest
-from typing import List, Optional
+from typing import Optional
 
 script_dir = pathlib.Path(__file__).parent
 sys.path.append(os.fspath(script_dir))
@@ -65,7 +65,7 @@ def discover_tests(
         sys.path.insert(0, cwd)
     payload: DiscoveryPayloadDict = {"cwd": cwd, "status": "success", "tests": None}
     tests = None
-    error: List[str] = []
+    error: list[str] = []
 
     try:
         loader = unittest.TestLoader()

--- a/python_files/unittestadapter/django_handler.py
+++ b/python_files/unittestadapter/django_handler.py
@@ -5,7 +5,6 @@ import os
 import pathlib
 import subprocess
 import sys
-from typing import List
 
 script_dir = pathlib.Path(__file__).parent
 sys.path.append(os.fspath(script_dir))
@@ -16,7 +15,7 @@ from pvsc_utils import (  # noqa: E402
 )
 
 
-def django_discovery_runner(manage_py_path: str, args: List[str]) -> None:
+def django_discovery_runner(manage_py_path: str, args: list[str]) -> None:
     # Attempt a small amount of validation on the manage.py path.
     if not pathlib.Path(manage_py_path).exists():
         raise VSCodeUnittestError("Error running Django, manage.py path does not exist.")
@@ -57,7 +56,7 @@ def django_discovery_runner(manage_py_path: str, args: List[str]) -> None:
         raise VSCodeUnittestError(f"Error during Django discovery: {e}")  # noqa: B904
 
 
-def django_execution_runner(manage_py_path: str, test_ids: List[str], args: List[str]) -> None:
+def django_execution_runner(manage_py_path: str, test_ids: list[str], args: list[str]) -> None:
     # Attempt a small amount of validation on the manage.py path.
     if not pathlib.Path(manage_py_path).exists():
         raise VSCodeUnittestError("Error running Django, manage.py path does not exist.")
@@ -73,7 +72,7 @@ def django_execution_runner(manage_py_path: str, test_ids: List[str], args: List
             env["PYTHONPATH"] = os.fspath(custom_test_runner_dir)
 
         # Build command to run 'python manage.py test'.
-        command: List[str] = [
+        command: list[str] = [
             sys.executable,
             manage_py_path,
             "test",

--- a/python_files/unittestadapter/execution.py
+++ b/python_files/unittestadapter/execution.py
@@ -10,7 +10,7 @@ import sysconfig
 import traceback
 import unittest
 from types import TracebackType
-from typing import Dict, List, Optional, Set, Tuple, Type, Union
+from typing import Optional, Union
 
 # Adds the scripts directory to the PATH as a workaround for enabling shell for test execution.
 path_var_name = "PATH" if "PATH" in os.environ else "Path"
@@ -33,7 +33,7 @@ from unittestadapter.pvsc_utils import (  # noqa: E402
     send_post_request,
 )
 
-ErrorType = Union[Tuple[Type[BaseException], BaseException, TracebackType], Tuple[None, None, None]]
+ErrorType = Union[tuple[type[BaseException], BaseException, TracebackType], tuple[None, None, None]]
 test_run_pipe = ""
 START_DIR = ""
 
@@ -51,7 +51,7 @@ class TestOutcomeEnum(str, enum.Enum):
 
 class UnittestTestResult(unittest.TextTestResult):
     def __init__(self, *args, **kwargs):
-        self.formatted: Dict[str, Dict[str, Union[str, None]]] = {}
+        self.formatted: dict[str, dict[str, Union[str, None]]] = {}
         super().__init__(*args, **kwargs)
 
     def startTest(self, test: unittest.TestCase):  # noqa: N802
@@ -149,7 +149,7 @@ class UnittestTestResult(unittest.TextTestResult):
         send_run_data(result, test_run_pipe)
 
 
-def filter_tests(suite: unittest.TestSuite, test_ids: List[str]) -> unittest.TestSuite:
+def filter_tests(suite: unittest.TestSuite, test_ids: list[str]) -> unittest.TestSuite:
     """Filter the tests in the suite to only run the ones with the given ids."""
     filtered_suite = unittest.TestSuite()
     for test in suite:
@@ -161,7 +161,7 @@ def filter_tests(suite: unittest.TestSuite, test_ids: List[str]) -> unittest.Tes
     return filtered_suite
 
 
-def get_all_test_ids(suite: unittest.TestSuite) -> List[str]:
+def get_all_test_ids(suite: unittest.TestSuite) -> list[str]:
     """Return a list of all test ids in the suite."""
     test_ids = []
     for test in suite:
@@ -172,7 +172,7 @@ def get_all_test_ids(suite: unittest.TestSuite) -> List[str]:
     return test_ids
 
 
-def find_missing_tests(test_ids: List[str], suite: unittest.TestSuite) -> List[str]:
+def find_missing_tests(test_ids: list[str], suite: unittest.TestSuite) -> list[str]:
     """Return a list of test ids that are not in the suite."""
     all_test_ids = get_all_test_ids(suite)
     return [test_id for test_id in test_ids if test_id not in all_test_ids]
@@ -185,7 +185,7 @@ def find_missing_tests(test_ids: List[str], suite: unittest.TestSuite) -> List[s
 # - if tests got added since the VS Code side last ran discovery and the current test run, ignore them.
 def run_tests(
     start_dir: str,
-    test_ids: List[str],
+    test_ids: list[str],
     pattern: str,
     top_level_dir: Optional[str],
     verbosity: int,
@@ -323,7 +323,7 @@ if __name__ == "__main__":
         )
         import coverage
 
-        source_ar: List[str] = []
+        source_ar: list[str] = []
         if workspace_root:
             source_ar.append(workspace_root)
         if top_level_dir:
@@ -358,8 +358,8 @@ if __name__ == "__main__":
         cov.stop()
         cov.save()
         cov.load()
-        file_set: Set[str] = cov.get_data().measured_files()
-        file_coverage_map: Dict[str, FileCoverageInfo] = {}
+        file_set: set[str] = cov.get_data().measured_files()
+        file_coverage_map: dict[str, FileCoverageInfo] = {}
         for file in file_set:
             analysis = cov.analysis2(file)
             lines_executable = {int(line_no) for line_no in analysis[1]}

--- a/python_files/unittestadapter/pvsc_utils.py
+++ b/python_files/unittestadapter/pvsc_utils.py
@@ -10,7 +10,7 @@ import os
 import pathlib
 import sys
 import unittest
-from typing import Dict, List, Literal, Optional, Tuple, TypedDict, Union
+from typing import Literal, Optional, TypedDict, Union
 
 script_dir = pathlib.Path(__file__).parent.parent
 sys.path.append(os.fspath(script_dir))
@@ -42,7 +42,7 @@ class TestItem(TestData):
 
 
 class TestNode(TestData):
-    children: "List[TestNode | TestItem]"
+    children: "list[TestNode | TestItem]"
 
 
 class TestExecutionStatus(str, enum.Enum):
@@ -61,28 +61,28 @@ class DiscoveryPayloadDict(TypedDict):
     cwd: str
     status: Literal["success", "error"]
     tests: Optional[TestNode]
-    error: NotRequired[List[str]]
+    error: NotRequired[list[str]]
 
 
 class ExecutionPayloadDict(TypedDict):
     cwd: str
     status: TestExecutionStatus
-    result: Optional[Dict[str, Dict[str, Optional[str]]]]
-    not_found: NotRequired[List[str]]
+    result: Optional[dict[str, dict[str, Optional[str]]]]
+    not_found: NotRequired[list[str]]
     error: NotRequired[str]
 
 
 class FileCoverageInfo(TypedDict):
-    lines_covered: List[int]
-    lines_missed: List[int]
+    lines_covered: list[int]
+    lines_missed: list[int]
 
 
-class CoveragePayloadDict(Dict):
+class CoveragePayloadDict(dict):
     """A dictionary that is used to send a execution post request to the server."""
 
     coverage: bool
     cwd: str
-    result: Optional[Dict[str, FileCoverageInfo]]
+    result: Optional[dict[str, FileCoverageInfo]]
     error: Optional[str]  # Currently unused need to check
 
 
@@ -154,7 +154,7 @@ def get_child_node(name: str, path: str, type_: TestNodeTypeEnum, root: TestNode
 
 def build_test_tree(
     suite: unittest.TestSuite, top_level_directory: str
-) -> Tuple[Union[TestNode, None], List[str]]:
+) -> tuple[Union[TestNode, None], list[str]]:
     """Build a test tree from a unittest test suite.
 
     This function returns the test tree, and any errors found by unittest.
@@ -260,8 +260,8 @@ def build_test_tree(
 
 
 def parse_unittest_args(
-    args: List[str],
-) -> Tuple[str, str, Union[str, None], int, Union[bool, None], Union[bool, None]]:
+    args: list[str],
+) -> tuple[str, str, Union[str, None], int, Union[bool, None], Union[bool, None]]:
     """Parse command-line arguments that should be forwarded to unittest to perform discovery.
 
     Valid unittest arguments are: -v, -s, -p, -t and their long-form counterparts,

--- a/python_files/visualstudio_py_testlauncher.py
+++ b/python_files/visualstudio_py_testlauncher.py
@@ -129,8 +129,8 @@ class _IpcChannel:
         with self.lock:
             body = {"type": "event", "seq": self.seq, "event": name, "body": args}
             self.seq += 1
-            content = json.dumps(body).encode("utf8")
-            headers = ("Content-Length: %d\n\n" % (len(content),)).encode("utf8")
+            content = json.dumps(body).encode()
+            headers = f"Content-Length: {len(content)}\n\n".encode()
             self.socket.send(headers)
             self.socket.send(content)
 

--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -10,7 +10,6 @@ import os
 import pathlib
 import sys
 import traceback
-from collections.abc import Generator
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -22,6 +21,8 @@ from typing import (
 import pytest
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from pluggy import Result
 
 
@@ -214,7 +215,7 @@ def pytest_keyboard_interrupt(excinfo):
     ERRORS.append(excinfo.exconly() + "\n Check Python Test Logs for more details.")
 
 
-class TestOutcome(Dict):
+class TestOutcome(dict):
     """A class that handles outcome for a single test.
 
     for pytest the outcome for a test is only 'passed', 'skipped' or 'failed'
@@ -244,7 +245,7 @@ def create_test_outcome(
     )
 
 
-class TestRunResultDict(Dict[str, Dict[str, TestOutcome]]):
+class TestRunResultDict(dict[str, dict[str, TestOutcome]]):
     """A class that stores all test run results."""
 
     outcome: str
@@ -790,7 +791,7 @@ class DiscoveryPayloadDict(TypedDict):
     error: list[str] | None
 
 
-class ExecutionPayloadDict(Dict):
+class ExecutionPayloadDict(dict):
     """A dictionary that is used to send a execution post request to the server."""
 
     cwd: str
@@ -800,7 +801,7 @@ class ExecutionPayloadDict(Dict):
     error: str | None  # Currently unused need to check
 
 
-class CoveragePayloadDict(Dict):
+class CoveragePayloadDict(dict):
     """A dictionary that is used to send a execution post request to the server."""
 
     coverage: bool

--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -13,7 +13,6 @@ import traceback
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     Literal,
     TypedDict,
 )

--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -10,11 +10,11 @@ import os
 import pathlib
 import sys
 import traceback
+from collections.abc import Generator
 from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
-    Generator,
     Literal,
     TypedDict,
 )


### PR DESCRIPTION
- Ruff 0.8.0 was released on November 22nd ([changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#080))
- [Lint action installs latest version of `ruff`](https://github.com/joar/vscode-python/blob/9059aeae6575e11c27f24df688016f9c2d6cdd2a/.github/actions/lint/action.yml#L46)