### PR TITLE
Allow to use Jedi language server in system environment or virtual environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -536,6 +536,12 @@
                     "scope": "window",
                     "type": "string"
                 },
+                "python.jedi.useJediInEnvPath": {
+                    "default": false,
+                    "description": "%python.jedi.useJediInEnvPath.description%",
+                    "scope": "window",
+                    "type": "boolean"
+                },
                 "python.interpreter.infoVisibility": {
                     "default": "onPythonRelated",
                     "description": "%python.interpreter.infoVisibility.description%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -56,6 +56,7 @@
     "python.languageServer.jediDescription": "Use Jedi behind the Language Server Protocol (LSP) as a language server.",
     "python.languageServer.pylanceDescription": "Use Pylance as a language server.",
     "python.languageServer.noneDescription": "Disable language server capabilities.",
+    "python.jedi.useJediInEnvPath.description": "Use Jedi in system environment (if pyenv is disabled) or virtual environments folder (if pyenv is enabled) instead of the builtin Jedi.",
     "python.interpreter.infoVisibility.description": "Controls when to display information of selected interpreter in the status bar.",
     "python.interpreter.infoVisibility.never.description": "Never display information.",
     "python.interpreter.infoVisibility.onPythonRelated.description": "Only display information if Python-related files are opened.",

--- a/python_files/run-jedi-language-server.py
+++ b/python_files/run-jedi-language-server.py
@@ -2,11 +2,21 @@ import os
 import pathlib
 import sys
 
-# Add the lib path to our sys path so jedi_language_server can find its references
-extension_dir = pathlib.Path(__file__).parent.parent
-EXTENSION_ROOT = os.fsdecode(extension_dir)
-sys.path.insert(0, os.fsdecode(extension_dir / "python_files" / "lib" / "jedilsp"))
-del extension_dir
+use_external_jedi = os.getenv("USE_JEDI_IN_ENV", '0') == "1"
+
+if use_external_jedi:
+    try:
+        import jedi_language_server
+    except Exception:
+        print("External Jedi is not found, fallback to the builtin one.", file=sys.stderr)
+        use_external_jedi = False
+
+if not use_external_jedi:
+    # Add the lib path to our sys path so jedi_language_server can find its references
+    extension_dir = pathlib.Path(__file__).parent.parent
+    EXTENSION_ROOT = os.fsdecode(extension_dir)
+    sys.path.insert(0, os.fsdecode(extension_dir / "python_files" / "lib" / "jedilsp"))
+    del extension_dir
 
 
 from jedi_language_server.cli import cli  # noqa: E402

--- a/src/client/languageServer/jediLSExtensionManager.ts
+++ b/src/client/languageServer/jediLSExtensionManager.ts
@@ -47,7 +47,10 @@ export class JediLSExtensionManager implements IDisposable, ILanguageServerExten
             configurationService,
             workspaceService,
         );
-        this.clientFactory = new JediLanguageClientFactory(interpreterService);
+        this.clientFactory = new JediLanguageClientFactory(
+            interpreterService,
+            workspaceService.getConfiguration('python'),
+        );
         this.serverProxy = new JediLanguageServerProxy(this.clientFactory);
         this.serverManager = new JediLanguageServerManager(
             serviceContainer,


### PR DESCRIPTION
As this extension uses an internal Jedi LSP, it is hard for the users to change the jedi setting to adapt various requirements. And in some cases, the user require a specific version of the Jedi, which is hard to change as it is embedded.

Add a new configuration property to allow the users to use Jedi LSP in their system environment or virtual environments, and auto fallback to the internal version if the external version is not found.

fixes: https://github.com/microsoft/vscode-python/issues/25722