### PR TITLE
Fix) Prevent keyboard interrupt for Python3.13 REPL non-Windows 

### DIFF
--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -22,6 +22,7 @@ import {
 import { traceVerbose } from '../../logging';
 import { getConfiguration } from '../vscodeApis/workspaceApis';
 import { isWindows } from '../utils/platform';
+import { getActiveInterpreter } from '../../repl/replUtils';
 
 @injectable()
 export class TerminalService implements ITerminalService, Disposable {
@@ -107,7 +108,16 @@ export class TerminalService implements ITerminalService, Disposable {
         // const pythonVersion = await this.getPythonVersion();
         // const isPython313 = pythonVersion?.startsWith('3.13');
 
-        if (isPythonShell && (!pythonrcSetting || isWindows())) {
+        let isPython313 = false;
+        if (this.options && this.options.resource) {
+            const pythonVersion = await getActiveInterpreter(
+                this.options.resource,
+                this.serviceContainer.get<IInterpreterService>(IInterpreterService),
+            );
+            pythonVersion?.sysVersion?.startsWith('3.13');
+        }
+
+        if (isPythonShell && (!pythonrcSetting || isWindows() || isPython313)) {
             // If user has explicitly disabled SI for Python, use sendText for inside Terminal REPL.
             terminal.sendText(commandLine);
             return undefined;

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -104,8 +104,8 @@ export class TerminalService implements ITerminalService, Disposable {
         }
         const config = getConfiguration('python');
         const pythonrcSetting = config.get<boolean>('terminal.shellIntegration.enabled');
-        const pythonVersion = await this.getPythonVersion();
-        const isPython313 = pythonVersion?.startsWith('3.13');
+        // const pythonVersion = await this.getPythonVersion();
+        // const isPython313 = pythonVersion?.startsWith('3.13');
 
         if (isPythonShell && (!pythonrcSetting || isWindows())) {
             // If user has explicitly disabled SI for Python, use sendText for inside Terminal REPL.
@@ -183,16 +183,16 @@ export class TerminalService implements ITerminalService, Disposable {
         });
     }
 
-    private async getPythonVersion(): Promise<string | undefined> {
-        const pythonPath = this.serviceContainer
-            .get<IConfigurationService>(IConfigurationService)
-            .getSettings(this.options?.resource).pythonPath;
-        const interpreterInfo =
-            this.options?.interpreter ||
-            (await this.serviceContainer
-                .get<IInterpreterService>(IInterpreterService)
-                .getInterpreterDetails(pythonPath));
-        const pythonVersion = interpreterInfo && interpreterInfo.version ? interpreterInfo.version.raw : undefined;
-        return pythonVersion;
-    }
+    // private async getPythonVersion(): Promise<string | undefined> {
+    //     const pythonPath = this.serviceContainer
+    //         .get<IConfigurationService>(IConfigurationService)
+    //         .getSettings(this.options?.resource).pythonPath;
+    //     const interpreterInfo =
+    //         this.options?.interpreter ||
+    //         (await this.serviceContainer
+    //             .get<IInterpreterService>(IInterpreterService)
+    //             .getInterpreterDetails(pythonPath));
+    //     const pythonVersion = interpreterInfo && interpreterInfo.version ? interpreterInfo.version.raw : undefined;
+    //     return pythonVersion;
+    // }
 }

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -104,8 +104,8 @@ export class TerminalService implements ITerminalService, Disposable {
         }
         const config = getConfiguration('python');
         const pythonrcSetting = config.get<boolean>('terminal.shellIntegration.enabled');
-        // const pythonVersion = 'await this.getPythonVersion()';
-        // const isPython313 = pythonVersion?.startsWith('3.13');
+        const pythonVersion = await this.getPythonVersion();
+        const isPython313 = pythonVersion?.startsWith('3.13');
 
         if (isPythonShell && (!pythonrcSetting || isWindows())) {
             // If user has explicitly disabled SI for Python, use sendText for inside Terminal REPL.
@@ -183,16 +183,16 @@ export class TerminalService implements ITerminalService, Disposable {
         });
     }
 
-    // private async getPythonVersion(): Promise<string | undefined> {
-    //     const pythonPath = this.serviceContainer
-    //         .get<IConfigurationService>(IConfigurationService)
-    //         .getSettings(this.options?.resource).pythonPath;
-    //     const interpreterInfo =
-    //         this.options?.interpreter ||
-    //         (await this.serviceContainer
-    //             .get<IInterpreterService>(IInterpreterService)
-    //             .getInterpreterDetails(pythonPath));
-    //     const pythonVersion = interpreterInfo && interpreterInfo.version ? interpreterInfo.version.raw : undefined;
-    //     return pythonVersion;
-    // }
+    private async getPythonVersion(): Promise<string | undefined> {
+        const pythonPath = this.serviceContainer
+            .get<IConfigurationService>(IConfigurationService)
+            .getSettings(this.options?.resource).pythonPath;
+        const interpreterInfo =
+            this.options?.interpreter ||
+            (await this.serviceContainer
+                .get<IInterpreterService>(IInterpreterService)
+                .getInterpreterDetails(pythonPath));
+        const pythonVersion = interpreterInfo && interpreterInfo.version ? interpreterInfo.version.raw : undefined;
+        return pythonVersion;
+    }
 }

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -104,10 +104,10 @@ export class TerminalService implements ITerminalService, Disposable {
         }
         const config = getConfiguration('python');
         const pythonrcSetting = config.get<boolean>('terminal.shellIntegration.enabled');
-        const pythonVersion = await this.getPythonVersion();
-        const isPython313 = pythonVersion?.startsWith('3.13');
+        // const pythonVersion = 'await this.getPythonVersion()';
+        // const isPython313 = pythonVersion?.startsWith('3.13');
 
-        if (isPythonShell && (!pythonrcSetting || isWindows() || isPython313)) {
+        if (isPythonShell && (!pythonrcSetting || isWindows())) {
             // If user has explicitly disabled SI for Python, use sendText for inside Terminal REPL.
             terminal.sendText(commandLine);
             return undefined;
@@ -183,16 +183,16 @@ export class TerminalService implements ITerminalService, Disposable {
         });
     }
 
-    private async getPythonVersion(): Promise<string | undefined> {
-        const pythonPath = this.serviceContainer
-            .get<IConfigurationService>(IConfigurationService)
-            .getSettings(this.options?.resource).pythonPath;
-        const interpreterInfo =
-            this.options?.interpreter ||
-            (await this.serviceContainer
-                .get<IInterpreterService>(IInterpreterService)
-                .getInterpreterDetails(pythonPath));
-        const pythonVersion = interpreterInfo && interpreterInfo.version ? interpreterInfo.version.raw : undefined;
-        return pythonVersion;
-    }
+    // private async getPythonVersion(): Promise<string | undefined> {
+    //     const pythonPath = this.serviceContainer
+    //         .get<IConfigurationService>(IConfigurationService)
+    //         .getSettings(this.options?.resource).pythonPath;
+    //     const interpreterInfo =
+    //         this.options?.interpreter ||
+    //         (await this.serviceContainer
+    //             .get<IInterpreterService>(IInterpreterService)
+    //             .getInterpreterDetails(pythonPath));
+    //     const pythonVersion = interpreterInfo && interpreterInfo.version ? interpreterInfo.version.raw : undefined;
+    //     return pythonVersion;
+    // }
 }

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -102,7 +102,6 @@ export class TerminalService implements ITerminalService, Disposable {
             });
             await promise;
         }
-        // TODO: need to use sendText for Python3.13 as well.
         const config = getConfiguration('python');
         const pythonrcSetting = config.get<boolean>('terminal.shellIntegration.enabled');
 
@@ -117,7 +116,7 @@ export class TerminalService implements ITerminalService, Disposable {
         const pythonVersion = interpreterInfo && interpreterInfo.version ? interpreterInfo.version.raw : undefined;
         const isPython313 = pythonVersion?.startsWith('3.13');
 
-        if (isPythonShell && (!pythonrcSetting || isWindows() || isWsl() || isPython313)) {
+        if (isPythonShell && (!pythonrcSetting || isWindows() || isPython313)) {
             // If user has explicitly disabled SI for Python, use sendText for inside Terminal REPL.
             terminal.sendText(commandLine);
             return undefined;

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -104,16 +104,7 @@ export class TerminalService implements ITerminalService, Disposable {
         }
         const config = getConfiguration('python');
         const pythonrcSetting = config.get<boolean>('terminal.shellIntegration.enabled');
-
-        const pythonPath = this.serviceContainer
-            .get<IConfigurationService>(IConfigurationService)
-            .getSettings(this.options?.resource).pythonPath;
-        const interpreterInfo =
-            this.options?.interpreter ||
-            (await this.serviceContainer
-                .get<IInterpreterService>(IInterpreterService)
-                .getInterpreterDetails(pythonPath));
-        const pythonVersion = interpreterInfo && interpreterInfo.version ? interpreterInfo.version.raw : undefined;
+        const pythonVersion = await this.getPythonVersion();
         const isPython313 = pythonVersion?.startsWith('3.13');
 
         if (isPythonShell && (!pythonrcSetting || isWindows() || isPython313)) {
@@ -190,5 +181,18 @@ export class TerminalService implements ITerminalService, Disposable {
             pythonVersion,
             interpreterType,
         });
+    }
+
+    private async getPythonVersion(): Promise<string | undefined> {
+        const pythonPath = this.serviceContainer
+            .get<IConfigurationService>(IConfigurationService)
+            .getSettings(this.options?.resource).pythonPath;
+        const interpreterInfo =
+            this.options?.interpreter ||
+            (await this.serviceContainer
+                .get<IInterpreterService>(IInterpreterService)
+                .getInterpreterDetails(pythonPath));
+        const pythonVersion = interpreterInfo && interpreterInfo.version ? interpreterInfo.version.raw : undefined;
+        return pythonVersion;
     }
 }

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -105,8 +105,6 @@ export class TerminalService implements ITerminalService, Disposable {
         }
         const config = getConfiguration('python');
         const pythonrcSetting = config.get<boolean>('terminal.shellIntegration.enabled');
-        // const pythonVersion = await this.getPythonVersion();
-        // const isPython313 = pythonVersion?.startsWith('3.13');
 
         let isPython313 = false;
         if (this.options && this.options.resource) {
@@ -192,17 +190,4 @@ export class TerminalService implements ITerminalService, Disposable {
             interpreterType,
         });
     }
-
-    // private async getPythonVersion(): Promise<string | undefined> {
-    //     const pythonPath = this.serviceContainer
-    //         .get<IConfigurationService>(IConfigurationService)
-    //         .getSettings(this.options?.resource).pythonPath;
-    //     const interpreterInfo =
-    //         this.options?.interpreter ||
-    //         (await this.serviceContainer
-    //             .get<IInterpreterService>(IInterpreterService)
-    //             .getInterpreterDetails(pythonPath));
-    //     const pythonVersion = interpreterInfo && interpreterInfo.version ? interpreterInfo.version.raw : undefined;
-    //     return pythonVersion;
-    // }
 }

--- a/src/test/common/terminals/service.unit.test.ts
+++ b/src/test/common/terminals/service.unit.test.ts
@@ -19,15 +19,19 @@ import { EXTENSION_ROOT_DIR } from '../../../client/common/constants';
 import { IPlatformService } from '../../../client/common/platform/types';
 import { TerminalService } from '../../../client/common/terminal/service';
 import { ITerminalActivator, ITerminalHelper, TerminalShellType } from '../../../client/common/terminal/types';
-import { IDisposableRegistry } from '../../../client/common/types';
+import { IConfigurationService, IDisposableRegistry } from '../../../client/common/types';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { ITerminalAutoActivation } from '../../../client/terminals/types';
 import { createPythonInterpreter } from '../../utils/interpreters';
 import * as workspaceApis from '../../../client/common/vscodeApis/workspaceApis';
 import * as platform from '../../../client/common/utils/platform';
+import { IInterpreterService } from '../../../client/interpreter/contracts';
+import { PythonEnvironment } from '../../../client/pythonEnvironments/info';
 
 suite('Terminal Service', () => {
     let service: TerminalService;
+    let configService: TypeMoq.IMock<IConfigurationService>;
+    let interpreterService: TypeMoq.IMock<IInterpreterService>;
     let terminal: TypeMoq.IMock<VSCodeTerminal>;
     let terminalManager: TypeMoq.IMock<ITerminalManager>;
     let terminalHelper: TypeMoq.IMock<ITerminalHelper>;
@@ -44,8 +48,23 @@ suite('Terminal Service', () => {
     let pythonConfig: TypeMoq.IMock<WorkspaceConfiguration>;
     let editorConfig: TypeMoq.IMock<WorkspaceConfiguration>;
     let isWindowsStub: sinon.SinonStub;
+    // let getPythonVersionStub: sinon.SinonStub;
 
     setup(() => {
+        configService = TypeMoq.Mock.ofType<IConfigurationService>();
+        configService.setup((c) => c.getSettings()).returns(() => ({ pythonPath: 'pythonPath' } as any));
+
+        // configService.setup((t) => t.getSettings);
+        interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
+        // when(interpreterService.getInterpreterDetails(anything())).thenResolve({
+        //     version: { major: 3 },
+        //     // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // } as any);
+
+        interpreterService
+            .setup((i) => i.getInterpreterDetails(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(({ envName: 'base' } as unknown) as PythonEnvironment));
+
         terminal = TypeMoq.Mock.ofType<VSCodeTerminal>();
         terminalShellIntegration = TypeMoq.Mock.ofType<TerminalShellIntegration>();
         terminal.setup((t) => t.shellIntegration).returns(() => terminalShellIntegration.object);
@@ -95,8 +114,11 @@ suite('Terminal Service', () => {
         mockServiceContainer.setup((c) => c.get(IWorkspaceService)).returns(() => workspaceService.object);
         mockServiceContainer.setup((c) => c.get(ITerminalActivator)).returns(() => terminalActivator.object);
         mockServiceContainer.setup((c) => c.get(ITerminalAutoActivation)).returns(() => terminalAutoActivator.object);
+        mockServiceContainer.setup((c) => c.get(IConfigurationService)).returns(() => configService.object);
+        mockServiceContainer.setup((c) => c.get(IInterpreterService)).returns(() => interpreterService.object);
         getConfigurationStub = sinon.stub(workspaceApis, 'getConfiguration');
         isWindowsStub = sinon.stub(platform, 'isWindows');
+
         pythonConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
         editorConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
         getConfigurationStub.callsFake((section: string) => {
@@ -234,7 +256,7 @@ suite('Terminal Service', () => {
         terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.exactly(1));
     });
 
-    test('Ensure sendText is NOT called when Python shell integration and terminal shell integration are both enabled - Mac, Linux', async () => {
+    test('Ensure sendText is NOT called when Python shell integration and terminal shell integration are both enabled - Mac, Linux : !Python3.13', async () => {
         isWindowsStub.returns(false);
         pythonConfig
             .setup((p) => p.get('terminal.shellIntegration.enabled'))
@@ -255,6 +277,8 @@ suite('Terminal Service', () => {
         terminal.verify((t) => t.show(TypeMoq.It.isValue(true)), TypeMoq.Times.exactly(1));
         terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.never());
     });
+
+    // Ensure sendText is NOT called when Python shell integration and terminal shell integration are both enabled - Mac, Linux : Python3.13
 
     test('Ensure sendText IS called even when Python shell integration and terminal shell integration are both enabled - Window', async () => {
         isWindowsStub.returns(true);

--- a/src/test/common/terminals/service.unit.test.ts
+++ b/src/test/common/terminals/service.unit.test.ts
@@ -243,7 +243,7 @@ suite('Terminal Service', () => {
         terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.exactly(1));
     });
 
-    test('Ensure sendText is NOT called when Python shell integration and terminal shell integration are both enabled - Mac, Linux', async () => {
+    test('Ensure sendText is NOT called when Python shell integration and terminal shell integration are both enabled - Mac, Linux - !Python3.13', async () => {
         isWindowsStub.returns(false);
         pythonConfig
             .setup((p) => p.get('terminal.shellIntegration.enabled'))

--- a/src/test/common/terminals/service.unit.test.ts
+++ b/src/test/common/terminals/service.unit.test.ts
@@ -25,6 +25,8 @@ import { ITerminalAutoActivation } from '../../../client/terminals/types';
 import { createPythonInterpreter } from '../../utils/interpreters';
 import * as workspaceApis from '../../../client/common/vscodeApis/workspaceApis';
 import * as platform from '../../../client/common/utils/platform';
+import { IInterpreterService } from '../../../client/interpreter/contracts';
+import { PythonEnvironment } from '../../../client/pythonEnvironments/info';
 
 suite('Terminal Service', () => {
     let service: TerminalService;
@@ -44,6 +46,7 @@ suite('Terminal Service', () => {
     let pythonConfig: TypeMoq.IMock<WorkspaceConfiguration>;
     let editorConfig: TypeMoq.IMock<WorkspaceConfiguration>;
     let isWindowsStub: sinon.SinonStub;
+    let interpreterService: TypeMoq.IMock<IInterpreterService>;
 
     setup(() => {
         terminal = TypeMoq.Mock.ofType<VSCodeTerminal>();
@@ -87,6 +90,10 @@ suite('Terminal Service', () => {
         disposables = [];
 
         mockServiceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
+        interpreterService
+            .setup((i) => i.getActiveInterpreter(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(({ path: 'ps' } as unknown) as PythonEnvironment));
 
         mockServiceContainer.setup((c) => c.get(ITerminalManager)).returns(() => terminalManager.object);
         mockServiceContainer.setup((c) => c.get(ITerminalHelper)).returns(() => terminalHelper.object);
@@ -95,6 +102,8 @@ suite('Terminal Service', () => {
         mockServiceContainer.setup((c) => c.get(IWorkspaceService)).returns(() => workspaceService.object);
         mockServiceContainer.setup((c) => c.get(ITerminalActivator)).returns(() => terminalActivator.object);
         mockServiceContainer.setup((c) => c.get(ITerminalAutoActivation)).returns(() => terminalAutoActivator.object);
+        mockServiceContainer.setup((c) => c.get(IInterpreterService)).returns(() => interpreterService.object);
+
         getConfigurationStub = sinon.stub(workspaceApis, 'getConfiguration');
         isWindowsStub = sinon.stub(platform, 'isWindows');
         pythonConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();


### PR DESCRIPTION
Further resolves: https://github.com/microsoft/vscode-python/issues/24422 
Prevent keyboard interrupt for Mac and Linux when using Python3.13

Having Python3.13 as interpreter choice and then enabling shell integration where it is normally supported (we disabled temporarily for Python3.13 due to https://github.com/python/cpython/issues/126131), lead to edge case. 

So although we don't override user's PS1 in Python side after checking Python3.13 is selected, we were not aware of this in typescript side, leading to wrongly using executeCommand inside Python terminal REPL (Python3.13 IDLE), instead of sendText. 