### PR TITLE
Change default configuration values to not load envFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -435,7 +435,7 @@
                     "type": "string"
                 },
                 "python.envFile": {
-                    "default": "${workspaceFolder}/.env",
+                    "default": "",
                     "description": "%python.envFile.description%",
                     "scope": "resource",
                     "type": "string"
@@ -964,7 +964,7 @@
                                 "type": "object"
                             },
                             "envFile": {
-                                "default": "${workspaceFolder}/.env",
+                                "default": "",
                                 "description": "Absolute path to a file containing environment variable definitions.",
                                 "type": "string"
                             },


### PR DESCRIPTION
## Proposed Change

Default to not loading any `.env` file instead of checking for and loading one at the workspace root if present. This is a potential breaking change for any developers implicitly relying on the current default value of `"${workspaceFolder}/.env"`. This solves #24209

## Why

`vscode-python` implements it's own version of dotenv support based on `https://github.com/motdotla/dotenv` (implementation references this in comments in multiple places).

This implementation is incompatible with the `python-dotenv` library, namely that `python-dotenv` supports multiline quoted values, but `vscode-python` does not. Inline comments are also not supported by `vscode-python` (see #23799).

We repeatedly run into this issue at my company, where VsCode is loading incomplete strings into env vars, making it impossible for `python-dotenv` to load them correctly afterwards (since `python-dotenv` won't overwrite already set variables to support easier overwriting for tests, etc).

In general I think that it is very unexpected that the `vscode-python` extension will load `.env` files using a different and incompatible implementation to the Python dotenv libraries. I think this is evidenced by various issues, such as #23575.

Long term, even if there is a goal to support automatic `.env` file loading within VsCode itself, IMO it makes more sense for this to be supported in VsCode itself or via a dedicated extension. Having a custom implementation embedded in the Python extension is almost certainly wrong, and disabling this by default is almost certainly a good start to eventually being able to sunset this logic in this extension.