### PR TITLE
Add GDPR declaration for pyrefly.detection telemetry event

### DIFF
--- a/src/client/telemetry/pylance.ts
+++ b/src/client/telemetry/pylance.ts
@@ -490,3 +490,20 @@
    "failed" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" }
 }
 */
+/**
+ * Telemetry event sent during background Pyrefly detection to measure the audience that could be
+ * offered a switch to Pyrefly. Reported once per workspace folder (per availability) for users who
+ * are not already on a Pyrefly diagnostics source.
+ */
+/* __GDPR__
+   "pyrefly.detection" : {
+      "available" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "rchiodo" },
+      "haspyreflytoml" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "rchiodo" },
+      "haspyprojectsection" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "rchiodo" },
+      "hasenvironmentbinary" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "rchiodo" },
+      "promptdismissed" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "rchiodo" },
+      "notificationenabled" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "rchiodo" },
+      "lsversion" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "rchiodo" },
+      "failed" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "owner": "rchiodo" }
+   }
+*/


### PR DESCRIPTION
## Summary

Adds a `__GDPR__` declaration for the Pylance `pyrefly.detection` telemetry event so it is allow-listed and reaches the telemetry pipeline.

## Background

Pylance emits a `PYREFLY.DETECTION` event (sent through the `ms-python.python` reporter as `ms-python.python/pyrefly.detection`) during background Pyrefly detection, to measure the addressable audience that could be offered a switch to Pyrefly. The event shipped in Pylance `2026.2.109` (pre-release) and `2026.3.1` (stable) and fires unconditionally on the **same** reporter as `language_server.ready`.

Despite millions of users on those builds emitting the sibling `language_server.ready` event, `pyrefly.detection` showed **zero** rows in telemetry. Root cause: the new event name was not declared in this GDPR allow-list, so it was scrubbed before ingestion. `language_server.ready` is declared here and flows fine; `pyrefly.detection` was missing.

## Change

Declares `pyrefly.detection` with its properties:

- `available`, `haspyreflytoml`, `haspyprojectsection`, `hasenvironmentbinary`, `promptdismissed`, `notificationenabled` — the event-specific fields emitted by Pylance's `_reportDetectionTelemetry`.
- `lsversion`, `failed` — common properties, mirroring the sibling `language_server.ready` declaration.

All properties are `SystemMetaData` / non-personal (booleans and the LS version).

## Impact

No runtime code change. Once a Python extension build containing this declaration reaches users, data will begin flowing from already-deployed Pylance clients that are already emitting the event.