### PR TITLE
release: Bump extension version to 2026.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "python",
-    "version": "2026.5.0-dev",
+    "version": "2026.6.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "python",
-            "version": "2026.5.0-dev",
+            "version": "2026.6.0",
             "license": "MIT",
             "dependencies": {
                 "@iarna/toml": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "python",
     "displayName": "Python",
     "description": "Python language support with extension access points for IntelliSense (Pylance), Debugging (Python Debugger), linting, formatting, refactoring, unit tests, and more.",
-    "version": "2026.5.0-dev",
+    "version": "2026.6.0",
     "featureFlags": {
         "usingNewInterpreterStorage": true
     },


### PR DESCRIPTION
## Summary
- bump the extension version from `2026.5.0-dev` to `2026.6.0`
- refresh `package-lock.json` with `npm install`