### PR TITLE
Return early in activate from env var collection

### DIFF
--- a/src/client/terminals/envCollectionActivation/service.ts
+++ b/src/client/terminals/envCollectionActivation/service.ts
@@ -98,7 +98,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
     public async activate(resource: Resource): Promise<void> {
         try {
             if (useEnvExtension()) {
-                traceVerbose('Return early of activate since env extension is being used');
+                traceVerbose('Ignoring environment variable experiment since env extension is being used');
                 this.context.environmentVariableCollection.clear();
                 // Needed for shell integration
                 await registerPythonStartup(this.context);

--- a/src/client/terminals/envCollectionActivation/service.ts
+++ b/src/client/terminals/envCollectionActivation/service.ts
@@ -45,7 +45,6 @@ import {
 import { ProgressService } from '../../common/application/progressService';
 import { useEnvExtension } from '../../envExt/api.internal';
 import { registerPythonStartup } from '../pythonStartup';
-import { trace } from 'console';
 
 @injectable()
 export class TerminalEnvVarCollectionService implements IExtensionActivationService, ITerminalEnvVarCollectionService {

--- a/src/client/terminals/envCollectionActivation/service.ts
+++ b/src/client/terminals/envCollectionActivation/service.ts
@@ -45,6 +45,7 @@ import {
 import { ProgressService } from '../../common/application/progressService';
 import { useEnvExtension } from '../../envExt/api.internal';
 import { registerPythonStartup } from '../pythonStartup';
+import { trace } from 'console';
 
 @injectable()
 export class TerminalEnvVarCollectionService implements IExtensionActivationService, ITerminalEnvVarCollectionService {
@@ -97,6 +98,14 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
 
     public async activate(resource: Resource): Promise<void> {
         try {
+            if (useEnvExtension()) {
+                traceVerbose('Return early of activate since env extension is being used');
+                this.context.environmentVariableCollection.clear();
+                // Needed for shell integration
+                await registerPythonStartup(this.context);
+                return;
+            }
+
             if (!inTerminalEnvVarExperiment(this.experimentService)) {
                 this.context.environmentVariableCollection.clear();
                 await this.handleMicroVenv(resource);


### PR DESCRIPTION
Resolves:  https://github.com/microsoft/vscode-python/issues/25275 https://github.com/microsoft/vscode-python/issues/25284
It seems like python env var experiment is interfering when env extension is being used.
We should not implicit activate with env var experiment if environment extension is installed and being used. 