### PR TITLE
chat: avoid redundant environment tool confirmation

### DIFF
--- a/src/client/chat/selectEnvTool.ts
+++ b/src/client/chat/selectEnvTool.ts
@@ -23,7 +23,6 @@ import { TerminalCodeExecutionProvider } from '../terminals/codeExecution/termin
 import {
     doesWorkspaceHaveVenvOrCondaEnv,
     getEnvDetailsForResponse,
-    getToolResponseIfNotebook,
     IResourceReference,
     raceCancellationError,
 } from './utils';
@@ -120,39 +119,11 @@ export class SelectPythonEnvTool extends BaseTool<ISelectPythonEnvToolArguments>
     }
 
     async prepareInvocationImpl(
-        options: LanguageModelToolInvocationPrepareOptions<ISelectPythonEnvToolArguments>,
-        resource: Uri | undefined,
+        _options: LanguageModelToolInvocationPrepareOptions<ISelectPythonEnvToolArguments>,
+        _resource: Uri | undefined,
         _token: CancellationToken,
     ): Promise<PreparedToolInvocation> {
-        if (getToolResponseIfNotebook(resource)) {
-            return {};
-        }
-        const hasVenvOrCondaEnvInWorkspaceFolder = doesWorkspaceHaveVenvOrCondaEnv(resource, this.api);
-
-        if (
-            hasVenvOrCondaEnvInWorkspaceFolder ||
-            !workspace.workspaceFolders?.length ||
-            options.input.reason === 'cancelled'
-        ) {
-            return {
-                confirmationMessages: {
-                    title: l10n.t('Select a Python Environment?'),
-                    message: '',
-                },
-            };
-        }
-
-        return {
-            confirmationMessages: {
-                title: l10n.t('Configure a Python Environment?'),
-                message: l10n.t(
-                    [
-                        'The recommended option is to create a new Python Environment, providing the benefit of isolating packages from other environments.  ',
-                        'Optionally you could select an existing Python Environment.',
-                    ].join('\n'),
-                ),
-            },
-        };
+        return {};
     }
 }
 

--- a/src/test/chat/selectEnvTool.unit.test.ts
+++ b/src/test/chat/selectEnvTool.unit.test.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect } from 'chai';
+import { CancellationTokenSource } from 'vscode';
+import { SelectPythonEnvTool } from '../../client/chat/selectEnvTool';
+
+suite('Select Python Environment Tool', () => {
+    test('Does not request confirmation before showing the environment picker', async () => {
+        const tool = Object.create(SelectPythonEnvTool.prototype) as SelectPythonEnvTool;
+        const tokenSource = new CancellationTokenSource();
+
+        try {
+            const result = await tool.prepareInvocation(
+                { input: { resourcePath: '/workspace' } },
+                tokenSource.token,
+            );
+
+            expect(result.confirmationMessages).to.be.undefined;
+        } finally {
+            tokenSource.dispose();
+        }
+    });
+});

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,14 @@
+# Project Tracker & Continuity Log
+
+## Progress
+- [x] Forked `microsoft/vscode-python` to `Yashraj-Jangra/vscode-python` and cloned locally.
+- [x] Created feature branch `chat-avoid-redundant-env-tool-confirmation`.
+- [x] Updated `src/client/chat/selectEnvTool.ts` to return `{}` from `prepareInvocationImpl`, removing the redundant pre-invocation confirmation modal.
+- [x] Added unit test in `src/test/chat/selectEnvTool.unit.test.ts` to verify confirmation is not requested.
+- [x] Verified compilation (`npx tsc -p ./`), unit test execution (`mocha`), and linting (`npm run lint`).
+- [ ] Commit changes with clean human commit formatting.
+- [ ] Push feature branch to `Yashraj-Jangra/vscode-python` and submit PR to `microsoft/vscode-python`.
+
+## Next Steps
+- Commit and push to GitHub fork.
+- Open PR on `microsoft/vscode-python`.


### PR DESCRIPTION
## Summary

- Remove the extra confirmation modal displayed before launching the Python environment picker in `SelectPythonEnvTool`.
- Allow tool invocation preparation to return an empty object directly, preserving explicit environment creation/selection choices inside the quick pick dialog.
- Add regression unit test coverage in `src/test/chat/selectEnvTool.unit.test.ts`.

## Rationale

The `configurePythonEnvironment` tool currently prompts the user with an extra confirmation dialog during tool preparation. Since the environment picker itself requires explicit user selection and approval before modifying any environment, the preceding confirmation step is redundant and unnecessarily blocks automated/allow-all tool flows.

## Testing

- Added `selectEnvTool.unit.test.ts` to test that `prepareInvocation` does not return `confirmationMessages`.
- Ran unit tests: `npx mocha --config ./build/.mocha.unittests.json --grep "Select Python Environment Tool"` (1 passing).
- Checked code formatting and linting: `npm run lint` (passed cleanly).
