### PR TITLE
Ensure survey notification respects telemetry.disableFeedback setting

### DIFF
--- a/src/client/activation/extensionSurvey.ts
+++ b/src/client/activation/extensionSurvey.ts
@@ -6,7 +6,7 @@
 import { inject, injectable } from 'inversify';
 import * as querystring from 'querystring';
 import { env, UIKind } from 'vscode';
-import { IApplicationEnvironment, IApplicationShell } from '../common/application/types';
+import { IApplicationEnvironment, IApplicationShell, IWorkspaceService } from '../common/application/types';
 import { ShowExtensionSurveyPrompt } from '../common/experiments/groups';
 import '../common/extensions';
 import { IPlatformService } from '../common/platform/types';
@@ -37,6 +37,7 @@ export class ExtensionSurveyPrompt implements IExtensionSingleActivationService 
         @inject(IExperimentService) private experiments: IExperimentService,
         @inject(IApplicationEnvironment) private appEnvironment: IApplicationEnvironment,
         @inject(IPlatformService) private platformService: IPlatformService,
+        @inject(IWorkspaceService) private readonly workspace: IWorkspaceService,
         private sampleSizePerOneHundredUsers: number = 10,
         private waitTimeToShowSurvey: number = WAIT_TIME_TO_SHOW_SURVEY,
     ) {}
@@ -57,6 +58,18 @@ export class ExtensionSurveyPrompt implements IExtensionSingleActivationService 
         if (env.uiKind === UIKind?.Web) {
             return false;
         }
+
+        let feedbackDisabled = false;
+
+        const telemetryConfig = this.workspace.getConfiguration('telemetry');
+        if (telemetryConfig) {
+            feedbackDisabled = telemetryConfig.get<boolean>('disableFeedback', false);
+        }
+
+        if (feedbackDisabled) {
+            return false;
+        }
+
         const doNotShowSurveyAgain = this.persistentState.createGlobalPersistentState(
             extensionSurveyStateKeys.doNotShowAgain,
             false,


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-python/issues/24904

Follow up to https://github.com/microsoft/vscode/pull/243276

This is to ensure that we only show the survey feedback if VS Code's `telemetry.disableFeedback` setting isn't enabled 