### PR TITLE
feat(tasks): add shell task for check-python with venv activation

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -34,12 +34,19 @@
             "label": "preTestJediLSP"
         },
         {
+            "type": "npm",
+            "script": "check-python",
+            "problemMatcher": ["$python"],
             "label": "npm: check-python",
+            "detail": "npm run check-python:ruff && npm run check-python:pyright"
+        },
+        {
+            "label": "npm: check-python (venv)",
             "type": "shell",
             "command": "bash",
             "args": ["-lc", "source .venv/bin/activate && npm run check-python"],
             "problemMatcher": [],
-            "detail": "Runs in the repo .venv (avoids pyenv/shim Python): npm run check-python",
+            "detail": "Activates the repo .venv first (avoids pyenv/shim Python) then runs: npm run check-python",
             "windows": {
                 "command": "pwsh",
                 "args": [
@@ -50,13 +57,6 @@
                     ".\\.venv\\Scripts\\Activate.ps1; npm run check-python"
                 ]
             }
-        },
-        {
-            "type": "npm",
-            "script": "check-python",
-            "problemMatcher": ["$python"],
-            "label": "npm: check-python (no venv)",
-            "detail": "Runs without activating .venv (uses the task shell's default python): npm run check-python"
         }
     ]
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python/issues/24121

since extension developers are frequently changing their shell activation settings, this provides a way to activate the venv then run the task to allow for consistent checks by developers that mirror CI
