### PR TITLE
chore: update tmp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "semver": "^7.5.2",
                 "stack-trace": "0.0.10",
                 "sudo-prompt": "^9.2.1",
-                "tmp": "^0.0.33",
+                "tmp": "^0.2.5",
                 "uint64be": "^3.0.0",
                 "unicode": "^14.0.0",
                 "vscode-debugprotocol": "^1.28.0",
@@ -2512,18 +2512,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/tmp": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-            "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-            "dev": true,
-            "dependencies": {
-                "rimraf": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8.17.0"
             }
         },
         "node_modules/@webassemblyjs/ast": {
@@ -11155,14 +11143,6 @@
             "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
             "dev": true
         },
-        "node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/p-cancelable": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
@@ -13374,14 +13354,12 @@
             }
         },
         "node_modules/tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dependencies": {
-                "os-tmpdir": "~1.0.2"
-            },
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "license": "MIT",
             "engines": {
-                "node": ">=0.6.0"
+                "node": ">=14.14"
             }
         },
         "node_modules/to-absolute-glob": {
@@ -16950,15 +16928,6 @@
                     "dev": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
-                    }
-                },
-                "tmp": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-                    "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-                    "dev": true,
-                    "requires": {
-                        "rimraf": "^3.0.0"
                     }
                 }
             }
@@ -23574,11 +23543,6 @@
             "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
             "dev": true
         },
-        "os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-        },
         "p-cancelable": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
@@ -25244,12 +25208,9 @@
             }
         },
         "tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "requires": {
-                "os-tmpdir": "~1.0.2"
-            }
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="
         },
         "to-absolute-glob": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1713,7 +1713,7 @@
         "semver": "^7.5.2",
         "stack-trace": "0.0.10",
         "sudo-prompt": "^9.2.1",
-        "tmp": "^0.0.33",
+        "tmp": "^0.2.5",
         "uint64be": "^3.0.0",
         "unicode": "^14.0.0",
         "vscode-debugprotocol": "^1.28.0",


### PR DESCRIPTION
It turns out the version string "^0.0.33" essentially means "0.0.33". This PR manually updates tmp to "^0.2.5", which allows for higher patch versions in the future, too.