### PR TITLE
Add activation command for micromamba

### DIFF
--- a/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
@@ -60,6 +60,11 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
 
         const condaEnv = envInfo.name.length > 0 ? envInfo.name : envInfo.path;
 
+        // Directly use the self-contained micromamba executable.
+        if (await this.condaService.isMicroMamba()) {
+            return [`micromamba activate ${condaEnv.toCommandArgumentForPythonExt()}`];
+        }
+
         // New version.
         const interpreterPath = await this.condaService.getInterpreterPathForEnvironment(envInfo);
         const activatePath = await this.condaService.getActivationScriptFromInterpreter(interpreterPath, envInfo.name);

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -62,6 +62,7 @@ export interface ICondaService {
     getCondaFile(forShellExecution?: boolean): Promise<string>;
     getCondaInfo(): Promise<CondaInfo | undefined>;
     isCondaAvailable(): Promise<boolean>;
+    isMicroMamba(): Promise<boolean>;
     getCondaVersion(): Promise<SemVer | undefined>;
     getInterpreterPathForEnvironment(condaEnv: CondaEnvironmentInfo): Promise<string | undefined>;
     getCondaFileFromInterpreter(interpreterPath?: string, envName?: string): Promise<string | undefined>;

--- a/src/client/pythonEnvironments/common/environmentManagers/condaService.ts
+++ b/src/client/pythonEnvironments/common/environmentManagers/condaService.ts
@@ -83,6 +83,15 @@ export class CondaService implements ICondaService {
     }
 
     /**
+     * Is the conda executable named "micromamba"?
+     */
+    public async isMicroMamba(): Promise<boolean> {
+        const file = await this.getCondaFile();
+        const name = path.basename(file, '.exe');
+        return name === 'micromamba';
+    }
+
+    /**
      * Return the conda version.
      */
     // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
Attempt to support #20919.

Currently, vscode-python can partially support micromamba with the following settings:

```
python.condaPath: "/usr/local/bin/micromamba"
python.locator: "native"
```

The extension can recognize the environments, however, it fails to ***activate*** the environment properly. This PR adds the activation script for micromamba, which is a self-contained executable and does not have the base environment.

**Example**
Suppose there is an environment named `foo`. The micromamba executable is located at `/usr/local/bin/micromamba`.
- Current behavior: `source /usr/local/bin/activate foo`;
- Expected behavior: `micromamba activate foo`.

**Caveats**
It is difficult to check whether the executable is micromamba, as there is no deterministic API available. Currently, the implementation relies solely on checking the executable's name.

Tested on macOS (zsh) and Windows (PowerShell).