### PR TITLE
Refactor environment extension activation checks to use shouldEnvExtHandleActivation function

### DIFF
--- a/src/client/interpreter/display/index.ts
+++ b/src/client/interpreter/display/index.ts
@@ -24,7 +24,7 @@ import {
     IInterpreterService,
     IInterpreterStatusbarVisibilityFilter,
 } from '../contracts';
-import { useEnvExtension } from '../../envExt/api.internal';
+import { shouldEnvExtHandleActivation } from '../../envExt/api.internal';
 
 /**
  * Based on https://github.com/microsoft/vscode-python/issues/18040#issuecomment-992567670.
@@ -68,7 +68,7 @@ export class InterpreterDisplay implements IInterpreterDisplay, IExtensionSingle
     }
 
     public async activate(): Promise<void> {
-        if (useEnvExtension()) {
+        if (shouldEnvExtHandleActivation()) {
             return;
         }
         const application = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
@@ -115,7 +115,7 @@ export class InterpreterDisplay implements IInterpreterDisplay, IExtensionSingle
         }
     }
     private async updateDisplay(workspaceFolder?: Uri) {
-        if (useEnvExtension()) {
+        if (shouldEnvExtHandleActivation()) {
             this.statusBar?.hide();
             this.languageStatus?.dispose();
             this.languageStatus = undefined;

--- a/src/test/interpreters/display.unit.test.ts
+++ b/src/test/interpreters/display.unit.test.ts
@@ -59,7 +59,7 @@ suite('Interpreters Display', () => {
     let pathUtils: TypeMoq.IMock<IPathUtils>;
     let languageStatusItem: TypeMoq.IMock<LanguageStatusItem>;
     let traceLogStub: sinon.SinonStub;
-    let useEnvExtensionStub: sinon.SinonStub;
+    let shouldEnvExtHandleActivationStub: sinon.SinonStub;
     async function createInterpreterDisplay(filters: IInterpreterStatusbarVisibilityFilter[] = []) {
         interpreterDisplay = new InterpreterDisplay(serviceContainer.object);
         try {
@@ -69,8 +69,8 @@ suite('Interpreters Display', () => {
     }
 
     async function setupMocks(useLanguageStatus: boolean) {
-        useEnvExtensionStub = sinon.stub(extapi, 'useEnvExtension');
-        useEnvExtensionStub.returns(false);
+        shouldEnvExtHandleActivationStub = sinon.stub(extapi, 'shouldEnvExtHandleActivation');
+        shouldEnvExtHandleActivationStub.returns(false);
 
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();


### PR DESCRIPTION
Problem
Fixes #1284

When the Python Environments extension (ms-python.vscode-python-envs) is installed but python.useEnvironmentsExtension is not explicitly set, users see two interpreter status bar items — one from each extension.

Root Cause
The interpreter display in InterpreterDisplay used useEnvExtension() to decide whether to create/show its status bar. That function requires python.useEnvironmentsExtension to be explicitly true (defaults to false). Meanwhile, the envs extension activates whenever the setting is not explicitly false — treating unset/undefined as enabled.