### PR TITLE
testing: refine compact discovery payload review feedback

### DIFF
--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -25,6 +25,7 @@ import pytest
 
 if TYPE_CHECKING:
     from pluggy import Result
+    from pytest_describe.plugin import DescribeBlock as DescribeBlockType
     from typing_extensions import NotRequired
 
 USES_PYTEST_DESCRIBE = False
@@ -873,7 +874,7 @@ def create_session_node(session: pytest.Session) -> TestNode:
     }
 
 
-def create_class_node(class_module: Any) -> TestNode:
+def create_class_node(class_module: pytest.Class | DescribeBlockType) -> TestNode:
     """Creates a class node from a pytest class object.
 
     Keyword arguments:

--- a/src/client/common/platform/fs-paths.ts
+++ b/src/client/common/platform/fs-paths.ts
@@ -148,6 +148,19 @@ export function normCasePath(filePath: string): string {
     return normCase(nodepath.normalize(filePath));
 }
 
+/**
+ * Returns true if the given path is absolute on either POSIX or Windows.
+ *
+ * Node's `path.isAbsolute` is platform-dependent, so a POSIX path like `/foo`
+ * is not recognized as absolute on Windows, and a Windows path like `C:\foo`
+ * is not recognized as absolute on POSIX. Use this helper when the path could
+ * have been produced on a different OS than the one currently running (e.g.
+ * paths received in a JSON payload from a Python subprocess).
+ */
+export function isAbsolutePath(value: string): boolean {
+    return nodepath.posix.isAbsolute(value) || nodepath.win32.isAbsolute(value);
+}
+
 export function normCase(s: string): string {
     return getOSType() === OSType.Windows ? s.toUpperCase() : s;
 }

--- a/src/client/testing/testController/common/testDiscoveryHandler.ts
+++ b/src/client/testing/testController/common/testDiscoveryHandler.ts
@@ -11,10 +11,7 @@ import { createErrorTestItem } from './testItemUtilities';
 import { buildErrorNodeOptions, populateTestTree } from './utils';
 import { TestItemIndex } from './testItemIndex';
 import { PROJECT_ID_SEPARATOR } from './projectUtils';
-
-function isAbsolutePath(value: string): boolean {
-    return /^([a-zA-Z]:[\\/]|\\\\)/.test(value) || value.startsWith('/');
-}
+import { isAbsolutePath } from '../../../common/platform/fs-paths';
 
 function joinWithBase(base: string, relativePath: string): string {
     if (!base || isAbsolutePath(relativePath)) {

--- a/src/test/common/platform/fs-paths.unit.test.ts
+++ b/src/test/common/platform/fs-paths.unit.test.ts
@@ -4,7 +4,7 @@
 import { expect } from 'chai';
 import * as path from 'path';
 import * as TypeMoq from 'typemoq';
-import { FileSystemPathUtils } from '../../../client/common/platform/fs-paths';
+import { FileSystemPathUtils, isAbsolutePath } from '../../../client/common/platform/fs-paths';
 import { getNamesAndValues } from '../../../client/common/utils/enum';
 import { OSType } from '../../../client/common/utils/platform';
 
@@ -110,5 +110,30 @@ suite('FileSystem - Path Utils', () => {
                 // * exercize normalization
             });
         });
+    });
+});
+
+suite('FileSystem - isAbsolutePath', () => {
+    test('Recognizes POSIX absolute paths', () => {
+        expect(isAbsolutePath('/foo/bar')).to.equal(true);
+        expect(isAbsolutePath('/')).to.equal(true);
+    });
+
+    test('Recognizes Windows drive-letter absolute paths', () => {
+        expect(isAbsolutePath('C:\\foo\\bar')).to.equal(true);
+        expect(isAbsolutePath('c:/foo/bar')).to.equal(true);
+        expect(isAbsolutePath('Z:\\')).to.equal(true);
+    });
+
+    test('Recognizes Windows UNC absolute paths', () => {
+        expect(isAbsolutePath('\\\\server\\share\\foo')).to.equal(true);
+    });
+
+    test('Rejects relative paths', () => {
+        expect(isAbsolutePath('foo/bar')).to.equal(false);
+        expect(isAbsolutePath('./foo')).to.equal(false);
+        expect(isAbsolutePath('../foo')).to.equal(false);
+        expect(isAbsolutePath('foo\\bar')).to.equal(false);
+        expect(isAbsolutePath('')).to.equal(false);
     });
 });


### PR DESCRIPTION
Follow-up to #25982 addressing review feedback.

## What changed

- **Shared `isAbsolutePath` helper.** Moved the cross-platform absolute-path check out of `testDiscoveryHandler.ts` and into `src/client/common/platform/fs-paths.ts` so it can be reused. The implementation now delegates to `path.posix.isAbsolute || path.win32.isAbsolute` instead of a hand-rolled regex. This is the right behavior here because the paths come from a Python subprocess and may be formatted for an OS different from the one currently running the extension.
- **Tightened `create_class_node` annotation.** Replaced `Any` with `pytest.Class | DescribeBlockType` in `python_files/vscode_pytest/__init__.py`. `DescribeBlockType` is imported inside the existing `if TYPE_CHECKING:` block so it stays optional at runtime (matching the runtime `DescribeBlock: Any = None` fallback when `pytest_describe` is not installed).
- **Unit tests for `isAbsolutePath`.** Added a 4-test suite in `fs-paths.unit.test.ts` covering POSIX absolute, Windows drive-letter, Windows UNC, and relative paths.

## Verification

- `tsc --noEmit - cleanp .` 
- `eslint` on touched  cleanfiles 
- `ruff check vscode_ cleanpytest/` 
- `pyright python_files/vscode_pytest/__init__. 0 errorspy` 
- 4 new `isAbsolutePath` unit  passtests 
- All 17 `TestDiscoveryHandler` unit  still passtests 
- 3 `compact_discovery_payload` pytest  passtests 

## Notes for reviewers

No behavior change is intended. The new `isAbsolutePath` is functionally equivalent to the regex it replaces (both recognize `/foo`, `C:\foo`, `c:/foo`, and `\\server\share`). The `create_class_node` signature change is purely a type-check improvement and has no runtime effect.