### PR TITLE
Fix #26039: REPL prompt disappears when builtins/globals shadowed under PYTHONSTARTUP

### DIFF
--- a/python_files/pythonrc.py
+++ b/python_files/pythonrc.py
@@ -107,4 +107,3 @@ if sys.platform == "darwin":
     print("Cmd click to launch VS Code Native REPL")
 else:
     print("Ctrl click to launch VS Code Native REPL")
-    

--- a/python_files/pythonrc.py
+++ b/python_files/pythonrc.py
@@ -7,6 +7,21 @@ if sys.platform != "win32":
 original_ps1 = ">>> "
 is_wsl = "microsoft-standard-WSL" in platform.release()
 
+# NOTE: PYTHONSTARTUP executes this file's code directly inside the user's
+# __main__ namespace, so everything defined below actually lives in
+# __main__.__dict__. That means PS1.__str__.__globals__ IS the user's
+# namespace: if the user later shadows a name we rely on at prompt-render
+# time (e.g. `int = 20`, `sys = 1`, `original_ps1 = ...`), a plain global
+# lookup would resolve to the user's value instead of ours and raise,
+# silently killing the prompt (see #26039). Capture the real objects here,
+# before any user code runs, so later reassignment in __main__ can't affect
+# us.
+_int = int
+_str = str
+_bool = bool
+_sys = sys
+_original_ps1 = original_ps1
+
 
 class REPLHooks:
     def __init__(self):
@@ -33,10 +48,16 @@ class REPLHooks:
 def get_last_command():
     # Get the last history item
     last_command = ""
-    if sys.platform != "win32":
-        last_command = readline.get_history_item(readline.get_current_history_length())
+    if _sys.platform != "win32":
+        last_command = _readline.get_history_item(_readline.get_current_history_length())
 
     return last_command
+
+
+# Capture the function object itself, not just the name: `get_last_command`
+# is also just a name in __main__, so it could be shadowed the same way.
+_get_last_command = get_last_command
+_readline = readline if sys.platform != "win32" else None
 
 
 class PS1:
@@ -46,27 +67,27 @@ class PS1:
 
     # str will get called for every prompt with exit code to show success/failure
     def __str__(self):
-        exit_code = int(bool(self.hooks.failure_flag))
+        exit_code = _int(_bool(self.hooks.failure_flag))
         self.hooks.failure_flag = False
         # Guide following official VS Code doc for shell integration sequence:
         result = ""
         # For non-windows allow recent_command history.
-        if sys.platform != "win32":
+        if _sys.platform != "win32":
             result = "{soh}{command_executed}{command_line}{command_finished}{prompt_started}{stx}{prompt}{soh}{command_start}{stx}".format(
                 soh="\001",
                 stx="\002",
                 command_executed="\x1b]633;C\x07",
-                command_line="\x1b]633;E;" + str(get_last_command()) + "\x07",
-                command_finished="\x1b]633;D;" + str(exit_code) + "\x07",
+                command_line="\x1b]633;E;" + _str(_get_last_command()) + "\x07",
+                command_finished="\x1b]633;D;" + _str(exit_code) + "\x07",
                 prompt_started="\x1b]633;A\x07",
-                prompt=original_ps1,
+                prompt=_original_ps1,
                 command_start="\x1b]633;B\x07",
             )
         else:
             result = "{command_finished}{prompt_started}{prompt}{command_start}{command_executed}".format(
-                command_finished="\x1b]633;D;" + str(exit_code) + "\x07",
+                command_finished="\x1b]633;D;" + _str(exit_code) + "\x07",
                 prompt_started="\x1b]633;A\x07",
-                prompt=original_ps1,
+                prompt=_original_ps1,
                 command_start="\x1b]633;B\x07",
                 command_executed="\x1b]633;C\x07",
             )
@@ -86,3 +107,4 @@ if sys.platform == "darwin":
     print("Cmd click to launch VS Code Native REPL")
 else:
     print("Ctrl click to launch VS Code Native REPL")
+    

--- a/python_files/tests/test_shell_integration.py
+++ b/python_files/tests/test_shell_integration.py
@@ -1,11 +1,29 @@
 import importlib
 import platform
 import sys
+from pathlib import Path
 from unittest.mock import Mock
 
 import pythonrc
 
 is_wsl = "microsoft-standard-WSL" in platform.release()
+ 
+PYTHONRC_PATH = Path(pythonrc.__file__)
+ 
+ 
+def test_decoration_success():
+    importlib.reload(pythonrc)
+    ps1 = pythonrc.PS1()
+ 
+    ps1.hooks.failure_flag = False
+    result = str(ps1)
+    if sys.platform != "win32" and (not is_wsl):
+        assert (
+            result
+            == "\x01\x1b]633;C\x07\x1b]633;E;None\x07\x1b]633;D;0\x07\x1b]633;A\x07\x02>>> \x01\x1b]633;B\x07\x02"
+        )
+    else:
+        pass
 
 
 def test_decoration_success():

--- a/python_files/tests/test_shell_integration.py
+++ b/python_files/tests/test_shell_integration.py
@@ -2,28 +2,14 @@ import importlib
 import platform
 import sys
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock
 
 import pythonrc
 
 is_wsl = "microsoft-standard-WSL" in platform.release()
- 
+
 PYTHONRC_PATH = Path(pythonrc.__file__)
- 
- 
-def test_decoration_success():
-    importlib.reload(pythonrc)
-    ps1 = pythonrc.PS1()
- 
-    ps1.hooks.failure_flag = False
-    result = str(ps1)
-    if sys.platform != "win32" and (not is_wsl):
-        assert (
-            result
-            == "\x01\x1b]633;C\x07\x1b]633;E;None\x07\x1b]633;D;0\x07\x1b]633;A\x07\x02>>> \x01\x1b]633;B\x07\x02"
-        )
-    else:
-        pass
 
 
 def test_decoration_success():
@@ -99,3 +85,38 @@ if sys.platform == "win32":
             m.setattr("builtins.print", Mock())
             importlib.reload(sys.modules["pythonrc"])
             print.assert_any_call("Ctrl click to launch VS Code Native REPL")
+
+
+def test_prompt_survives_shadowed_builtins_under_pythonstartup():
+    """Regression test for #26039.
+
+    PYTHONSTARTUP executes pythonrc.py's code directly inside __main__, not
+    as a normal module import, so PS1.__str__.__globals__ ends up being the
+    user's own namespace. `import pythonrc` (used by every other test in
+    this file) does not reproduce that, since it gives PS1 its own module
+    namespace instead. Simulate the real PYTHONSTARTUP path here: exec the
+    source into a stand-in __main__ dict, then shadow the names the prompt
+    depends on exactly as a user would (`int = 20`, `sys = 1`, etc.) and
+    confirm str(sys.ps1) still renders instead of raising.
+    """
+    if sys.platform == "win32" or is_wsl:
+        return
+
+    main_ns: dict[str, Any] = {"__name__": "__main__"}
+    source = PYTHONRC_PATH.read_text()
+    exec(compile(source, str(PYTHONRC_PATH), "exec"), main_ns)
+
+    ps1 = main_ns["sys"].ps1
+    assert str(ps1)  # sanity: works before any shadowing
+
+    for name, value in {
+        "int": 20,
+        "sys": 1,
+        "str": "nope",
+        "bool": "nope",
+        "original_ps1": "hijacked",
+        "get_last_command": "hijacked",
+    }.items():
+        main_ns[name] = value
+        assert str(ps1), f"prompt failed to render after shadowing {name!r}"
+        

--- a/python_files/tests/test_shell_integration.py
+++ b/python_files/tests/test_shell_integration.py
@@ -119,4 +119,3 @@ def test_prompt_survives_shadowed_builtins_under_pythonstartup():
     }.items():
         main_ns[name] = value
         assert str(ps1), f"prompt failed to render after shadowing {name!r}"
-        


### PR DESCRIPTION
Fixes #26039

`PYTHONSTARTUP` executes `pythonrc.py`'s code directly inside the user's `__main__` namespace rather than importing it as a module. That means `PS1.__str__.__globals__` *is* the user's namespace — so shadowing any name it relies on at prompt-render time (`int`, `sys`, `str`, `bool`, `original_ps1`, `get_last_command`) breaks `str(sys.ps1)` and silently kills the prompt.

This captures the real objects into private `_`-prefixed aliases right after they're defined, before any user code runs, so later reassignment of those names in `__main__` can't affect the prompt anymore.

**How I tested:**
- Reproduced by `exec`-ing `pythonrc.py`'s source into a synthetic `__main__` dict (mirroring the real `PYTHONSTARTUP` path) and shadowing `int`/`sys`/`str`/`bool`/`original_ps1`/`get_last_command` — confirmed it broke on the original file and is fixed on the patched one.
- Added `test_prompt_survives_shadowed_builtins_under_pythonstartup`,  which encodes that reproduction as a regression test. The existing tests `import pythonrc` as a normal module, which gives `PS1` its own module namespace instead of `__main__` — that's why they never caught this bug.
- `npm run check-python` (ruff check, ruff format --check, pyright) — clean, 0 errors.
- `python -m pytest python_files/tests/test_shell_integration.py -v` — 5/5 passed.

**Notes for reviewers:** the fix is intentionally minimal (capture at definition time) rather than moving the class into a separate module, since `pythonStartup.ts` only ever copies the single `pythonrc.py` file to the PYTHONSTARTUP location — splitting into two files would require extension-side deployment changes.