### PR TITLE
Configuration tool with improved workflow and UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1475,6 +1475,7 @@
                 "modelDescription": "This tool will retrieve the details of the Python Environment for the specified file or workspace. The details returned include the 1. Type of Environment (conda, venv, etec), 2. Version of Python, 3. List of all installed packages with their versions. ALWAYS call configure_python_environment before using this tool.",
                 "toolReferenceName": "pythonGetEnvironmentInfo",
                 "tags": [
+                    "extension_installed_by_tool",
                     "enable_other_tool_configure_python_environment"
                 ],
                 "icon": "$(snake)",
@@ -1498,6 +1499,7 @@
                 "modelDescription": "This tool will retrieve the details of the Python Environment for the specified file or workspace. ALWAYS use this tool before executing any Python command in the terminal. This tool returns the details of how to construct the fully qualified path and or command including details such as arguments required to run Python in a terminal. Note: Instead of executing `python --version` or `python -c 'import sys; print(sys.executable)'`, use this tool to get the Python executable path to replace the `python` command. E.g. instead of using `python -c 'import sys; print(sys.executable)'`, use this tool to build the command `conda run -n <env_name> -c 'import sys; print(sys.executable)'`. ALWAYS call configure_python_environment before using this tool.",
                 "toolReferenceName": "pythonExecutableCommand",
                 "tags": [
+                    "extension_installed_by_tool",
                     "enable_other_tool_configure_python_environment"
                 ],
                 "icon": "$(terminal)",
@@ -1521,6 +1523,7 @@
                 "modelDescription": "Installs Python packages in the given workspace. Use this tool to install packages in the user's chosen environment. ALWAYS call configure_python_environment before using this tool.",
                 "toolReferenceName": "pythonInstallPackage",
                 "tags": [
+                    "extension_installed_by_tool",
                     "enable_other_tool_configure_python_environment"
                 ],
                 "icon": "$(package)",
@@ -1552,7 +1555,9 @@
                 "modelDescription": "This tool configures a Python environment in the given workspace. ALWAYS Use this tool to set up the user's chosen environment and ALWAYS call this tool before using any other Python related tools.",
                 "userDescription": "%python.languageModelTools.configure_python_environment.userDescription%",
                 "toolReferenceName": "configurePythonEnvironment",
-                "tags": [],
+                "tags": [
+                    "extension_installed_by_tool"
+                ],
                 "icon": "$(gear)",
                 "canBeReferencedInPrompt": true,
                 "inputSchema": {
@@ -1566,6 +1571,46 @@
                     "required": []
                 },
                 "when": "!pythonEnvExtensionInstalled"
+            },
+            {
+                "name": "create_virtual_environment",
+                "displayName": "Create a Virtual Environment",
+                "modelDescription": "This tool will create a Virual Environment",
+                "tags": [
+                    "extension_installed_by_tool"
+                ],
+                "canBeReferencedInPrompt": false,
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "resourcePath": {
+                            "type": "string",
+                            "description": "The path to the Python file or workspace for which a Python Environment needs to be configured."
+                        }
+                    },
+                    "required": []
+                },
+                "when": "false"
+            },
+            {
+                "name": "selectEnvironment",
+                "displayName": "Select a Python Environment",
+                "modelDescription": "This tool will prompt the user to select an existing Python Environment",
+                "tags": [
+                    "extension_installed_by_tool"
+                ],
+                "canBeReferencedInPrompt": false,
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "resourcePath": {
+                            "type": "string",
+                            "description": "The path to the Python file or workspace for which a Python Environment needs to be configured."
+                        }
+                    },
+                    "required": []
+                },
+                "when": "false"
             }
         ]
     },

--- a/src/client/chat/configurePythonEnvTool.ts
+++ b/src/client/chat/configurePythonEnvTool.ts
@@ -3,8 +3,6 @@
 
 import {
     CancellationToken,
-    l10n,
-    LanguageModelTextPart,
     LanguageModelTool,
     LanguageModelToolInvocationOptions,
     LanguageModelToolInvocationPrepareOptions,
@@ -12,32 +10,25 @@ import {
     PreparedToolInvocation,
     Uri,
     workspace,
-    commands,
-    QuickPickItem,
+    lm,
 } from 'vscode';
-import { PythonExtension, ResolvedEnvironment } from '../api/types';
+import { PythonExtension } from '../api/types';
 import { IServiceContainer } from '../ioc/types';
 import { ICodeExecutionService } from '../terminals/types';
 import { TerminalCodeExecutionProvider } from '../terminals/codeExecution/terminalCodeExecution';
-import { getEnvironmentDetails, getToolResponseIfNotebook, raceCancellationError } from './utils';
+import {
+    getEnvDetailsForResponse,
+    getToolResponseIfNotebook,
+    IResourceReference,
+    isCancellationError,
+    raceCancellationError,
+} from './utils';
 import { resolveFilePath } from './utils';
-import { IRecommendedEnvironmentService } from '../interpreter/configuration/types';
 import { ITerminalHelper } from '../common/terminal/types';
-import { raceTimeout } from '../common/utils/async';
-import { Commands, Octicons } from '../common/constants';
-import { CreateEnvironmentResult } from '../pythonEnvironments/creation/proposed.createEnvApis';
-import { IInterpreterPathService } from '../common/types';
-import { DisposableStore } from '../common/utils/resourceLifecycle';
-import { Common, InterpreterQuickPickList } from '../common/utils/localize';
-import { QuickPickItemKind } from '../../test/mocks/vsc';
-import { showQuickPick } from '../common/vscodeApis/windowApis';
-import { SelectEnvironmentResult } from '../interpreter/configuration/interpreterSelector/commands/setInterpreter';
-
-export interface IResourceReference {
-    resourcePath?: string;
-}
-
-let _environmentConfigured = false;
+import { IRecommendedEnvironmentService } from '../interpreter/configuration/types';
+import { IDiscoveryAPI } from '../pythonEnvironments/base/locator';
+import { CreateVirtualEnvTool } from './createVirtualEnvTool';
+import { SelectPythonEnvTool } from './selectEnvTool';
 
 export class ConfigurePythonEnvTool implements LanguageModelTool<IResourceReference> {
     private readonly terminalExecutionService: TerminalCodeExecutionProvider;
@@ -45,6 +36,7 @@ export class ConfigurePythonEnvTool implements LanguageModelTool<IResourceRefere
     private readonly recommendedEnvService: IRecommendedEnvironmentService;
     public static readonly toolName = 'configure_python_environment';
     constructor(
+        private readonly discoveryApi: IDiscoveryAPI,
         private readonly api: PythonExtension['environments'],
         private readonly serviceContainer: IServiceContainer,
     ) {
@@ -57,12 +49,7 @@ export class ConfigurePythonEnvTool implements LanguageModelTool<IResourceRefere
             IRecommendedEnvironmentService,
         );
     }
-    /**
-     * Invokes the tool to get the information about the Python environment.
-     * @param options - The invocation options containing the file path.
-     * @param token - The cancellation token.
-     * @returns The result containing the information about the Python environment or an error message.
-     */
+
     async invoke(
         options: LanguageModelToolInvocationOptions<IResourceReference>,
         token: CancellationToken,
@@ -73,22 +60,14 @@ export class ConfigurePythonEnvTool implements LanguageModelTool<IResourceRefere
             return notebookResponse;
         }
 
-        const recommededEnv = await this.recommendedEnvService.getRecommededEnvironment(resource);
-        // Already selected workspace env, hence nothing to do.
-        if (recommededEnv?.reason === 'workspaceUserSelected' && workspace.workspaceFolders?.length) {
-            return await getEnvDetailsForResponse(
-                recommededEnv.environment,
-                this.api,
-                this.terminalExecutionService,
-                this.terminalHelper,
-                resource,
-                token,
-            );
-        }
-        // No workspace folders, and the user selected a global environment.
-        if (recommededEnv?.reason === 'globalUserSelected' && !workspace.workspaceFolders?.length) {
-            return await getEnvDetailsForResponse(
-                recommededEnv.environment,
+        const workspaceSpecificEnv = await raceCancellationError(
+            this.hasAlreadyGotAWorkspaceSpecificEnvironment(resource),
+            token,
+        );
+
+        if (workspaceSpecificEnv) {
+            return getEnvDetailsForResponse(
+                workspaceSpecificEnv,
                 this.api,
                 this.terminalExecutionService,
                 this.terminalHelper,
@@ -97,174 +76,46 @@ export class ConfigurePythonEnvTool implements LanguageModelTool<IResourceRefere
             );
         }
 
-        if (!workspace.workspaceFolders?.length) {
-            const selected = await Promise.resolve(commands.executeCommand(Commands.Set_Interpreter));
-            const env = await this.api.resolveEnvironment(this.api.getActiveEnvironmentPath(resource));
-            if (selected && env) {
-                return await getEnvDetailsForResponse(
-                    env,
-                    this.api,
-                    this.terminalExecutionService,
-                    this.terminalHelper,
-                    resource,
-                    token,
-                );
+        let reason: 'cancelled' | undefined;
+        if (
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
+            await new CreateVirtualEnvTool(this.discoveryApi, this.api, this.serviceContainer).canCreateNewVirtualEnv(
+                resolveFilePath(options.input.resourcePath),
+                token,
+            )
+        ) {
+            reason = 'cancelled';
+            try {
+                return await lm.invokeTool(CreateVirtualEnvTool.toolName, options, token);
+            } catch (ex) {
+                // If the user cancelled the tool, then we should not invoke the select env tool.
+                if (!isCancellationError(ex)) {
+                    throw ex;
+                }
             }
-            return new LanguageModelToolResult([
-                new LanguageModelTextPart('User did not select a Python environment.'),
-            ]);
         }
 
-        const selected = await showCreateAndSelectEnvironmentQuickPick(resource, this.serviceContainer);
-        const env = await this.api.resolveEnvironment(this.api.getActiveEnvironmentPath(resource));
-        if (selected && env) {
-            return await getEnvDetailsForResponse(
-                env,
-                this.api,
-                this.terminalExecutionService,
-                this.terminalHelper,
-                resource,
-                token,
-            );
-        }
-        return new LanguageModelToolResult([
-            new LanguageModelTextPart('User did not create nor select a Python environment.'),
-        ]);
+        return lm.invokeTool(SelectPythonEnvTool.toolName, { ...options, input: { ...options.input, reason } }, token);
     }
 
     async prepareInvocation?(
-        options: LanguageModelToolInvocationPrepareOptions<IResourceReference>,
+        _options: LanguageModelToolInvocationPrepareOptions<IResourceReference>,
         _token: CancellationToken,
     ): Promise<PreparedToolInvocation> {
-        if (_environmentConfigured) {
-            return {};
-        }
-        const resource = resolveFilePath(options.input.resourcePath);
-        if (getToolResponseIfNotebook(resource)) {
-            return {};
-        }
+        return {
+            invocationMessage: 'Configuring a Python Environment',
+        };
+    }
+
+    async hasAlreadyGotAWorkspaceSpecificEnvironment(resource: Uri | undefined) {
         const recommededEnv = await this.recommendedEnvService.getRecommededEnvironment(resource);
         // Already selected workspace env, hence nothing to do.
         if (recommededEnv?.reason === 'workspaceUserSelected' && workspace.workspaceFolders?.length) {
-            return {};
+            return recommededEnv.environment;
         }
         // No workspace folders, and the user selected a global environment.
         if (recommededEnv?.reason === 'globalUserSelected' && !workspace.workspaceFolders?.length) {
-            return {};
-        }
-
-        if (!workspace.workspaceFolders?.length) {
-            return {
-                confirmationMessages: {
-                    title: l10n.t('Configure a Python Environment?'),
-                    message: l10n.t('You will be prompted to select a Python Environment.'),
-                },
-            };
-        }
-        return {
-            confirmationMessages: {
-                title: l10n.t('Configure a Python Environment?'),
-                message: l10n.t(
-                    [
-                        'The recommended option is to create a new Python Environment, providing the benefit of isolating packages from other environments.  ',
-                        'Optionally you could select an existing Python Environment.',
-                    ].join('\n'),
-                ),
-            },
-        };
-    }
-}
-
-async function getEnvDetailsForResponse(
-    environment: ResolvedEnvironment | undefined,
-    api: PythonExtension['environments'],
-    terminalExecutionService: TerminalCodeExecutionProvider,
-    terminalHelper: ITerminalHelper,
-    resource: Uri | undefined,
-    token: CancellationToken,
-): Promise<LanguageModelToolResult> {
-    const envPath = api.getActiveEnvironmentPath(resource);
-    environment = environment || (await raceCancellationError(api.resolveEnvironment(envPath), token));
-    if (!environment || !environment.version) {
-        throw new Error('No environment found for the provided resource path: ' + resource?.fsPath);
-    }
-    const message = await getEnvironmentDetails(
-        resource,
-        api,
-        terminalExecutionService,
-        terminalHelper,
-        undefined,
-        token,
-    );
-    return new LanguageModelToolResult([
-        new LanguageModelTextPart(`A Python Environment has been configured.  \n` + message),
-    ]);
-}
-
-async function showCreateAndSelectEnvironmentQuickPick(
-    uri: Uri | undefined,
-    serviceContainer: IServiceContainer,
-): Promise<boolean | undefined> {
-    const createLabel = `${Octicons.Add} ${InterpreterQuickPickList.create.label}`;
-    const selectLabel = l10n.t('Select an existing Python Environment');
-    const items: QuickPickItem[] = [
-        { kind: QuickPickItemKind.Separator, label: Common.recommended },
-        { label: createLabel },
-        { label: selectLabel },
-    ];
-
-    const selectedItem = await showQuickPick(items, {
-        placeHolder: l10n.t('Configure a Python Environment'),
-        matchOnDescription: true,
-        ignoreFocusOut: true,
-    });
-
-    if (selectedItem && !Array.isArray(selectedItem) && selectedItem.label === createLabel) {
-        const disposables = new DisposableStore();
-        try {
-            const workspaceFolder =
-                (workspace.workspaceFolders?.length && uri ? workspace.getWorkspaceFolder(uri) : undefined) ||
-                (workspace.workspaceFolders?.length === 1 ? workspace.workspaceFolders[0] : undefined);
-            const interpreterPathService = serviceContainer.get<IInterpreterPathService>(IInterpreterPathService);
-            const interpreterChanged = new Promise<void>((resolve) => {
-                disposables.add(interpreterPathService.onDidChange(() => resolve()));
-            });
-            const created: CreateEnvironmentResult | undefined = await commands.executeCommand(
-                Commands.Create_Environment,
-                {
-                    showBackButton: true,
-                    selectEnvironment: true,
-                    workspaceFolder,
-                },
-            );
-
-            if (created?.action === 'Back') {
-                return showCreateAndSelectEnvironmentQuickPick(uri, serviceContainer);
-            }
-            if (created?.action === 'Cancel') {
-                return undefined;
-            }
-            if (created?.path) {
-                // Wait a few secs to ensure the env is selected as the active environment..
-                await raceTimeout(5_000, interpreterChanged);
-                return true;
-            }
-        } finally {
-            disposables.dispose();
-        }
-    }
-    if (selectedItem && !Array.isArray(selectedItem) && selectedItem.label === selectLabel) {
-        const result = (await Promise.resolve(
-            commands.executeCommand(Commands.Set_Interpreter, { hideCreateVenv: true, showBackButton: true }),
-        )) as SelectEnvironmentResult | undefined;
-        if (result?.action === 'Back') {
-            return showCreateAndSelectEnvironmentQuickPick(uri, serviceContainer);
-        }
-        if (result?.action === 'Cancel') {
-            return undefined;
-        }
-        if (result?.path) {
-            return true;
+            return recommededEnv.environment;
         }
     }
 }

--- a/src/client/chat/configurePythonEnvTool.ts
+++ b/src/client/chat/configurePythonEnvTool.ts
@@ -26,7 +26,6 @@ import {
 import { resolveFilePath } from './utils';
 import { ITerminalHelper } from '../common/terminal/types';
 import { IRecommendedEnvironmentService } from '../interpreter/configuration/types';
-import { IDiscoveryAPI } from '../pythonEnvironments/base/locator';
 import { CreateVirtualEnvTool } from './createVirtualEnvTool';
 import { SelectPythonEnvTool } from './selectEnvTool';
 
@@ -36,9 +35,9 @@ export class ConfigurePythonEnvTool implements LanguageModelTool<IResourceRefere
     private readonly recommendedEnvService: IRecommendedEnvironmentService;
     public static readonly toolName = 'configure_python_environment';
     constructor(
-        private readonly discoveryApi: IDiscoveryAPI,
         private readonly api: PythonExtension['environments'],
         private readonly serviceContainer: IServiceContainer,
+        private readonly createVirtualEnvTool: CreateVirtualEnvTool,
     ) {
         this.terminalExecutionService = this.serviceContainer.get<TerminalCodeExecutionProvider>(
             ICodeExecutionService,
@@ -78,11 +77,7 @@ export class ConfigurePythonEnvTool implements LanguageModelTool<IResourceRefere
 
         let reason: 'cancelled' | undefined;
         if (
-            // eslint-disable-next-line @typescript-eslint/no-use-before-define
-            await new CreateVirtualEnvTool(this.discoveryApi, this.api, this.serviceContainer).canCreateNewVirtualEnv(
-                resolveFilePath(options.input.resourcePath),
-                token,
-            )
+            await this.createVirtualEnvTool.canCreateNewVirtualEnv(resolveFilePath(options.input.resourcePath), token)
         ) {
             reason = 'cancelled';
             try {

--- a/src/client/chat/createVirtualEnvTool.ts
+++ b/src/client/chat/createVirtualEnvTool.ts
@@ -1,0 +1,191 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {
+    CancellationToken,
+    l10n,
+    LanguageModelTool,
+    LanguageModelToolInvocationOptions,
+    LanguageModelToolInvocationPrepareOptions,
+    LanguageModelToolResult,
+    PreparedToolInvocation,
+    Uri,
+    workspace,
+} from 'vscode';
+import { PythonExtension } from '../api/types';
+import { IServiceContainer } from '../ioc/types';
+import { ICodeExecutionService } from '../terminals/types';
+import { TerminalCodeExecutionProvider } from '../terminals/codeExecution/terminalCodeExecution';
+import {
+    doesWorkspaceHaveVenvOrCondaEnv,
+    getDisplayVersion,
+    getEnvDetailsForResponse,
+    IResourceReference,
+    raceCancellationError,
+} from './utils';
+import { resolveFilePath } from './utils';
+import { ITerminalHelper } from '../common/terminal/types';
+import { raceTimeout } from '../common/utils/async';
+import { IInterpreterPathService } from '../common/types';
+import { DisposableStore } from '../common/utils/resourceLifecycle';
+import { IRecommendedEnvironmentService } from '../interpreter/configuration/types';
+import { EnvironmentType } from '../pythonEnvironments/info';
+import { IDiscoveryAPI } from '../pythonEnvironments/base/locator';
+import { convertEnvInfoToPythonEnvironment } from '../pythonEnvironments/legacyIOC';
+import { sortInterpreters } from '../interpreter/helpers';
+import { isStableVersion } from '../pythonEnvironments/info/pythonVersion';
+import { createVirtualEnvironment } from '../pythonEnvironments/creation/createEnvApi';
+
+export class CreateVirtualEnvTool implements LanguageModelTool<IResourceReference> {
+    private readonly terminalExecutionService: TerminalCodeExecutionProvider;
+    private readonly terminalHelper: ITerminalHelper;
+    private readonly recommendedEnvService: IRecommendedEnvironmentService;
+
+    public static readonly toolName = 'create_virtual_environment';
+    constructor(
+        private readonly discoveryApi: IDiscoveryAPI,
+        private readonly api: PythonExtension['environments'],
+        private readonly serviceContainer: IServiceContainer,
+    ) {
+        this.terminalExecutionService = this.serviceContainer.get<TerminalCodeExecutionProvider>(
+            ICodeExecutionService,
+            'standard',
+        );
+        this.terminalHelper = this.serviceContainer.get<ITerminalHelper>(ITerminalHelper);
+        this.recommendedEnvService = this.serviceContainer.get<IRecommendedEnvironmentService>(
+            IRecommendedEnvironmentService,
+        );
+    }
+
+    async invoke(
+        options: LanguageModelToolInvocationOptions<IResourceReference>,
+        token: CancellationToken,
+    ): Promise<LanguageModelToolResult | undefined> {
+        const resource = resolveFilePath(options.input.resourcePath);
+        let info = await this.getPreferredEnvForCreation(resource);
+        if (!info) {
+            return;
+        }
+        const { workspaceFolder, preferredGlobalPythonEnv } = info;
+        const interpreterPathService = this.serviceContainer.get<IInterpreterPathService>(IInterpreterPathService);
+        const disposables = new DisposableStore();
+        try {
+            const interpreterChanged = new Promise<void>((resolve) => {
+                disposables.add(interpreterPathService.onDidChange(() => resolve()));
+            });
+
+            const created = await raceCancellationError(
+                createVirtualEnvironment({
+                    interpreter: preferredGlobalPythonEnv.id,
+                    workspaceFolder,
+                }),
+                token,
+            );
+            if (!created?.path) {
+                return;
+            }
+            // Wait a few secs to ensure the env is selected as the active environment..
+            // If this doesn't work, then something went wrong.
+            await raceTimeout(5_000, interpreterChanged);
+            const env = await this.api.resolveEnvironment(created.path);
+            if (!env) {
+                return;
+            }
+            return await getEnvDetailsForResponse(
+                env,
+                this.api,
+                this.terminalExecutionService,
+                this.terminalHelper,
+                resource,
+                token,
+            );
+        } finally {
+            disposables.dispose();
+        }
+    }
+
+    public async canCreateNewVirtualEnv(resource: Uri | undefined, token: CancellationToken): Promise<boolean> {
+        if (doesWorkspaceHaveVenvOrCondaEnv(resource, this.api)) {
+            // If we already have a .venv or .conda in this workspace, then do not prompt to create a virtual environment.
+            return false;
+        }
+
+        const info = await raceCancellationError(this.getPreferredEnvForCreation(resource), token);
+        return info ? true : false;
+    }
+
+    async prepareInvocation?(
+        options: LanguageModelToolInvocationPrepareOptions<IResourceReference>,
+        token: CancellationToken,
+    ): Promise<PreparedToolInvocation> {
+        const resource = resolveFilePath(options.input.resourcePath);
+        const info = await raceCancellationError(this.getPreferredEnvForCreation(resource), token);
+        if (!info) {
+            return {};
+        }
+        const { preferredGlobalPythonEnv } = info;
+        const version = getDisplayVersion(preferredGlobalPythonEnv.version);
+        return {
+            confirmationMessages: {
+                title: l10n.t('Create a Virtual Environment{0}?', version ? ` (${version})` : ''),
+                message: l10n.t(`Virtual Environments provide the benefit of package isolation and more.`),
+            },
+        };
+    }
+    async hasAlreadyGotAWorkspaceSpecificEnvironment(resource: Uri | undefined) {
+        const recommededEnv = await this.recommendedEnvService.getRecommededEnvironment(resource);
+        // Already selected workspace env, hence nothing to do.
+        if (recommededEnv?.reason === 'workspaceUserSelected' && workspace.workspaceFolders?.length) {
+            return recommededEnv.environment;
+        }
+        // No workspace folders, and the user selected a global environment.
+        if (recommededEnv?.reason === 'globalUserSelected' && !workspace.workspaceFolders?.length) {
+            return recommededEnv.environment;
+        }
+    }
+
+    private async getPreferredEnvForCreation(resource: Uri | undefined) {
+        if (await this.hasAlreadyGotAWorkspaceSpecificEnvironment(resource)) {
+            return undefined;
+        }
+
+        // If we have a resource or have only one workspace folder && there is no .venv and no workspace specific environment.
+        // Then lets recommend creating a virtual environment.
+        const workspaceFolder =
+            resource && workspace.workspaceFolders?.length
+                ? workspace.getWorkspaceFolder(resource)
+                : workspace.workspaceFolders?.length === 1
+                ? workspace.workspaceFolders[0]
+                : undefined;
+        if (!workspaceFolder) {
+            // No workspace folder, hence no need to create a virtual environment.
+            return undefined;
+        }
+
+        // Find the latest stable version of Python from the list of know envs.
+        let globalPythonEnvs = this.discoveryApi
+            .getEnvs()
+            .map((env) => convertEnvInfoToPythonEnvironment(env))
+            .filter((env) =>
+                [
+                    EnvironmentType.System,
+                    EnvironmentType.MicrosoftStore,
+                    EnvironmentType.Global,
+                    EnvironmentType.Pyenv,
+                ].includes(env.envType),
+            )
+            .filter((env) => env.version && isStableVersion(env.version));
+
+        globalPythonEnvs = sortInterpreters(globalPythonEnvs);
+        const preferredGlobalPythonEnv = globalPythonEnvs.length
+            ? this.api.known.find((e) => e.id === globalPythonEnvs[globalPythonEnvs.length - 1].id)
+            : undefined;
+
+        return workspaceFolder && preferredGlobalPythonEnv
+            ? {
+                  workspaceFolder,
+                  preferredGlobalPythonEnv,
+              }
+            : undefined;
+    }
+}

--- a/src/client/chat/createVirtualEnvTool.ts
+++ b/src/client/chat/createVirtualEnvTool.ts
@@ -135,7 +135,7 @@ export class CreateVirtualEnvTool implements LanguageModelTool<IResourceReferenc
         }
     }
 
-    public async canCreateNewVirtualEnv(resource: Uri | undefined, token: CancellationToken): Promise<boolean> {
+    public async shouldCreateNewVirtualEnv(resource: Uri | undefined, token: CancellationToken): Promise<boolean> {
         if (doesWorkspaceHaveVenvOrCondaEnv(resource, this.api)) {
             // If we already have a .venv or .conda in this workspace, then do not prompt to create a virtual environment.
             return false;

--- a/src/client/chat/index.ts
+++ b/src/client/chat/index.ts
@@ -12,6 +12,8 @@ import { IDiscoveryAPI } from '../pythonEnvironments/base/locator';
 import { GetExecutableTool } from './getExecutableTool';
 import { GetEnvironmentInfoTool } from './getPythonEnvTool';
 import { ConfigurePythonEnvTool } from './configurePythonEnvTool';
+import { SelectPythonEnvTool } from './selectEnvTool';
+import { CreateVirtualEnvTool } from './createVirtualEnvTool';
 
 export function registerTools(
     context: IExtensionContext,
@@ -43,7 +45,19 @@ export function registerTools(
         ),
     );
     ourTools.add(
-        lm.registerTool(ConfigurePythonEnvTool.toolName, new ConfigurePythonEnvTool(environmentsApi, serviceContainer)),
+        lm.registerTool(
+            CreateVirtualEnvTool.toolName,
+            new CreateVirtualEnvTool(discoverApi, environmentsApi, serviceContainer),
+        ),
+    );
+    ourTools.add(
+        lm.registerTool(SelectPythonEnvTool.toolName, new SelectPythonEnvTool(environmentsApi, serviceContainer)),
+    );
+    ourTools.add(
+        lm.registerTool(
+            ConfigurePythonEnvTool.toolName,
+            new ConfigurePythonEnvTool(discoverApi, environmentsApi, serviceContainer),
+        ),
     );
     ourTools.add(
         extensions.onDidChange(() => {

--- a/src/client/chat/index.ts
+++ b/src/client/chat/index.ts
@@ -44,19 +44,15 @@ export function registerTools(
             new InstallPackagesTool(environmentsApi, serviceContainer, discoverApi),
         ),
     );
-    ourTools.add(
-        lm.registerTool(
-            CreateVirtualEnvTool.toolName,
-            new CreateVirtualEnvTool(discoverApi, environmentsApi, serviceContainer),
-        ),
-    );
+    const createVirtualEnvTool = new CreateVirtualEnvTool(discoverApi, environmentsApi, serviceContainer);
+    ourTools.add(lm.registerTool(CreateVirtualEnvTool.toolName, createVirtualEnvTool));
     ourTools.add(
         lm.registerTool(SelectPythonEnvTool.toolName, new SelectPythonEnvTool(environmentsApi, serviceContainer)),
     );
     ourTools.add(
         lm.registerTool(
             ConfigurePythonEnvTool.toolName,
-            new ConfigurePythonEnvTool(discoverApi, environmentsApi, serviceContainer),
+            new ConfigurePythonEnvTool(environmentsApi, serviceContainer, createVirtualEnvTool),
         ),
     );
     ourTools.add(

--- a/src/client/chat/installPackagesTool.ts
+++ b/src/client/chat/installPackagesTool.ts
@@ -14,7 +14,13 @@ import {
 } from 'vscode';
 import { PythonExtension } from '../api/types';
 import { IServiceContainer } from '../ioc/types';
-import { getEnvDisplayName, getToolResponseIfNotebook, IResourceReference, isCondaEnv, raceCancellationError } from './utils';
+import {
+    getEnvDisplayName,
+    getToolResponseIfNotebook,
+    IResourceReference,
+    isCondaEnv,
+    raceCancellationError,
+} from './utils';
 import { resolveFilePath } from './utils';
 import { IModuleInstaller } from '../common/installer/types';
 import { ModuleInstallerType } from '../pythonEnvironments/info';

--- a/src/client/chat/installPackagesTool.ts
+++ b/src/client/chat/installPackagesTool.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import {
-    CancellationError,
     CancellationToken,
     l10n,
     LanguageModelTextPart,
@@ -18,6 +17,7 @@ import {
     getEnvDisplayName,
     getToolResponseIfNotebook,
     IResourceReference,
+    isCancellationError,
     isCondaEnv,
     raceCancellationError,
 } from './utils';
@@ -74,7 +74,7 @@ export class InstallPackagesTool implements LanguageModelTool<IInstallPackageArg
             const resultMessage = `Successfully installed ${packagePlurality}: ${options.input.packageList.join(', ')}`;
             return new LanguageModelToolResult([new LanguageModelTextPart(resultMessage)]);
         } catch (error) {
-            if (error instanceof CancellationError) {
+            if (isCancellationError(error)) {
                 throw error;
             }
             const errorMessage = `An error occurred while installing ${packagePlurality}: ${error}`;

--- a/src/client/chat/listPackagesTool.ts
+++ b/src/client/chat/listPackagesTool.ts
@@ -47,7 +47,7 @@ async function listPipPackages(
     resource: Uri | undefined,
 ): Promise<[string, string][]> {
     // Add option --format to subcommand list of pip  cache, with abspath choice to output the full path of a wheel file. (#8355)
-    // Added in 202. Thats almost 5 years ago. When Python 3.8 was released.
+    // Added in 2020. Thats almost 5 years ago. When Python 3.8 was released.
     const exec = await execFactory.createActivatedEnvironment({ allowEnvironmentFetchExceptions: true, resource });
     const output = await exec.execModule('pip', ['list'], { throwOnStdErr: false, encoding: 'utf8' });
     return parsePipList(output.stdout).map((pkg) => [pkg.name, pkg.version]);

--- a/src/client/chat/selectEnvTool.ts
+++ b/src/client/chat/selectEnvTool.ts
@@ -38,7 +38,7 @@ import { showQuickPick } from '../common/vscodeApis/windowApis';
 import { DisposableStore } from '../common/utils/resourceLifecycle';
 import { traceError, traceVerbose, traceWarn } from '../logging';
 
-interface ISelectPythonEnvToolArguments extends IResourceReference {
+export interface ISelectPythonEnvToolArguments extends IResourceReference {
     reason?: 'cancelled';
 }
 

--- a/src/client/chat/selectEnvTool.ts
+++ b/src/client/chat/selectEnvTool.ts
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {
+    CancellationToken,
+    l10n,
+    LanguageModelTextPart,
+    LanguageModelTool,
+    LanguageModelToolInvocationOptions,
+    LanguageModelToolInvocationPrepareOptions,
+    LanguageModelToolResult,
+    PreparedToolInvocation,
+    Uri,
+    workspace,
+    commands,
+    QuickPickItem,
+    QuickPickItemKind,
+} from 'vscode';
+import { PythonExtension } from '../api/types';
+import { IServiceContainer } from '../ioc/types';
+import { ICodeExecutionService } from '../terminals/types';
+import { TerminalCodeExecutionProvider } from '../terminals/codeExecution/terminalCodeExecution';
+import {
+    doesWorkspaceHaveVenvOrCondaEnv,
+    getEnvDetailsForResponse,
+    getToolResponseIfNotebook,
+    IResourceReference,
+} from './utils';
+import { resolveFilePath } from './utils';
+import { ITerminalHelper } from '../common/terminal/types';
+import { raceTimeout } from '../common/utils/async';
+import { Commands, Octicons } from '../common/constants';
+import { CreateEnvironmentResult } from '../pythonEnvironments/creation/proposed.createEnvApis';
+import { IInterpreterPathService } from '../common/types';
+import { SelectEnvironmentResult } from '../interpreter/configuration/interpreterSelector/commands/setInterpreter';
+import { Common, InterpreterQuickPickList } from '../common/utils/localize';
+import { showQuickPick } from '../common/vscodeApis/windowApis';
+import { DisposableStore } from '../common/utils/resourceLifecycle';
+
+interface ISelectPythonEnvToolArguments extends IResourceReference {
+    reason?: 'cancelled';
+}
+
+export class SelectPythonEnvTool implements LanguageModelTool<ISelectPythonEnvToolArguments> {
+    private readonly terminalExecutionService: TerminalCodeExecutionProvider;
+    private readonly terminalHelper: ITerminalHelper;
+    public static readonly toolName = 'selectEnvironment';
+    constructor(
+        private readonly api: PythonExtension['environments'],
+        private readonly serviceContainer: IServiceContainer,
+    ) {
+        this.terminalExecutionService = this.serviceContainer.get<TerminalCodeExecutionProvider>(
+            ICodeExecutionService,
+            'standard',
+        );
+        this.terminalHelper = this.serviceContainer.get<ITerminalHelper>(ITerminalHelper);
+    }
+
+    async invoke(
+        options: LanguageModelToolInvocationOptions<ISelectPythonEnvToolArguments>,
+        token: CancellationToken,
+    ): Promise<LanguageModelToolResult> {
+        const resource = resolveFilePath(options.input.resourcePath);
+        let selected: boolean | undefined = false;
+        const hasVenvOrCondaEnvInWorkspaceFolder = doesWorkspaceHaveVenvOrCondaEnv(resource, this.api);
+        if (options.input.reason === 'cancelled' || hasVenvOrCondaEnvInWorkspaceFolder) {
+            const result = (await Promise.resolve(
+                commands.executeCommand(Commands.Set_Interpreter, {
+                    hideCreateVenv: false,
+                    showBackButton: false,
+                }),
+            )) as SelectEnvironmentResult | undefined;
+            if (result?.path) {
+                selected = true;
+            }
+        } else {
+            selected = await showCreateAndSelectEnvironmentQuickPick(resource, this.serviceContainer);
+        }
+        const env = selected
+            ? await this.api.resolveEnvironment(this.api.getActiveEnvironmentPath(resource))
+            : undefined;
+        if (selected && env) {
+            return await getEnvDetailsForResponse(
+                env,
+                this.api,
+                this.terminalExecutionService,
+                this.terminalHelper,
+                resource,
+                token,
+            );
+        }
+        return new LanguageModelToolResult([
+            new LanguageModelTextPart('User did not create nor select a Python environment.'),
+        ]);
+    }
+
+    async prepareInvocation?(
+        options: LanguageModelToolInvocationPrepareOptions<ISelectPythonEnvToolArguments>,
+        _token: CancellationToken,
+    ): Promise<PreparedToolInvocation> {
+        const resource = resolveFilePath(options.input.resourcePath);
+        if (getToolResponseIfNotebook(resource)) {
+            return {};
+        }
+        const hasVenvOrCondaEnvInWorkspaceFolder = doesWorkspaceHaveVenvOrCondaEnv(resource, this.api);
+
+        if (
+            hasVenvOrCondaEnvInWorkspaceFolder ||
+            !workspace.workspaceFolders?.length ||
+            options.input.reason === 'cancelled'
+        ) {
+            return {
+                confirmationMessages: {
+                    title: l10n.t('Select a Python Environment?'),
+                    message: '',
+                },
+            };
+        }
+
+        return {
+            confirmationMessages: {
+                title: l10n.t('Configure a Python Environment?'),
+                message: l10n.t(
+                    [
+                        'The recommended option is to create a new Python Environment, providing the benefit of isolating packages from other environments.  ',
+                        'Optionally you could select an existing Python Environment.',
+                    ].join('\n'),
+                ),
+            },
+        };
+    }
+}
+
+async function showCreateAndSelectEnvironmentQuickPick(
+    uri: Uri | undefined,
+    serviceContainer: IServiceContainer,
+): Promise<boolean | undefined> {
+    const createLabel = `${Octicons.Add} ${InterpreterQuickPickList.create.label}`;
+    const selectLabel = l10n.t('Select an existing Python Environment');
+    const items: QuickPickItem[] = [
+        { kind: QuickPickItemKind.Separator, label: Common.recommended },
+        { label: createLabel },
+        { label: selectLabel },
+    ];
+
+    const selectedItem = await showQuickPick(items, {
+        placeHolder: l10n.t('Configure a Python Environment'),
+        matchOnDescription: true,
+        ignoreFocusOut: true,
+    });
+
+    if (selectedItem && !Array.isArray(selectedItem) && selectedItem.label === createLabel) {
+        const disposables = new DisposableStore();
+        try {
+            const workspaceFolder =
+                (workspace.workspaceFolders?.length && uri ? workspace.getWorkspaceFolder(uri) : undefined) ||
+                (workspace.workspaceFolders?.length === 1 ? workspace.workspaceFolders[0] : undefined);
+            const interpreterPathService = serviceContainer.get<IInterpreterPathService>(IInterpreterPathService);
+            const interpreterChanged = new Promise<void>((resolve) => {
+                disposables.add(interpreterPathService.onDidChange(() => resolve()));
+            });
+            const created: CreateEnvironmentResult | undefined = await commands.executeCommand(
+                Commands.Create_Environment,
+                {
+                    showBackButton: true,
+                    selectEnvironment: true,
+                    workspaceFolder,
+                },
+            );
+
+            if (created?.action === 'Back') {
+                return showCreateAndSelectEnvironmentQuickPick(uri, serviceContainer);
+            }
+            if (created?.action === 'Cancel') {
+                return undefined;
+            }
+            if (created?.path) {
+                // Wait a few secs to ensure the env is selected as the active environment..
+                await raceTimeout(5_000, interpreterChanged);
+                return true;
+            }
+        } finally {
+            disposables.dispose();
+        }
+    }
+    if (selectedItem && !Array.isArray(selectedItem) && selectedItem.label === selectLabel) {
+        const result = (await Promise.resolve(
+            commands.executeCommand(Commands.Set_Interpreter, { hideCreateVenv: true, showBackButton: true }),
+        )) as SelectEnvironmentResult | undefined;
+        if (result?.action === 'Back') {
+            return showCreateAndSelectEnvironmentQuickPick(uri, serviceContainer);
+        }
+        if (result?.action === 'Cancel') {
+            return undefined;
+        }
+        if (result?.path) {
+            return true;
+        }
+    }
+}

--- a/src/client/chat/utils.ts
+++ b/src/client/chat/utils.ts
@@ -11,11 +11,16 @@ import {
     workspace,
 } from 'vscode';
 import { IDiscoveryAPI } from '../pythonEnvironments/base/locator';
-import { PythonExtension, ResolvedEnvironment } from '../api/types';
+import { Environment, PythonExtension, ResolvedEnvironment, VersionInfo } from '../api/types';
 import { ITerminalHelper, TerminalShellType } from '../common/terminal/types';
 import { TerminalCodeExecutionProvider } from '../terminals/codeExecution/terminalCodeExecution';
 import { Conda } from '../pythonEnvironments/common/environmentManagers/conda';
 import { JUPYTER_EXTENSION_ID, NotebookCellScheme } from '../common/constants';
+import { dirname, join } from 'path';
+
+export interface IResourceReference {
+    resourcePath?: string;
+}
 
 export function resolveFilePath(filepath?: string): Uri | undefined {
     if (!filepath) {
@@ -155,4 +160,72 @@ export function getToolResponseIfNotebook(resource: Uri | undefined) {
             ),
         ]);
     }
+}
+
+export function isCancellationError(error: unknown): boolean {
+    return !!error && (error instanceof CancellationError || (error as Error).name === 'CancellationError');
+}
+
+export function doesWorkspaceHaveVenvOrCondaEnv(resource: Uri | undefined, api: PythonExtension['environments']) {
+    const workspaceFolder =
+        resource && workspace.workspaceFolders?.length
+            ? workspace.getWorkspaceFolder(resource)
+            : workspace.workspaceFolders?.length === 1
+            ? workspace.workspaceFolders[0]
+            : undefined;
+    if (!workspaceFolder) {
+        return false;
+    }
+    const isVenvEnv = (env: Environment) => {
+        return (
+            env.environment?.folderUri &&
+            env.executable.sysPrefix &&
+            dirname(env.executable.sysPrefix) === workspaceFolder.uri.fsPath &&
+            env.environment.name === '.venv' &&
+            env.environment.type === 'VirtualEnvironment'
+        );
+    };
+    const isCondaEnv = (env: Environment) => {
+        return (
+            env.environment?.folderUri &&
+            env.executable.sysPrefix &&
+            dirname(env.executable.sysPrefix) === workspaceFolder.uri.fsPath &&
+            env.environment.folderUri.fsPath === join(workspaceFolder.uri.fsPath, '.conda') &&
+            env.environment.type === 'Conda'
+        );
+    };
+    // If we alraedy have a .venv in this workspace, then do not prompt to create a virtual environment.
+    return api.known.find((e) => isVenvEnv(e) || isCondaEnv(e));
+}
+
+export async function getEnvDetailsForResponse(
+    environment: ResolvedEnvironment | undefined,
+    api: PythonExtension['environments'],
+    terminalExecutionService: TerminalCodeExecutionProvider,
+    terminalHelper: ITerminalHelper,
+    resource: Uri | undefined,
+    token: CancellationToken,
+): Promise<LanguageModelToolResult> {
+    const envPath = api.getActiveEnvironmentPath(resource);
+    environment = environment || (await raceCancellationError(api.resolveEnvironment(envPath), token));
+    if (!environment || !environment.version) {
+        throw new Error('No environment found for the provided resource path: ' + resource?.fsPath);
+    }
+    const message = await getEnvironmentDetails(
+        resource,
+        api,
+        terminalExecutionService,
+        terminalHelper,
+        undefined,
+        token,
+    );
+    return new LanguageModelToolResult([
+        new LanguageModelTextPart(`A Python Environment has been configured.  \n` + message),
+    ]);
+}
+export function getDisplayVersion(version?: VersionInfo): string | undefined {
+    if (!version || version.major === undefined || version.minor === undefined || version.micro === undefined) {
+        return undefined;
+    }
+    return `${version.major}.${version.minor}.${version.micro}`;
 }

--- a/src/client/chat/utils.ts
+++ b/src/client/chat/utils.ts
@@ -163,7 +163,9 @@ export function getToolResponseIfNotebook(resource: Uri | undefined) {
 }
 
 export function isCancellationError(error: unknown): boolean {
-    return !!error && (error instanceof CancellationError || (error as Error).name === 'CancellationError');
+    return (
+        !!error && (error instanceof CancellationError || (error as Error).message === new CancellationError().message)
+    );
 }
 
 export function doesWorkspaceHaveVenvOrCondaEnv(resource: Uri | undefined, api: PythonExtension['environments']) {

--- a/src/client/interpreter/helpers.ts
+++ b/src/client/interpreter/helpers.ts
@@ -19,7 +19,7 @@ export function isInterpreterLocatedInWorkspace(interpreter: PythonEnvironment, 
 /**
  * Build a version-sorted list from the given one, with lowest first.
  */
-function sortInterpreters(interpreters: PythonEnvironment[]): PythonEnvironment[] {
+export function sortInterpreters(interpreters: PythonEnvironment[]): PythonEnvironment[] {
     if (interpreters.length === 0) {
         return [];
     }

--- a/src/client/pythonEnvironments/creation/createEnvApi.ts
+++ b/src/client/pythonEnvironments/creation/createEnvApi.ts
@@ -8,7 +8,7 @@ import { executeCommand, registerCommand } from '../../common/vscodeApis/command
 import { IInterpreterQuickPick, IPythonPathUpdaterServiceManager } from '../../interpreter/configuration/types';
 import { getCreationEvents, handleCreateEnvironmentCommand } from './createEnvironment';
 import { condaCreationProvider } from './provider/condaCreationProvider';
-import { VenvCreationProvider } from './provider/venvCreationProvider';
+import { VenvCreationProvider, VenvCreationProviderId } from './provider/venvCreationProvider';
 import { showInformationMessage } from '../../common/vscodeApis/windowApis';
 import { CreateEnv } from '../../common/utils/localize';
 import {
@@ -132,4 +132,12 @@ export function buildEnvironmentCreationApi(): ProposedCreateEnvironmentAPI {
         registerCreateEnvironmentProvider: (provider: CreateEnvironmentProvider) =>
             registerCreateEnvironmentProvider(provider),
     };
+}
+
+export async function createVirtualEnvironment(options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal) {
+    const provider = _createEnvironmentProviders.getAll().find((p) => p.id === VenvCreationProviderId);
+    if (!provider) {
+        return;
+    }
+    return handleCreateEnvironmentCommand([provider], { ...options, providerId: provider.id });
 }

--- a/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
+++ b/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
@@ -149,21 +149,26 @@ async function createVenv(
     return deferred.promise;
 }
 
+export const VenvCreationProviderId = `${PVSC_EXTENSION_ID}:venv`;
 export class VenvCreationProvider implements CreateEnvironmentProvider {
     constructor(private readonly interpreterQuickPick: IInterpreterQuickPick) {}
 
     public async createEnvironment(
         options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
     ): Promise<CreateEnvironmentResult | undefined> {
-        let workspace: WorkspaceFolder | undefined;
+        let workspace = options?.workspaceFolder;
+        const bypassQuickPicks = options?.workspaceFolder && options.interpreter && options.providerId ? true : false;
         const workspaceStep = new MultiStepNode(
             undefined,
             async (context?: MultiStepAction) => {
                 try {
-                    workspace = (await pickWorkspaceFolder(
-                        { preSelectedWorkspace: options?.workspaceFolder },
-                        context,
-                    )) as WorkspaceFolder | undefined;
+                    workspace =
+                        workspace && bypassQuickPicks
+                            ? workspace
+                            : ((await pickWorkspaceFolder(
+                                  { preSelectedWorkspace: options?.workspaceFolder },
+                                  context,
+                              )) as WorkspaceFolder | undefined);
                 } catch (ex) {
                     if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
                         return ex;
@@ -182,6 +187,9 @@ export class VenvCreationProvider implements CreateEnvironmentProvider {
         );
 
         let existingVenvAction: ExistingVenvAction | undefined;
+        if (bypassQuickPicks) {
+            existingVenvAction = ExistingVenvAction.Create;
+        }
         const existingEnvStep = new MultiStepNode(
             workspaceStep,
             async (context?: MultiStepAction) => {
@@ -204,7 +212,7 @@ export class VenvCreationProvider implements CreateEnvironmentProvider {
         );
         workspaceStep.next = existingEnvStep;
 
-        let interpreter: string | undefined;
+        let interpreter = options?.interpreter;
         const interpreterStep = new MultiStepNode(
             existingEnvStep,
             async (context?: MultiStepAction) => {
@@ -214,22 +222,25 @@ export class VenvCreationProvider implements CreateEnvironmentProvider {
                         existingVenvAction === ExistingVenvAction.Create
                     ) {
                         try {
-                            interpreter = await this.interpreterQuickPick.getInterpreterViaQuickPick(
-                                workspace.uri,
-                                (i: PythonEnvironment) =>
-                                    [
-                                        EnvironmentType.System,
-                                        EnvironmentType.MicrosoftStore,
-                                        EnvironmentType.Global,
-                                        EnvironmentType.Pyenv,
-                                    ].includes(i.envType) && i.type === undefined, // only global intepreters
-                                {
-                                    skipRecommended: true,
-                                    showBackButton: true,
-                                    placeholder: CreateEnv.Venv.selectPythonPlaceHolder,
-                                    title: null,
-                                },
-                            );
+                            interpreter =
+                                interpreter && bypassQuickPicks
+                                    ? interpreter
+                                    : await this.interpreterQuickPick.getInterpreterViaQuickPick(
+                                          workspace.uri,
+                                          (i: PythonEnvironment) =>
+                                              [
+                                                  EnvironmentType.System,
+                                                  EnvironmentType.MicrosoftStore,
+                                                  EnvironmentType.Global,
+                                                  EnvironmentType.Pyenv,
+                                              ].includes(i.envType) && i.type === undefined, // only global intepreters
+                                          {
+                                              skipRecommended: true,
+                                              showBackButton: true,
+                                              placeholder: CreateEnv.Venv.selectPythonPlaceHolder,
+                                              title: null,
+                                          },
+                                      );
                         } catch (ex) {
                             if (ex === InputFlowAction.back) {
                                 return MultiStepAction.Back;
@@ -362,7 +373,7 @@ export class VenvCreationProvider implements CreateEnvironmentProvider {
 
     description: string = CreateEnv.Venv.providerDescription;
 
-    id = `${PVSC_EXTENSION_ID}:venv`;
+    id = VenvCreationProviderId;
 
     tools = ['Venv'];
 }

--- a/src/client/pythonEnvironments/creation/types.ts
+++ b/src/client/pythonEnvironments/creation/types.ts
@@ -5,7 +5,12 @@ import { Progress, WorkspaceFolder } from 'vscode';
 
 export interface CreateEnvironmentProgress extends Progress<{ message?: string; increment?: number }> {}
 
+/**
+ * The interpreter path to use for the environment creation. If not provided, will prompt the user to select one.
+ * If the value of `interpreter` & `workspaceFolder` & `providerId` are provided we will not prompt the user to select a provider, nor folder, nor an interpreter.
+ */
 export interface CreateEnvironmentOptionsInternal {
     workspaceFolder?: WorkspaceFolder;
     providerId?: string;
+    interpreter?: string;
 }

--- a/src/client/pythonEnvironments/info/pythonVersion.ts
+++ b/src/client/pythonEnvironments/info/pythonVersion.ts
@@ -25,3 +25,11 @@ export type PythonVersion = {
     build: string[];
     prerelease: string[];
 };
+
+export function isStableVersion(version: PythonVersion): boolean {
+    // A stable version is one that has no prerelease tags.
+    return (
+        version.prerelease.length === 0 &&
+        (version.build.length === 0 || (version.build.length === 1 && version.build[0] === 'final'))
+    );
+}

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -46,6 +46,10 @@ const convertedKinds = new Map(
     }),
 );
 
+export function convertEnvInfoToPythonEnvironment(info: PythonEnvInfo): PythonEnvironment {
+    return convertEnvInfo(info);
+}
+
 function convertEnvInfo(info: PythonEnvInfo): PythonEnvironment {
     const { name, location, executable, arch, kind, version, distro, id } = info;
     const { filename, sysPrefix } = executable;


### PR DESCRIPTION
The new tool `Configure Python` will get invoked before other tools (at least if Model decides to do so)
* We prompt the user to create a virtual env with the latest stable version of Python available
* If user cancels we prompt the user to select an existing Python env

https://github.com/user-attachments/assets/d4bfbadf-fcbf-4a17-b1b6-7670e16c8cf4

