### PR TITLE
Optimize pytest duplicate check from O(n) to O(1) using set

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -123,12 +123,11 @@ async function activateUnsafe(
     // Note standard utils especially experiment and platform code are fundamental to the extension
     // and should be available before we activate anything else.Hence register them first.
     initializeStandard(ext);
-    
-    // Register test services and commands early, before any async operations, to prevent race conditions
-    // where commands are invoked before the extension has fully activated.
+
+    // Register test services and commands early to prevent race conditions.
     unitTestsRegisterTypes(ext.legacyIOC.serviceManager);
     registerTestCommands(activatedServiceContainer);
-    
+
     // We need to activate experiments before initializing components as objects are created or not created based on experiments.
     const experimentService = activatedServiceContainer.get<IExperimentService>(IExperimentService);
     // This guarantees that all experiment information has loaded & all telemetry will contain experiment info.

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -33,7 +33,6 @@ import { setExtensionInstallTelemetryProperties } from './telemetry/extensionIns
 import { registerTypes as tensorBoardRegisterTypes } from './tensorBoard/serviceRegistry';
 import { registerTypes as commonRegisterTerminalTypes } from './terminals/serviceRegistry';
 import { ICodeExecutionHelper, ICodeExecutionManager, ITerminalAutoActivation } from './terminals/types';
-import { registerTypes as unitTestsRegisterTypes } from './testing/serviceRegistry';
 
 // components
 import * as pythonEnvironments from './pythonEnvironments';
@@ -144,7 +143,6 @@ async function activateLegacy(ext: ExtensionState, startupStopWatch: StopWatch):
     const { enableProposedApi } = applicationEnv.packageJson;
     serviceManager.addSingletonInstance<boolean>(UseProposedApi, enableProposedApi);
     // Feature specific registrations.
-    // Note: unitTestsRegisterTypes is now called earlier in extension.ts before the first await
     installerRegisterTypes(serviceManager);
     commonRegisterTerminalTypes(serviceManager);
     debugConfigurationRegisterTypes(serviceManager);


### PR DESCRIPTION
The pytest hooks use a list to track collected tests and check for duplicates with if test_id not in collected_tests_so_far, which scales poorly for large test suites (O(n) per check). Switch to using a set