### PR TITLE
Remove single quotes surrounding displayed venv

### DIFF
--- a/src/client/pythonEnvironments/nativeAPI.ts
+++ b/src/client/pythonEnvironments/nativeAPI.ts
@@ -112,14 +112,14 @@ function getDisplayName(version: PythonVersion, kind: PythonEnvKind, arch: Archi
     const kindStr = kindToShortString(kind);
     if (arch === Architecture.x86) {
         if (kindStr) {
-            return name ? `Python ${versionStr} 32-bit ('${name}')` : `Python ${versionStr} 32-bit (${kindStr})`;
+            return name ? `Python ${versionStr} 32-bit (${name})` : `Python ${versionStr} 32-bit (${kindStr})`;
         }
-        return name ? `Python ${versionStr} 32-bit ('${name}')` : `Python ${versionStr} 32-bit`;
+        return name ? `Python ${versionStr} 32-bit (${name})` : `Python ${versionStr} 32-bit`;
     }
     if (kindStr) {
-        return name ? `Python ${versionStr} ('${name}')` : `Python ${versionStr} (${kindStr})`;
+        return name ? `Python ${versionStr} (${name})` : `Python ${versionStr} (${kindStr})`;
     }
-    return name ? `Python ${versionStr} ('${name}')` : `Python ${versionStr}`;
+    return name ? `Python ${versionStr} (${name})` : `Python ${versionStr}`;
 }
 
 function validEnv(nativeEnv: NativeEnvInfo): boolean {

--- a/src/test/pythonEnvironments/nativeAPI.unit.test.ts
+++ b/src/test/pythonEnvironments/nativeAPI.unit.test.ts
@@ -53,8 +53,8 @@ suite('Native Python API', () => {
     const expectedBasicEnv: PythonEnvInfo = {
         arch: Architecture.Unknown,
         id: '/usr/bin/python',
-        detailedDisplayName: "Python 3.12.0 ('basic_python')",
-        display: "Python 3.12.0 ('basic_python')",
+        detailedDisplayName: 'Python 3.12.0 (basic_python)',
+        display: 'Python 3.12.0 (basic_python)',
         distro: { org: '' },
         executable: { filename: '/usr/bin/python', sysPrefix: '/usr/bin', ctime: -1, mtime: -1 },
         kind: PythonEnvKind.System,
@@ -98,8 +98,8 @@ suite('Native Python API', () => {
 
     const expectedConda1: PythonEnvInfo = {
         arch: Architecture.Unknown,
-        detailedDisplayName: "Python 3.12.0 ('conda_python')",
-        display: "Python 3.12.0 ('conda_python')",
+        detailedDisplayName: 'Python 3.12.0 (conda_python)',
+        display: 'Python 3.12.0 (conda_python)',
         distro: { org: '' },
         id: '/home/user/.conda/envs/conda_python/python',
         executable: {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-python/issues/23978

Removed single quotes both from the Select Interpreter list:
![Screenshot from 2025-05-22 17-35-29](https://github.com/user-attachments/assets/6ba1df87-51c9-4cdf-9231-abd84bd4abf7)

And also from the status bar:
![Screenshot from 2025-05-22 17-36-00](https://github.com/user-attachments/assets/472a63b7-45ab-435e-9923-612c8c32941c)
