### PR TITLE
Always use environment path when running conda environment commands

### DIFF
--- a/src/client/pythonEnvironments/common/environmentManagers/conda.ts
+++ b/src/client/pythonEnvironments/common/environmentManagers/conda.ts
@@ -564,11 +564,8 @@ export class Conda {
             return undefined;
         }
         const args = [];
-        if (env.name) {
-            args.push('-n', env.name);
-        } else {
-            args.push('-p', env.prefix);
-        }
+        args.push('-p', env.prefix);
+
         const python = [
             forShellExecution ? this.shellCommand : this.command,
             'run',

--- a/src/test/common/process/pythonEnvironment.unit.test.ts
+++ b/src/test/common/process/pythonEnvironment.unit.test.ts
@@ -284,7 +284,7 @@ suite('CondaEnvironment', () => {
 
     teardown(() => sinon.restore());
 
-    test('getExecutionInfo with a named environment should return execution info using the environment name', async () => {
+    test('getExecutionInfo with a named environment should return execution info using the environment path', async () => {
         const condaInfo = { name: 'foo', path: 'bar' };
         const env = await createCondaEnv(condaInfo, processService.object, fileSystem.object);
 
@@ -292,8 +292,8 @@ suite('CondaEnvironment', () => {
 
         expect(result).to.deep.equal({
             command: condaFile,
-            args: ['run', '-n', condaInfo.name, '--no-capture-output', 'python', OUTPUT_MARKER_SCRIPT, ...args],
-            python: [condaFile, 'run', '-n', condaInfo.name, '--no-capture-output', 'python', OUTPUT_MARKER_SCRIPT],
+            args: ['run', '-p', condaInfo.path, '--no-capture-output', 'python', OUTPUT_MARKER_SCRIPT, ...args],
+            python: [condaFile, 'run', '-p', condaInfo.path, '--no-capture-output', 'python', OUTPUT_MARKER_SCRIPT],
             pythonExecutable: pythonPath,
         });
     });
@@ -312,12 +312,12 @@ suite('CondaEnvironment', () => {
         });
     });
 
-    test('getExecutionObservableInfo with a named environment should return execution info using conda full path with the name', async () => {
+    test('getExecutionObservableInfo with a named environment should return execution info using conda full path with the path', async () => {
         const condaInfo = { name: 'foo', path: 'bar' };
         const expected = {
             command: condaFile,
-            args: ['run', '-n', condaInfo.name, '--no-capture-output', 'python', OUTPUT_MARKER_SCRIPT, ...args],
-            python: [condaFile, 'run', '-n', condaInfo.name, '--no-capture-output', 'python', OUTPUT_MARKER_SCRIPT],
+            args: ['run', '-p', condaInfo.path, '--no-capture-output', 'python', OUTPUT_MARKER_SCRIPT, ...args],
+            python: [condaFile, 'run', '-p', condaInfo.path, '--no-capture-output', 'python', OUTPUT_MARKER_SCRIPT],
             pythonExecutable: pythonPath,
         };
         const env = await createCondaEnv(condaInfo, processService.object, fileSystem.object);

--- a/src/test/pythonEnvironments/common/environmentManagers/conda.unit.test.ts
+++ b/src/test/pythonEnvironments/common/environmentManagers/conda.unit.test.ts
@@ -536,7 +536,7 @@ suite('Conda and its environments are located correctly', () => {
         expect(args).to.not.equal(undefined);
         assert.deepStrictEqual(
             args,
-            ['conda', 'run', '-n', 'envName', '--no-capture-output', 'python', OUTPUT_MARKER_SCRIPT],
+            ['conda', 'run', '-p', 'envPrefix', '--no-capture-output', 'python', OUTPUT_MARKER_SCRIPT],
             'Incorrect args for case 1',
         );
 


### PR DESCRIPTION
Attempt at fixing https://github.com/microsoft/vscode-python/issues/24585

There are many edge scenarious where refering to the name of the environment rather than the path can cause breaks in the extension. Some examples 

1 -**If we have two anonymous environments with the same name in different folders**

/path1/my-env
/path2/my-env (where my active vscode python interpreter is)
by using conda -n my-env it'll always use the first env.

2 - **Some times people avoid actually activating their conda envs when using conda-pack** https://github.com/conda/conda-pack

This is because the activation scripts are known to be flaky and not very reliable

3 - **The environment may have been created by a conda-compliant replacement**

Therefore conda itself is not aware of it by name but can work with it properly using the path. This is the case of [hawk](https://community.palantir.com/t/introducing-hawk-for-python-package-management-in-code-repositories/500) or frankly anyone building their own conda package manager on top of [rattler](https://github.com/conda/rattler).


Some of these points are also hinted at https://github.com/microsoft/vscode-python/issues/24627#issuecomment-2584819147 , and supported by a conda maintainer in https://github.com/microsoft/vscode-python/issues/24585#issuecomment-2603071038

This PR has a minimal attempt at changing that by always forcing -p usage