### PR TITLE
Fix fifo communication for large testing projects

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -53,6 +53,7 @@ def install_python_libs(session: nox.Session):
         )
 
     session.install("packaging")
+    session.install("debugpy")
 
     # Download get-pip script
     session.run(

--- a/python_files/testing_tools/socket_manager.py
+++ b/python_files/testing_tools/socket_manager.py
@@ -20,39 +20,24 @@ class PipeManager:
         self.close()
 
     def connect(self):
-        if sys.platform == "win32":
-            self._writer = open(self.name, "w", encoding="utf-8")  # noqa: SIM115, PTH123
-            # reader created in read method
-        else:
-            self._socket = _SOCKET(socket.AF_UNIX, socket.SOCK_STREAM)
-            self._socket.connect(self.name)
+        self._writer = open(self.name, "w", encoding="utf-8")  # noqa: SIM115, PTH123
+        # reader created in read method
         return self
 
     def close(self):
-        if sys.platform == "win32":
-            self._writer.close()
-        else:
-            # add exception catch
-            self._socket.close()
+        self._writer.close()
+        if hasattr(self, "_reader"):
+            self._reader.close()
 
     def write(self, data: str):
-        if sys.platform == "win32":
-            try:
-                # for windows, is should only use \n\n
-                request = (
-                    f"""content-length: {len(data)}\ncontent-type: application/json\n\n{data}"""
-                )
-                self._writer.write(request)
-                self._writer.flush()
-            except Exception as e:
-                print("error attempting to write to pipe", e)
-                raise (e)
-        else:
-            # must include the carriage-return defined (as \r\n) for unix systems
-            request = (
-                f"""content-length: {len(data)}\r\ncontent-type: application/json\r\n\r\n{data}"""
-            )
-            self._socket.send(request.encode("utf-8"))
+        try:
+            # for windows, is should only use \n\n
+            request = f"""content-length: {len(data)}\ncontent-type: application/json\n\n{data}"""
+            self._writer.write(request)
+            self._writer.flush()
+        except Exception as e:
+            print("error attempting to write to pipe", e)
+            raise (e)
 
     def read(self, bufsize=1024) -> str:
         """Read data from the socket.
@@ -63,17 +48,10 @@ class PipeManager:
         Returns:
             data (str): Data received from the socket.
         """
-        if sys.platform == "win32":
-            # returns a string automatically from read
-            if not hasattr(self, "_reader"):
-                self._reader = open(self.name, encoding="utf-8")  # noqa: SIM115, PTH123
-            return self._reader.read(bufsize)
-        else:
-            # receive bytes and convert to string
-            while True:
-                part: bytes = self._socket.recv(bufsize)
-                data: str = part.decode("utf-8")
-                return data
+        # returns a string automatically from read
+        if not hasattr(self, "_reader"):
+            self._reader = open(self.name, encoding="utf-8")  # noqa: SIM115, PTH123
+        return self._reader.read(bufsize)
 
 
 class SocketManager:

--- a/python_files/unittestadapter/pvsc_utils.py
+++ b/python_files/unittestadapter/pvsc_utils.py
@@ -329,7 +329,7 @@ def send_post_request(
 
     if __writer is None:
         try:
-            __writer = open(test_run_pipe, "w", encoding="utf-8", newline="\r\n")  # noqa: SIM115, PTH123
+            __writer = open(test_run_pipe, "wb")  # noqa: SIM115, PTH123
         except Exception as error:
             error_msg = f"Error attempting to connect to extension named pipe {test_run_pipe}[vscode-unittest]: {error}"
             print(error_msg, file=sys.stderr)
@@ -343,9 +343,17 @@ def send_post_request(
     data = json.dumps(rpc)
     try:
         if __writer:
-            request = f"""content-length: {len(data)}\ncontent-type: application/json\n\n{data}"""
-            __writer.write(request)
-            __writer.flush()
+            request = (
+                f"""content-length: {len(data)}\r\ncontent-type: application/json\r\n\r\n{data}"""
+            )
+            size = 4096
+            encoded = request.encode("utf-8")
+            bytes_written = 0
+            while bytes_written < len(encoded):
+                print("writing more bytes!")
+                segment = encoded[bytes_written : bytes_written + size]
+                bytes_written += __writer.write(segment)
+                __writer.flush()
         else:
             print(
                 f"Connection error[vscode-unittest], writer is None \n[vscode-unittest] data: \n{data} \n",

--- a/python_files/unittestadapter/pvsc_utils.py
+++ b/python_files/unittestadapter/pvsc_utils.py
@@ -18,8 +18,6 @@ sys.path.append(os.fspath(script_dir / "lib" / "python"))
 
 from typing_extensions import NotRequired  # noqa: E402
 
-from testing_tools import socket_manager  # noqa: E402
-
 # Types
 
 
@@ -331,10 +329,10 @@ def send_post_request(
 
     if __writer is None:
         try:
-            __writer = socket_manager.PipeManager(test_run_pipe)
-            __writer.connect()
+            __writer = open(test_run_pipe, "w", encoding="utf-8", newline="\r\n")  # noqa: SIM115, PTH123
         except Exception as error:
             error_msg = f"Error attempting to connect to extension named pipe {test_run_pipe}[vscode-unittest]: {error}"
+            print(error_msg, file=sys.stderr)
             __writer = None
             raise VSCodeUnittestError(error_msg) from error
 
@@ -343,10 +341,11 @@ def send_post_request(
         "params": payload,
     }
     data = json.dumps(rpc)
-
     try:
         if __writer:
-            __writer.write(data)
+            request = f"""content-length: {len(data)}\ncontent-type: application/json\n\n{data}"""
+            __writer.write(request)
+            __writer.flush()
         else:
             print(
                 f"Connection error[vscode-unittest], writer is None \n[vscode-unittest] data: \n{data} \n",

--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -21,11 +21,6 @@ from typing import (
 
 import pytest
 
-script_dir = pathlib.Path(__file__).parent.parent
-sys.path.append(os.fspath(script_dir))
-sys.path.append(os.fspath(script_dir / "lib" / "python"))
-from testing_tools import socket_manager  # noqa: E402
-
 if TYPE_CHECKING:
     from pluggy import Result
 
@@ -171,7 +166,7 @@ def pytest_exception_interact(node, call, report):
             collected_test = TestRunResultDict()
             collected_test[node_id] = item_result
             cwd = pathlib.Path.cwd()
-            execution_post(
+            send_execution_message(
                 os.fsdecode(cwd),
                 "success",
                 collected_test if collected_test else None,
@@ -295,7 +290,7 @@ def pytest_report_teststatus(report, config):  # noqa: ARG001
             )
             collected_test = TestRunResultDict()
             collected_test[absolute_node_id] = item_result
-            execution_post(
+            send_execution_message(
                 os.fsdecode(cwd),
                 "success",
                 collected_test if collected_test else None,
@@ -329,7 +324,7 @@ def pytest_runtest_protocol(item, nextitem):  # noqa: ARG001
             )
             collected_test = TestRunResultDict()
             collected_test[absolute_node_id] = item_result
-            execution_post(
+            send_execution_message(
                 os.fsdecode(cwd),
                 "success",
                 collected_test if collected_test else None,
@@ -405,7 +400,7 @@ def pytest_sessionfinish(session, exitstatus):
                 "children": [],
                 "id_": "",
             }
-            post_response(os.fsdecode(cwd), error_node)
+            send_discovery_message(os.fsdecode(cwd), error_node)
         try:
             session_node: TestNode | None = build_test_tree(session)
             if not session_node:
@@ -413,7 +408,7 @@ def pytest_sessionfinish(session, exitstatus):
                     "Something went wrong following pytest finish, \
                         no session node was created"
                 )
-            post_response(os.fsdecode(cwd), session_node)
+            send_discovery_message(os.fsdecode(cwd), session_node)
         except Exception as e:
             ERRORS.append(
                 f"Error Occurred, traceback: {(traceback.format_exc() if e.__traceback__ else '')}"
@@ -425,7 +420,7 @@ def pytest_sessionfinish(session, exitstatus):
                 "children": [],
                 "id_": "",
             }
-            post_response(os.fsdecode(cwd), error_node)
+            send_discovery_message(os.fsdecode(cwd), error_node)
     else:
         if exitstatus == 0 or exitstatus == 1:
             exitstatus_bool = "success"
@@ -435,7 +430,7 @@ def pytest_sessionfinish(session, exitstatus):
             )
             exitstatus_bool = "error"
 
-            execution_post(
+            send_execution_message(
                 os.fsdecode(cwd),
                 exitstatus_bool,
                 None,
@@ -489,7 +484,7 @@ def pytest_sessionfinish(session, exitstatus):
             result=file_coverage_map,
             error=None,
         )
-        send_post_request(payload)
+        send_message(payload)
 
 
 def build_test_tree(session: pytest.Session) -> TestNode:
@@ -857,8 +852,10 @@ __writer = None
 atexit.register(lambda: __writer.close() if __writer else None)
 
 
-def execution_post(cwd: str, status: Literal["success", "error"], tests: TestRunResultDict | None):
-    """Sends a POST request with execution payload details.
+def send_execution_message(
+    cwd: str, status: Literal["success", "error"], tests: TestRunResultDict | None
+):
+    """Sends message execution payload details.
 
     Args:
         cwd (str): Current working directory.
@@ -870,10 +867,10 @@ def execution_post(cwd: str, status: Literal["success", "error"], tests: TestRun
     )
     if ERRORS:
         payload["error"] = ERRORS
-    send_post_request(payload)
+    send_message(payload)
 
 
-def post_response(cwd: str, session_node: TestNode) -> None:
+def send_discovery_message(cwd: str, session_node: TestNode) -> None:
     """
     Sends a POST request with test session details in payload.
 
@@ -889,7 +886,7 @@ def post_response(cwd: str, session_node: TestNode) -> None:
     }
     if ERRORS is not None:
         payload["error"] = ERRORS
-    send_post_request(payload, cls_encoder=PathEncoder)
+    send_message(payload, cls_encoder=PathEncoder)
 
 
 class PathEncoder(json.JSONEncoder):
@@ -901,7 +898,7 @@ class PathEncoder(json.JSONEncoder):
         return super().default(o)
 
 
-def send_post_request(
+def send_message(
     payload: ExecutionPayloadDict | DiscoveryPayloadDict | CoveragePayloadDict,
     cls_encoder=None,
 ):
@@ -926,8 +923,7 @@ def send_post_request(
 
     if __writer is None:
         try:
-            __writer = socket_manager.PipeManager(TEST_RUN_PIPE)
-            __writer.connect()
+            __writer = open(TEST_RUN_PIPE, "w", encoding="utf-8", newline="\r\n")  # noqa: SIM115, PTH123
         except Exception as error:
             error_msg = f"Error attempting to connect to extension named pipe {TEST_RUN_PIPE}[vscode-pytest]: {error}"
             print(error_msg, file=sys.stderr)
@@ -945,10 +941,11 @@ def send_post_request(
         "params": payload,
     }
     data = json.dumps(rpc, cls=cls_encoder)
-
     try:
         if __writer:
-            __writer.write(data)
+            request = f"""content-length: {len(data)}\ncontent-type: application/json\n\n{data}"""
+            __writer.write(request)
+            __writer.flush()
         else:
             print(
                 f"Plugin error connection error[vscode-pytest], writer is None \n[vscode-pytest] data: \n{data} \n",

--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -923,8 +923,7 @@ def send_message(
 
     if __writer is None:
         try:
-            # option B: put this there: , buffering=1024
-            __writer = open(TEST_RUN_PIPE, "wb")  # noqa: SIM115, PTH123 (-1 no ,0 auto,1, int [this is the value of the buffer size])
+            __writer = open(TEST_RUN_PIPE, "wb")  # noqa: SIM115, PTH123
         except Exception as error:
             error_msg = f"Error attempting to connect to extension named pipe {TEST_RUN_PIPE}[vscode-pytest]: {error}"
             print(error_msg, file=sys.stderr)

--- a/python_files/vscode_pytest/_common.py
+++ b/python_files/vscode_pytest/_common.py
@@ -1,0 +1,2 @@
+# def send_post_request():
+#     return

--- a/src/client/common/pipes/namedPipes.ts
+++ b/src/client/common/pipes/namedPipes.ts
@@ -1,67 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import * as cp from 'child_process';
 import * as crypto from 'crypto';
+import * as fs from 'fs-extra';
 import * as net from 'net';
 import * as os from 'os';
 import * as path from 'path';
 import * as rpc from 'vscode-jsonrpc/node';
+import { CancellationError, CancellationToken, Disposable } from 'vscode';
 import { traceVerbose } from '../../logging';
-
-export interface ConnectedServerObj {
-    serverOnClosePromise(): Promise<void>;
-}
-
-export function createNamedPipeServer(
-    pipeName: string,
-    onConnectionCallback: (value: [rpc.MessageReader, rpc.MessageWriter]) => void,
-): Promise<ConnectedServerObj> {
-    traceVerbose(`Creating named pipe server on ${pipeName}`);
-
-    let connectionCount = 0;
-    return new Promise((resolve, reject) => {
-        // create a server, resolves and returns server on listen
-        const server = net.createServer((socket) => {
-            // this lambda function is called whenever a client connects to the server
-            connectionCount += 1;
-            traceVerbose('new client is connected to the socket, connectionCount: ', connectionCount, pipeName);
-            socket.on('close', () => {
-                // close event is emitted by client to the server
-                connectionCount -= 1;
-                traceVerbose('client emitted close event, connectionCount: ', connectionCount);
-                if (connectionCount <= 0) {
-                    // if all clients are closed, close the server
-                    traceVerbose('connection count is <= 0, closing the server: ', pipeName);
-                    server.close();
-                }
-            });
-
-            // upon connection create a reader and writer and pass it to the callback
-            onConnectionCallback([
-                new rpc.SocketMessageReader(socket, 'utf-8'),
-                new rpc.SocketMessageWriter(socket, 'utf-8'),
-            ]);
-        });
-        const closedServerPromise = new Promise<void>((resolveOnServerClose) => {
-            // get executed on connection close and resolves
-            // implementation of the promise is the arrow function
-            server.on('close', resolveOnServerClose);
-        });
-        server.on('error', reject);
-
-        server.listen(pipeName, () => {
-            // this function is called when the server is listening
-            server.removeListener('error', reject);
-            const connectedServer = {
-                // when onClosed event is called, so is closed function
-                // goes backwards up the chain, when resolve2 is called, so is onClosed that means server.onClosed() on the other end can work
-                // event C
-                serverOnClosePromise: () => closedServerPromise,
-            };
-            resolve(connectedServer);
-        });
-    });
-}
+import { isWindows } from '../utils/platform';
+import { createDeferred } from '../utils/async';
+import { noop } from '../utils/misc';
 
 const { XDG_RUNTIME_DIR } = process.env;
 export function generateRandomPipeName(prefix: string): string {
@@ -72,20 +23,178 @@ export function generateRandomPipeName(prefix: string): string {
     }
 
     if (process.platform === 'win32') {
-        return `\\\\.\\pipe\\${prefix}-${randomSuffix}-sock`;
+        return `\\\\.\\pipe\\${prefix}-${randomSuffix}`;
     }
 
     let result;
     if (XDG_RUNTIME_DIR) {
-        result = path.join(XDG_RUNTIME_DIR, `${prefix}-${randomSuffix}.sock`);
+        result = path.join(XDG_RUNTIME_DIR, `${prefix}-${randomSuffix}`);
     } else {
-        result = path.join(os.tmpdir(), `${prefix}-${randomSuffix}.sock`);
+        result = path.join(os.tmpdir(), `${prefix}-${randomSuffix}`);
     }
 
     return result;
 }
 
-export function namedPipeClient(name: string): [rpc.MessageReader, rpc.MessageWriter] {
-    const socket = net.connect(name);
-    return [new rpc.SocketMessageReader(socket, 'utf-8'), new rpc.SocketMessageWriter(socket, 'utf-8')];
+async function mkfifo(fifoPath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const proc = cp.spawn('mkfifo', [fifoPath]);
+        proc.on('error', (err) => {
+            reject(err);
+        });
+        proc.on('exit', (code) => {
+            if (code === 0) {
+                resolve();
+            }
+        });
+    });
+}
+
+export async function createWriterPipe(pipeName: string, token?: CancellationToken): Promise<rpc.MessageWriter> {
+    // windows implementation of FIFO using named pipes
+    if (isWindows()) {
+        const deferred = createDeferred<rpc.MessageWriter>();
+        const server = net.createServer((socket) => {
+            traceVerbose(`Pipe connected: ${pipeName}`);
+            server.close();
+            deferred.resolve(new rpc.SocketMessageWriter(socket, 'utf-8'));
+        });
+
+        server.on('error', deferred.reject);
+        server.listen(pipeName);
+        if (token) {
+            token.onCancellationRequested(() => {
+                if (server.listening) {
+                    server.close();
+                }
+                deferred.reject(new CancellationError());
+            });
+        }
+        return deferred.promise;
+    }
+    // linux implementation of FIFO
+    await mkfifo(pipeName);
+    try {
+        await fs.chmod(pipeName, 0o666);
+    } catch {
+        // Intentionally ignored
+    }
+    const writer = fs.createWriteStream(pipeName, {
+        encoding: 'utf-8',
+    });
+    return new rpc.StreamMessageWriter(writer, 'utf-8');
+}
+
+class CombinedReader implements rpc.MessageReader {
+    private _onError = new rpc.Emitter<Error>();
+
+    private _onClose = new rpc.Emitter<void>();
+
+    private _onPartialMessage = new rpc.Emitter<rpc.PartialMessageInfo>();
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    private _callback: rpc.DataCallback = () => {};
+
+    private _disposables: rpc.Disposable[] = [];
+
+    private _readers: rpc.MessageReader[] = [];
+
+    constructor() {
+        this._disposables.push(this._onClose, this._onError, this._onPartialMessage);
+    }
+
+    onError: rpc.Event<Error> = this._onError.event;
+
+    onClose: rpc.Event<void> = this._onClose.event;
+
+    onPartialMessage: rpc.Event<rpc.PartialMessageInfo> = this._onPartialMessage.event;
+
+    listen(callback: rpc.DataCallback): rpc.Disposable {
+        this._callback = callback;
+        // eslint-disable-next-line no-return-assign, @typescript-eslint/no-empty-function
+        return new Disposable(() => (this._callback = () => {}));
+    }
+
+    add(reader: rpc.MessageReader): void {
+        this._readers.push(reader);
+        reader.listen((msg) => {
+            this._callback(msg as rpc.NotificationMessage);
+        });
+        this._disposables.push(reader);
+        reader.onClose(() => {
+            this.remove(reader);
+            if (this._readers.length === 0) {
+                this._onClose.fire();
+            }
+        });
+        reader.onError((e) => {
+            this.remove(reader);
+            this._onError.fire(e);
+        });
+    }
+
+    remove(reader: rpc.MessageReader): void {
+        const found = this._readers.find((r) => r === reader);
+        if (found) {
+            this._readers = this._readers.filter((r) => r !== reader);
+            reader.dispose();
+        }
+    }
+
+    dispose(): void {
+        this._readers.forEach((r) => r.dispose());
+        this._readers = [];
+        this._disposables.forEach((disposable) => disposable.dispose());
+        this._disposables = [];
+    }
+}
+
+export async function createReaderPipe(pipeName: string, token?: CancellationToken): Promise<rpc.MessageReader> {
+    if (isWindows()) {
+        // windows implementation of FIFO using named pipes
+        const deferred = createDeferred<rpc.MessageReader>();
+        const combined = new CombinedReader();
+
+        let refs = 0;
+        const server = net.createServer((socket) => {
+            traceVerbose(`Pipe connected: ${pipeName}`);
+            refs += 1;
+
+            socket.on('close', () => {
+                refs -= 1;
+                if (refs <= 0) {
+                    server.close();
+                }
+            });
+            combined.add(new rpc.SocketMessageReader(socket, 'utf-8'));
+        });
+        server.on('error', deferred.reject);
+        server.listen(pipeName);
+        if (token) {
+            token.onCancellationRequested(() => {
+                if (server.listening) {
+                    server.close();
+                }
+                deferred.reject(new CancellationError());
+            });
+        }
+        deferred.resolve(combined);
+        return deferred.promise;
+    }
+    // mac/linux implementation of FIFO
+    await mkfifo(pipeName);
+    try {
+        await fs.chmod(pipeName, 0o666);
+    } catch {
+        // Intentionally ignored
+    }
+    const fd = await fs.open(pipeName, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+    const socket = new net.Socket({ fd });
+    const reader = new rpc.SocketMessageReader(socket, 'utf-8');
+    socket.on('close', () => {
+        fs.close(fd).catch(noop);
+        reader.dispose();
+    });
+
+    return reader;
 }

--- a/src/client/testing/testController/pytest/pytestDiscoveryAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestDiscoveryAdapter.ts
@@ -42,15 +42,12 @@ export class PytestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
         executionFactory?: IPythonExecutionFactory,
         interpreter?: PythonEnvironment,
     ): Promise<DiscoveredTestPayload> {
-        const { name, dispose } = await startDiscoveryNamedPipe((data: DiscoveredTestPayload) => {
+        const name = await startDiscoveryNamedPipe((data: DiscoveredTestPayload) => {
             this.resultResolver?.resolveDiscovery(data);
         });
 
-        try {
-            await this.runPytestDiscovery(uri, name, executionFactory, interpreter);
-        } finally {
-            dispose();
-        }
+        await this.runPytestDiscovery(uri, name, executionFactory, interpreter);
+
         // this is only a placeholder to handle function overloading until rewrite is finished
         const discoveryPayload: DiscoveredTestPayload = { cwd: uri.fsPath, status: 'success' };
         return discoveryPayload;

--- a/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { DebugSessionOptions, TestRun, TestRunProfileKind, Uri } from 'vscode';
+import { CancellationTokenSource, DebugSessionOptions, TestRun, TestRunProfileKind, Uri } from 'vscode';
 import * as path from 'path';
 import { ChildProcess } from 'child_process';
 import { IConfigurationService, ITestOutputChannel } from '../../../common/types';
@@ -49,16 +49,16 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                 traceError(`No run instance found, cannot resolve execution, for workspace ${uri.fsPath}.`);
             }
         };
-        const { name, dispose: serverDispose } = await utils.startRunResultNamedPipe(
+        const cSource = new CancellationTokenSource();
+        runInstance?.token.onCancellationRequested(() => cSource.cancel());
+
+        const name = await utils.startRunResultNamedPipe(
             dataReceivedCallback, // callback to handle data received
             deferredTillServerClose, // deferred to resolve when server closes
-            runInstance?.token, // token to cancel
+            cSource.token, // token to cancel
         );
         runInstance?.token.onCancellationRequested(() => {
             traceInfo(`Test run cancelled, resolving 'TillServerClose' deferred for ${uri.fsPath}.`);
-            // if canceled, stop listening for results
-            serverDispose(); // this will resolve deferredTillServerClose
-
             const executionPayload: ExecutionTestPayload = {
                 cwd: uri.fsPath,
                 status: 'success',
@@ -72,7 +72,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                 uri,
                 testIds,
                 name,
-                serverDispose,
+                cSource,
                 runInstance,
                 profileKind,
                 executionFactory,
@@ -97,7 +97,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
         uri: Uri,
         testIds: string[],
         resultNamedPipeName: string,
-        serverDispose: () => void,
+        serverCancel: CancellationTokenSource,
         runInstance?: TestRun,
         profileKind?: TestRunProfileKind,
         executionFactory?: IPythonExecutionFactory,
@@ -174,7 +174,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                 await debugLauncher!.launchDebugger(
                     launchOptions,
                     () => {
-                        serverDispose(); // this will resolve the deferredTillAllServerClose
+                        serverCancel.cancel();
                     },
                     sessionOptions,
                 );
@@ -196,7 +196,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                         traceInfo(`Test run cancelled, killing pytest subprocess for workspace ${uri.fsPath}`);
                         proc.kill();
                         deferredTillExecClose.resolve();
-                        serverDispose(); // this will resolve the deferredTillAllServerClose
+                        serverCancel.cancel();
                     });
                     proc.stdout.on('data', (data) => {
                         const out = utils.fixLogLinesNoTrailing(data.toString());
@@ -216,7 +216,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                             );
                         }
                         deferredTillExecClose.resolve();
-                        serverDispose(); // this will resolve the deferredTillAllServerClose
+                        serverCancel.cancel();
                     });
                     await deferredTillExecClose.promise;
                 } else {
@@ -239,6 +239,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                         resultProc?.kill();
                     } else {
                         deferredTillExecClose.resolve();
+                        serverCancel.cancel();
                     }
                 });
 
@@ -282,12 +283,12 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                                 runInstance,
                             );
                         }
-                        // this doesn't work, it instead directs us to the noop one which is defined first
-                        // potentially this is due to the server already being close, if this is the case?
-                        serverDispose(); // this will resolve deferredTillServerClose
                     }
+
+                    // deferredTillEOT is resolved when all data sent on stdout and stderr is received, close event is only called when this occurs
                     // due to the sync reading of the output.
                     deferredTillExecClose.resolve();
+                    serverCancel.cancel();
                 });
                 await deferredTillExecClose.promise;
             }

--- a/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
+++ b/src/client/testing/testController/unittest/testDiscoveryAdapter.ts
@@ -45,7 +45,7 @@ export class UnittestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
         const { unittestArgs } = settings.testing;
         const cwd = settings.testing.cwd && settings.testing.cwd.length > 0 ? settings.testing.cwd : uri.fsPath;
 
-        const { name, dispose } = await startDiscoveryNamedPipe((data: DiscoveredTestPayload) => {
+        const name = await startDiscoveryNamedPipe((data: DiscoveredTestPayload) => {
             this.resultResolver?.resolveDiscovery(data);
         });
 
@@ -67,7 +67,7 @@ export class UnittestTestDiscoveryAdapter implements ITestDiscoveryAdapter {
         try {
             await this.runDiscovery(uri, options, name, cwd, executionFactory);
         } finally {
-            dispose();
+            // none
         }
         // placeholder until after the rewrite is adopted
         // TODO: remove after adoption.

--- a/src/test/testing/common/testingAdapter.test.ts
+++ b/src/test/testing/common/testingAdapter.test.ts
@@ -1066,7 +1066,6 @@ suite('End to End Tests: test adapters', () => {
         let callCount = 0;
         let failureOccurred = false;
         let failureMsg = '';
-        console.log('EFB: beginning function');
         resultResolver._resolveExecution = async (data, _token?) => {
             // do the following asserts for each time resolveExecution is called, should be called once per test.
             console.log(`pytest execution adapter seg fault error handling \n  ${JSON.stringify(data)}`);

--- a/src/test/testing/common/testingAdapter.test.ts
+++ b/src/test/testing/common/testingAdapter.test.ts
@@ -81,8 +81,6 @@ suite('End to End Tests: test adapters', () => {
         'coverageWorkspace',
     );
     suiteSetup(async () => {
-        serviceContainer = (await initialize()).serviceContainer;
-
         // create symlink for specific symlink test
         const target = rootPathSmallWorkspace;
         const dest = rootPathDiscoverySymlink;
@@ -107,6 +105,7 @@ suite('End to End Tests: test adapters', () => {
     });
 
     setup(async () => {
+        serviceContainer = (await initialize()).serviceContainer;
         getPixiStub = sinon.stub(pixi, 'getPixi');
         getPixiStub.resolves(undefined);
 
@@ -678,7 +677,7 @@ suite('End to End Tests: test adapters', () => {
     });
     test('pytest execution adapter small workspace with correct output', async () => {
         // result resolver and saved data for assertions
-        resultResolver = new PythonResultResolver(testController, unittestProvider, workspaceUri);
+        resultResolver = new PythonResultResolver(testController, pytestProvider, workspaceUri);
         let callCount = 0;
         let failureOccurred = false;
         let failureMsg = '';
@@ -875,7 +874,7 @@ suite('End to End Tests: test adapters', () => {
     });
     test('pytest execution adapter large workspace', async () => {
         // result resolver and saved data for assertions
-        resultResolver = new PythonResultResolver(testController, unittestProvider, workspaceUri);
+        resultResolver = new PythonResultResolver(testController, pytestProvider, workspaceUri);
         let callCount = 0;
         let failureOccurred = false;
         let failureMsg = '';
@@ -1062,88 +1061,12 @@ suite('End to End Tests: test adapters', () => {
             assert.strictEqual(failureOccurred, false, failureMsg);
         });
     });
-    test('unittest execution adapter seg fault error handling', async () => {
-        resultResolver = new PythonResultResolver(testController, unittestProvider, workspaceUri);
-        let callCount = 0;
-        let failureOccurred = false;
-        let failureMsg = '';
-        resultResolver._resolveExecution = async (data, _token?) => {
-            // do the following asserts for each time resolveExecution is called, should be called once per test.
-            callCount = callCount + 1;
-            traceLog(`unittest execution adapter seg fault error handling \n  ${JSON.stringify(data)}`);
-            try {
-                if (data.status === 'error') {
-                    if (data.error === undefined) {
-                        // Dereference a NULL pointer
-                        const indexOfTest = JSON.stringify(data).search('Dereference a NULL pointer');
-                        if (indexOfTest === -1) {
-                            failureOccurred = true;
-                            failureMsg = 'Expected test to have a null pointer';
-                        }
-                    } else if (data.error.length === 0) {
-                        failureOccurred = true;
-                        failureMsg = "Expected errors in 'error' field";
-                    }
-                } else {
-                    const indexOfTest = JSON.stringify(data.result).search('error');
-                    if (indexOfTest === -1) {
-                        failureOccurred = true;
-                        failureMsg =
-                            'If payload status is not error then the individual tests should be marked as errors. This should occur on windows machines.';
-                    }
-                }
-                if (data.result === undefined) {
-                    failureOccurred = true;
-                    failureMsg = 'Expected results to be present';
-                }
-                // make sure the testID is found in the results
-                const indexOfTest = JSON.stringify(data).search('test_seg_fault.TestSegmentationFault.test_segfault');
-                if (indexOfTest === -1) {
-                    failureOccurred = true;
-                    failureMsg = 'Expected testId to be present';
-                }
-            } catch (err) {
-                failureMsg = err ? (err as Error).toString() : '';
-                failureOccurred = true;
-            }
-            return Promise.resolve();
-        };
-
-        const testId = `test_seg_fault.TestSegmentationFault.test_segfault`;
-        const testIds: string[] = [testId];
-
-        // set workspace to test workspace folder
-        workspaceUri = Uri.parse(rootPathErrorWorkspace);
-        configService.getSettings(workspaceUri).testing.unittestArgs = ['-s', '.', '-p', '*test*.py'];
-
-        // run pytest execution
-        const executionAdapter = new UnittestTestExecutionAdapter(
-            configService,
-            testOutputChannel.object,
-            resultResolver,
-            envVarsService,
-        );
-        const testRun = typeMoq.Mock.ofType<TestRun>();
-        testRun
-            .setup((t) => t.token)
-            .returns(
-                () =>
-                    ({
-                        onCancellationRequested: () => undefined,
-                    } as any),
-            );
-        await executionAdapter
-            .runTests(workspaceUri, testIds, TestRunProfileKind.Run, testRun.object, pythonExecFactory)
-            .finally(() => {
-                assert.strictEqual(callCount, 1, 'Expected _resolveExecution to be called once');
-                assert.strictEqual(failureOccurred, false, failureMsg);
-            });
-    });
     test('pytest execution adapter seg fault error handling', async () => {
         resultResolver = new PythonResultResolver(testController, pytestProvider, workspaceUri);
         let callCount = 0;
         let failureOccurred = false;
         let failureMsg = '';
+        console.log('EFB: beginning function');
         resultResolver._resolveExecution = async (data, _token?) => {
             // do the following asserts for each time resolveExecution is called, should be called once per test.
             console.log(`pytest execution adapter seg fault error handling \n  ${JSON.stringify(data)}`);
@@ -1169,7 +1092,7 @@ suite('End to End Tests: test adapters', () => {
                 failureMsg = err ? (err as Error).toString() : '';
                 failureOccurred = true;
             }
-            // return Promise.resolve();
+            return Promise.resolve();
         };
 
         const testId = `${rootPathErrorWorkspace}/test_seg_fault.py::TestSegmentationFault::test_segfault`;

--- a/src/test/testing/testController/pytest/pytestDiscoveryAdapter.unit.test.ts
+++ b/src/test/testing/testController/pytest/pytestDiscoveryAdapter.unit.test.ts
@@ -45,14 +45,7 @@ suite('pytest test discovery adapter', () => {
         mockExtensionRootDir.setup((m) => m.toString()).returns(() => '/mocked/extension/root/dir');
 
         utilsStartDiscoveryNamedPipeStub = sinon.stub(util, 'startDiscoveryNamedPipe');
-        utilsStartDiscoveryNamedPipeStub.callsFake(() =>
-            Promise.resolve({
-                name: 'discoveryResultPipe-mockName',
-                dispose: () => {
-                    /* no-op */
-                },
-            }),
-        );
+        utilsStartDiscoveryNamedPipeStub.callsFake(() => Promise.resolve('discoveryResultPipe-mockName'));
 
         // constants
         expectedPath = path.join('/', 'my', 'test', 'path');

--- a/src/test/testing/testController/pytest/pytestExecutionAdapter.unit.test.ts
+++ b/src/test/testing/testController/pytest/pytestExecutionAdapter.unit.test.ts
@@ -88,14 +88,7 @@ suite('pytest test execution adapter', () => {
         myTestPath = path.join('/', 'my', 'test', 'path', '/');
 
         utilsStartRunResultNamedPipeStub = sinon.stub(util, 'startRunResultNamedPipe');
-        utilsStartRunResultNamedPipeStub.callsFake(() =>
-            Promise.resolve({
-                name: 'runResultPipe-mockName',
-                dispose: () => {
-                    /* no-op */
-                },
-            }),
-        );
+        utilsStartRunResultNamedPipeStub.callsFake(() => Promise.resolve('runResultPipe-mockName'));
     });
     teardown(() => {
         sinon.restore();

--- a/src/test/testing/testController/testCancellationRunAdapters.unit.test.ts
+++ b/src/test/testing/testController/testCancellationRunAdapters.unit.test.ts
@@ -71,6 +71,9 @@ suite('Execution Flow Run Adapters', () => {
             const { token } = cancellationToken;
             testRunMock.setup((t) => t.token).returns(() => token);
 
+            // run result pipe mocking and the related server close dispose
+            let deferredTillServerCloseTester: Deferred<void> | undefined;
+
             // // mock exec service and exec factory
             execServiceStub
                 .setup((x) => x.execObservable(typeMoq.It.isAny(), typeMoq.It.isAny()))
@@ -97,11 +100,13 @@ suite('Execution Flow Run Adapters', () => {
                 return Promise.resolve('named-pipe');
             });
 
-            // run result pipe mocking and the related server close dispose
-            let deferredTillServerCloseTester: Deferred<void> | undefined;
-            utilsStartRunResultNamedPipe.callsFake((_callback, deferredTillServerClose, _token) => {
+            utilsStartRunResultNamedPipe.callsFake((_callback, deferredTillServerClose, token) => {
                 deferredTillServerCloseTester = deferredTillServerClose;
-                return Promise.resolve({ name: 'named-pipes-socket-name', dispose: serverDisposeStub });
+                token?.onCancellationRequested(() => {
+                    deferredTillServerCloseTester?.resolve();
+                });
+
+                return Promise.resolve('named-pipes-socket-name');
             });
             serverDisposeStub.callsFake(() => {
                 console.log('server disposed');
@@ -127,9 +132,6 @@ suite('Execution Flow Run Adapters', () => {
             );
             // wait for server to start to keep test from failing
             await deferredStartTestIdsNamedPipe.promise;
-
-            // assert the server dispose function was called correctly
-            sinon.assert.calledOnce(serverDisposeStub);
         });
         test(`Adapter ${adapter}: token called mid-debug resolves correctly`, async () => {
             // mock test run and cancelation token
@@ -137,6 +139,9 @@ suite('Execution Flow Run Adapters', () => {
             const cancellationToken = new CancellationTokenSource();
             const { token } = cancellationToken;
             testRunMock.setup((t) => t.token).returns(() => token);
+
+            // run result pipe mocking and the related server close dispose
+            let deferredTillServerCloseTester: Deferred<void> | undefined;
 
             // // mock exec service and exec factory
             execServiceStub
@@ -164,14 +169,12 @@ suite('Execution Flow Run Adapters', () => {
                 return Promise.resolve('named-pipe');
             });
 
-            // run result pipe mocking and the related server close dispose
-            let deferredTillServerCloseTester: Deferred<void> | undefined;
             utilsStartRunResultNamedPipe.callsFake((_callback, deferredTillServerClose, _token) => {
                 deferredTillServerCloseTester = deferredTillServerClose;
-                return Promise.resolve({
-                    name: 'named-pipes-socket-name',
-                    dispose: serverDisposeStub,
+                token?.onCancellationRequested(() => {
+                    deferredTillServerCloseTester?.resolve();
                 });
+                return Promise.resolve('named-pipes-socket-name');
             });
             serverDisposeStub.callsFake(() => {
                 console.log('server disposed');
@@ -210,10 +213,6 @@ suite('Execution Flow Run Adapters', () => {
             );
             // wait for server to start to keep test from failing
             await deferredStartTestIdsNamedPipe.promise;
-
-            // TODO: fix the server disposal so it is called once not twice,
-            // currently not a problem but would be useful to improve clarity
-            sinon.assert.called(serverDisposeStub);
         });
     });
 });

--- a/src/test/testing/testController/unittest/testDiscoveryAdapter.unit.test.ts
+++ b/src/test/testing/testController/unittest/testDiscoveryAdapter.unit.test.ts
@@ -82,14 +82,7 @@ suite('Unittest test discovery adapter', () => {
         };
 
         utilsStartDiscoveryNamedPipeStub = sinon.stub(util, 'startDiscoveryNamedPipe');
-        utilsStartDiscoveryNamedPipeStub.callsFake(() =>
-            Promise.resolve({
-                name: 'discoveryResultPipe-mockName',
-                dispose: () => {
-                    /* no-op */
-                },
-            }),
-        );
+        utilsStartDiscoveryNamedPipeStub.callsFake(() => Promise.resolve('discoveryResultPipe-mockName'));
     });
     teardown(() => {
         sinon.restore();

--- a/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
+++ b/src/test/testing/testController/unittest/testExecutionAdapter.unit.test.ts
@@ -87,14 +87,7 @@ suite('Unittest test execution adapter', () => {
         myTestPath = path.join('/', 'my', 'test', 'path', '/');
 
         utilsStartRunResultNamedPipeStub = sinon.stub(util, 'startRunResultNamedPipe');
-        utilsStartRunResultNamedPipeStub.callsFake(() =>
-            Promise.resolve({
-                name: 'runResultPipe-mockName',
-                dispose: () => {
-                    /* no-op */
-                },
-            }),
-        );
+        utilsStartRunResultNamedPipeStub.callsFake(() => Promise.resolve('runResultPipe-mockName'));
     });
     teardown(() => {
         sinon.restore();

--- a/src/testTestingRootWkspc/errorWorkspace/test_seg_fault.py
+++ b/src/testTestingRootWkspc/errorWorkspace/test_seg_fault.py
@@ -7,11 +7,12 @@ import ctypes
 
 class TestSegmentationFault(unittest.TestCase):
     def cause_segfault(self):
+        print("Causing a segmentation fault")
         ctypes.string_at(0)  # Dereference a NULL pointer
 
     def test_segfault(self):
-        assert True
         self.cause_segfault()
+        assert True
 
 
 if __name__ == "__main__":

--- a/src/testTestingRootWkspc/largeWorkspace/test_parameterized_subtest.py
+++ b/src/testTestingRootWkspc/largeWorkspace/test_parameterized_subtest.py
@@ -14,3 +14,106 @@ class NumbersTest(unittest.TestCase):
         for i in range(0, 2000):
             with self.subTest(i=i):
                 self.assertEqual(i % 2, 0)
+
+
+# The repeated tests below are to test the unittest communication as it hits it maximum limit of bytes.
+
+
+class NumberedTests1(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests2(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests3(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests4(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests5(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests6(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests7(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests8(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests9(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests10(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests11(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests12(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests13(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests14(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests15(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests16(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests17(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests18(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests19(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)
+
+
+class NumberedTests20(unittest.TestCase):
+    def test_abc(self):
+        self.assertEqual(1 % 2, 0)


### PR DESCRIPTION
revert the revert of the old commit so now main uses fifo again
add a limit of 4096 bytes per communication sent between python subprocess and extension
fixes https://github.com/microsoft/vscode-python/issues/24656