### PR TITLE
bundle envs ext with stable

### DIFF
--- a/.github/actions/build-vsix/action.yml
+++ b/.github/actions/build-vsix/action.yml
@@ -70,15 +70,8 @@ runs:
       shell: bash
 
     - name: Update optional extension dependencies
-      run: |
-        if [[ "${VSIX_NAME}" == *"insiders"* ]]; then
-        npm run addExtensionPackDependenciesPreRelease
-        else
-        npm run addExtensionPackDependencies
-        fi
+      run: npm run addExtensionPackDependencies
       shell: bash
-      env:
-        VSIX_NAME: ${{ inputs.vsix_name }}
 
     - name: Build Webpack
       run: |

--- a/build/azure-pipeline.pre-release.yml
+++ b/build/azure-pipeline.pre-release.yml
@@ -91,7 +91,7 @@ extends:
       - script: python ./build/update_package_file.py
         displayName: Update telemetry in package.json
 
-      - script: npm run addExtensionPackDependenciesPreRelease
+      - script: npm run addExtensionPackDependencies
         displayName: Update optional extension dependencies
 
       - script: npx gulp prePublishBundle

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -93,23 +93,16 @@ gulp.task('addExtensionPackDependencies', async () => {
     await addExtensionPackDependencies();
 });
 
-// This task adds 'ms-python.vscode-python-envs' as required deps only for pre-release builds.
-gulp.task('addExtensionPackDependenciesPreRelease', async () => {
-    await buildLicense();
-    await addExtensionPackDependencies(true);
-});
-
-async function addExtensionPackDependencies(isPreRelease = false) {
+async function addExtensionPackDependencies() {
     // Update the package.json to add extension pack dependencies at build time so that
     // extension dependencies need not be installed during development
     const packageJsonContents = await fsExtra.readFile('package.json', 'utf-8');
     const packageJson = JSON.parse(packageJsonContents);
-    let deps = ['ms-python.vscode-pylance', 'ms-python.debugpy'];
-    if (isPreRelease) {
-        deps.push('ms-python.vscode-python-envs');
-    }
-    packageJson.extensionPack = deps.concat(packageJson.extensionPack ? packageJson.extensionPack : []);
-
+    packageJson.extensionPack = [
+        'ms-python.vscode-pylance',
+        'ms-python.debugpy',
+        'ms-python.vscode-python-envs',
+    ].concat(packageJson.extensionPack ? packageJson.extensionPack : []);
     // Remove potential duplicates.
     packageJson.extensionPack = packageJson.extensionPack.filter(
         (item, index) => packageJson.extensionPack.indexOf(item) === index,

--- a/package.json
+++ b/package.json
@@ -1689,7 +1689,6 @@
         "format-fix": "prettier --write 'src/**/*.ts' 'build/**/*.js' '.github/**/*.yml' gulpfile.js",
         "clean": "gulp clean",
         "addExtensionPackDependencies": "gulp addExtensionPackDependencies",
-        "addExtensionPackDependenciesPreRelease": "gulp addExtensionPackDependenciesPreRelease",
         "updateBuildNumber": "gulp updateBuildNumber",
         "verifyBundle": "gulp verifyBundle",
         "webpack": "webpack"


### PR DESCRIPTION
reverts https://github.com/microsoft/vscode-python/commit/8c3a49fe6ec4aabef26f10feda9452aa259811bc which switched to only bundling with pre-release so now it is bundled for stable and pre-release