### PR TITLE
support new env kind from pet `venvUv`

### DIFF
--- a/src/client/pythonEnvironments/base/locators/common/nativePythonUtils.ts
+++ b/src/client/pythonEnvironments/base/locators/common/nativePythonUtils.ts
@@ -23,6 +23,7 @@ export enum NativePythonEnvironmentKind {
     VirtualEnvWrapper = 'VirtualEnvWrapper',
     WindowsStore = 'WindowsStore',
     WindowsRegistry = 'WindowsRegistry',
+    VenvUv = 'VenvUv',
 }
 
 const mapping = new Map<NativePythonEnvironmentKind, PythonEnvKind>([
@@ -36,6 +37,7 @@ const mapping = new Map<NativePythonEnvironmentKind, PythonEnvKind>([
     [NativePythonEnvironmentKind.VirtualEnv, PythonEnvKind.VirtualEnv],
     [NativePythonEnvironmentKind.VirtualEnvWrapper, PythonEnvKind.VirtualEnvWrapper],
     [NativePythonEnvironmentKind.Venv, PythonEnvKind.Venv],
+    [NativePythonEnvironmentKind.VenvUv, PythonEnvKind.Venv],
     [NativePythonEnvironmentKind.WindowsRegistry, PythonEnvKind.System],
     [NativePythonEnvironmentKind.WindowsStore, PythonEnvKind.MicrosoftStore],
     [NativePythonEnvironmentKind.Homebrew, PythonEnvKind.System],


### PR DESCRIPTION
python extension will handle envs created by uv the same as any venvs, so just adding the `venvUv` kind to map to `venv`. The python environments extension will handle uv environments differently and not just bundle them by default