### PR TITLE
PYTHONSTARTUP should be injected regardless of terminalEnv experiment

### DIFF
--- a/src/client/terminals/envCollectionActivation/service.ts
+++ b/src/client/terminals/envCollectionActivation/service.ts
@@ -99,7 +99,6 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
         try {
             if (!inTerminalEnvVarExperiment(this.experimentService)) {
                 this.context.environmentVariableCollection.clear();
-                await registerPythonStartup(this.context);
                 await this.handleMicroVenv(resource);
                 if (!this.registeredOnce) {
                     this.interpreterService.onDidChangeInterpreter(
@@ -111,6 +110,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
                     );
                     this.registeredOnce = true;
                 }
+                await registerPythonStartup(this.context);
                 return;
             }
             if (!this.registeredOnce) {

--- a/src/client/terminals/envCollectionActivation/service.ts
+++ b/src/client/terminals/envCollectionActivation/service.ts
@@ -44,6 +44,7 @@ import {
 } from '../types';
 import { ProgressService } from '../../common/application/progressService';
 import { useEnvExtension } from '../../envExt/api.internal';
+import { registerPythonStartup } from '../pythonStartup';
 
 @injectable()
 export class TerminalEnvVarCollectionService implements IExtensionActivationService, ITerminalEnvVarCollectionService {
@@ -98,6 +99,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
         try {
             if (!inTerminalEnvVarExperiment(this.experimentService)) {
                 this.context.environmentVariableCollection.clear();
+                await registerPythonStartup(this.context);
                 await this.handleMicroVenv(resource);
                 if (!this.registeredOnce) {
                     this.interpreterService.onDidChangeInterpreter(

--- a/src/test/interpreters/activation/terminalEnvVarCollectionService.unit.test.ts
+++ b/src/test/interpreters/activation/terminalEnvVarCollectionService.unit.test.ts
@@ -6,12 +6,14 @@
 import * as sinon from 'sinon';
 import { assert, expect } from 'chai';
 import { mock, instance, when, anything, verify, reset } from 'ts-mockito';
+import * as TypeMoq from 'typemoq';
 import {
     EnvironmentVariableCollection,
     EnvironmentVariableMutatorOptions,
     GlobalEnvironmentVariableCollection,
     ProgressLocation,
     Uri,
+    WorkspaceConfiguration,
     WorkspaceFolder,
 } from 'vscode';
 import {
@@ -55,6 +57,7 @@ suite('Terminal Environment Variable Collection Service', () => {
     let terminalEnvVarCollectionService: TerminalEnvVarCollectionService;
     let terminalDeactivateService: ITerminalDeactivateService;
     let useEnvExtensionStub: sinon.SinonStub;
+    let pythonConfig: TypeMoq.IMock<WorkspaceConfiguration>;
     const progressOptions = {
         location: ProgressLocation.Window,
         title: Interpreters.activatingTerminals,
@@ -122,6 +125,8 @@ suite('Terminal Environment Variable Collection Service', () => {
             instance(shellIntegrationService),
             instance(envVarProvider),
         );
+        pythonConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
+        pythonConfig.setup((p) => p.get('terminal.shellIntegration.enabled')).returns(() => false);
     });
 
     teardown(() => {


### PR DESCRIPTION
Resolve: https://github.com/microsoft/vscode-python/issues/25013 

Python shell integration env var injection via env var collection was getting cleared undesirable, when user had opted out of terminal env var experiment.

We want to inject PYTHONSTARTUP regardless of the experiment, depending on user setting. 