### PR TITLE
Remove onExp tag from native locator experiment 

### DIFF
--- a/package.json
+++ b/package.json
@@ -573,15 +573,11 @@
                     "type": "string"
                 },
                 "python.locator": {
-                    "default": "js",
+                    "default": "native",
                     "description": "%python.locator.description%",
                     "enum": [
                         "js",
                         "native"
-                    ],
-                    "tags": [
-                        "onExP",
-                        "preview"
                     ],
                     "scope": "machine",
                     "type": "string"


### PR DESCRIPTION
Updates the `python.locator` configuration in `package.json` to change its default value and remove `onExp` and `preview` tags. 