### PR TITLE
Disable PyREPL

### DIFF
--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -53,7 +53,7 @@ import { DebuggerTypeName } from './debugger/constants';
 import { StopWatch } from './common/utils/stopWatch';
 import { registerReplCommands, registerReplExecuteOnEnter, registerStartNativeReplCommand } from './repl/replCommands';
 import { registerTriggerForTerminalREPL } from './terminals/codeExecution/terminalReplWatcher';
-import { registerPythonStartup } from './terminals/pythonStartup';
+import { registerBasicRepl, registerPythonStartup } from './terminals/pythonStartup';
 import { registerPixiFeatures } from './pythonEnvironments/common/environmentManagers/pixi';
 import { registerCustomTerminalLinkProvider } from './terminals/pythonStartupLinkProvider';
 import { registerEnvExtFeatures } from './envExt/api.internal';
@@ -184,6 +184,7 @@ async function activateLegacy(ext: ExtensionState, startupStopWatch: StopWatch):
             serviceManager.get<ITerminalAutoActivation>(ITerminalAutoActivation).register();
 
             await registerPythonStartup(ext.context);
+            await registerBasicRepl(ext.context);
 
             serviceManager.get<ICodeExecutionManager>(ICodeExecutionManager).registerCommands();
 

--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -55,7 +55,7 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
 
     public async normalizeLines(
         code: string,
-        replType: ReplType,
+        _replType: ReplType,
         wholeFileContent?: string,
         resource?: Uri,
     ): Promise<string> {

--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -124,15 +124,6 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
                 const lineOffset = object.nextBlockLineno - activeEditor!.selection.start.line - 1;
                 await this.moveToNextBlock(lineOffset, activeEditor);
             }
-            // For new _pyrepl for Python3.13 and above, we need to send code via bracketed paste mode.
-            if (object.attach_bracket_paste && replType === ReplType.terminal) {
-                let trimmedNormalized = object.normalized.replace(/\n$/, '');
-                if (trimmedNormalized.endsWith(':\n')) {
-                    // In case where statement is unfinished via :, truncate so auto-indentation lands nicely.
-                    trimmedNormalized = trimmedNormalized.replace(/\n$/, '');
-                }
-                return `\u001b[200~${trimmedNormalized}\u001b[201~`;
-            }
 
             return parse(object.normalized);
         } catch (ex) {

--- a/src/client/terminals/pythonStartup.ts
+++ b/src/client/terminals/pythonStartup.ts
@@ -36,3 +36,8 @@ export async function registerPythonStartup(context: ExtensionContext): Promise<
         }),
     );
 }
+
+export async function registerBasicRepl(context: ExtensionContext): Promise<void> {
+    // TODO: Configurable by setting
+    context.environmentVariableCollection.replace('PYTHON_BASIC_REPL', '1');
+}

--- a/src/test/terminals/codeExecution/helper.test.ts
+++ b/src/test/terminals/codeExecution/helper.test.ts
@@ -137,7 +137,7 @@ suite('Terminal - Code Execution Helper', async () => {
         editor.setup((e) => e.document).returns(() => document.object);
     });
 
-    test('normalizeLines should handle attach_bracket_paste correctly', async () => {
+    test('normalizeLines with BASIC_REPL does not attach bracketed paste mode', async () => {
         configurationService
             .setup((c) => c.getSettings(TypeMoq.It.isAny()))
             .returns({
@@ -163,7 +163,7 @@ suite('Terminal - Code Execution Helper', async () => {
 
         const result = await helper.normalizeLines('print("Looks like you are on 3.13")', ReplType.terminal);
 
-        expect(result).to.equal(`\u001b[200~print("Looks like you are on 3.13")\u001b[201~`);
+        expect(result).to.equal(`print("Looks like you are on 3.13")`);
         jsonParseStub.restore();
     });
 

--- a/src/test/terminals/shellIntegration/pythonStartup.test.ts
+++ b/src/test/terminals/shellIntegration/pythonStartup.test.ts
@@ -135,6 +135,14 @@ suite('Terminal - Shell Integration with PYTHONSTARTUP', () => {
         globalEnvironmentVariableCollection.verify((c) => c.delete('PYTHONSTARTUP'), TypeMoq.Times.once());
     });
 
+    test('PYTHON_BASIC_REPL is set when registerBasicRepl is called', async () => {
+        await registerPythonStartup(context.object);
+        globalEnvironmentVariableCollection.verify(
+            (c) => c.replace('PYTHON_BASIC_REPL', '1', TypeMoq.It.isAny()),
+            TypeMoq.Times.once(),
+        );
+    });
+
     test('Ensure registering terminal link calls registerTerminalLinkProvider', async () => {
         const registerTerminalLinkProviderStub = sinon.stub(
             pythonStartupLinkProvider,

--- a/src/test/terminals/shellIntegration/pythonStartup.test.ts
+++ b/src/test/terminals/shellIntegration/pythonStartup.test.ts
@@ -16,7 +16,7 @@ import {
 } from 'vscode';
 import { assert } from 'chai';
 import * as workspaceApis from '../../../client/common/vscodeApis/workspaceApis';
-import { registerPythonStartup } from '../../../client/terminals/pythonStartup';
+import { registerBasicRepl, registerPythonStartup } from '../../../client/terminals/pythonStartup';
 import { IExtensionContext } from '../../../client/common/types';
 import * as pythonStartupLinkProvider from '../../../client/terminals/pythonStartupLinkProvider';
 import { CustomTerminalLinkProvider } from '../../../client/terminals/pythonStartupLinkProvider';
@@ -136,7 +136,7 @@ suite('Terminal - Shell Integration with PYTHONSTARTUP', () => {
     });
 
     test('PYTHON_BASIC_REPL is set when registerBasicRepl is called', async () => {
-        await registerPythonStartup(context.object);
+        await registerBasicRepl(context.object);
         globalEnvironmentVariableCollection.verify(
             (c) => c.replace('PYTHON_BASIC_REPL', '1', TypeMoq.It.isAny()),
             TypeMoq.Times.once(),


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-python/issues/25164 

We can enable shell integration again before https://github.com/python/cpython/issues/126131 
Since we are using `PYTHON_BASIC_REPL` there is no need to use bracketed paste mode to avoid indentation error prevalent on the PyREPL from cpython >= 3.13 

When there is upstream fix in the future, we should start using bracketed paste mode again, and won't have to inject `PYTHON_BASIC_REPL`