### PR TITLE
Add ai-artifacts to .gitignore to exclude generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ python_files/tests/*/.data/.coverage*
 python_files/tests/*/.data/*/.coverage*
 src/testTestingRootWkspc/coverageWorkspace/.coverage
 
+# ignore ai artifacts generated and placed in this folder
+ai-artifacts/*


### PR DESCRIPTION
This adds a place within the github workspace that developers can store any AI related artifacts they create that could be useful but they don't want to commit. Things like issue summarization, plans for features, code analysis etc