### PR TITLE
release: Bump extension version to 2026.7.0-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "python",
-    "version": "2026.6.0",
+    "version": "2026.7.0-dev",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "python",
-            "version": "2026.6.0",
+            "version": "2026.7.0-dev",
             "license": "MIT",
             "dependencies": {
                 "@iarna/toml": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "python",
     "displayName": "Python",
     "description": "Python language support with extension access points for IntelliSense (Pylance), Debugging (Python Debugger), linting, formatting, refactoring, unit tests, and more.",
-    "version": "2026.6.0",
+    "version": "2026.7.0-dev",
     "featureFlags": {
         "usingNewInterpreterStorage": true
     },


### PR DESCRIPTION
## Summary
- bump the extension version from `2026.6.0` to `2026.7.0-dev`
- refresh `package-lock.json` with `npm install`