### PR TITLE
Add PR check for proposed API changes

### DIFF
--- a/.github/workflows/pr-file-check.yml
+++ b/.github/workflows/pr-file-check.yml
@@ -42,3 +42,6 @@ jobs:
             .github/test_plan.md
           skip-label: 'skip tests'
           failure-message: 'TypeScript code was edited without also editing a ${file-pattern} file; see the Testing page in our wiki on testing guidelines (the ${skip-label} label can be used to pass this check)'
+
+      - name: 'Check for proposed API changes'
+        run: npm run check-proposed-api

--- a/package.json
+++ b/package.json
@@ -1552,7 +1552,8 @@
         "addExtensionPackDependencies": "gulp addExtensionPackDependencies",
         "updateBuildNumber": "gulp updateBuildNumber",
         "verifyBundle": "gulp verifyBundle",
-        "webpack": "webpack"
+        "webpack": "webpack",
+        "check-proposed-api": "node ./src/check-proposed-api.js"
     },
     "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/src/check-proposed-api.js
+++ b/src/check-proposed-api.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+
+const packageJsonPath = './package.json';
+
+function checkProposedApiChanges() {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+    const enabledApiProposals = packageJson.enabledApiProposals;
+    const vscodeEngineVersion = packageJson.engines.vscode;
+
+    const originalPackageJson = JSON.parse(fs.readFileSync(packageJsonPath + '.original', 'utf8'));
+    const originalEnabledApiProposals = originalPackageJson.enabledApiProposals;
+    const originalVscodeEngineVersion = originalPackageJson.engines.vscode;
+
+    if (JSON.stringify(enabledApiProposals) !== JSON.stringify(originalEnabledApiProposals) &&
+        vscodeEngineVersion === originalVscodeEngineVersion) {
+        console.error('Error: `enabledApiProposals` was modified but `vscode` engine version was not updated.');
+        process.exit(1);
+    }
+}
+
+checkProposedApiChanges();

--- a/src/check-proposed-api.js
+++ b/src/check-proposed-api.js
@@ -5,8 +5,8 @@ const packageJsonPath = './package.json';
 function checkProposedApiChanges() {
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
-    const enabledApiProposals = packageJson.enabledApiProposals;
-    const vscodeEngineVersion = packageJson.engines.vscode;
+    const { enabledApiProposals, engines } = packageJson;
+    const vscodeEngineVersion = engines.vscode;
 
     const originalPackageJson = JSON.parse(fs.readFileSync(packageJsonPath + '.original', 'utf8'));
     const originalEnabledApiProposals = originalPackageJson.enabledApiProposals;


### PR DESCRIPTION
Fixes #20939

Add a PR check for proposed API changes without VS Code engine update.

* Modify `package.json` to add a new script entry `check-proposed-api`.
* Modify `.github/workflows/pr-file-check.yml` to add a new step to run the `check-proposed-api` script.
* Add `src/check-proposed-api.js` to check for changes in `enabledApiProposals` and `vscode` engine version, and fail if `enabledApiProposals` is modified but `vscode` engine version is not updated.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/vscode-python/pull/24586?shareId=79add1bb-2a4f-49fd-9de9-747ad0a5bd8a).