### PR TITLE
Added pylock to activationevents

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
         "workspaceContains:Pipfile",
         "workspaceContains:setup.py",
         "workspaceContains:requirements.txt",
+        "workspaceContains:pylock.toml",
+        "workspaceContains:**/pylock.*.toml",
         "workspaceContains:manage.py",
         "workspaceContains:app.py",
         "workspaceContains:.venv",


### PR DESCRIPTION
This fixes #25016

Added some changes to package.json, so that the extension gets activated whenever there is a file with the name `pylock.toml` or match the regular expression `r"^pylock\.([^.]+)\.toml$"`. 

I followed [PEP 751](https://peps.python.org/pep-0751/#file-name)'s naming specification.

![Screenshot (127)](https://github.com/user-attachments/assets/476abd9b-9251-457b-bdcc-ae3d3c16fd73)
