### PR TITLE
Fix 'coverage.exceptions.NoSource` import to fallback to previous exception path

### DIFF
--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -442,7 +442,11 @@ def pytest_sessionfinish(session, exitstatus):
     if is_coverage_run == "True":
         # load the report and build the json result to return
         import coverage
-        from coverage import exceptions
+
+        try:
+            from coverage.exceptions import NoSource
+        except ImportError:
+            from coverage.misc import NoSource
 
         cov = coverage.Coverage()
         cov.load()
@@ -462,7 +466,7 @@ def pytest_sessionfinish(session, exitstatus):
         for file in file_set:
             try:
                 analysis = cov.analysis2(file)
-            except exceptions.NoSource:
+            except NoSource:
                 # as per issue 24308 this best way to handle this edge case
                 continue
             lines_executable = {int(line_no) for line_no in analysis[1]}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-python/issues/24607