### PR TITLE
Add "Native" in front of "Python REPL" under Run Python menu

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -15,7 +15,7 @@
     "python.command.python.configureTests.title": "Configure Tests",
     "python.command.testing.rerunFailedTests.title": "Rerun Failed Tests",
     "python.command.python.execSelectionInTerminal.title": "Run Selection/Line in Python Terminal",
-    "python.command.python.execInREPL.title": "Run Selection/Line in Python REPL",
+    "python.command.python.execInREPL.title": "Run Selection/Line in Native Python REPL",
     "python.command.python.execSelectionInDjangoShell.title": "Run Selection/Line in Django Shell",
     "python.command.python.reportIssue.title": "Report Issue...",
     "python.command.python.clearCacheAndReload.title": "Clear Cache and Reload Window",


### PR DESCRIPTION
Aligning more with command palette option we have: `Python: Start Native Python REPL` and taking feedback from https://github.com/microsoft/vscode-python/discussions/24443#discussioncomment-12063285 