### PR TITLE
Prefer using Notebook tools over Python tools for notebooks

### DIFF
--- a/src/client/chat/configurePythonEnvTool.ts
+++ b/src/client/chat/configurePythonEnvTool.ts
@@ -19,7 +19,7 @@ import { PythonExtension, ResolvedEnvironment } from '../api/types';
 import { IServiceContainer } from '../ioc/types';
 import { ICodeExecutionService } from '../terminals/types';
 import { TerminalCodeExecutionProvider } from '../terminals/codeExecution/terminalCodeExecution';
-import { getEnvironmentDetails, raceCancellationError } from './utils';
+import { getEnvironmentDetails, raceCancellationError, throwIfNotebookUri } from './utils';
 import { resolveFilePath } from './utils';
 import { IRecommendedEnvironmentService } from '../interpreter/configuration/types';
 import { ITerminalHelper } from '../common/terminal/types';
@@ -135,6 +135,7 @@ export class ConfigurePythonEnvTool implements LanguageModelTool<IResourceRefere
             return {};
         }
         const resource = resolveFilePath(options.input.resourcePath);
+        throwIfNotebookUri(resource);
         const recommededEnv = await this.recommendedEnvService.getRecommededEnvironment(resource);
         // Already selected workspace env, hence nothing to do.
         if (recommededEnv?.reason === 'workspaceUserSelected' && workspace.workspaceFolders?.length) {

--- a/src/client/chat/configurePythonEnvTool.ts
+++ b/src/client/chat/configurePythonEnvTool.ts
@@ -19,7 +19,7 @@ import { PythonExtension, ResolvedEnvironment } from '../api/types';
 import { IServiceContainer } from '../ioc/types';
 import { ICodeExecutionService } from '../terminals/types';
 import { TerminalCodeExecutionProvider } from '../terminals/codeExecution/terminalCodeExecution';
-import { getEnvironmentDetails, raceCancellationError, throwIfNotebookUri } from './utils';
+import { getEnvironmentDetails, getToolResponseIfNotebook, raceCancellationError } from './utils';
 import { resolveFilePath } from './utils';
 import { IRecommendedEnvironmentService } from '../interpreter/configuration/types';
 import { ITerminalHelper } from '../common/terminal/types';
@@ -68,6 +68,11 @@ export class ConfigurePythonEnvTool implements LanguageModelTool<IResourceRefere
         token: CancellationToken,
     ): Promise<LanguageModelToolResult> {
         const resource = resolveFilePath(options.input.resourcePath);
+        const notebookResponse = getToolResponseIfNotebook(resource);
+        if (notebookResponse) {
+            return notebookResponse;
+        }
+
         const recommededEnv = await this.recommendedEnvService.getRecommededEnvironment(resource);
         // Already selected workspace env, hence nothing to do.
         if (recommededEnv?.reason === 'workspaceUserSelected' && workspace.workspaceFolders?.length) {
@@ -135,7 +140,9 @@ export class ConfigurePythonEnvTool implements LanguageModelTool<IResourceRefere
             return {};
         }
         const resource = resolveFilePath(options.input.resourcePath);
-        throwIfNotebookUri(resource);
+        if (getToolResponseIfNotebook(resource)) {
+            return {};
+        }
         const recommededEnv = await this.recommendedEnvService.getRecommededEnvironment(resource);
         // Already selected workspace env, hence nothing to do.
         if (recommededEnv?.reason === 'workspaceUserSelected' && workspace.workspaceFolders?.length) {

--- a/src/client/chat/getExecutableTool.ts
+++ b/src/client/chat/getExecutableTool.ts
@@ -16,7 +16,7 @@ import { PythonExtension } from '../api/types';
 import { IServiceContainer } from '../ioc/types';
 import { ICodeExecutionService } from '../terminals/types';
 import { TerminalCodeExecutionProvider } from '../terminals/codeExecution/terminalCodeExecution';
-import { getEnvDisplayName, getEnvironmentDetails, raceCancellationError, throwIfNotebookUri } from './utils';
+import { getEnvDisplayName, getEnvironmentDetails, getToolResponseIfNotebook, raceCancellationError } from './utils';
 import { resolveFilePath } from './utils';
 import { traceError } from '../logging';
 import { ITerminalHelper } from '../common/terminal/types';
@@ -46,6 +46,10 @@ export class GetExecutableTool implements LanguageModelTool<IResourceReference> 
         token: CancellationToken,
     ): Promise<LanguageModelToolResult> {
         const resourcePath = resolveFilePath(options.input.resourcePath);
+        const notebookResponse = getToolResponseIfNotebook(resourcePath);
+        if (notebookResponse) {
+            return notebookResponse;
+        }
 
         try {
             const message = await getEnvironmentDetails(
@@ -72,7 +76,10 @@ export class GetExecutableTool implements LanguageModelTool<IResourceReference> 
         token: CancellationToken,
     ): Promise<PreparedToolInvocation> {
         const resourcePath = resolveFilePath(options.input.resourcePath);
-        throwIfNotebookUri(resourcePath);
+        if (getToolResponseIfNotebook(resourcePath)) {
+            return {};
+        }
+
         const envName = await raceCancellationError(getEnvDisplayName(this.discovery, resourcePath, this.api), token);
         return {
             invocationMessage: envName

--- a/src/client/chat/getExecutableTool.ts
+++ b/src/client/chat/getExecutableTool.ts
@@ -16,7 +16,7 @@ import { PythonExtension } from '../api/types';
 import { IServiceContainer } from '../ioc/types';
 import { ICodeExecutionService } from '../terminals/types';
 import { TerminalCodeExecutionProvider } from '../terminals/codeExecution/terminalCodeExecution';
-import { getEnvDisplayName, getEnvironmentDetails, raceCancellationError } from './utils';
+import { getEnvDisplayName, getEnvironmentDetails, raceCancellationError, throwIfNotebookUri } from './utils';
 import { resolveFilePath } from './utils';
 import { traceError } from '../logging';
 import { ITerminalHelper } from '../common/terminal/types';
@@ -72,6 +72,7 @@ export class GetExecutableTool implements LanguageModelTool<IResourceReference> 
         token: CancellationToken,
     ): Promise<PreparedToolInvocation> {
         const resourcePath = resolveFilePath(options.input.resourcePath);
+        throwIfNotebookUri(resourcePath);
         const envName = await raceCancellationError(getEnvDisplayName(this.discovery, resourcePath, this.api), token);
         return {
             invocationMessage: envName

--- a/src/client/chat/getPythonEnvTool.ts
+++ b/src/client/chat/getPythonEnvTool.ts
@@ -17,7 +17,7 @@ import { IServiceContainer } from '../ioc/types';
 import { ICodeExecutionService } from '../terminals/types';
 import { TerminalCodeExecutionProvider } from '../terminals/codeExecution/terminalCodeExecution';
 import { IProcessServiceFactory, IPythonExecutionFactory } from '../common/process/types';
-import { getEnvironmentDetails, raceCancellationError } from './utils';
+import { getEnvironmentDetails, raceCancellationError, throwIfNotebookUri } from './utils';
 import { resolveFilePath } from './utils';
 import { getPythonPackagesResponse } from './listPackagesTool';
 import { ITerminalHelper } from '../common/terminal/types';
@@ -91,9 +91,11 @@ export class GetEnvironmentInfoTool implements LanguageModelTool<IResourceRefere
     }
 
     async prepareInvocation?(
-        _options: LanguageModelToolInvocationPrepareOptions<IResourceReference>,
+        options: LanguageModelToolInvocationPrepareOptions<IResourceReference>,
         _token: CancellationToken,
     ): Promise<PreparedToolInvocation> {
+        const resourcePath = resolveFilePath(options.input.resourcePath);
+        throwIfNotebookUri(resourcePath);
         return {
             invocationMessage: l10n.t('Fetching Python environment information'),
         };

--- a/src/client/chat/getPythonEnvTool.ts
+++ b/src/client/chat/getPythonEnvTool.ts
@@ -17,7 +17,7 @@ import { IServiceContainer } from '../ioc/types';
 import { ICodeExecutionService } from '../terminals/types';
 import { TerminalCodeExecutionProvider } from '../terminals/codeExecution/terminalCodeExecution';
 import { IProcessServiceFactory, IPythonExecutionFactory } from '../common/process/types';
-import { getEnvironmentDetails, raceCancellationError, throwIfNotebookUri } from './utils';
+import { getEnvironmentDetails, getToolResponseIfNotebook, raceCancellationError } from './utils';
 import { resolveFilePath } from './utils';
 import { getPythonPackagesResponse } from './listPackagesTool';
 import { ITerminalHelper } from '../common/terminal/types';
@@ -55,6 +55,10 @@ export class GetEnvironmentInfoTool implements LanguageModelTool<IResourceRefere
         token: CancellationToken,
     ): Promise<LanguageModelToolResult> {
         const resourcePath = resolveFilePath(options.input.resourcePath);
+        const notebookResponse = getToolResponseIfNotebook(resourcePath);
+        if (notebookResponse) {
+            return notebookResponse;
+        }
 
         try {
             // environment
@@ -95,7 +99,10 @@ export class GetEnvironmentInfoTool implements LanguageModelTool<IResourceRefere
         _token: CancellationToken,
     ): Promise<PreparedToolInvocation> {
         const resourcePath = resolveFilePath(options.input.resourcePath);
-        throwIfNotebookUri(resourcePath);
+        if (getToolResponseIfNotebook(resourcePath)) {
+            return {};
+        }
+
         return {
             invocationMessage: l10n.t('Fetching Python environment information'),
         };

--- a/src/client/chat/installPackagesTool.ts
+++ b/src/client/chat/installPackagesTool.ts
@@ -14,7 +14,7 @@ import {
 } from 'vscode';
 import { PythonExtension } from '../api/types';
 import { IServiceContainer } from '../ioc/types';
-import { getEnvDisplayName, raceCancellationError } from './utils';
+import { getEnvDisplayName, raceCancellationError, throwIfNotebookUri } from './utils';
 import { resolveFilePath } from './utils';
 import { IModuleInstaller } from '../common/installer/types';
 import { ModuleInstallerType } from '../pythonEnvironments/info';
@@ -84,6 +84,7 @@ export class InstallPackagesTool implements LanguageModelTool<IInstallPackageArg
     ): Promise<PreparedToolInvocation> {
         const resourcePath = resolveFilePath(options.input.resourcePath);
         const packageCount = options.input.packageList.length;
+        throwIfNotebookUri(resourcePath);
 
         const envName = await raceCancellationError(getEnvDisplayName(this.discovery, resourcePath, this.api), token);
         let title = '';

--- a/src/client/chat/installPackagesTool.ts
+++ b/src/client/chat/installPackagesTool.ts
@@ -14,7 +14,7 @@ import {
 } from 'vscode';
 import { PythonExtension } from '../api/types';
 import { IServiceContainer } from '../ioc/types';
-import { getEnvDisplayName, raceCancellationError, throwIfNotebookUri } from './utils';
+import { getEnvDisplayName, getToolResponseIfNotebook, raceCancellationError } from './utils';
 import { resolveFilePath } from './utils';
 import { IModuleInstaller } from '../common/installer/types';
 import { ModuleInstallerType } from '../pythonEnvironments/info';
@@ -45,6 +45,10 @@ export class InstallPackagesTool implements LanguageModelTool<IInstallPackageArg
         const resourcePath = resolveFilePath(options.input.resourcePath);
         const packageCount = options.input.packageList.length;
         const packagePlurality = packageCount === 1 ? 'package' : 'packages';
+        const notebookResponse = getToolResponseIfNotebook(resourcePath);
+        if (notebookResponse) {
+            return notebookResponse;
+        }
 
         try {
             // environment
@@ -84,7 +88,9 @@ export class InstallPackagesTool implements LanguageModelTool<IInstallPackageArg
     ): Promise<PreparedToolInvocation> {
         const resourcePath = resolveFilePath(options.input.resourcePath);
         const packageCount = options.input.packageList.length;
-        throwIfNotebookUri(resourcePath);
+        if (getToolResponseIfNotebook(resourcePath)) {
+            return {};
+        }
 
         const envName = await raceCancellationError(getEnvDisplayName(this.discovery, resourcePath, this.api), token);
         let title = '';

--- a/src/client/chat/utils.ts
+++ b/src/client/chat/utils.ts
@@ -7,7 +7,6 @@ import {
     extensions,
     LanguageModelTextPart,
     LanguageModelToolResult,
-    NotebookDocument,
     Uri,
     workspace,
 } from 'vscode';


### PR DESCRIPTION
@karthiknadig @eleanorjboyd @rebornix @amunger 
This change will change how the Python tools work.
The python tools will no longer work with Notebooks.
Previously it would,

From my testing, this change works perfectly well.

I think thats fraught with danger.  There are a lot of things to consider.
**Ideally there should ever be only one way of doing things, whether its local/remote/python/non-python notebooks.**

