### PR TITLE
Use sendText to send Python code to Terminal REPL for Python >= 3.13 

### DIFF
--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -25,6 +25,7 @@ import { useEnvExtension } from '../../envExt/api.internal';
 import { ensureTerminalLegacy } from '../../envExt/api.legacy';
 import { sleep } from '../utils/async';
 import { isWindows } from '../utils/platform';
+import { getActiveInterpreter } from '../../repl/replUtils';
 
 @injectable()
 export class TerminalService implements ITerminalService, Disposable {
@@ -108,7 +109,17 @@ export class TerminalService implements ITerminalService, Disposable {
 
         const config = getConfiguration('python');
         const pythonrcSetting = config.get<boolean>('terminal.shellIntegration.enabled');
-        if ((isPythonShell && !pythonrcSetting) || (isPythonShell && isWindows())) {
+
+        // Need to check for if Python version is >= 3.13 since we have turned off SI on python side.
+        // Because we are not sending explicit commandline info to core, it will inject ^C. (We want to avoid)
+        if (this.options && this.options.resource) {
+            const pythonVersion = await getActiveInterpreter(
+                this.options.resource,
+                this.serviceContainer.get<IInterpreterService>(IInterpreterService),
+            );
+            const minorVersion = pythonVersion?.version?.minor;
+
+        if ((isPythonShell && !pythonrcSetting) || (isPythonShell && isWindows()) || ((minorVersion ?? 0) >= 13)) {
             // If user has explicitly disabled SI for Python, use sendText for inside Terminal REPL.
             terminal.sendText(commandLine);
             return undefined;

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -25,7 +25,7 @@ import { useEnvExtension } from '../../envExt/api.internal';
 import { ensureTerminalLegacy } from '../../envExt/api.legacy';
 import { sleep } from '../utils/async';
 import { isWindows } from '../utils/platform';
-import { getPythonMinorVersion } from '../../repl/replUtils';
+// import { getPythonMinorVersion } from '../../repl/replUtils';
 
 @injectable()
 export class TerminalService implements ITerminalService, Disposable {
@@ -110,14 +110,15 @@ export class TerminalService implements ITerminalService, Disposable {
         const config = getConfiguration('python');
         const pythonrcSetting = config.get<boolean>('terminal.shellIntegration.enabled');
 
-        const minorVersion = this.options?.resource
-            ? await getPythonMinorVersion(
-                  this.options.resource,
-                  this.serviceContainer.get<IInterpreterService>(IInterpreterService),
-              )
-            : undefined;
+        // const minorVersion = this.options?.resource
+        //     ? await getPythonMinorVersion(
+        //           this.options.resource,
+        //           this.serviceContainer.get<IInterpreterService>(IInterpreterService),
+        //       )
+        //     : undefined;
+        // || (minorVersion ?? 0) >= 13
 
-        if ((isPythonShell && !pythonrcSetting) || (isPythonShell && isWindows()) || (minorVersion ?? 0) >= 13) {
+        if ((isPythonShell && !pythonrcSetting) || (isPythonShell && isWindows())) {
             // If user has explicitly disabled SI for Python, use sendText for inside Terminal REPL.
             terminal.sendText(commandLine);
             return undefined;

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -116,9 +116,8 @@ export class TerminalService implements ITerminalService, Disposable {
                   this.serviceContainer.get<IInterpreterService>(IInterpreterService),
               )
             : undefined;
-        || (minorVersion ?? 0) >= 13
 
-        if ((isPythonShell && !pythonrcSetting) || (isPythonShell && isWindows())) {
+        if ((isPythonShell && !pythonrcSetting) || (isPythonShell && isWindows()) || (minorVersion ?? 0) >= 13) {
             // If user has explicitly disabled SI for Python, use sendText for inside Terminal REPL.
             terminal.sendText(commandLine);
             return undefined;

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -25,7 +25,7 @@ import { useEnvExtension } from '../../envExt/api.internal';
 import { ensureTerminalLegacy } from '../../envExt/api.legacy';
 import { sleep } from '../utils/async';
 import { isWindows } from '../utils/platform';
-// import { getPythonMinorVersion } from '../../repl/replUtils';
+import { getPythonMinorVersion } from '../../repl/replUtils';
 
 @injectable()
 export class TerminalService implements ITerminalService, Disposable {
@@ -110,13 +110,13 @@ export class TerminalService implements ITerminalService, Disposable {
         const config = getConfiguration('python');
         const pythonrcSetting = config.get<boolean>('terminal.shellIntegration.enabled');
 
-        // const minorVersion = this.options?.resource
-        //     ? await getPythonMinorVersion(
-        //           this.options.resource,
-        //           this.serviceContainer.get<IInterpreterService>(IInterpreterService),
-        //       )
-        //     : undefined;
-        // || (minorVersion ?? 0) >= 13
+        const minorVersion = this.options?.resource
+            ? await getPythonMinorVersion(
+                  this.options.resource,
+                  this.serviceContainer.get<IInterpreterService>(IInterpreterService),
+              )
+            : undefined;
+        || (minorVersion ?? 0) >= 13
 
         if ((isPythonShell && !pythonrcSetting) || (isPythonShell && isWindows())) {
             // If user has explicitly disabled SI for Python, use sendText for inside Terminal REPL.

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -110,6 +110,7 @@ export class TerminalService implements ITerminalService, Disposable {
         const config = getConfiguration('python');
         const pythonrcSetting = config.get<boolean>('terminal.shellIntegration.enabled');
 
+        let minorVersion: number | undefined;
         // Need to check for if Python version is >= 3.13 since we have turned off SI on python side.
         // Because we are not sending explicit commandline info to core, it will inject ^C. (We want to avoid)
         if (this.options && this.options.resource) {
@@ -117,9 +118,10 @@ export class TerminalService implements ITerminalService, Disposable {
                 this.options.resource,
                 this.serviceContainer.get<IInterpreterService>(IInterpreterService),
             );
-            const minorVersion = pythonVersion?.version?.minor;
+            minorVersion = pythonVersion?.version?.minor;
+        }
 
-        if ((isPythonShell && !pythonrcSetting) || (isPythonShell && isWindows()) || ((minorVersion ?? 0) >= 13)) {
+        if ((isPythonShell && !pythonrcSetting) || (isPythonShell && isWindows()) || (minorVersion ?? 0) >= 13) {
             // If user has explicitly disabled SI for Python, use sendText for inside Terminal REPL.
             terminal.sendText(commandLine);
             return undefined;

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -25,7 +25,7 @@ import { useEnvExtension } from '../../envExt/api.internal';
 import { ensureTerminalLegacy } from '../../envExt/api.legacy';
 import { sleep } from '../utils/async';
 import { isWindows } from '../utils/platform';
-import { getActiveInterpreter } from '../../repl/replUtils';
+import { getPythonMinorVersion } from '../../repl/replUtils';
 
 @injectable()
 export class TerminalService implements ITerminalService, Disposable {
@@ -110,16 +110,12 @@ export class TerminalService implements ITerminalService, Disposable {
         const config = getConfiguration('python');
         const pythonrcSetting = config.get<boolean>('terminal.shellIntegration.enabled');
 
-        let minorVersion: number | undefined;
-        // Need to check for if Python version is >= 3.13 since we have turned off SI on python side.
-        // Because we are not sending explicit commandline info to core, it will inject ^C. (We want to avoid)
-        if (this.options && this.options.resource) {
-            const pythonVersion = await getActiveInterpreter(
-                this.options.resource,
-                this.serviceContainer.get<IInterpreterService>(IInterpreterService),
-            );
-            minorVersion = pythonVersion?.version?.minor;
-        }
+        const minorVersion = this.options?.resource
+            ? await getPythonMinorVersion(
+                  this.options.resource,
+                  this.serviceContainer.get<IInterpreterService>(IInterpreterService),
+              )
+            : undefined;
 
         if ((isPythonShell && !pythonrcSetting) || (isPythonShell && isWindows()) || (minorVersion ?? 0) >= 13) {
             // If user has explicitly disabled SI for Python, use sendText for inside Terminal REPL.

--- a/src/client/repl/replUtils.ts
+++ b/src/client/repl/replUtils.ts
@@ -118,3 +118,17 @@ export function getTabNameForUri(uri: Uri): string | undefined {
 
     return undefined;
 }
+
+/**
+ * Function that will return the minor version of current active Python interpreter.
+ */
+export async function getPythonMinorVersion(
+    uri: Uri | undefined,
+    interpreterService: IInterpreterService,
+): Promise<number | undefined> {
+    if (uri) {
+        const pythonVersion = await getActiveInterpreter(uri, interpreterService);
+        return pythonVersion?.version?.minor;
+    }
+    return undefined;
+}

--- a/src/test/common/terminals/service.unit.test.ts
+++ b/src/test/common/terminals/service.unit.test.ts
@@ -11,7 +11,7 @@ import {
     TerminalShellExecution,
     TerminalShellExecutionEndEvent,
     TerminalShellIntegration,
-    Uri,
+    // Uri,
     Terminal as VSCodeTerminal,
     WorkspaceConfiguration,
 } from 'vscode';
@@ -22,7 +22,7 @@ import { TerminalService } from '../../../client/common/terminal/service';
 import {
     ITerminalActivator,
     ITerminalHelper,
-    TerminalCreationOptions,
+    // TerminalCreationOptions,
     TerminalShellType,
 } from '../../../client/common/terminal/types';
 import { IDisposableRegistry } from '../../../client/common/types';
@@ -33,7 +33,7 @@ import * as workspaceApis from '../../../client/common/vscodeApis/workspaceApis'
 import * as platform from '../../../client/common/utils/platform';
 import * as extapi from '../../../client/envExt/api.internal';
 import { IInterpreterService } from '../../../client/interpreter/contracts';
-import { PythonEnvironment } from '../../../client/pythonEnvironments/info';
+// import { PythonEnvironment } from '../../../client/pythonEnvironments/info';
 
 suite('Terminal Service', () => {
     let service: TerminalService;
@@ -55,7 +55,7 @@ suite('Terminal Service', () => {
     let isWindowsStub: sinon.SinonStub;
     let useEnvExtensionStub: sinon.SinonStub;
     let interpreterService: TypeMoq.IMock<IInterpreterService>;
-    let options: TypeMoq.IMock<TerminalCreationOptions>;
+    // let options: TypeMoq.IMock<TerminalCreationOptions>;
 
     setup(() => {
         useEnvExtensionStub = sinon.stub(extapi, 'useEnvExtension');

--- a/src/test/common/terminals/service.unit.test.ts
+++ b/src/test/common/terminals/service.unit.test.ts
@@ -102,13 +102,13 @@ suite('Terminal Service', () => {
         disposables = [];
 
         mockServiceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
-        interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
-        interpreterService
-            .setup((i) => i.getActiveInterpreter(TypeMoq.It.isAny()))
-            .returns(() => Promise.resolve(({ path: 'ps' } as unknown) as PythonEnvironment));
+        // interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
+        // interpreterService
+        //     .setup((i) => i.getActiveInterpreter(TypeMoq.It.isAny()))
+        //     .returns(() => Promise.resolve(({ path: 'ps' } as unknown) as PythonEnvironment));
 
-        options = TypeMoq.Mock.ofType<TerminalCreationOptions>();
-        options.setup((o) => o.resource).returns(() => Uri.parse('a'));
+        // options = TypeMoq.Mock.ofType<TerminalCreationOptions>();
+        // options.setup((o) => o.resource).returns(() => Uri.parse('a'));
 
         mockServiceContainer.setup((c) => c.get(ITerminalManager)).returns(() => terminalManager.object);
         mockServiceContainer.setup((c) => c.get(ITerminalHelper)).returns(() => terminalHelper.object);
@@ -136,7 +136,7 @@ suite('Terminal Service', () => {
         disposables.filter((item) => !!item).forEach((item) => item.dispose());
         sinon.restore();
         // reset setup for interpreterService
-        interpreterService.reset();
+        // interpreterService.reset();
     });
 
     test('Ensure terminal is disposed', async () => {
@@ -259,57 +259,57 @@ suite('Terminal Service', () => {
         terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.exactly(1));
     });
 
-    test('Ensure sendText is NOT called when Python shell integration and terminal shell integration are both enabled - Mac, Linux && Python < 3.13', async () => {
-        isWindowsStub.returns(false);
-        pythonConfig
-            .setup((p) => p.get('terminal.shellIntegration.enabled'))
-            .returns(() => true)
-            .verifiable(TypeMoq.Times.once());
+    // test('Ensure sendText is NOT called when Python shell integration and terminal shell integration are both enabled - Mac, Linux && Python < 3.13', async () => {
+    //     isWindowsStub.returns(false);
+    //     pythonConfig
+    //         .setup((p) => p.get('terminal.shellIntegration.enabled'))
+    //         .returns(() => true)
+    //         .verifiable(TypeMoq.Times.once());
 
-        terminalHelper
-            .setup((helper) => helper.getEnvironmentActivationCommands(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-            .returns(() => Promise.resolve(undefined));
-        service = new TerminalService(mockServiceContainer.object);
-        const textToSend = 'Some Text';
-        terminalHelper.setup((h) => h.identifyTerminalShell(TypeMoq.It.isAny())).returns(() => TerminalShellType.bash);
-        terminalManager.setup((t) => t.createTerminal(TypeMoq.It.isAny())).returns(() => terminal.object);
+    //     terminalHelper
+    //         .setup((helper) => helper.getEnvironmentActivationCommands(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+    //         .returns(() => Promise.resolve(undefined));
+    //     service = new TerminalService(mockServiceContainer.object);
+    //     const textToSend = 'Some Text';
+    //     terminalHelper.setup((h) => h.identifyTerminalShell(TypeMoq.It.isAny())).returns(() => TerminalShellType.bash);
+    //     terminalManager.setup((t) => t.createTerminal(TypeMoq.It.isAny())).returns(() => terminal.object);
 
-        service.ensureTerminal();
-        service.executeCommand(textToSend, true);
+    //     service.ensureTerminal();
+    //     service.executeCommand(textToSend, true);
 
-        terminal.verify((t) => t.show(TypeMoq.It.isValue(true)), TypeMoq.Times.exactly(1));
-        terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.never());
-    });
+    //     terminal.verify((t) => t.show(TypeMoq.It.isValue(true)), TypeMoq.Times.exactly(1));
+    //     terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.never());
+    // });
 
-    test('Ensure sendText is called when Python shell integration and terminal shell integration are both enabled - Mac, Linux && Python >= 3.13', async () => {
-        interpreterService.reset();
+    // test('Ensure sendText is called when Python shell integration and terminal shell integration are both enabled - Mac, Linux && Python >= 3.13', async () => {
+    //     interpreterService.reset();
 
-        interpreterService
-            .setup((i) => i.getActiveInterpreter(TypeMoq.It.isAny()))
-            .returns(() =>
-                Promise.resolve({ path: 'yo', version: { major: 3, minor: 13, patch: 0 } } as PythonEnvironment),
-            );
+    //     interpreterService
+    //         .setup((i) => i.getActiveInterpreter(TypeMoq.It.isAny()))
+    //         .returns(() =>
+    //             Promise.resolve({ path: 'yo', version: { major: 3, minor: 13, patch: 0 } } as PythonEnvironment),
+    //         );
 
-        isWindowsStub.returns(false);
-        pythonConfig
-            .setup((p) => p.get('terminal.shellIntegration.enabled'))
-            .returns(() => true)
-            .verifiable(TypeMoq.Times.once());
+    //     isWindowsStub.returns(false);
+    //     pythonConfig
+    //         .setup((p) => p.get('terminal.shellIntegration.enabled'))
+    //         .returns(() => true)
+    //         .verifiable(TypeMoq.Times.once());
 
-        terminalHelper
-            .setup((helper) => helper.getEnvironmentActivationCommands(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-            .returns(() => Promise.resolve(undefined));
+    //     terminalHelper
+    //         .setup((helper) => helper.getEnvironmentActivationCommands(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+    //         .returns(() => Promise.resolve(undefined));
 
-        service = new TerminalService(mockServiceContainer.object, options.object);
-        const textToSend = 'Some Text';
-        terminalHelper.setup((h) => h.identifyTerminalShell(TypeMoq.It.isAny())).returns(() => TerminalShellType.bash);
-        terminalManager.setup((t) => t.createTerminal(TypeMoq.It.isAny())).returns(() => terminal.object);
+    //     service = new TerminalService(mockServiceContainer.object, options.object);
+    //     const textToSend = 'Some Text';
+    //     terminalHelper.setup((h) => h.identifyTerminalShell(TypeMoq.It.isAny())).returns(() => TerminalShellType.bash);
+    //     terminalManager.setup((t) => t.createTerminal(TypeMoq.It.isAny())).returns(() => terminal.object);
 
-        await service.ensureTerminal();
-        await service.executeCommand(textToSend, true);
+    //     await service.ensureTerminal();
+    //     await service.executeCommand(textToSend, true);
 
-        terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.once());
-    });
+    //     terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.once());
+    // });
 
     test('Ensure sendText IS called even when Python shell integration and terminal shell integration are both enabled - Window', async () => {
         isWindowsStub.returns(true);

--- a/src/test/common/terminals/service.unit.test.ts
+++ b/src/test/common/terminals/service.unit.test.ts
@@ -11,6 +11,7 @@ import {
     TerminalShellExecution,
     TerminalShellExecutionEndEvent,
     TerminalShellIntegration,
+    Uri,
     Terminal as VSCodeTerminal,
     WorkspaceConfiguration,
 } from 'vscode';
@@ -18,7 +19,12 @@ import { ITerminalManager, IWorkspaceService } from '../../../client/common/appl
 import { EXTENSION_ROOT_DIR } from '../../../client/common/constants';
 import { IPlatformService } from '../../../client/common/platform/types';
 import { TerminalService } from '../../../client/common/terminal/service';
-import { ITerminalActivator, ITerminalHelper, TerminalShellType } from '../../../client/common/terminal/types';
+import {
+    ITerminalActivator,
+    ITerminalHelper,
+    TerminalCreationOptions,
+    TerminalShellType,
+} from '../../../client/common/terminal/types';
 import { IDisposableRegistry } from '../../../client/common/types';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { ITerminalAutoActivation } from '../../../client/terminals/types';
@@ -26,6 +32,8 @@ import { createPythonInterpreter } from '../../utils/interpreters';
 import * as workspaceApis from '../../../client/common/vscodeApis/workspaceApis';
 import * as platform from '../../../client/common/utils/platform';
 import * as extapi from '../../../client/envExt/api.internal';
+import { IInterpreterService } from '../../../client/interpreter/contracts';
+import { PythonEnvironment } from '../../../client/pythonEnvironments/info';
 
 suite('Terminal Service', () => {
     let service: TerminalService;
@@ -46,6 +54,8 @@ suite('Terminal Service', () => {
     let editorConfig: TypeMoq.IMock<WorkspaceConfiguration>;
     let isWindowsStub: sinon.SinonStub;
     let useEnvExtensionStub: sinon.SinonStub;
+    let interpreterService: TypeMoq.IMock<IInterpreterService>;
+    let options: TypeMoq.IMock<TerminalCreationOptions>;
 
     setup(() => {
         useEnvExtensionStub = sinon.stub(extapi, 'useEnvExtension');
@@ -92,6 +102,13 @@ suite('Terminal Service', () => {
         disposables = [];
 
         mockServiceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
+        interpreterService
+            .setup((i) => i.getActiveInterpreter(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(({ path: 'ps' } as unknown) as PythonEnvironment));
+
+        options = TypeMoq.Mock.ofType<TerminalCreationOptions>();
+        options.setup((o) => o.resource).returns(() => Uri.parse('a'));
 
         mockServiceContainer.setup((c) => c.get(ITerminalManager)).returns(() => terminalManager.object);
         mockServiceContainer.setup((c) => c.get(ITerminalHelper)).returns(() => terminalHelper.object);
@@ -100,6 +117,7 @@ suite('Terminal Service', () => {
         mockServiceContainer.setup((c) => c.get(IWorkspaceService)).returns(() => workspaceService.object);
         mockServiceContainer.setup((c) => c.get(ITerminalActivator)).returns(() => terminalActivator.object);
         mockServiceContainer.setup((c) => c.get(ITerminalAutoActivation)).returns(() => terminalAutoActivator.object);
+        mockServiceContainer.setup((c) => c.get(IInterpreterService)).returns(() => interpreterService.object);
         getConfigurationStub = sinon.stub(workspaceApis, 'getConfiguration');
         isWindowsStub = sinon.stub(platform, 'isWindows');
         pythonConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
@@ -117,6 +135,8 @@ suite('Terminal Service', () => {
         }
         disposables.filter((item) => !!item).forEach((item) => item.dispose());
         sinon.restore();
+        // reset setup for interpreterService
+        interpreterService.reset();
     });
 
     test('Ensure terminal is disposed', async () => {
@@ -239,7 +259,7 @@ suite('Terminal Service', () => {
         terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.exactly(1));
     });
 
-    test('Ensure sendText is NOT called when Python shell integration and terminal shell integration are both enabled - Mac, Linux', async () => {
+    test('Ensure sendText is NOT called when Python shell integration and terminal shell integration are both enabled - Mac, Linux && Python < 3.13', async () => {
         isWindowsStub.returns(false);
         pythonConfig
             .setup((p) => p.get('terminal.shellIntegration.enabled'))
@@ -259,6 +279,36 @@ suite('Terminal Service', () => {
 
         terminal.verify((t) => t.show(TypeMoq.It.isValue(true)), TypeMoq.Times.exactly(1));
         terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.never());
+    });
+
+    test('Ensure sendText is called when Python shell integration and terminal shell integration are both enabled - Mac, Linux && Python >= 3.13', async () => {
+        interpreterService.reset();
+
+        interpreterService
+            .setup((i) => i.getActiveInterpreter(TypeMoq.It.isAny()))
+            .returns(() =>
+                Promise.resolve({ path: 'yo', version: { major: 3, minor: 13, patch: 0 } } as PythonEnvironment),
+            );
+
+        isWindowsStub.returns(false);
+        pythonConfig
+            .setup((p) => p.get('terminal.shellIntegration.enabled'))
+            .returns(() => true)
+            .verifiable(TypeMoq.Times.once());
+
+        terminalHelper
+            .setup((helper) => helper.getEnvironmentActivationCommands(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(undefined));
+
+        service = new TerminalService(mockServiceContainer.object, options.object);
+        const textToSend = 'Some Text';
+        terminalHelper.setup((h) => h.identifyTerminalShell(TypeMoq.It.isAny())).returns(() => TerminalShellType.bash);
+        terminalManager.setup((t) => t.createTerminal(TypeMoq.It.isAny())).returns(() => terminal.object);
+
+        await service.ensureTerminal();
+        await service.executeCommand(textToSend, true);
+
+        terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.once());
     });
 
     test('Ensure sendText IS called even when Python shell integration and terminal shell integration are both enabled - Window', async () => {

--- a/src/test/common/terminals/service.unit.test.ts
+++ b/src/test/common/terminals/service.unit.test.ts
@@ -135,8 +135,7 @@ suite('Terminal Service', () => {
         }
         disposables.filter((item) => !!item).forEach((item) => item.dispose());
         sinon.restore();
-        // reset setup for interpreterService
-        // interpreterService.reset();
+        interpreterService.reset();
     });
 
     test('Ensure terminal is disposed', async () => {

--- a/src/test/common/terminals/service.unit.test.ts
+++ b/src/test/common/terminals/service.unit.test.ts
@@ -11,7 +11,7 @@ import {
     TerminalShellExecution,
     TerminalShellExecutionEndEvent,
     TerminalShellIntegration,
-    // Uri,
+    Uri,
     Terminal as VSCodeTerminal,
     WorkspaceConfiguration,
 } from 'vscode';
@@ -22,7 +22,7 @@ import { TerminalService } from '../../../client/common/terminal/service';
 import {
     ITerminalActivator,
     ITerminalHelper,
-    // TerminalCreationOptions,
+    TerminalCreationOptions,
     TerminalShellType,
 } from '../../../client/common/terminal/types';
 import { IDisposableRegistry } from '../../../client/common/types';
@@ -33,7 +33,7 @@ import * as workspaceApis from '../../../client/common/vscodeApis/workspaceApis'
 import * as platform from '../../../client/common/utils/platform';
 import * as extapi from '../../../client/envExt/api.internal';
 import { IInterpreterService } from '../../../client/interpreter/contracts';
-// import { PythonEnvironment } from '../../../client/pythonEnvironments/info';
+import { PythonEnvironment } from '../../../client/pythonEnvironments/info';
 
 suite('Terminal Service', () => {
     let service: TerminalService;
@@ -55,7 +55,7 @@ suite('Terminal Service', () => {
     let isWindowsStub: sinon.SinonStub;
     let useEnvExtensionStub: sinon.SinonStub;
     let interpreterService: TypeMoq.IMock<IInterpreterService>;
-    // let options: TypeMoq.IMock<TerminalCreationOptions>;
+    let options: TypeMoq.IMock<TerminalCreationOptions>;
 
     setup(() => {
         useEnvExtensionStub = sinon.stub(extapi, 'useEnvExtension');
@@ -102,13 +102,13 @@ suite('Terminal Service', () => {
         disposables = [];
 
         mockServiceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
-        // interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
-        // interpreterService
-        //     .setup((i) => i.getActiveInterpreter(TypeMoq.It.isAny()))
-        //     .returns(() => Promise.resolve(({ path: 'ps' } as unknown) as PythonEnvironment));
+        interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
+        interpreterService
+            .setup((i) => i.getActiveInterpreter(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(({ path: 'ps' } as unknown) as PythonEnvironment));
 
-        // options = TypeMoq.Mock.ofType<TerminalCreationOptions>();
-        // options.setup((o) => o.resource).returns(() => Uri.parse('a'));
+        options = TypeMoq.Mock.ofType<TerminalCreationOptions>();
+        options.setup((o) => o.resource).returns(() => Uri.parse('a'));
 
         mockServiceContainer.setup((c) => c.get(ITerminalManager)).returns(() => terminalManager.object);
         mockServiceContainer.setup((c) => c.get(ITerminalHelper)).returns(() => terminalHelper.object);
@@ -259,57 +259,57 @@ suite('Terminal Service', () => {
         terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.exactly(1));
     });
 
-    // test('Ensure sendText is NOT called when Python shell integration and terminal shell integration are both enabled - Mac, Linux && Python < 3.13', async () => {
-    //     isWindowsStub.returns(false);
-    //     pythonConfig
-    //         .setup((p) => p.get('terminal.shellIntegration.enabled'))
-    //         .returns(() => true)
-    //         .verifiable(TypeMoq.Times.once());
+    test('Ensure sendText is NOT called when Python shell integration and terminal shell integration are both enabled - Mac, Linux && Python < 3.13', async () => {
+        isWindowsStub.returns(false);
+        pythonConfig
+            .setup((p) => p.get('terminal.shellIntegration.enabled'))
+            .returns(() => true)
+            .verifiable(TypeMoq.Times.once());
 
-    //     terminalHelper
-    //         .setup((helper) => helper.getEnvironmentActivationCommands(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-    //         .returns(() => Promise.resolve(undefined));
-    //     service = new TerminalService(mockServiceContainer.object);
-    //     const textToSend = 'Some Text';
-    //     terminalHelper.setup((h) => h.identifyTerminalShell(TypeMoq.It.isAny())).returns(() => TerminalShellType.bash);
-    //     terminalManager.setup((t) => t.createTerminal(TypeMoq.It.isAny())).returns(() => terminal.object);
+        terminalHelper
+            .setup((helper) => helper.getEnvironmentActivationCommands(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(undefined));
+        service = new TerminalService(mockServiceContainer.object);
+        const textToSend = 'Some Text';
+        terminalHelper.setup((h) => h.identifyTerminalShell(TypeMoq.It.isAny())).returns(() => TerminalShellType.bash);
+        terminalManager.setup((t) => t.createTerminal(TypeMoq.It.isAny())).returns(() => terminal.object);
 
-    //     service.ensureTerminal();
-    //     service.executeCommand(textToSend, true);
+        service.ensureTerminal();
+        service.executeCommand(textToSend, true);
 
-    //     terminal.verify((t) => t.show(TypeMoq.It.isValue(true)), TypeMoq.Times.exactly(1));
-    //     terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.never());
-    // });
+        terminal.verify((t) => t.show(TypeMoq.It.isValue(true)), TypeMoq.Times.exactly(1));
+        terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.never());
+    });
 
-    // test('Ensure sendText is called when Python shell integration and terminal shell integration are both enabled - Mac, Linux && Python >= 3.13', async () => {
-    //     interpreterService.reset();
+    test('Ensure sendText is called when Python shell integration and terminal shell integration are both enabled - Mac, Linux && Python >= 3.13', async () => {
+        interpreterService.reset();
 
-    //     interpreterService
-    //         .setup((i) => i.getActiveInterpreter(TypeMoq.It.isAny()))
-    //         .returns(() =>
-    //             Promise.resolve({ path: 'yo', version: { major: 3, minor: 13, patch: 0 } } as PythonEnvironment),
-    //         );
+        interpreterService
+            .setup((i) => i.getActiveInterpreter(TypeMoq.It.isAny()))
+            .returns(() =>
+                Promise.resolve({ path: 'yo', version: { major: 3, minor: 13, patch: 0 } } as PythonEnvironment),
+            );
 
-    //     isWindowsStub.returns(false);
-    //     pythonConfig
-    //         .setup((p) => p.get('terminal.shellIntegration.enabled'))
-    //         .returns(() => true)
-    //         .verifiable(TypeMoq.Times.once());
+        isWindowsStub.returns(false);
+        pythonConfig
+            .setup((p) => p.get('terminal.shellIntegration.enabled'))
+            .returns(() => true)
+            .verifiable(TypeMoq.Times.once());
 
-    //     terminalHelper
-    //         .setup((helper) => helper.getEnvironmentActivationCommands(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-    //         .returns(() => Promise.resolve(undefined));
+        terminalHelper
+            .setup((helper) => helper.getEnvironmentActivationCommands(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(undefined));
 
-    //     service = new TerminalService(mockServiceContainer.object, options.object);
-    //     const textToSend = 'Some Text';
-    //     terminalHelper.setup((h) => h.identifyTerminalShell(TypeMoq.It.isAny())).returns(() => TerminalShellType.bash);
-    //     terminalManager.setup((t) => t.createTerminal(TypeMoq.It.isAny())).returns(() => terminal.object);
+        service = new TerminalService(mockServiceContainer.object, options.object);
+        const textToSend = 'Some Text';
+        terminalHelper.setup((h) => h.identifyTerminalShell(TypeMoq.It.isAny())).returns(() => TerminalShellType.bash);
+        terminalManager.setup((t) => t.createTerminal(TypeMoq.It.isAny())).returns(() => terminal.object);
 
-    //     await service.ensureTerminal();
-    //     await service.executeCommand(textToSend, true);
+        await service.ensureTerminal();
+        await service.executeCommand(textToSend, true);
 
-    //     terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.once());
-    // });
+        terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.once());
+    });
 
     test('Ensure sendText IS called even when Python shell integration and terminal shell integration are both enabled - Window', async () => {
         isWindowsStub.returns(true);

--- a/src/test/terminals/codeExecution/helper.test.ts
+++ b/src/test/terminals/codeExecution/helper.test.ts
@@ -38,7 +38,7 @@ import { ReplType } from '../../../client/repl/types';
 
 const TEST_FILES_PATH = path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'python_files', 'terminalExec');
 
-suite('Terminal - Code Execution Helper', () => {
+suite('Terminal - Code Execution Helper', async () => {
     let activeResourceService: TypeMoq.IMock<IActiveResourceService>;
     let documentManager: TypeMoq.IMock<IDocumentManager>;
     let applicationShell: TypeMoq.IMock<IApplicationShell>;

--- a/src/test/terminals/codeExecution/helper.test.ts
+++ b/src/test/terminals/codeExecution/helper.test.ts
@@ -233,10 +233,11 @@ suite('Terminal - Code Execution Helper', async () => {
         const normalizedExpected = expectedSource.replace(/\r\n/g, '\n');
         expect(normalizedCode).to.be.equal(normalizedExpected);
     }
-    const pythonVersion = await getPythonSemVer();
-    if (pythonVersion && pythonVersion.minor < 13) {
+
+    const pythonTestVersion = await getPythonSemVer();
+    if (pythonTestVersion && pythonTestVersion.minor < 13) {
         ['', '1', '2', '3', '4', '5', '6', '7', '8'].forEach((fileNameSuffix) => {
-            test(`Ensure code is normalized (Sample${fileNameSuffix})`, async () => {
+            test(`Ensure code is normalized (Sample${fileNameSuffix}) - Python < 3.13`, async () => {
                 configurationService
                     .setup((c) => c.getSettings(TypeMoq.It.isAny()))
                     .returns({
@@ -255,6 +256,7 @@ suite('Terminal - Code Execution Helper', async () => {
             });
         });
     }
+
     test("Display message if there's no active file", async () => {
         documentManager.setup((doc) => doc.activeTextEditor).returns(() => undefined);
 

--- a/src/test/terminals/codeExecution/smartSend.test.ts
+++ b/src/test/terminals/codeExecution/smartSend.test.ts
@@ -21,7 +21,7 @@ import { IServiceContainer } from '../../../client/ioc/types';
 import { ICodeExecutionHelper } from '../../../client/terminals/types';
 import { Commands, EXTENSION_ROOT_DIR } from '../../../client/common/constants';
 import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
-import { PYTHON_PATH } from '../../common';
+import { PYTHON_PATH, getPythonSemVer } from '../../common';
 import { Architecture } from '../../../client/common/utils/platform';
 import { ProcessService } from '../../../client/common/process/proc';
 import { l10n } from '../../mocks/vsc';
@@ -168,67 +168,72 @@ suite('REPL - Smart Send', async () => {
         commandManager.verifyAll();
     });
 
-    test('Smart send should perform smart selection and move cursor', async () => {
-        configurationService
-            .setup((c) => c.getSettings(TypeMoq.It.isAny()))
-            .returns({
-                REPL: {
-                    REPLSmartSend: true,
-                },
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            } as any);
+    const pythonVersion = await getPythonSemVer();
+    console.log('Just printed pythoNVersion: \n');
+    console.log(pythonVersion);
+    if (pythonVersion && pythonVersion.minor < 13) {
+        test('Smart send should perform smart selection and move cursor', async () => {
+            configurationService
+                .setup((c) => c.getSettings(TypeMoq.It.isAny()))
+                .returns({
+                    REPL: {
+                        REPLSmartSend: true,
+                    },
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                } as any);
 
-        const activeEditor = TypeMoq.Mock.ofType<TextEditor>();
-        const firstIndexPosition = new Position(0, 0);
-        const selection = TypeMoq.Mock.ofType<Selection>();
-        const wholeFileContent = await fs.readFile(path.join(TEST_FILES_PATH, `sample_smart_selection.py`), 'utf8');
+            const activeEditor = TypeMoq.Mock.ofType<TextEditor>();
+            const firstIndexPosition = new Position(0, 0);
+            const selection = TypeMoq.Mock.ofType<Selection>();
+            const wholeFileContent = await fs.readFile(path.join(TEST_FILES_PATH, `sample_smart_selection.py`), 'utf8');
 
-        selection.setup((s) => s.anchor).returns(() => firstIndexPosition);
-        selection.setup((s) => s.active).returns(() => firstIndexPosition);
-        selection.setup((s) => s.isEmpty).returns(() => true);
-        activeEditor.setup((e) => e.selection).returns(() => selection.object);
+            selection.setup((s) => s.anchor).returns(() => firstIndexPosition);
+            selection.setup((s) => s.active).returns(() => firstIndexPosition);
+            selection.setup((s) => s.isEmpty).returns(() => true);
+            activeEditor.setup((e) => e.selection).returns(() => selection.object);
 
-        documentManager.setup((d) => d.activeTextEditor).returns(() => activeEditor.object);
-        document.setup((d) => d.getText(TypeMoq.It.isAny())).returns(() => wholeFileContent);
-        const actualProcessService = new ProcessService();
+            documentManager.setup((d) => d.activeTextEditor).returns(() => activeEditor.object);
+            document.setup((d) => d.getText(TypeMoq.It.isAny())).returns(() => wholeFileContent);
+            const actualProcessService = new ProcessService();
 
-        const { execObservable } = actualProcessService;
+            const { execObservable } = actualProcessService;
 
-        processService
-            .setup((p) => p.execObservable(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-            .returns((file, args, options) => execObservable.apply(actualProcessService, [file, args, options]));
+            processService
+                .setup((p) => p.execObservable(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                .returns((file, args, options) => execObservable.apply(actualProcessService, [file, args, options]));
 
-        const actualSmartOutput = await codeExecutionHelper.normalizeLines(
-            'my_dict = {',
-            ReplType.terminal,
-            wholeFileContent,
-        );
+            const actualSmartOutput = await codeExecutionHelper.normalizeLines(
+                'my_dict = {',
+                ReplType.terminal,
+                wholeFileContent,
+            );
 
-        // my_dict = {  <----- smart shift+enter here
-        //     "key1": "value1",
-        //     "key2": "value2"
-        // } <---- cursor should be here afterwards, hence offset 3
-        commandManager
-            .setup((c) => c.executeCommand('cursorMove', TypeMoq.It.isAny()))
-            .callback((_, arg2) => {
-                assert.deepEqual(arg2, {
-                    to: 'down',
-                    by: 'line',
-                    value: 3,
-                });
-                return Promise.resolve();
-            })
-            .verifiable(TypeMoq.Times.once());
+            // my_dict = {  <----- smart shift+enter here
+            //     "key1": "value1",
+            //     "key2": "value2"
+            // } <---- cursor should be here afterwards, hence offset 3
+            commandManager
+                .setup((c) => c.executeCommand('cursorMove', TypeMoq.It.isAny()))
+                .callback((_, arg2) => {
+                    assert.deepEqual(arg2, {
+                        to: 'down',
+                        by: 'line',
+                        value: 3,
+                    });
+                    return Promise.resolve();
+                })
+                .verifiable(TypeMoq.Times.once());
 
-        commandManager
-            .setup((c) => c.executeCommand('cursorEnd'))
-            .returns(() => Promise.resolve())
-            .verifiable(TypeMoq.Times.once());
+            commandManager
+                .setup((c) => c.executeCommand('cursorEnd'))
+                .returns(() => Promise.resolve())
+                .verifiable(TypeMoq.Times.once());
 
-        const expectedSmartOutput = 'my_dict = {\n    "key1": "value1",\n    "key2": "value2"\n}\n';
-        expect(actualSmartOutput).to.be.equal(expectedSmartOutput);
-        commandManager.verifyAll();
-    });
+            const expectedSmartOutput = 'my_dict = {\n    "key1": "value1",\n    "key2": "value2"\n}\n';
+            expect(actualSmartOutput).to.be.equal(expectedSmartOutput);
+            commandManager.verifyAll();
+        });
+    }
 
     // Do not perform smart selection when there is explicit selection
     test('Smart send should not perform smart selection when there is explicit selection', async () => {

--- a/src/test/terminals/codeExecution/smartSend.test.ts
+++ b/src/test/terminals/codeExecution/smartSend.test.ts
@@ -168,11 +168,10 @@ suite('REPL - Smart Send', async () => {
         commandManager.verifyAll();
     });
 
-    const pythonVersion = await getPythonSemVer();
-    console.log('Just printed pythoNVersion: \n');
-    console.log(pythonVersion);
-    if (pythonVersion && pythonVersion.minor < 13) {
-        test('Smart send should perform smart selection and move cursor', async () => {
+    const pythonTestVersion = await getPythonSemVer();
+
+    if (pythonTestVersion && pythonTestVersion.minor < 13) {
+        test('Smart send should perform smart selection and move cursor - Python < 3.13', async () => {
             configurationService
                 .setup((c) => c.getSettings(TypeMoq.It.isAny()))
                 .returns({

--- a/src/test/terminals/codeExecution/smartSend.test.ts
+++ b/src/test/terminals/codeExecution/smartSend.test.ts
@@ -21,7 +21,7 @@ import { IServiceContainer } from '../../../client/ioc/types';
 import { ICodeExecutionHelper } from '../../../client/terminals/types';
 import { Commands, EXTENSION_ROOT_DIR } from '../../../client/common/constants';
 import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
-import { PYTHON_PATH, getPythonSemVer } from '../../common';
+import { PYTHON_PATH } from '../../common';
 import { Architecture } from '../../../client/common/utils/platform';
 import { ProcessService } from '../../../client/common/process/proc';
 import { l10n } from '../../mocks/vsc';

--- a/src/test/terminals/codeExecution/smartSend.test.ts
+++ b/src/test/terminals/codeExecution/smartSend.test.ts
@@ -168,70 +168,67 @@ suite('REPL - Smart Send', async () => {
         commandManager.verifyAll();
     });
 
-    const pythonVersion = await getPythonSemVer();
-    if (pythonVersion && pythonVersion.minor < 13) {
-        test('Smart send should perform smart selection and move cursor', async () => {
-            configurationService
-                .setup((c) => c.getSettings(TypeMoq.It.isAny()))
-                .returns({
-                    REPL: {
-                        REPLSmartSend: true,
-                    },
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                } as any);
+    test('Smart send should perform smart selection and move cursor', async () => {
+        configurationService
+            .setup((c) => c.getSettings(TypeMoq.It.isAny()))
+            .returns({
+                REPL: {
+                    REPLSmartSend: true,
+                },
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any);
 
-            const activeEditor = TypeMoq.Mock.ofType<TextEditor>();
-            const firstIndexPosition = new Position(0, 0);
-            const selection = TypeMoq.Mock.ofType<Selection>();
-            const wholeFileContent = await fs.readFile(path.join(TEST_FILES_PATH, `sample_smart_selection.py`), 'utf8');
+        const activeEditor = TypeMoq.Mock.ofType<TextEditor>();
+        const firstIndexPosition = new Position(0, 0);
+        const selection = TypeMoq.Mock.ofType<Selection>();
+        const wholeFileContent = await fs.readFile(path.join(TEST_FILES_PATH, `sample_smart_selection.py`), 'utf8');
 
-            selection.setup((s) => s.anchor).returns(() => firstIndexPosition);
-            selection.setup((s) => s.active).returns(() => firstIndexPosition);
-            selection.setup((s) => s.isEmpty).returns(() => true);
-            activeEditor.setup((e) => e.selection).returns(() => selection.object);
+        selection.setup((s) => s.anchor).returns(() => firstIndexPosition);
+        selection.setup((s) => s.active).returns(() => firstIndexPosition);
+        selection.setup((s) => s.isEmpty).returns(() => true);
+        activeEditor.setup((e) => e.selection).returns(() => selection.object);
 
-            documentManager.setup((d) => d.activeTextEditor).returns(() => activeEditor.object);
-            document.setup((d) => d.getText(TypeMoq.It.isAny())).returns(() => wholeFileContent);
-            const actualProcessService = new ProcessService();
+        documentManager.setup((d) => d.activeTextEditor).returns(() => activeEditor.object);
+        document.setup((d) => d.getText(TypeMoq.It.isAny())).returns(() => wholeFileContent);
+        const actualProcessService = new ProcessService();
 
-            const { execObservable } = actualProcessService;
+        const { execObservable } = actualProcessService;
 
-            processService
-                .setup((p) => p.execObservable(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-                .returns((file, args, options) => execObservable.apply(actualProcessService, [file, args, options]));
+        processService
+            .setup((p) => p.execObservable(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns((file, args, options) => execObservable.apply(actualProcessService, [file, args, options]));
 
-            const actualSmartOutput = await codeExecutionHelper.normalizeLines(
-                'my_dict = {',
-                ReplType.terminal,
-                wholeFileContent,
-            );
+        const actualSmartOutput = await codeExecutionHelper.normalizeLines(
+            'my_dict = {',
+            ReplType.terminal,
+            wholeFileContent,
+        );
 
-            // my_dict = {  <----- smart shift+enter here
-            //     "key1": "value1",
-            //     "key2": "value2"
-            // } <---- cursor should be here afterwards, hence offset 3
-            commandManager
-                .setup((c) => c.executeCommand('cursorMove', TypeMoq.It.isAny()))
-                .callback((_, arg2) => {
-                    assert.deepEqual(arg2, {
-                        to: 'down',
-                        by: 'line',
-                        value: 3,
-                    });
-                    return Promise.resolve();
-                })
-                .verifiable(TypeMoq.Times.once());
+        // my_dict = {  <----- smart shift+enter here
+        //     "key1": "value1",
+        //     "key2": "value2"
+        // } <---- cursor should be here afterwards, hence offset 3
+        commandManager
+            .setup((c) => c.executeCommand('cursorMove', TypeMoq.It.isAny()))
+            .callback((_, arg2) => {
+                assert.deepEqual(arg2, {
+                    to: 'down',
+                    by: 'line',
+                    value: 3,
+                });
+                return Promise.resolve();
+            })
+            .verifiable(TypeMoq.Times.once());
 
-            commandManager
-                .setup((c) => c.executeCommand('cursorEnd'))
-                .returns(() => Promise.resolve())
-                .verifiable(TypeMoq.Times.once());
+        commandManager
+            .setup((c) => c.executeCommand('cursorEnd'))
+            .returns(() => Promise.resolve())
+            .verifiable(TypeMoq.Times.once());
 
-            const expectedSmartOutput = 'my_dict = {\n    "key1": "value1",\n    "key2": "value2"\n}\n';
-            expect(actualSmartOutput).to.be.equal(expectedSmartOutput);
-            commandManager.verifyAll();
-        });
-    }
+        const expectedSmartOutput = 'my_dict = {\n    "key1": "value1",\n    "key2": "value2"\n}\n';
+        expect(actualSmartOutput).to.be.equal(expectedSmartOutput);
+        commandManager.verifyAll();
+    });
 
     // Do not perform smart selection when there is explicit selection
     test('Smart send should not perform smart selection when there is explicit selection', async () => {


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-python/issues/24674#issuecomment-2574108023 
Use sendText to send Python code to Terminal REPL for Python >= 3.13 to prevent keyboard interrupt.

Relevant file context from VS Code: https://github.com/microsoft/vscode/blob/f9c927cf7a29a59b896b6cdac2d8b5d2d43afea5/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts#L906 

It seems like we are on this edge scenario where generic terminal shell integration is enabled (so executeCommand can be used), but we have temporarily disabled Python shell integration for Python >= 3.13 (and of course sending the relevant escape sequences such as the commandLine itself to VS Code). Why?
* https://github.com/python/cpython/issues/126131 placing user's mouse cursor position at odd place. 

Why and where I think the keyboard interrupt is happening:
Python extension tries to executeCommand when sending commands to terminal REPL >= Python3.13, where we are not sending shell integration escape sequences from the Python side. 
* I think this is why it is attaching the keyboard interrupt all the sudden, because VS Code see that Python extension is requesting executeCommand but is not sending the commandLine escape sequence to them. For every other versions < 3.13 (where we send all the shell integration escape sequences including the commandLine), this does not happen.

