### PR TITLE
Fix environment extension activation scope mismatch

### DIFF
--- a/src/client/envExt/api.internal.ts
+++ b/src/client/envExt/api.internal.ts
@@ -55,14 +55,19 @@ export function shouldEnvExtHandleActivation(): boolean {
 }
 
 let _useExt: boolean | undefined;
+export function shouldUseEnvExtension(): boolean {
+    const config = getConfiguration('python');
+    const inExpSetting = config?.get<boolean>('useEnvironmentsExtension', false) ?? false;
+    return inExpSetting && shouldEnvExtHandleActivation();
+}
+
 export function useEnvExtension(): boolean {
     if (_useExt !== undefined) {
         return _useExt;
     }
-    const config = getConfiguration('python');
-    const inExpSetting = config?.get<boolean>('useEnvironmentsExtension', false) ?? false;
-    // If extension is installed and in experiment, then use it.
-    _useExt = !!getExtension(ENVS_EXTENSION_ID) && inExpSetting;
+    // Use the extension only when it is enabled and its own activation logic
+    // will expose the API.
+    _useExt = shouldUseEnvExtension();
     return _useExt;
 }
 

--- a/src/test/common/terminals/activator/index.unit.test.ts
+++ b/src/test/common/terminals/activator/index.unit.test.ts
@@ -174,6 +174,15 @@ suite('shouldEnvExtHandleActivation', () => {
         assert.strictEqual(extapi.shouldEnvExtHandleActivation(), false);
     });
 
+    test('Does not use envs extension when workspace enables it but user settings disable activation', () => {
+        getExtensionStub.returns({ id: extapi.ENVS_EXTENSION_ID });
+        getConfigurationStub.returns({
+            get: () => true,
+            inspect: () => ({ globalValue: false, workspaceValue: true }),
+        });
+        assert.strictEqual(extapi.shouldUseEnvExtension(), false);
+    });
+
     test('Returns false when envs extension is installed but workspaceValue is false', () => {
         getExtensionStub.returns({ id: extapi.ENVS_EXTENSION_ID });
         getConfigurationStub.returns({


### PR DESCRIPTION
Fixes #26068.

## Problem

`useEnvExtension()` used the effective value of `python.useEnvironmentsExtension`, while the Python Environments extension declines activation if any user, workspace, or workspace-folder scope explicitly sets it to `false`.

With a user-level `false` and workspace-level `true`, the Python extension therefore tried to consume an API that the Python Environments extension did not export and failed on `undefined.onDidChangeEnvironment`.

This change aligns the activation checks; it does not change configuration-scope precedence.

## Change

- Require both the effective opt-in and `shouldEnvExtHandleActivation()` before using the Python Environments API.
- Add a regression test for conflicting user/workspace settings.

## Validation

- TypeScript compile and targeted ESLint pass.
- Focused activation-check suite: 7 passing.
- Fresh stable baseline reproduces the exception.
- Patched Python VSIX with the same settings activates and uses the legacy locator.
- Stable extensions with the user-level `false` removed start Python Environments and discover the nested `.venv`.

AI disclosure: Prepared with assistance from OpenAI Codex.
