### PR TITLE
Update condarc.json

### DIFF
--- a/schemas/condarc.json
+++ b/schemas/condarc.json
@@ -59,7 +59,14 @@
             }
         },
         "ssl_verify": {
-            "type": "boolean"
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "string"
+                }
+            ]
         },
         "offline": {
             "type": "boolean"


### PR DESCRIPTION
Hello!
[According to the docs](https://docs.conda.io/projects/conda/en/stable/user-guide/configuration/settings.html#ssl-verify-ssl-verification), the ssl_verify option should support strings (for certificate paths and `truststore`)