### PR TITLE
Prevent python extension from overriding gitbash pwd

### DIFF
--- a/src/client/terminals/envCollectionActivation/service.ts
+++ b/src/client/terminals/envCollectionActivation/service.ts
@@ -472,6 +472,7 @@ function shouldSkip(env: string) {
         'PYTHONUTF8',
         // We have deactivate service which takes care of setting it.
         '_OLD_VIRTUAL_PATH',
+        'PWD',
     ].includes(env);
 }
 


### PR DESCRIPTION
Gitbash repro steps:
- Opt into Terminal Env Var experiment
- Make sure shell integration setting is on (generic terminal one)
- Be on Windows gitbash (with activated environment)
- You will see messed up prompt cwd 
