### PR TITLE
Show a more meaningful error when sending code to the Python terminal.

### DIFF
--- a/python_files/normalizeSelection.py
+++ b/python_files/normalizeSelection.py
@@ -162,11 +162,11 @@ def traverse_file(whole_file_content, start_line, end_line, was_highlighted):  #
 
     try:
         parsed_file_content = ast.parse(whole_file_content)
-    except Exception:
-        # Handle case where user is attempting to run code where file contains deprecated Python code.
+    except Exception as e:
+        # Handle case where user is attempting to run code where file contains invalid Python code.
         # Let typescript side know and show warning message.
         return {
-            "normalized_smart_result": "deprecated",
+            "normalized_smart_result": repr("vscode-python error: " + repr(e)),
             "which_line_next": 0,
         }
 
@@ -289,7 +289,7 @@ if __name__ == "__main__":
         )
         normalized = result["normalized_smart_result"]
         which_line_next = result["which_line_next"]
-        if normalized == "deprecated":
+        if "vscode-python error: " in normalized:
             data = json.dumps(
                 {"normalized": normalized, "attach_bracket_paste": attach_bracket_paste}
             )

--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -122,7 +122,7 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
             const result = await normalizeOutput.promise;
             const object = JSON.parse(result);
 
-            if (activeEditor?.selection && smartSendSettingsEnabledVal && object.normalized !== 'deprecated') {
+            if (activeEditor?.selection && smartSendSettingsEnabledVal && !object.normalized.includes('vscode-python error: ')) {
                 const lineOffset = object.nextBlockLineno - activeEditor!.selection.start.line - 1;
                 await this.moveToNextBlock(lineOffset, activeEditor);
             }


### PR DESCRIPTION
If there is any syntax error in the file where the user sends code, `deprecated` will be sent to the Python terminal. This PR modifies to show the exception from `ast.parse`.
Related: #25117