### PR TITLE
Update attach.ts to fix "clientOS" configuration

### DIFF
--- a/src/client/debugger/extension/configuration/resolvers/attach.ts
+++ b/src/client/debugger/extension/configuration/resolvers/attach.ts
@@ -75,6 +75,11 @@ export class AttachConfigurationResolver extends BaseConfigurationResolver<Attac
         }
         if (debugConfiguration.clientOS === undefined) {
             debugConfiguration.clientOS = getOSType() === OSType.Windows ? 'windows' : 'unix';
+            if (debugConfiguration.clientOS === 'windows') {
+                AttachConfigurationResolver.debugOption(debugOptions, DebugOptions.WindowsClient);
+            } else {
+                AttachConfigurationResolver.debugOption(debugOptions, DebugOptions.UnixClient);
+            }
         }
         if (debugConfiguration.showReturnValue) {
             AttachConfigurationResolver.debugOption(debugOptions, DebugOptions.ShowReturnValue);


### PR DESCRIPTION
Fix "clientOS" options

My debugger works in VS Code versions <=1.71.2. In higher versions, it can attach but fails to hit breakpoints. By comparing the logs, I found that in higher versions of VS Code, the option "WindowsClient" was missing during the debugger initialization. I manually added it, and the breakpoints were successfully hit.

So, I reviewed the code of this plugin and found that the options "WindowsClient" and "UnixClient" were defined but not set according to "clientOS".