### PR TITLE
optimize getting of line number in pytest discovery

### DIFF
--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -849,20 +849,17 @@ def create_test_node(
     test_case -- the pytest test case.
     """
 
-    lineno0 = None
+    lineno0: int | None = None
     if PYTEST_INTERNAL_AVAILABLE:
-        try:
-            # test_case.location returns tuple of path and line number
-            # Obtaining the path is expensive and we do not need it anyway.
-            # Before falling back to that high-level API, we try to use
-            # internal API to get just line number without the path.
-            lineno0 = Code.from_function(cast(PyobjMixin, test_case).obj).firstlineno # type: ignore
-        except Exception:
-            pass
-    
+        obj = getattr(test_case, "obj", None)
+        if obj is not None:
+            try:
+                lineno0 = Code.from_function(obj).firstlineno
+            except (AttributeError, OSError, TypeError):
+                lineno0 = None
+
     if lineno0 is None:
         lineno0 = test_case.location[1]
-
     test_case_loc: str = (
         str(lineno0 + 1) if (lineno0 is not None) else ""
     )

--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -22,6 +22,8 @@ from typing import (
 )
 
 import pytest
+from _pytest.python import PyobjMixin
+from _pytest._code.code import Code
 
 if TYPE_CHECKING:
     from pluggy import Result
@@ -842,8 +844,18 @@ def create_test_node(
     Keyword arguments:
     test_case -- the pytest test case.
     """
+
+    try:
+        # test_case.location returns tuple of path and line number
+        # Obtaining the path is expensive and we do not need it anyway.
+        # Before falling back to that high-level API, we try to use
+        # internal API to get just line number without the path.
+        lineno0 = Code.from_function(cast(PyobjMixin, test_case).obj).firstlineno
+    except:
+        lineno0 = test_case.location[1]
+
     test_case_loc: str = (
-        str(test_case.location[1] + 1) if (test_case.location[1] is not None) else ""
+        str(lineno0 + 1) if (lineno0 is not None) else ""
     )
     absolute_test_id = get_absolute_test_id(test_case.nodeid, get_node_path(test_case))
     return {
@@ -1261,3 +1273,4 @@ def pytest_plugin_registered(plugin: object, manager: pytest.PytestPluginManager
         and not manager.hasplugin(plugin_name)
     ):
         manager.register(DeferPlugin(), name=plugin_name)
+

--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -22,8 +22,12 @@ from typing import (
 )
 
 import pytest
-from _pytest.python import PyobjMixin
-from _pytest._code.code import Code
+
+PYTEST_INTERNAL_AVAILABLE = False
+with contextlib.suppress(ImportError):
+    from _pytest.python import PyobjMixin
+    from _pytest._code.code import Code
+    PYTEST_INTERNAL_AVAILABLE = True
 
 if TYPE_CHECKING:
     from pluggy import Result
@@ -845,13 +849,18 @@ def create_test_node(
     test_case -- the pytest test case.
     """
 
-    try:
-        # test_case.location returns tuple of path and line number
-        # Obtaining the path is expensive and we do not need it anyway.
-        # Before falling back to that high-level API, we try to use
-        # internal API to get just line number without the path.
-        lineno0 = Code.from_function(cast(PyobjMixin, test_case).obj).firstlineno
-    except:
+    lineno0 = None
+    if PYTEST_INTERNAL_AVAILABLE:
+        try:
+            # test_case.location returns tuple of path and line number
+            # Obtaining the path is expensive and we do not need it anyway.
+            # Before falling back to that high-level API, we try to use
+            # internal API to get just line number without the path.
+            lineno0 = Code.from_function(cast(PyobjMixin, test_case).obj).firstlineno # type: ignore
+        except Exception:
+            pass
+    
+    if lineno0 is None:
         lineno0 = test_case.location[1]
 
     test_case_loc: str = (

--- a/python_files/vscode_pytest/__init__.py
+++ b/python_files/vscode_pytest/__init__.py
@@ -25,8 +25,8 @@ import pytest
 
 PYTEST_INTERNAL_AVAILABLE = False
 with contextlib.suppress(ImportError):
-    from _pytest.python import PyobjMixin
     from _pytest._code.code import Code
+
     PYTEST_INTERNAL_AVAILABLE = True
 
 if TYPE_CHECKING:
@@ -848,7 +848,6 @@ def create_test_node(
     Keyword arguments:
     test_case -- the pytest test case.
     """
-
     lineno0: int | None = None
     if PYTEST_INTERNAL_AVAILABLE:
         obj = getattr(test_case, "obj", None)
@@ -860,9 +859,7 @@ def create_test_node(
 
     if lineno0 is None:
         lineno0 = test_case.location[1]
-    test_case_loc: str = (
-        str(lineno0 + 1) if (lineno0 is not None) else ""
-    )
+    test_case_loc: str = str(lineno0 + 1) if (lineno0 is not None) else ""
     absolute_test_id = get_absolute_test_id(test_case.nodeid, get_node_path(test_case))
     return {
         "name": test_case.name,
@@ -1279,4 +1276,3 @@ def pytest_plugin_registered(plugin: object, manager: pytest.PytestPluginManager
         and not manager.hasplugin(plugin_name)
     ):
         manager.register(DeferPlugin(), name=plugin_name)
-


### PR DESCRIPTION
The discovery for pytest is still quite a bit slower than running plain `-m pytest --collect-only` so I investigated a bit more and the next most significant (at least for our test suite) slowdown is caused by the `pytest.Item.location` call used to get line number of the test:

<img width="1200" height="1082" alt="profile_location" src="https://github.com/user-attachments/assets/f17f2caf-7d57-4900-955f-35ad3354f955" />

This is because the `.location` returns tuple of path and line number, of which only the line number is used by the discovery, but computing the path is rather expensive. This PR proposes an optimization which uses internal pytest API in exactly the same way as the `location` function itself, but without also computing the path. 

In particular, the `location` call hierarchy is:
* [Item.location](https://github.com/pytest-dev/pytest/blob/f78e909f6e7b0aa7e234dd7ee3918350f352d469/src/_pytest/nodes.py#L760)
* [PyobjMixin.reportinfo](https://github.com/pytest-dev/pytest/blob/f78e909f6e7b0aa7e234dd7ee3918350f352d469/src/_pytest/python.py#L328)
* [getfslineno](https://github.com/pytest-dev/pytest/blob/f78e909f6e7b0aa7e234dd7ee3918350f352d469/src/_pytest/_code/code.py#L1542)
* [Code.from_function](https://github.com/pytest-dev/pytest/blob/f78e909f6e7b0aa7e234dd7ee3918350f352d469/src/_pytest/_code/code.py#L1557)
* [Code.firstlineno](https://github.com/pytest-dev/pytest/blob/f78e909f6e7b0aa7e234dd7ee3918350f352d469/src/_pytest/_code/code.py#L77) +  [Code.path](https://github.com/pytest-dev/pytest/blob/f78e909f6e7b0aa7e234dd7ee3918350f352d469/src/_pytest/_code/code.py#L85) - this is the expensive call we need to avoid

This PR calls `Code.from_function` directly and only gets `.firstlineno` from it.

<img width="1200" height="906" alt="profile_firstlineno" src="https://github.com/user-attachments/assets/970906f5-94cc-41b9-aa83-ef1d7fa37001" />

Both profiles are captured with this PR cherry-picked to main branch prior to the discovery result compaction introduced in 5389068da3a3b1b55536cd6ca6b8d51d13c43c2f which causes significant performance hit that overshadows the optimization done here, for that I created a separate PR #26016 with proposed fix.

This change makes the discovery about 20% faster for our suite, now almost on par with the raw `pytest` call
