### PR TITLE
Add __repr__ to custom PS1 class

### DIFF
--- a/python_files/pythonrc.py
+++ b/python_files/pythonrc.py
@@ -76,7 +76,7 @@ class PS1:
         return result
 
     def __repr__(self):
-        return "<Custom PS1 for VSCode Python Shell Integration>"
+        return "<Custom PS1 for VS Code Python Shell Integration>"
 
 
 if sys.platform != "win32" and (not is_wsl):


### PR DESCRIPTION
During my debugging and implementation of #25521, I find a descriptive `__repr__()` for the custom PS1 object very helpful, so this PR comes as an addition for #25521.