### PR TITLE
Fix absence of pytest kill in Cancel Test Run

### DIFF
--- a/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
@@ -246,6 +246,7 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                 });
 
                 const result = execService?.execObservable(runArgs, spawnOptions);
+                resultProc = result?.proc;
 
                 // Take all output from the subprocess and add it to the test output channel. This will be the pytest output.
                 // Displays output to user and ensure the subprocess doesn't run into buffer overflow.

--- a/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
@@ -233,13 +233,19 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
                 traceInfo(`Running pytest with arguments: ${runArgs.join(' ')} for workspace ${uri.fsPath} \r\n`);
 
                 let resultProc: ChildProcess | undefined;
+                let processKilled = false;
+                const killResultProcess = () => {
+                    if (resultProc && !processKilled) {
+                        processKilled = true;
+                        resultProc.kill();
+                        return true;
+                    }
+                    return false;
+                };
 
                 runInstance.token.onCancellationRequested(() => {
                     traceInfo(`Test run cancelled, killing pytest subprocess for workspace ${uri.fsPath}`);
-                    // if the resultProc exists just call kill on it which will handle resolving the ExecClose deferred, otherwise resolve the deferred here.
-                    if (resultProc) {
-                        resultProc?.kill();
-                    } else {
+                    if (!killResultProcess()) {
                         deferredTillExecClose.resolve();
                         serverCancel.cancel();
                     }
@@ -247,6 +253,9 @@ export class PytestTestExecutionAdapter implements ITestExecutionAdapter {
 
                 const result = execService?.execObservable(runArgs, spawnOptions);
                 resultProc = result?.proc;
+                if (runInstance.token.isCancellationRequested) {
+                    killResultProcess();
+                }
 
                 // Take all output from the subprocess and add it to the test output channel. This will be the pytest output.
                 // Displays output to user and ensure the subprocess doesn't run into buffer overflow.

--- a/src/test/testing/testController/pytest/pytestExecutionAdapter.unit.test.ts
+++ b/src/test/testing/testController/pytest/pytestExecutionAdapter.unit.test.ts
@@ -38,8 +38,10 @@ suite('pytest test execution adapter', () => {
     let mockProc: MockChildProcess;
     let utilsWriteTestIdsFileStub: sinon.SinonStub;
     let utilsStartRunResultNamedPipeStub: sinon.SinonStub;
+    let onExecObservable: (() => void) | undefined;
 
     setup(() => {
+        onExecObservable = undefined;
         useEnvExtensionStub = sinon.stub(extapi, 'useEnvExtension');
         useEnvExtensionStub.returns(false);
         configService = ({
@@ -59,6 +61,7 @@ suite('pytest test execution adapter', () => {
         execService
             .setup((x) => x.execObservable(typeMoq.It.isAny(), typeMoq.It.isAny()))
             .returns(() => {
+                onExecObservable?.();
                 deferred4.resolve();
                 return {
                     proc: mockProc as any,
@@ -202,6 +205,25 @@ suite('pytest test execution adapter', () => {
         sinon.assert.calledOnce(killStub);
         mockProc.emit('close', 0, null);
         await execution;
+        cancellationToken.dispose();
+    });
+    test('cancelling before the pytest subprocess is captured kills it once available', async () => {
+        utilsWriteTestIdsFileStub.resolves('testIdPipe-mockName');
+        utilsStartRunResultNamedPipeStub.callsFake((_callback, deferredTillServerClose, token) => {
+            token?.onCancellationRequested(() => deferredTillServerClose.resolve());
+            return Promise.resolve('runResultPipe-mockName');
+        });
+        const cancellationToken = new CancellationTokenSource();
+        const testRun = typeMoq.Mock.ofType<TestRun>();
+        testRun.setup((t) => t.token).returns(() => cancellationToken.token);
+        const killStub = sinon.stub(mockProc, 'kill');
+        onExecObservable = () => cancellationToken.cancel();
+        const uri = Uri.file(myTestPath);
+        adapter = new PytestTestExecutionAdapter(configService);
+
+        await adapter.runTests(uri, [], TestRunProfileKind.Run, testRun.object, execFactory.object);
+
+        sinon.assert.calledOnce(killStub);
         cancellationToken.dispose();
     });
     test('pytest execution respects settings.testing.cwd when present', async () => {


### PR DESCRIPTION
Fixes #21507 

Commit  354fcd6 has removed initialisation of `resultProc` variable. So cancelling can't kill pytest because `resultProc` is undefined. PR restores that initialisation.

Tested by click on 'Cancel Test Run'. Reaction on cancelling has appeared immediately.

Label: bug