### PR TITLE
fix: show Restart Language Server command in all Python contexts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1256,7 +1256,7 @@
                     "category": "Python",
                     "command": "python.analysis.restartLanguageServer",
                     "title": "%python.command.python.analysis.restartLanguageServer.title%",
-                    "when": "!virtualWorkspace && shellExecutionSupported && (editorLangId == python || notebookType == jupyter-notebook)"
+                    "when": "!virtualWorkspace && shellExecutionSupported"
                 },
                 {
                     "category": "Python",


### PR DESCRIPTION
Fixes #22045

## Problem
The "Python: Restart Language Server" command disappears from the command palette when the active editor is a Jupyter notebook. This is because the `when` clause required `editorLangId == python || notebookType == jupyter-notebook`, but that condition is not satisfied in all Jupyter notebook contexts.

## Solution
Remove the editor language condition from the `when` clause, matching the pattern already used by the `python.viewLanguageServerOutput` command:

**Before:**
```
"when": "!virtualWorkspace && shellExecutionSupported && (editorLangId == python || notebookType == jupyter-notebook)"
```

**After:**
```
"when": "!virtualWorkspace && shellExecutionSupported"
```

## Test plan
- [ ] Open a `.py` file -- "Python: Restart Language Server" should appear in command palette
- [ ] Open a Jupyter notebook (`.ipynb`) -- "Python: Restart Language Server" should appear in command palette
- [ ] Verify `python.viewLanguageServerOutput` behavior is unchanged
