### PR TITLE
Wrap `pythonrc.py` logic in a setup()` function to prevent leaking variables

### DIFF
--- a/python_files/pythonrc.py
+++ b/python_files/pythonrc.py
@@ -1,85 +1,83 @@
-import platform
-import sys
+def setup():
+    import platform
+    import sys
 
-if sys.platform != "win32":
-    import readline
-
-original_ps1 = ">>> "
-is_wsl = "microsoft-standard-WSL" in platform.release()
-
-
-class REPLHooks:
-    def __init__(self):
-        self.global_exit = None
-        self.failure_flag = False
-        self.original_excepthook = sys.excepthook
-        self.original_displayhook = sys.displayhook
-        sys.excepthook = self.my_excepthook
-        sys.displayhook = self.my_displayhook
-
-    def my_displayhook(self, value):
-        if value is None:
-            self.failure_flag = False
-
-        self.original_displayhook(value)
-
-    def my_excepthook(self, type_, value, traceback):
-        self.global_exit = value
-        self.failure_flag = True
-
-        self.original_excepthook(type_, value, traceback)
-
-
-def get_last_command():
-    # Get the last history item
-    last_command = ""
     if sys.platform != "win32":
-        last_command = readline.get_history_item(readline.get_current_history_length())
+        import readline
 
-    return last_command
+    original_ps1 = ">>> "
+    is_wsl = "microsoft-standard-WSL" in platform.release()
 
+    class REPLHooks:
+        def __init__(self):
+            self.global_exit = None
+            self.failure_flag = False
+            self.original_excepthook = sys.excepthook
+            self.original_displayhook = sys.displayhook
+            sys.excepthook = self.my_excepthook
+            sys.displayhook = self.my_displayhook
 
-class PS1:
-    hooks = REPLHooks()
-    sys.excepthook = hooks.my_excepthook
-    sys.displayhook = hooks.my_displayhook
+        def my_displayhook(self, value):
+            if value is None:
+                self.failure_flag = False
+            self.original_displayhook(value)
 
-    # str will get called for every prompt with exit code to show success/failure
-    def __str__(self):
-        exit_code = int(bool(self.hooks.failure_flag))
-        self.hooks.failure_flag = False
-        # Guide following official VS Code doc for shell integration sequence:
-        result = ""
-        # For non-windows allow recent_command history.
+        def my_excepthook(self, type_, value, traceback):
+            self.global_exit = value
+            self.failure_flag = True
+            self.original_excepthook(type_, value, traceback)
+
+    def get_last_command():
+        # Get the last history item
+        last_command = ""
         if sys.platform != "win32":
-            result = "{soh}{command_executed}{command_line}{command_finished}{prompt_started}{stx}{prompt}{soh}{command_start}{stx}".format(
-                soh="\001",
-                stx="\002",
-                command_executed="\x1b]633;C\x07",
-                command_line="\x1b]633;E;" + str(get_last_command()) + "\x07",
-                command_finished="\x1b]633;D;" + str(exit_code) + "\x07",
-                prompt_started="\x1b]633;A\x07",
-                prompt=original_ps1,
-                command_start="\x1b]633;B\x07",
-            )
-        else:
-            result = "{command_finished}{prompt_started}{prompt}{command_start}{command_executed}".format(
-                command_finished="\x1b]633;D;" + str(exit_code) + "\x07",
-                prompt_started="\x1b]633;A\x07",
-                prompt=original_ps1,
-                command_start="\x1b]633;B\x07",
-                command_executed="\x1b]633;C\x07",
-            )
+            last_command = readline.get_history_item(readline.get_current_history_length())
+        return last_command
 
-        # result = f"{chr(27)}]633;D;{exit_code}{chr(7)}{chr(27)}]633;A{chr(7)}{original_ps1}{chr(27)}]633;B{chr(7)}{chr(27)}]633;C{chr(7)}"
+    class PS1:
+        hooks = REPLHooks()
+        sys.excepthook = hooks.my_excepthook
+        sys.displayhook = hooks.my_displayhook
 
-        return result
+        # str will get called for every prompt with exit code to show success/failure
+        def __str__(self):
+            exit_code = int(bool(self.hooks.failure_flag))
+            self.hooks.failure_flag = False
+            # Guide following official VS Code doc for shell integration sequence:
+            result = ""
+            # For non-windows allow recent_command history.
+            if sys.platform != "win32":
+                result = "{soh}{command_executed}{command_line}{command_finished}{prompt_started}{stx}{prompt}{soh}{command_start}{stx}".format(
+                    soh="\001",
+                    stx="\002",
+                    command_executed="\x1b]633;C\x07",
+                    command_line="\x1b]633;E;" + str(get_last_command()) + "\x07",
+                    command_finished="\x1b]633;D;" + str(exit_code) + "\x07",
+                    prompt_started="\x1b]633;A\x07",
+                    prompt=original_ps1,
+                    command_start="\x1b]633;B\x07",
+                )
+            else:
+                result = "{command_finished}{prompt_started}{prompt}{command_start}{command_executed}".format(
+                    command_finished="\x1b]633;D;" + str(exit_code) + "\x07",
+                    prompt_started="\x1b]633;A\x07",
+                    prompt=original_ps1,
+                    command_start="\x1b]633;B\x07",
+                    command_executed="\x1b]633;C\x07",
+                )
+
+            # result = f"{chr(27)}]633;D;{exit_code}{chr(7)}{chr(27)}]633;A{chr(7)}{original_ps1}{chr(27)}]633;B{chr(7)}{chr(27)}]633;C{chr(7)}"
+
+            return result
+
+    if sys.platform != "win32" and (not is_wsl):
+        sys.ps1 = PS1()
+
+    if sys.platform == "darwin":
+        print("Cmd click to launch VS Code Native REPL")
+    else:
+        print("Ctrl click to launch VS Code Native REPL")
 
 
-if sys.platform != "win32" and (not is_wsl):
-    sys.ps1 = PS1()
-
-if sys.platform == "darwin":
-    print("Cmd click to launch VS Code Native REPL")
-else:
-    print("Ctrl click to launch VS Code Native REPL")
+setup()
+del setup


### PR DESCRIPTION
This PR wraps the contents of `pythonrc.py` inside a `setup()` function to avoid polluting the variables panel of jupyterlab debugger when launched from VS Code and this extension is installed.

**Context**

<img width="1300" height="586" alt="Image" src="https://github.com/user-attachments/assets/e8932d03-4a4a-424f-856b-b0cdff583cf0" />

When JupyterLab is launched from VS Code, the debugger’s *Globals* panel becomes cluttered with variables injected from the VS Code Python extension’s `pythonrc.py`. Examples include `original_ps1`, `is_wsl`, `result`, and other internal helper variables. These show up as top-level globals in Jupyter kernels, making the debugger view noisy.

This change potentially reduces unwanted side effects for external tools (e.g., JupyterLab) while keeping functionality intact.
