### PR TITLE
Fix: Don't use executeCommand on python sub-shell for WSL 

### DIFF
--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -21,7 +21,7 @@ import {
 } from './types';
 import { traceVerbose } from '../../logging';
 import { getConfiguration } from '../vscodeApis/workspaceApis';
-import { isWindows } from '../utils/platform';
+import { isWindows, isWsl } from '../utils/platform';
 
 @injectable()
 export class TerminalService implements ITerminalService, Disposable {
@@ -105,7 +105,7 @@ export class TerminalService implements ITerminalService, Disposable {
 
         const config = getConfiguration('python');
         const pythonrcSetting = config.get<boolean>('terminal.shellIntegration.enabled');
-        if ((isPythonShell && !pythonrcSetting) || (isPythonShell && isWindows())) {
+        if ((isPythonShell && !pythonrcSetting) || (isPythonShell && isWindows()) || (isPythonShell && isWsl())) {
             // If user has explicitly disabled SI for Python, use sendText for inside Terminal REPL.
             terminal.sendText(commandLine);
             return undefined;

--- a/src/client/common/utils/platform.ts
+++ b/src/client/common/utils/platform.ts
@@ -3,8 +3,8 @@
 
 'use strict';
 
+import { env } from 'vscode';
 import { EnvironmentVariables } from '../variables/types';
-
 export enum Architecture {
     Unknown = 1,
     x86 = 2,
@@ -28,6 +28,10 @@ export function getOSType(platform: string = process.platform): OSType {
     } else {
         return OSType.Unknown;
     }
+}
+
+export function isWsl(): boolean {
+    return env.remoteName === 'wsl';
 }
 
 const architectures: Record<string, Architecture> = {


### PR DESCRIPTION
Related: https://github.com/microsoft/vscode-python/pull/24418
Further resolves: https://github.com/microsoft/vscode-python/issues/24422
Shell integration does not exist on windows python repl so dont use execute command on python subshell in this case. --- Guard against WSL too. 

This will prevent keyboard interrupt from happening even when setting for shell integration is enabled for python shell (which is currently only supported on mac and linux)