### PR TITLE
watch pyrefly settings

### DIFF
--- a/src/client/languageServer/watcher.ts
+++ b/src/client/languageServer/watcher.ts
@@ -297,6 +297,8 @@ export class LanguageServerWatcher implements IExtensionActivationService, ILang
                 await this.refreshLanguageServer(resource);
             } else if (event.affectsConfiguration(`python.analysis.pylanceLspClientEnabled`, resource)) {
                 await this.refreshLanguageServer(resource, /* forced */ true);
+            } else if (event.affectsConfiguration(`python.pyrefly.disableLanguageServices`, resource)) {
+                await this.refreshLanguageServer(resource);
             }
         });
     }


### PR DESCRIPTION
I tested my [patch](https://github.com/microsoft/vscode-python/pull/24987?fbclid=IwZXh0bgNhZW0CMTEAYnJpZBExeXdndjR6U21jUDcwYWluVwEe9GIvZez2F32HhUOjgIw_mGhjcZkw2P4kp7LhmkV3AuFz-AdYGA3JjCnGwrc_aem_KhY9FN13JRNGfSyxp1RYKw) in pre-release this morning and it doesn't work in the following cases:
- on pyrefly setting change

https://github.com/user-attachments/assets/b010e0bb-9a63-4c70-9de3-08bd0f197346


- on install of pyrefly (it flickers but does nothing)


https://github.com/user-attachments/assets/921f612c-3bcd-45f2-a2cd-f1c60ede50b9



In the PR, I tested the config settings but not the watch behavior because I couldn't get Pylance working locally.

The first issue makes sense to me: I'm pretty sure I [should've kept this](https://github.com/microsoft/vscode-python/pull/24987?fbclid=IwZXh0bgNhZW0CMTEAYnJpZBExeXdndjR6U21jUDcwYWluVwEesd0ykWr6V4_F44rc3tK5793Y_gU2-iegUpZK7FrRrbAMsiL1YNpTeV1EMx4_aem_5I_U6hgOyoPkFZSZNQ3KTA#discussion_r2052655512) (fixed in this PR).

The second issue does not: we [refresh on settings changes](https://github.com/microsoft/vscode-python/blob/a3dd3aa1bca82be1fb5c44f04c689233010eaeab/src/client/languageServer/watcher.ts?fbclid=IwZXh0bgNhZW0CMTEAYnJpZBExeXdndjR6U21jUDcwYWluVwEeihSXwYuswd8ieEtrGycnGpCM2RwHeFB1k0MzRh_cWG5Re_Ejy4Ri6ELGbmw_aem_EJnaavheNaY9IZ5K6SqBUQ#L345) assuming this.languageServer != the new one. 

I'm still not able to test this locally: my windows machine is failing to compile right now. I will have access to a mac later today. In the meantime, I've patched pyrefly to change `python.languageServer` then change it back on activation and changes to the disableLanguageServices setting. 

I'm looking for advice:
- Is it too late to put this in the pre-release? (likely, but that is OK with me because of my patch)
- Any idea why Pylance is not disabled on install of pyrefly?