### PR TITLE
Remove unused testresources import and related load_tests function from unittestadapter

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -12,7 +12,6 @@ flask
 fastapi
 uvicorn
 django
-testresources
 testscenarios
 
 # Integrated TensorBoard tests

--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -13,6 +13,7 @@ fastapi
 uvicorn
 django
 testscenarios
+testtools
 
 # Integrated TensorBoard tests
 tensorboard

--- a/python_files/tests/unittestadapter/.data/test_scenarios/tests/__init__.py
+++ b/python_files/tests/unittestadapter/.data/test_scenarios/tests/__init__.py
@@ -1,17 +1,2 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-
-from testscenarios import generate_scenarios
-
-
-def load_tests(loader, tests, pattern):  # noqa: ARG001
-    # Pre-expand TestWithScenarios scenarios at load time so individual
-    # scenario-multiplied test IDs (e.g. ``test_operations(add)``) can be
-    # resolved by ``unittest.TestLoader.loadTestsFromName``. Without this,
-    # ``TestWithScenarios`` only multiplies scenarios at ``run()`` time and
-    # loading a specific scenario by name raises ``AttributeError``.
-    import unittest
-
-    result = unittest.TestSuite()
-    result.addTests(generate_scenarios(tests))
-    return result

--- a/python_files/tests/unittestadapter/.data/test_scenarios/tests/__init__.py
+++ b/python_files/tests/unittestadapter/.data/test_scenarios/tests/__init__.py
@@ -1,3 +1,17 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+from testscenarios import generate_scenarios
+
+
+def load_tests(loader, tests, pattern):  # noqa: ARG001
+    # Pre-expand TestWithScenarios scenarios at load time so individual
+    # scenario-multiplied test IDs (e.g. ``test_operations(add)``) can be
+    # resolved by ``unittest.TestLoader.loadTestsFromName``. Without this,
+    # ``TestWithScenarios`` only multiplies scenarios at ``run()`` time and
+    # loading a specific scenario by name raises ``AttributeError``.
+    import unittest
+
+    result = unittest.TestSuite()
+    result.addTests(generate_scenarios(tests))
+    return result

--- a/python_files/tests/unittestadapter/.data/test_scenarios/tests/__init__.py
+++ b/python_files/tests/unittestadapter/.data/test_scenarios/tests/__init__.py
@@ -1,15 +1,3 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import os
-
-import testresources
-from testscenarios import generate_scenarios
-
-def load_tests(loader, tests, pattern):
-    this_dir = os.path.dirname(__file__)
-    mytests = loader.discover(start_dir=this_dir, pattern=pattern)
-    result = testresources.OptimisingTestSuite()
-    result.addTests(generate_scenarios(mytests))
-    result.addTests(generate_scenarios(tests))
-    return result

--- a/python_files/tests/unittestadapter/.data/test_scenarios/tests/test_scene.py
+++ b/python_files/tests/unittestadapter/.data/test_scenarios/tests/test_scene.py
@@ -3,11 +3,12 @@
 
 from testscenarios import TestWithScenarios
 
+
 class TestMathOperations(TestWithScenarios):
     scenarios = [
         ('add', {'test_id': 'test_add', 'a': 5, 'b': 3, 'expected': 8}),
         ('subtract', {'test_id': 'test_subtract', 'a': 5, 'b': 3, 'expected': 2}),
-        ('multiply', {'test_id': 'test_multiply', 'a': 5, 'b': 3, 'expected': 15})
+        ('multiply', {'test_id': 'test_multiply', 'a': 5, 'b': 3, 'expected': 15}),
     ]
     a: int = 0
     b: int = 0

--- a/python_files/tests/unittestadapter/.data/test_scenarios/tests/test_scene.py
+++ b/python_files/tests/unittestadapter/.data/test_scenarios/tests/test_scene.py
@@ -1,7 +1,20 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from testscenarios import TestWithScenarios
+import unittest
+
+from testscenarios import TestWithScenarios, generate_scenarios
+
+
+def load_tests(loader, standard_tests, pattern):  # noqa: ARG001
+    # Pre-expand ``TestWithScenarios`` scenarios at load time so individual
+    # scenario-multiplied test IDs (e.g. ``test_operations(add)``) can be
+    # resolved by ``unittest.TestLoader.loadTestsFromName``. Without this,
+    # ``TestWithScenarios`` only multiplies scenarios at ``run()`` time and
+    # loading a specific scenario by name raises ``AttributeError``.
+    result = unittest.TestSuite()
+    result.addTests(generate_scenarios(standard_tests))
+    return result
 
 
 class TestMathOperations(TestWithScenarios):


### PR DESCRIPTION
goal to resolve CI issues

Keeps coverage of the testscenarios-based dynamic test-ID pattern (which was the whole point of this fixture). Declaring testtools explicitly replaces the fragile transitive dependency that was causing the CI import failure described in test-scenarios-ci-failure.md.