### PR TITLE
fix(testing): respect TestRunRequest.exclude when running tests

### DIFF
--- a/src/client/testing/testController/common/testItemUtilities.ts
+++ b/src/client/testing/testController/common/testItemUtilities.ts
@@ -498,14 +498,69 @@ export async function updateTestItemFromRawData(
     item.busy = false;
 }
 
-export function getTestCaseNodes(testNode: TestItem, collection: TestItem[] = []): TestItem[] {
+/**
+ * Checks if a test item or any of its ancestors is in the exclude set.
+ */
+export function isTestItemExcluded(item: TestItem, excludeSet: Set<TestItem> | undefined): boolean {
+    if (!excludeSet || excludeSet.size === 0) {
+        return false;
+    }
+    let current: TestItem | undefined = item;
+    while (current) {
+        if (excludeSet.has(current)) {
+            return true;
+        }
+        current = current.parent;
+    }
+    return false;
+}
+
+/**
+ * Expands an exclude set to include all descendants of excluded items.
+ * After expansion, checking if a node is excluded is O(1) - just check set membership.
+ */
+export function expandExcludeSet(excludeSet: Set<TestItem> | undefined): Set<TestItem> | undefined {
+    if (!excludeSet || excludeSet.size === 0) {
+        return excludeSet;
+    }
+    const expanded = new Set<TestItem>();
+    excludeSet.forEach((item) => {
+        addWithDescendants(item, expanded);
+    });
+    return expanded;
+}
+
+function addWithDescendants(item: TestItem, set: Set<TestItem>): void {
+    if (set.has(item)) {
+        return;
+    }
+    set.add(item);
+    item.children.forEach((child) => addWithDescendants(child, set));
+}
+
+export function getTestCaseNodes(
+    testNode: TestItem,
+    collection: TestItem[] = [],
+    visited?: Set<TestItem>,
+    excludeSet?: Set<TestItem>,
+): TestItem[] {
+    if (visited?.has(testNode)) {
+        return collection;
+    }
+    visited?.add(testNode);
+
+    // Skip excluded nodes (excludeSet should be pre-expanded to include descendants)
+    if (excludeSet?.has(testNode)) {
+        return collection;
+    }
+
     if (!testNode.canResolveChildren && testNode.tags.length > 0) {
         collection.push(testNode);
     }
 
     testNode.children.forEach((c) => {
         if (testNode.canResolveChildren) {
-            getTestCaseNodes(c, collection);
+            getTestCaseNodes(c, collection, visited, excludeSet);
         } else {
             collection.push(testNode);
         }

--- a/src/client/testing/testController/common/testItemUtilities.ts
+++ b/src/client/testing/testController/common/testItemUtilities.ts
@@ -499,23 +499,6 @@ export async function updateTestItemFromRawData(
 }
 
 /**
- * Checks if a test item or any of its ancestors is in the exclude set.
- */
-export function isTestItemExcluded(item: TestItem, excludeSet: Set<TestItem> | undefined): boolean {
-    if (!excludeSet || excludeSet.size === 0) {
-        return false;
-    }
-    let current: TestItem | undefined = item;
-    while (current) {
-        if (excludeSet.has(current)) {
-            return true;
-        }
-        current = current.parent;
-    }
-    return false;
-}
-
-/**
  * Expands an exclude set to include all descendants of excluded items.
  * After expansion, checking if a node is excluded is O(1) - just check set membership.
  */

--- a/src/client/testing/testController/controller.ts
+++ b/src/client/testing/testController/controller.ts
@@ -34,7 +34,7 @@ import { IEventNamePropertyMapping, sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { PYTEST_PROVIDER, UNITTEST_PROVIDER } from '../common/constants';
 import { TestProvider } from '../types';
-import { createErrorTestItem, DebugTestTag, getNodeByUri, isTestItemExcluded, RunTestTag } from './common/testItemUtilities';
+import { createErrorTestItem, DebugTestTag, getNodeByUri, RunTestTag } from './common/testItemUtilities';
 import { buildErrorNodeOptions } from './common/utils';
 import { ITestController, ITestFrameworkController, TestRefreshOptions } from './common/types';
 import { WorkspaceTestAdapter } from './workspaceTestAdapter';
@@ -848,14 +848,12 @@ export class PythonTestController implements ITestController, IExtensionSingleAc
      */
     private getTestItemsForWorkspace(workspace: WorkspaceFolder, request: TestRunRequest): TestItem[] {
         const testItems: TestItem[] = [];
-        const excludeSet = request.exclude?.length ? new Set(request.exclude) : undefined;
         // If the run request includes test items then collect only items that belong to
         // `workspace`. If there are no items in the run request then just run the `workspace`
         // root test node. Include will be `undefined` in the "run all" scenario.
-        // Exclusions are applied after inclusions per VS Code API contract.
         (request.include ?? this.testController.items).forEach((i: TestItem) => {
             const w = this.workspaceService.getWorkspaceFolder(i.uri);
-            if (w?.uri.fsPath === workspace.uri.fsPath && !isTestItemExcluded(i, excludeSet)) {
+            if (w?.uri.fsPath === workspace.uri.fsPath) {
                 testItems.push(i);
             }
         });

--- a/src/test/testing/testController/testItemUtilities.unit.test.ts
+++ b/src/test/testing/testController/testItemUtilities.unit.test.ts
@@ -1,0 +1,171 @@
+import * as assert from 'assert';
+import { TestItem } from 'vscode';
+import {
+    isTestItemExcluded,
+    expandExcludeSet,
+    getTestCaseNodes,
+    RunTestTag,
+    DebugTestTag,
+} from '../../../client/testing/testController/common/testItemUtilities';
+
+function createMockTestItem(id: string, canResolveChildren: boolean, children: TestItem[] = []): TestItem {
+    const item = {
+        id,
+        canResolveChildren,
+        tags: [RunTestTag, DebugTestTag],
+        children: {
+            forEach: (callback: (item: TestItem) => void) => {
+                children.forEach(callback);
+            },
+            size: children.length,
+        },
+        parent: undefined as TestItem | undefined,
+    } as any;
+    // Set parent references on children
+    children.forEach((child) => {
+        (child as any).parent = item;
+    });
+    return item;
+}
+
+suite('isTestItemExcluded', () => {
+    test('should return false when excludeSet is undefined', () => {
+        const item = createMockTestItem('item1', false);
+        assert.strictEqual(isTestItemExcluded(item, undefined), false);
+    });
+
+    test('should return false when excludeSet is empty', () => {
+        const item = createMockTestItem('item1', false);
+        assert.strictEqual(isTestItemExcluded(item, new Set()), false);
+    });
+
+    test('should return true when item is directly in excludeSet', () => {
+        const item = createMockTestItem('item1', false);
+        const excludeSet = new Set([item]);
+        assert.strictEqual(isTestItemExcluded(item, excludeSet), true);
+    });
+
+    test('should return true when ancestor is in excludeSet', () => {
+        const child = createMockTestItem('child', false);
+        const parent = createMockTestItem('parent', true, [child]);
+        const excludeSet = new Set([parent]);
+        assert.strictEqual(isTestItemExcluded(child, excludeSet), true);
+    });
+
+    test('should return false when unrelated item is in excludeSet', () => {
+        const child = createMockTestItem('child', false);
+        createMockTestItem('parent', true, [child]);
+        const other = createMockTestItem('other', false);
+        const excludeSet = new Set([other]);
+        assert.strictEqual(isTestItemExcluded(child, excludeSet), false);
+    });
+
+    test('should walk multiple levels of ancestor chain', () => {
+        const grandchild = createMockTestItem('grandchild', false);
+        const child = createMockTestItem('child', true, [grandchild]);
+        const root = createMockTestItem('root', true, [child]);
+        const excludeSet = new Set([root]);
+        assert.strictEqual(isTestItemExcluded(grandchild, excludeSet), true);
+    });
+});
+
+suite('expandExcludeSet', () => {
+    test('should return undefined when excludeSet is undefined', () => {
+        assert.strictEqual(expandExcludeSet(undefined), undefined);
+    });
+
+    test('should return empty set when excludeSet is empty', () => {
+        const result = expandExcludeSet(new Set());
+        assert.ok(result);
+        assert.strictEqual(result!.size, 0);
+    });
+
+    test('should include the excluded item itself', () => {
+        const item = createMockTestItem('leaf', false);
+        const result = expandExcludeSet(new Set([item]));
+        assert.ok(result);
+        assert.ok(result!.has(item));
+    });
+
+    test('should include all descendants of excluded items', () => {
+        const child1 = createMockTestItem('child1', false);
+        const child2 = createMockTestItem('child2', false);
+        const parent = createMockTestItem('parent', true, [child1, child2]);
+        const result = expandExcludeSet(new Set([parent]));
+        assert.ok(result);
+        assert.strictEqual(result!.size, 3);
+        assert.ok(result!.has(parent));
+        assert.ok(result!.has(child1));
+        assert.ok(result!.has(child2));
+    });
+
+    test('should include deeply nested descendants', () => {
+        const grandchild = createMockTestItem('grandchild', false);
+        const child = createMockTestItem('child', true, [grandchild]);
+        const root = createMockTestItem('root', true, [child]);
+        const result = expandExcludeSet(new Set([root]));
+        assert.ok(result);
+        assert.strictEqual(result!.size, 3);
+        assert.ok(result!.has(root));
+        assert.ok(result!.has(child));
+        assert.ok(result!.has(grandchild));
+    });
+});
+
+suite('getTestCaseNodes with exclude and visited', () => {
+    test('should collect leaf test nodes', () => {
+        const leaf1 = createMockTestItem('leaf1', false);
+        const leaf2 = createMockTestItem('leaf2', false);
+        const parent = createMockTestItem('parent', true, [leaf1, leaf2]);
+        const result = getTestCaseNodes(parent);
+        assert.strictEqual(result.length, 2);
+        assert.ok(result.includes(leaf1));
+        assert.ok(result.includes(leaf2));
+    });
+
+    test('should skip nodes in excludeSet', () => {
+        const leaf1 = createMockTestItem('leaf1', false);
+        const leaf2 = createMockTestItem('leaf2', false);
+        const parent = createMockTestItem('parent', true, [leaf1, leaf2]);
+        const excludeSet = new Set([leaf1]);
+        const result = getTestCaseNodes(parent, [], new Set(), excludeSet);
+        assert.strictEqual(result.length, 1);
+        assert.ok(result.includes(leaf2));
+    });
+
+    test('should skip entire subtree when parent is in excludeSet', () => {
+        const leaf = createMockTestItem('leaf', false);
+        const folder = createMockTestItem('folder', true, [leaf]);
+        const root = createMockTestItem('root', true, [folder]);
+        // Pre-expanded excludeSet (as expandExcludeSet would produce)
+        const excludeSet = new Set([folder, leaf]);
+        const result = getTestCaseNodes(root, [], new Set(), excludeSet);
+        assert.strictEqual(result.length, 0);
+    });
+
+    test('should not visit same node twice when visited set is used', () => {
+        const leaf = createMockTestItem('leaf', false);
+        const parent = createMockTestItem('parent', true, [leaf]);
+        const visited = new Set<TestItem>();
+        const collection: TestItem[] = [];
+        getTestCaseNodes(parent, collection, visited);
+        getTestCaseNodes(parent, collection, visited);
+        assert.strictEqual(collection.length, 1);
+    });
+
+    test('should work without optional visited and excludeSet parameters', () => {
+        const leaf = createMockTestItem('leaf', false);
+        const parent = createMockTestItem('parent', true, [leaf]);
+        const result = getTestCaseNodes(parent);
+        assert.strictEqual(result.length, 1);
+        assert.ok(result.includes(leaf));
+    });
+
+    test('should skip excluded root node entirely', () => {
+        const leaf = createMockTestItem('leaf', false);
+        const root = createMockTestItem('root', true, [leaf]);
+        const excludeSet = new Set([root, leaf]);
+        const result = getTestCaseNodes(root, [], new Set(), excludeSet);
+        assert.strictEqual(result.length, 0);
+    });
+});

--- a/src/test/testing/testController/testItemUtilities.unit.test.ts
+++ b/src/test/testing/testController/testItemUtilities.unit.test.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
 import { TestItem } from 'vscode';
 import {
-    isTestItemExcluded,
     expandExcludeSet,
     getTestCaseNodes,
     RunTestTag,
@@ -27,47 +26,6 @@ function createMockTestItem(id: string, canResolveChildren: boolean, children: T
     });
     return item;
 }
-
-suite('isTestItemExcluded', () => {
-    test('should return false when excludeSet is undefined', () => {
-        const item = createMockTestItem('item1', false);
-        assert.strictEqual(isTestItemExcluded(item, undefined), false);
-    });
-
-    test('should return false when excludeSet is empty', () => {
-        const item = createMockTestItem('item1', false);
-        assert.strictEqual(isTestItemExcluded(item, new Set()), false);
-    });
-
-    test('should return true when item is directly in excludeSet', () => {
-        const item = createMockTestItem('item1', false);
-        const excludeSet = new Set([item]);
-        assert.strictEqual(isTestItemExcluded(item, excludeSet), true);
-    });
-
-    test('should return true when ancestor is in excludeSet', () => {
-        const child = createMockTestItem('child', false);
-        const parent = createMockTestItem('parent', true, [child]);
-        const excludeSet = new Set([parent]);
-        assert.strictEqual(isTestItemExcluded(child, excludeSet), true);
-    });
-
-    test('should return false when unrelated item is in excludeSet', () => {
-        const child = createMockTestItem('child', false);
-        createMockTestItem('parent', true, [child]);
-        const other = createMockTestItem('other', false);
-        const excludeSet = new Set([other]);
-        assert.strictEqual(isTestItemExcluded(child, excludeSet), false);
-    });
-
-    test('should walk multiple levels of ancestor chain', () => {
-        const grandchild = createMockTestItem('grandchild', false);
-        const child = createMockTestItem('child', true, [grandchild]);
-        const root = createMockTestItem('root', true, [child]);
-        const excludeSet = new Set([root]);
-        assert.strictEqual(isTestItemExcluded(grandchild, excludeSet), true);
-    });
-});
 
 suite('expandExcludeSet', () => {
     test('should return undefined when excludeSet is undefined', () => {

--- a/src/test/testing/testController/testMocks.ts
+++ b/src/test/testing/testController/testMocks.ts
@@ -14,6 +14,7 @@ import { ITestDebugLauncher } from '../../../client/testing/common/types';
 import { ProjectAdapter } from '../../../client/testing/testController/common/projectAdapter';
 import { ProjectExecutionDependencies } from '../../../client/testing/testController/common/projectTestExecution';
 import { TestProjectRegistry } from '../../../client/testing/testController/common/testProjectRegistry';
+import { RunTestTag, DebugTestTag } from '../../../client/testing/testController/common/testItemUtilities';
 import { ITestExecutionAdapter, ITestResultResolver } from '../../../client/testing/testController/common/types';
 
 /**
@@ -42,14 +43,16 @@ export function createMockTestItem(id: string, uriPath: string, children?: TestI
         },
     } as TestItemCollection;
 
+    // Parent nodes (with children) have canResolveChildren=true, leaf nodes have canResolveChildren=false
+    const hasChildren = children && children.length > 0;
     return ({
         id,
         uri: Uri.file(uriPath),
         children: mockChildren,
         label: id,
-        canResolveChildren: false,
+        canResolveChildren: hasChildren,
         busy: false,
-        tags: [],
+        tags: [RunTestTag, DebugTestTag],
         range: undefined,
         error: undefined,
         parent: undefined,

--- a/src/test/testing/testController/workspaceTestAdapter.unit.test.ts
+++ b/src/test/testing/testController/workspaceTestAdapter.unit.test.ts
@@ -355,12 +355,14 @@ suite('Workspace test adapter', () => {
             );
             resultResolver.runIdToVSid.set('mockTestItem1', 'mockTestItem1');
 
-            sinon.stub(testItemUtilities, 'getTestCaseNodes').callsFake((testNode: TestItem) =>
-                // Custom implementation logic here based on the provided testNode and collection
-
-                // Example implementation: returning a predefined array of TestItem objects
-                [testNode],
-            );
+            sinon
+                .stub(testItemUtilities, 'getTestCaseNodes')
+                .callsFake((testNode: TestItem, collection: TestItem[] = []) => {
+                    // Custom implementation logic here based on the provided testNode and collection
+                    // Push the testNode to the collection (matching the real implementation behavior)
+                    collection.push(testNode);
+                    return collection;
+                });
 
             const mockTestItem1 = createMockTestItem('mockTestItem1');
             const mockTestItem2 = createMockTestItem('mockTestItem2');


### PR DESCRIPTION
The VS Code Test Explorer API documents that `TestRunRequest.exclude` contains tests the user has marked as excluded (e.g., via filtering). The  [documentation](https://github.com/microsoft/vscode/blob/c8d90ab45fd1612379bbdf2208f042a4d4e58ed3/src/vscode-dts/vscode.d.ts#L18564-L18567) says,

> If given, the extension should run all of the included tests and all their children, excluding any tests
> that appear in `TestRunRequest.exclude`.

Previously, the Python extension ignored `request.exclude`, so invoking **Run Tests** would execute all tests even when the Test Explorer view was filtered. 

This fix adds exclude handling in `WorkspaceTestAdapter.executeTests()`: Pre-expand the exclude set to include all descendants, then pass to `getTestCaseNodes()` which skips excluded nodes with O(1) set lookups during traversal

This change also adds a visited set to `getTestCaseNodes()` to avoid expanding the same node multiple times when `include` contains overlapping items.

Fixes the issue where filtering tests in Test Explorer (e.g., by tag) and clicking **Run Tests** would still run all tests.

Fixes #25742