### PR TITLE
Introduce `autoTestDiscoverOnSavePattern` configuration option

### DIFF
--- a/package.json
+++ b/package.json
@@ -657,6 +657,12 @@
                     "scope": "resource",
                     "type": "boolean"
                 },
+                "python.testing.autoTestDiscoverOnSavePattern": {
+                    "default": "**.py",
+                    "description": "%python.testing.autoTestDiscoverOnSavePattern.description%",
+                    "scope": "resource",
+                    "type": "string"
+                },
                 "python.testing.cwd": {
                     "default": null,
                     "description": "%python.testing.cwd.description%",

--- a/package.json
+++ b/package.json
@@ -658,7 +658,7 @@
                     "type": "boolean"
                 },
                 "python.testing.autoTestDiscoverOnSavePattern": {
-                    "default": "**.py",
+                    "default": "**/*.py",
                     "description": "%python.testing.autoTestDiscoverOnSavePattern.description%",
                     "scope": "resource",
                     "type": "string"

--- a/package.nls.json
+++ b/package.nls.json
@@ -74,6 +74,7 @@
     "python.terminal.focusAfterLaunch.description": "When launching a python terminal, whether to focus the cursor on the terminal.",
     "python.terminal.launchArgs.description": "Python launch arguments to use when executing a file in the terminal.",
     "python.testing.autoTestDiscoverOnSaveEnabled.description": "Enable auto run test discovery when saving a test file.",
+    "python.testing.autoTestDiscoverOnSavePattern.description": "Glob pattern used to determine which files are used by autoTestDiscoverOnSaveEnabled.",
     "python.testing.cwd.description": "Optional working directory for tests.",
     "python.testing.debugPort.description": "Port number used for debugging of tests.",
     "python.testing.promptToConfigure.description": "Prompt to configure a test framework if potential tests directories are discovered.",

--- a/resources/report_issue_user_settings.json
+++ b/resources/report_issue_user_settings.json
@@ -79,7 +79,8 @@
         "pytestPath": "placeholder",
         "unittestArgs": "placeholder",
         "unittestEnabled": true,
-        "autoTestDiscoverOnSaveEnabled": true
+        "autoTestDiscoverOnSaveEnabled": true,
+        "autoTestDiscoverOnSavePattern": "placeholder"
     },
     "terminal": {
         "activateEnvironment": true,

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -320,7 +320,7 @@ export class PythonSettings implements IPythonSettings {
                     unittestEnabled: false,
                     pytestPath: 'pytest',
                     autoTestDiscoverOnSaveEnabled: true,
-                    autoTestDiscoverOnSavePattern: '**.py',
+                    autoTestDiscoverOnSavePattern: '**/*.py',
                 } as ITestingSettings;
             }
         }

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -337,7 +337,7 @@ export class PythonSettings implements IPythonSettings {
                   unittestArgs: [],
                   unittestEnabled: false,
                   autoTestDiscoverOnSaveEnabled: true,
-                  autoTestDiscoverOnSavePattern: '**.py',
+                  autoTestDiscoverOnSavePattern: '**/*.py',
               };
         this.testing.pytestPath = getAbsolutePath(systemVariables.resolveAny(this.testing.pytestPath), workspaceRoot);
         if (this.testing.cwd) {

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -320,6 +320,7 @@ export class PythonSettings implements IPythonSettings {
                     unittestEnabled: false,
                     pytestPath: 'pytest',
                     autoTestDiscoverOnSaveEnabled: true,
+                    autoTestDiscoverOnSavePattern: "**.py"
                 } as ITestingSettings;
             }
         }
@@ -336,6 +337,7 @@ export class PythonSettings implements IPythonSettings {
                   unittestArgs: [],
                   unittestEnabled: false,
                   autoTestDiscoverOnSaveEnabled: true,
+                  autoTestDiscoverOnSavePattern: "**.py",
               };
         this.testing.pytestPath = getAbsolutePath(systemVariables.resolveAny(this.testing.pytestPath), workspaceRoot);
         if (this.testing.cwd) {

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -320,7 +320,7 @@ export class PythonSettings implements IPythonSettings {
                     unittestEnabled: false,
                     pytestPath: 'pytest',
                     autoTestDiscoverOnSaveEnabled: true,
-                    autoTestDiscoverOnSavePattern: "**.py"
+                    autoTestDiscoverOnSavePattern: '**.py',
                 } as ITestingSettings;
             }
         }
@@ -337,7 +337,7 @@ export class PythonSettings implements IPythonSettings {
                   unittestArgs: [],
                   unittestEnabled: false,
                   autoTestDiscoverOnSaveEnabled: true,
-                  autoTestDiscoverOnSavePattern: "**.py",
+                  autoTestDiscoverOnSavePattern: '**.py',
               };
         this.testing.pytestPath = getAbsolutePath(systemVariables.resolveAny(this.testing.pytestPath), workspaceRoot);
         if (this.testing.cwd) {

--- a/src/client/testing/configuration/types.ts
+++ b/src/client/testing/configuration/types.ts
@@ -11,6 +11,7 @@ export interface ITestingSettings {
     unittestArgs: string[];
     cwd?: string;
     readonly autoTestDiscoverOnSaveEnabled: boolean;
+    readonly autoTestDiscoverOnSavePattern: string;
 }
 
 export type TestSettingsPropertyNames = {

--- a/src/client/testing/testController/controller.ts
+++ b/src/client/testing/testController/controller.ts
@@ -3,7 +3,7 @@
 
 import { inject, injectable, named } from 'inversify';
 import { uniq } from 'lodash';
-import { minimatch } from 'minimatch';
+import * as minimatch from 'minimatch';
 import {
     CancellationToken,
     TestController,
@@ -216,7 +216,7 @@ export class PythonTestController implements ITestController, IExtensionSingleAc
             if (settings.testing.autoTestDiscoverOnSaveEnabled) {
                 traceVerbose(`Testing: Setting up watcher for ${workspace.uri.fsPath}`);
                 this.watchForSettingsChanges(workspace);
-                this.watchForTestContentChangeOnSave(settings.testing.autoTestDiscoverOnSavePattern);
+                this.watchForTestContentChangeOnSave();
             }
         });
     }
@@ -550,10 +550,11 @@ export class PythonTestController implements ITestController, IExtensionSingleAc
         );
     }
 
-    private watchForTestContentChangeOnSave(testFileGlob: String): void {
+    private watchForTestContentChangeOnSave(): void {
         this.disposables.push(
             onDidSaveTextDocument(async (doc: TextDocument) => {
-                if (minimatch(doc.uri.fs, testFileGlob)) {
+                const settings = this.configSettings.getSettings(doc.uri);
+                if (minimatch.default(doc.uri.fsPath, settings.testing.autoTestDiscoverOnSavePattern)) {
                     traceVerbose(`Testing: Trigger refresh after saving ${doc.uri.fsPath}`);
                     this.sendTriggerTelemetry('watching');
                     this.refreshData.trigger(doc.uri, false);

--- a/src/client/testing/testController/controller.ts
+++ b/src/client/testing/testController/controller.ts
@@ -3,6 +3,7 @@
 
 import { inject, injectable, named } from 'inversify';
 import { uniq } from 'lodash';
+import { minimatch } from 'minimatch';
 import {
     CancellationToken,
     TestController,
@@ -215,7 +216,7 @@ export class PythonTestController implements ITestController, IExtensionSingleAc
             if (settings.testing.autoTestDiscoverOnSaveEnabled) {
                 traceVerbose(`Testing: Setting up watcher for ${workspace.uri.fsPath}`);
                 this.watchForSettingsChanges(workspace);
-                this.watchForTestContentChangeOnSave();
+                this.watchForTestContentChangeOnSave(settings.testing.autoTestDiscoverOnSavePattern);
             }
         });
     }
@@ -549,10 +550,10 @@ export class PythonTestController implements ITestController, IExtensionSingleAc
         );
     }
 
-    private watchForTestContentChangeOnSave(): void {
+    private watchForTestContentChangeOnSave(testFileGlob: String): void {
         this.disposables.push(
             onDidSaveTextDocument(async (doc: TextDocument) => {
-                if (doc.fileName.endsWith('.py')) {
+                if (minimatch(doc.uri.fs, testFileGlob)) {
                     traceVerbose(`Testing: Trigger refresh after saving ${doc.uri.fsPath}`);
                     this.sendTriggerTelemetry('watching');
                     this.refreshData.trigger(doc.uri, false);


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-python/issues/24817

## What this change does

Introduce `autoTestDiscoverOnSavePattern` configuration option to control `autoTestDiscoverOnSaveEnabled` behavior to only attempt test discovery refresh when files matching the specified glob pattern are saved.

## Why this change

In a Python project we have with over 40K tests, developers definitely notice issues when pytest discovery is running whenever any file in the workspace is saved, despite all tests matching a very consistent pattern (`./tests/**/test_*.py`).

## Other alternatives I considered

I did consider trying to match only the specific patterns used by unittest/pytest here. Given that would require parsing underlying configuration files / raw args in the test configuration for the workspace for both unittest and pytest (plus any other test runners supported in future) - I don't think that's going to be easy to maintain. Plus the addition / deletion of `__init__.py` files play a significant part in test discovery despite not being covered by the test configuration pattern - so this solution would be incomplete.

Another alternative would be to accept a parent directory and only include python files from that directory + subdirectories (using workspace directory as default value). This avoids introducing a glob configuration value, but feels very limiting.