### PR TITLE
Fix duplicate command python.getRecommendedEnvironment

### DIFF
--- a/src/client/interpreter/configuration/recommededEnvironmentService.ts
+++ b/src/client/interpreter/configuration/recommededEnvironmentService.ts
@@ -52,7 +52,9 @@ export class RecommendedEnvironmentService implements IRecommendedEnvironmentSer
         }
     }
 
-    async getRecommededEnvironment(resource: Resource): Promise<
+    async getRecommededEnvironment(
+        resource: Resource,
+    ): Promise<
         | {
               environment: ResolvedEnvironment;
               reason: 'globalUserSelected' | 'workspaceUserSelected' | 'defaultRecommended';

--- a/src/client/interpreter/configuration/recommededEnvironmentService.ts
+++ b/src/client/interpreter/configuration/recommededEnvironmentService.ts
@@ -17,6 +17,7 @@ const MEMENTO_KEY = 'userSelectedEnvPath';
 @injectable()
 export class RecommendedEnvironmentService implements IRecommendedEnvironmentService, IExtensionActivationService {
     private api?: PythonExtension['environments'];
+    private hasRegisteredCommand = false;
     constructor(@inject(IExtensionContext) private readonly extensionContext: IExtensionContext) {}
     supportedWorkspaceTypes: { untrustedWorkspace: boolean; virtualWorkspace: boolean } = {
         untrustedWorkspace: true,
@@ -24,6 +25,10 @@ export class RecommendedEnvironmentService implements IRecommendedEnvironmentSer
     };
 
     async activate(_resource: Resource, _startupStopWatch?: StopWatch): Promise<void> {
+        if (this.hasRegisteredCommand) {
+            return;
+        }
+        this.hasRegisteredCommand = true;
         this.extensionContext.subscriptions.push(
             commands.registerCommand('python.getRecommendedEnvironment', async (resource: Resource) => {
                 return this.getRecommededEnvironment(resource);
@@ -47,9 +52,7 @@ export class RecommendedEnvironmentService implements IRecommendedEnvironmentSer
         }
     }
 
-    async getRecommededEnvironment(
-        resource: Resource,
-    ): Promise<
+    async getRecommededEnvironment(resource: Resource): Promise<
         | {
               environment: ResolvedEnvironment;
               reason: 'globalUserSelected' | 'workspaceUserSelected' | 'defaultRecommended';

--- a/src/test/interpreters/recommededEnvironmentService.unit.test.ts
+++ b/src/test/interpreters/recommededEnvironmentService.unit.test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect } from 'chai';
+import { anything, reset, verify, when } from 'ts-mockito';
+import { Disposable, Uri } from 'vscode';
+import { mockedVSCodeNamespaces } from '../vscode-mock';
+import { RecommendedEnvironmentService } from '../../client/interpreter/configuration/recommededEnvironmentService';
+
+suite('RecommendedEnvironmentService - activate', () => {
+    let service: RecommendedEnvironmentService;
+    let subscriptions: Disposable[];
+
+    setup(() => {
+        subscriptions = [];
+        const extensionContext = {
+            subscriptions,
+            globalState: {
+                get: () => undefined,
+                update: () => Promise.resolve(),
+            },
+        } as any;
+
+        when(mockedVSCodeNamespaces.commands!.registerCommand(anything(), anything())).thenReturn({
+            dispose: () => {},
+        } as Disposable);
+
+        service = new RecommendedEnvironmentService(extensionContext);
+    });
+
+    teardown(() => {
+        reset(mockedVSCodeNamespaces.commands!);
+    });
+
+    test('Multiroot workspace: command is registered only once across multiple activate calls', async () => {
+        // Simulate multiroot workspace where activate is called once per workspace root
+        const workspaceRoot1 = Uri.file('/workspace/root1');
+        const workspaceRoot2 = Uri.file('/workspace/root2');
+        const workspaceRoot3 = Uri.file('/workspace/root3');
+
+        await service.activate(workspaceRoot1);
+        await service.activate(workspaceRoot2);
+        await service.activate(workspaceRoot3);
+
+        verify(mockedVSCodeNamespaces.commands!.registerCommand('python.getRecommendedEnvironment', anything())).once();
+        expect(subscriptions).to.have.lengthOf(1);
+    });
+});


### PR DESCRIPTION
Adds guards when calling RecommendedEnvironmentService::activate per folder on a multiroot workspace to avoid registering the command several times.

Fixes #25949