### PR TITLE
Support ruff `0.8.0` by setting ruff `target-version` to `py38`

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -43,7 +43,7 @@ runs:
 
     - name: Run Ruff
       run: |
-        python -m pip install -U "ruff<0.8.0"
+        python -m pip install -U "ruff"
         python -m ruff check .
         python -m ruff format --check
       working-directory: python_files

--- a/python_files/pyproject.toml
+++ b/python_files/pyproject.toml
@@ -23,6 +23,7 @@ ignore = [
 
 [tool.ruff]
 line-length = 100
+target-version = "py38"
 exclude = [
     "**/.data",
     "lib",

--- a/python_files/visualstudio_py_testlauncher.py
+++ b/python_files/visualstudio_py_testlauncher.py
@@ -130,7 +130,7 @@ class _IpcChannel:
             body = {"type": "event", "seq": self.seq, "event": name, "body": args}
             self.seq += 1
             content = json.dumps(body).encode("utf8")
-            headers = ("Content-Length: %d\n\n" % (len(content),)).encode("utf8")
+            headers = f"Content-Length: {len(content)}\n\n".encode()
             self.socket.send(headers)
             self.socket.send(content)
 


### PR DESCRIPTION
`ruff` 0.8.0 (released 2024-11-22) no longer defaults to supporting Python 3.8,

> Ruff now defaults to Python 3.9 instead of 3.8 if no explicit Python version
> is configured using [`ruff.target-version`](https://docs.astral.sh/ruff/settings/#target-version)
> or [`project.requires-python`](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#python-requires)
> ([https://github.com/microsoft/vscode-python/pull/13896](https://github.com/astral-sh/ruff/pull/13896))
> — https://github.com/astral-sh/ruff/blob/f3dac27e9aa6ac6a20fc2fb27ff2e4f5d369b076/CHANGELOG.md#080

We want to support Python 3.8 until February 2025, so we need to set
`target-version`.

> The minimum Python version to target, e.g., when considering automatic code
> upgrades, like rewriting type annotations. Ruff will not propose changes
> using features that are not available in the given version.
> — https://docs.astral.sh/ruff/settings/#target-version

Can be used as an alternative to https://github.com/microsoft/vscode-python/pull/24488 until py38 support is dropped.

This PR also reverts the pinning of `ruff` merged in #24484.