### PR TITLE
chore: remove needsTools parameter

### DIFF
--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -25,7 +25,6 @@ extends:
   parameters:
     publishExtension: ${{ parameters.publishExtension }}
     l10nSourcePaths: ./src/client
-    needsTools: true
 
     buildPlatforms:
       - name: Linux


### PR DESCRIPTION
This PR removes the needsTool parameter because the template does not recognize this parameter and because the pre-release pipeline does not use it. 