### PR TITLE
Fix python.interpreterPath resolving wrong interpreter in tasks.json when other variables are present

### DIFF
--- a/src/client/interpreter/interpreterPathCommand.ts
+++ b/src/client/interpreter/interpreterPathCommand.ts
@@ -43,6 +43,17 @@ export class InterpreterPathCommand implements IExtensionSingleActivationService
             if (Array.isArray(workspace.workspaceFolders) && workspace.workspaceFolders.length > 0) {
                 workspaceFolder = workspace.workspaceFolders[0].uri.fsPath;
             }
+        } else if (
+            Array.isArray(args) &&
+            Array.isArray(workspace.workspaceFolders) &&
+            workspace.workspaceFolders.length === 1
+        ) {
+            // tasks.json case: args[1] isn't always populated by VS Code's task variable resolver
+            // when other variable kinds (${input:...}, ${env:...}) are resolved alongside this
+            // command in the same task. Single-root workspace is unambiguous, so fall back to it
+            // instead of resolving the global interpreter. Multi-root stays undefined below --
+            // we can't guess which folder without args.
+            workspaceFolder = workspace.workspaceFolders[0].uri.fsPath;
         } else {
             workspaceFolder = undefined;
         }

--- a/src/test/interpreters/interpreterPathCommand.unit.test.ts
+++ b/src/test/interpreters/interpreterPathCommand.unit.test.ts
@@ -5,7 +5,7 @@
 
 import { assert, expect } from 'chai';
 import * as sinon from 'sinon';
-import { anything, instance, mock, when } from 'ts-mockito';
+import { anything, instance, mock, reset, when } from 'ts-mockito';
 import * as TypeMoq from 'typemoq';
 import { Uri } from 'vscode';
 import { IDisposable } from '../../client/common/types';
@@ -14,6 +14,7 @@ import { InterpreterPathCommand } from '../../client/interpreter/interpreterPath
 import { IInterpreterService } from '../../client/interpreter/contracts';
 import { PythonEnvironment } from '../../client/pythonEnvironments/info';
 import * as workspaceApis from '../../client/common/vscodeApis/workspaceApis';
+import { mockedVSCodeNamespaces } from '../vscode-mock';
 
 suite('Interpreter Path Command', () => {
     let interpreterService: IInterpreterService;
@@ -30,6 +31,7 @@ suite('Interpreter Path Command', () => {
 
     teardown(() => {
         sinon.restore();
+        reset(mockedVSCodeNamespaces.workspace);
     });
 
     test('Ensure command is registered with the correct callback handler', async () => {
@@ -64,6 +66,35 @@ suite('Interpreter Path Command', () => {
 
             return Promise.resolve({ path: 'settingValue' }) as unknown;
         });
+        const setting = await interpreterPathCommand._getSelectedInterpreterPath(args);
+        expect(setting).to.equal('settingValue');
+    });
+
+    test('If `args[1]` is missing but there is exactly one workspace folder, fall back to it (tasks.json case)', async () => {
+        when(mockedVSCodeNamespaces.workspace!.workspaceFolders).thenReturn([
+            { uri: Uri.file('onlyFolderPath'), name: 'onlyFolder', index: 0 },
+        ]);
+
+        const args = ['command'];
+        when(interpreterService.getActiveInterpreter(anything())).thenCall((arg) => {
+            assert.deepEqual(arg, Uri.file('onlyFolderPath'));
+
+            return Promise.resolve({ path: 'settingValue' }) as unknown;
+        });
+        const setting = await interpreterPathCommand._getSelectedInterpreterPath(args);
+        expect(setting).to.equal('settingValue');
+    });
+
+    test('If `args[1]` is missing and there are multiple (or zero) workspace folders, value of workspace folder is `undefined`', async () => {
+        when(mockedVSCodeNamespaces.workspace!.workspaceFolders).thenReturn([
+            { uri: Uri.file('folderOne'), name: 'folderOne', index: 0 },
+            { uri: Uri.file('folderTwo'), name: 'folderTwo', index: 1 },
+        ]);
+
+        const args = ['command'];
+        when(interpreterService.getActiveInterpreter(undefined)).thenReturn(
+            Promise.resolve({ path: 'settingValue' }) as Promise<PythonEnvironment | undefined>,
+        );
         const setting = await interpreterPathCommand._getSelectedInterpreterPath(args);
         expect(setting).to.equal('settingValue');
     });


### PR DESCRIPTION
## Summary
`${command:python.interpreterPath}` in `tasks.json` resolves to the wrong (global) interpreter instead of the workspace-selected one, but only when the task also resolves other variable kinds (`${input:...}`, `${env:...}`) alongside it. The command alone, or combined with `${workspaceFolder}`, works fine.

Cross-filed from microsoft/vscode-python-environments#1659 --- confirmed the environments extension resolves correctly in every case; the bug is here in `vscode-python`.

## Root cause
`_getSelectedInterpreterPath` in `interpreterPathCommand.ts` assumes `args[1]` always carries the workspace folder path when invoked from `tasks.json`. When VS Code's task variable resolver processes other variable kinds in the same task, that assumption doesn't hold and `args[1]` comes back empty, so `workspaceFolder` stays `undefined`.

That `undefined` flows into `interpreterService.getActiveInterpreter(resource)`, which keys its resolution/cache off `getWorkspaceFolderIdentifier(resource)`. With `resource === undefined`, it resolves/caches against a different (global) key than the one populated for the real workspace at startup — so the wrong interpreter comes back.

## Fix
When `args[1]` is missing and it's the `tasks.json` (array) invocation shape, fall back to the single workspace folder instead of leaving it `undefined` --- unambiguous for single-root workspaces, which is also what the repro used. Multi-root stays `undefined` as before (no way to disambiguate without args), so no behavior change there. The existing `debugpy`/`launch.json` branch is untouched.

## Testing
- Added two unit tests: single-folder fallback when `args[1]` is missing, and multi/zero-folder case still resolving to `undefined`.
- `npm run test:unittests` passes locally, no regressions.
- `npx eslint` / `npx prettier --check` clean on both changed files.
- Manually repro'd the original tasks.json from the linked issue against a `uv`-managed venv; interpreter now resolves correctly.

Fixes microsoft/vscode-python-environments#1659