### PR TITLE
chore: register dependent pipeline for APIScan

### DIFF
--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -102,7 +102,7 @@ extends:
             project: 'Monaco'
             definition: 593
             buildVersionToDownload: 'latestFromBranch'
-            branchName: 'refs/heads/release/2024.18'
+            branchName: 'refs/heads/release/2024.20'
             targetPath: '$(Build.SourcesDirectory)/python-env-tools/bin'
             artifactName: 'bin-$(vsceTarget)'
             itemPattern: |
@@ -123,5 +123,5 @@ extends:
             areaPath: 'Visual Studio Code Python Extensions'
             serviceTreeID: '6e6194bc-7baa-4486-86d0-9f5419626d46'
         enabled: true
-    apiScanDependentPipelineId: '593'
+    apiScanDependentPipelineId: '593' # python-environment-tools
     apiScanSoftwareVersion: '2024'

--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -123,4 +123,5 @@ extends:
             areaPath: 'Visual Studio Code Python Extensions'
             serviceTreeID: '6e6194bc-7baa-4486-86d0-9f5419626d46'
         enabled: true
+    apiScanDependentPipelineId: '593'
     apiScanSoftwareVersion: '2024'


### PR DESCRIPTION
After confirming that I'm still unable to get APIScan to read org-level symbols, I'm adding this registration to allow the APIScan stage for this pipeline to directly fetch the pipeline artifact containing symbols from the other pipeline.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=307394&view=results