### PR TITLE
Narrow test discovery-on-save default (#25866)

### DIFF
--- a/package.json
+++ b/package.json
@@ -674,7 +674,7 @@
                     "type": "boolean"
                 },
                 "python.testing.autoTestDiscoverOnSavePattern": {
-                    "default": "**/*.py",
+                    "default": "**/{test*.py,*_test.py,conftest.py}",
                     "description": "%python.testing.autoTestDiscoverOnSavePattern.description%",
                     "scope": "resource",
                     "type": "string"

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -18,6 +18,7 @@ import { IInterpreterAutoSelectionProxyService } from '../interpreter/autoSelect
 import { sendTelemetryEvent } from '../telemetry';
 import { EventName } from '../telemetry/constants';
 import { sendSettingTelemetry } from '../telemetry/envFileTelemetry';
+import { DEFAULT_TEST_DISCOVERY_ON_SAVE_PATTERN } from '../testing/common/constants';
 import { ITestingSettings } from '../testing/configuration/types';
 import { IWorkspaceService } from './application/types';
 import { WorkspaceService } from './application/workspace';
@@ -331,7 +332,7 @@ export class PythonSettings implements IPythonSettings {
                     unittestEnabled: false,
                     pytestPath: 'pytest',
                     autoTestDiscoverOnSaveEnabled: true,
-                    autoTestDiscoverOnSavePattern: '**/*.py',
+                    autoTestDiscoverOnSavePattern: DEFAULT_TEST_DISCOVERY_ON_SAVE_PATTERN,
                 } as ITestingSettings;
             }
         }
@@ -348,7 +349,7 @@ export class PythonSettings implements IPythonSettings {
                   unittestArgs: [],
                   unittestEnabled: false,
                   autoTestDiscoverOnSaveEnabled: true,
-                  autoTestDiscoverOnSavePattern: '**/*.py',
+                  autoTestDiscoverOnSavePattern: DEFAULT_TEST_DISCOVERY_ON_SAVE_PATTERN,
               };
         this.testing.pytestPath = getAbsolutePath(systemVariables.resolveAny(this.testing.pytestPath), workspaceRoot);
         if (this.testing.cwd) {

--- a/src/client/testing/common/constants.ts
+++ b/src/client/testing/common/constants.ts
@@ -5,3 +5,4 @@ import { UnitTestProduct } from './types';
 export const UNIT_TEST_PRODUCTS: UnitTestProduct[] = [Product.pytest, Product.unittest];
 export const PYTEST_PROVIDER: TestProvider = 'pytest';
 export const UNITTEST_PROVIDER: TestProvider = 'unittest';
+export const DEFAULT_TEST_DISCOVERY_ON_SAVE_PATTERN = '**/{test*.py,*_test.py,conftest.py}';

--- a/src/test/testing/testController/controller.unit.test.ts
+++ b/src/test/testing/testController/controller.unit.test.ts
@@ -2,11 +2,18 @@
 // Licensed under the MIT License.
 
 import * as assert from 'assert';
+import * as path from 'path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { TestController, Uri } from 'vscode';
 
-import { PYTEST_PROVIDER, UNITTEST_PROVIDER } from '../../../client/testing/common/constants';
+import { EXTENSION_ROOT_DIR } from '../../../client/common/constants';
+import {
+    DEFAULT_TEST_DISCOVERY_ON_SAVE_PATTERN,
+    PYTEST_PROVIDER,
+    UNITTEST_PROVIDER,
+} from '../../../client/testing/common/constants';
+import * as workspaceApis from '../../../client/common/vscodeApis/workspaceApis';
 import * as envExtApiInternal from '../../../client/envExt/api.internal';
 import * as projectUtils from '../../../client/testing/testController/common/projectUtils';
 import { PythonTestController } from '../../../client/testing/testController/controller';
@@ -46,7 +53,15 @@ suite('PythonTestController', () => {
         sandbox.restore();
     });
 
-    function createController(options?: { unittestEnabled?: boolean; interpreter?: any; workspaceService?: any }): any {
+    function createController(options?: {
+        unittestEnabled?: boolean;
+        interpreter?: any;
+        workspaceService?: any;
+        testingSettings?: {
+            autoTestDiscoverOnSaveEnabled: boolean;
+            autoTestDiscoverOnSavePattern: string;
+        };
+    }): any {
         const unittestEnabled = options?.unittestEnabled ?? false;
         const interpreter =
             options?.interpreter ??
@@ -63,6 +78,7 @@ suite('PythonTestController', () => {
                 testing: {
                     unittestEnabled,
                     autoTestDiscoverOnSaveEnabled: false,
+                    ...options?.testingSettings,
                 },
             }),
         } as unknown) as any;
@@ -112,6 +128,73 @@ suite('PythonTestController', () => {
             const provider = (controller as any).getTestProvider(workspaceUri);
 
             assert.strictEqual(provider, PYTEST_PROVIDER);
+        });
+    });
+
+    suite('watchForTestContentChangeOnSave', () => {
+        function registerSaveHandler(pattern: string) {
+            let saveHandler: ((document: vscode.TextDocument) => void) | undefined;
+            sandbox.stub(workspaceApis, 'onDidSaveTextDocument').callsFake((handler) => {
+                saveHandler = handler;
+                return { dispose: () => undefined };
+            });
+            const controller = createController({
+                testingSettings: {
+                    autoTestDiscoverOnSaveEnabled: true,
+                    autoTestDiscoverOnSavePattern: pattern,
+                },
+            });
+            const triggerStub = sandbox.stub((controller as any).refreshData, 'trigger');
+            (controller as any).watchForTestContentChangeOnSave();
+
+            assert.ok(saveHandler);
+            return { saveHandler, triggerStub };
+        }
+
+        test('uses the same default save pattern in the extension manifest and runtime fallback', () => {
+            // eslint-disable-next-line import/no-dynamic-require
+            const packageJson = require(path.join(EXTENSION_ROOT_DIR, 'package.json'));
+            const manifestDefault =
+                packageJson.contributes.configuration.properties['python.testing.autoTestDiscoverOnSavePattern']
+                    .default;
+
+            assert.strictEqual(manifestDefault, DEFAULT_TEST_DISCOVERY_ON_SAVE_PATTERN);
+        });
+
+        test('triggers discovery only when a default test-related file is saved', async () => {
+            const { saveHandler, triggerStub } = registerSaveHandler(DEFAULT_TEST_DISCOVERY_ON_SAVE_PATTERN);
+            const sourceUri = vscode.Uri.file('/workspace/src/module.py');
+            await saveHandler({
+                fileName: sourceUri.fsPath,
+                uri: sourceUri,
+            } as vscode.TextDocument);
+            assert.strictEqual(triggerStub.notCalled, true);
+
+            for (const file of ['test_sample.py', 'sample_test.py', 'conftest.py']) {
+                const testUri = vscode.Uri.file(`/workspace/tests/${file}`);
+                await saveHandler({
+                    fileName: testUri.fsPath,
+                    uri: testUri,
+                } as vscode.TextDocument);
+            }
+            assert.strictEqual(triggerStub.callCount, 3);
+        });
+
+        test('respects a custom discovery-on-save pattern', async () => {
+            const { saveHandler, triggerStub } = registerSaveHandler('**/*.spec.py');
+            const defaultTestUri = vscode.Uri.file('/workspace/tests/test_sample.py');
+            await saveHandler({
+                fileName: defaultTestUri.fsPath,
+                uri: defaultTestUri,
+            } as vscode.TextDocument);
+            assert.strictEqual(triggerStub.notCalled, true);
+
+            const customTestUri = vscode.Uri.file('/workspace/specs/sample.spec.py');
+            await saveHandler({
+                fileName: customTestUri.fsPath,
+                uri: customTestUri,
+            } as vscode.TextDocument);
+            assert.strictEqual(triggerStub.calledOnce, true);
         });
     });
 


### PR DESCRIPTION
Limit the default save trigger to conventional test files and conftest.py while preserving custom patterns. Keep runtime fallbacks aligned and cover default, custom, and manifest parity behavior.