### PR TITLE
fix bugs in telemetry for envs ext

### DIFF
--- a/src/client/startupTelemetry.ts
+++ b/src/client/startupTelemetry.ts
@@ -16,6 +16,7 @@ import { sendTelemetryEvent } from './telemetry';
 import { EventName } from './telemetry/constants';
 import { EditorLoadTelemetry } from './telemetry/types';
 import { IStartupDurations } from './types';
+import { useEnvExtension } from './envExt/api.internal';
 
 export async function sendStartupTelemetry(
     activatedPromise: Promise<any>,
@@ -105,9 +106,19 @@ async function getActivationTelemetryProps(
     // finish. API getActiveInterpreter() does not block on windows registry by default as
     // it is slow.
     await interpreterService.refreshPromise;
-    const interpreter = await interpreterService
-        .getActiveInterpreter(mainWorkspaceUri)
-        .catch<PythonEnvironment | undefined>(() => undefined);
+    let interpreter: PythonEnvironment | undefined;
+
+    // include main workspace uri if using env extension
+    if (useEnvExtension()) {
+        interpreter = await interpreterService
+            .getActiveInterpreter(mainWorkspaceUri)
+            .catch<PythonEnvironment | undefined>(() => undefined);
+    } else {
+        interpreter = await interpreterService
+            .getActiveInterpreter()
+            .catch<PythonEnvironment | undefined>(() => undefined);
+    }
+
     const pythonVersion = interpreter && interpreter.version ? interpreter.version.raw : undefined;
     const interpreterType = interpreter ? interpreter.envType : undefined;
     if (interpreterType === EnvironmentType.Unknown) {

--- a/src/client/startupTelemetry.ts
+++ b/src/client/startupTelemetry.ts
@@ -106,7 +106,7 @@ async function getActivationTelemetryProps(
     // it is slow.
     await interpreterService.refreshPromise;
     const interpreter = await interpreterService
-        .getActiveInterpreter()
+        .getActiveInterpreter(mainWorkspaceUri)
         .catch<PythonEnvironment | undefined>(() => undefined);
     const pythonVersion = interpreter && interpreter.version ? interpreter.version.raw : undefined;
     const interpreterType = interpreter ? interpreter.envType : undefined;

--- a/src/client/terminals/codeExecution/codeExecutionManager.ts
+++ b/src/client/terminals/codeExecution/codeExecutionManager.ts
@@ -48,6 +48,9 @@ export class CodeExecutionManager implements ICodeExecutionManager {
                             } catch (ex) {
                                 traceError('Failed to execute file in terminal', ex);
                             }
+                            sendTelemetryEvent(EventName.ENVIRONMENT_CHECK_TRIGGER, undefined, {
+                                trigger: 'run-in-terminal',
+                            });
                             return;
                         }
 


### PR DESCRIPTION
- wasn't sending `EventName == "ms-python.python/execution_code"&&Properties["trigger"]=="icon` when I run a python file using the play button
- when opening the editor and have a venv selected in the panel, telemetry event is sending the editor.load event with InterpreterType as System instead of venv