### PR TITLE
fix: parsing mixed-value toml arrays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2025.13.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@iarna/toml": "^2.2.5",
+                "@iarna/toml": "^3.0.0",
                 "@vscode/extension-telemetry": "^0.8.4",
                 "arch": "^2.1.0",
                 "fs-extra": "^11.2.0",
@@ -1086,9 +1086,10 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@iarna/toml": {
-            "version": "2.2.5",
-            "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-            "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-3.0.0.tgz",
+            "integrity": "sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==",
+            "license": "ISC"
         },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
@@ -15921,9 +15922,9 @@
             "dev": true
         },
         "@iarna/toml": {
-            "version": "2.2.5",
-            "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-            "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-3.0.0.tgz",
+            "integrity": "sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q=="
         },
         "@isaacs/cliui": {
             "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -1695,7 +1695,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@iarna/toml": "^2.2.5",
+        "@iarna/toml": "^3.0.0",
         "@vscode/extension-telemetry": "^0.8.4",
         "arch": "^2.1.0",
         "fs-extra": "^11.2.0",

--- a/src/test/pythonEnvironments/creation/pyProjectTomlContext.unit.test.ts
+++ b/src/test/pythonEnvironments/creation/pyProjectTomlContext.unit.test.ts
@@ -28,7 +28,7 @@ function getInstallableToml(): typemoq.IMock<TextDocument> {
         .setup((p) => p.getText(typemoq.It.isAny()))
         .returns(
             () =>
-                '[project]\nname = "spam"\nversion = "2020.0.0"\n[build-system]\nrequires = ["setuptools ~= 58.0", "cython ~= 0.29.0"]\n[project.optional-dependencies]\ntest = ["pytest"]\ndoc = ["sphinx", "furo"]',
+                '[project]\nname = "spam"\nversion = "2020.0.0"\n[build-system]\nrequires = ["setuptools ~= 58.0", "cython ~= 0.29.0"]\n[dependency-groups]\ndev = ["ruff", { include-group = "test" }]\ntest = ["pytest"]',
         );
     return pyprojectToml;
 }


### PR DESCRIPTION
Upgrade `@iarna/toml` to v3 which should support mixed values within TOML arrays.

Updated one of the test fixtures to make use of the newer `[dependency-groups]` section.

Fixes: #25413