### PR TITLE
fix flaky test

### DIFF
--- a/src/test/smoke/runInTerminal.smoke.test.ts
+++ b/src/test/smoke/runInTerminal.smoke.test.ts
@@ -17,8 +17,13 @@ suite('Smoke Test: Run Python File In Terminal', () => {
             return this.skip();
         }
         await initialize();
+        // Ensure the environments extension is not used for this test
+        await vscode.workspace
+            .getConfiguration('python')
+            .update('useEnvironmentsExtension', false, vscode.ConfigurationTarget.Global);
         return undefined;
     });
+
     setup(initializeTest);
     suiteTeardown(closeActiveWindows);
     teardown(closeActiveWindows);


### PR DESCRIPTION
fix flaky smoke test by setting the setting for useEnvExt to false. Fixes test runs like this: https://github.com/microsoft/vscode-python/actions/runs/19273356638/job/55107677667