### PR TITLE
fix: terminal error notification in untrusted workspace

### DIFF
--- a/src/client/terminals/envCollectionActivation/shellIntegrationService.ts
+++ b/src/client/terminals/envCollectionActivation/shellIntegrationService.ts
@@ -15,6 +15,7 @@ import { IDisposableRegistry, IPersistentStateFactory } from '../../common/types
 import { sleep } from '../../common/utils/async';
 import { traceError, traceVerbose } from '../../logging';
 import { IShellIntegrationDetectionService } from '../types';
+import { isTrusted } from '../../common/vscodeApis/workspaceApis';
 
 /**
  * This is a list of shells which support shell integration:
@@ -151,10 +152,12 @@ export class ShellIntegrationDetectionService implements IShellIntegrationDetect
      * Creates a dummy terminal so that we are guaranteed a data write event for this shell type.
      */
     private createDummyHiddenTerminal(shell: string) {
-        this.terminalManager.createTerminal({
-            shellPath: shell,
-            hideFromUser: true,
-        });
+        if (isTrusted()) {
+            this.terminalManager.createTerminal({
+                shellPath: shell,
+                hideFromUser: true,
+            });
+        }
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-python/issues/24770

This call does not create a terminal in untrusted workspace. The call fails and creates a terminal failed notification. We should not be trying to create a terminal in untrusted workspace.