### PR TITLE
Fix environment extension activation with scoped settings

### DIFF
--- a/src/client/envExt/api.internal.ts
+++ b/src/client/envExt/api.internal.ts
@@ -61,10 +61,16 @@ export function useEnvExtension(): boolean {
     }
     const config = getConfiguration('python');
     const inExpSetting = config?.get<boolean>('useEnvironmentsExtension', false) ?? false;
-    // If extension is installed and in experiment, then use it.
-    _useExt = !!getExtension(ENVS_EXTENSION_ID) && inExpSetting;
+    // Use the extension only when it will also accept activation.
+    _useExt = inExpSetting && shouldEnvExtHandleActivation();
     return _useExt;
 }
+
+export const EnvExtApiInternalTests = {
+    resetState: (): void => {
+        _useExt = undefined;
+    },
+};
 
 const onDidChangeEnvironmentEnvExtEmitter: EventEmitter<DidChangeEnvironmentEventArgs> = new EventEmitter<
     DidChangeEnvironmentEventArgs

--- a/src/test/common/terminals/activator/index.unit.test.ts
+++ b/src/test/common/terminals/activator/index.unit.test.ts
@@ -207,3 +207,37 @@ suite('shouldEnvExtHandleActivation', () => {
         assert.strictEqual(extapi.shouldEnvExtHandleActivation(), false);
     });
 });
+
+suite('useEnvExtension', () => {
+    let getConfigurationStub: sinon.SinonStub;
+
+    setup(() => {
+        extapi.EnvExtApiInternalTests.resetState();
+        const getExtensionStub: sinon.SinonStub = sinon.stub(extensionsApi, 'getExtension');
+        getExtensionStub.returns({ id: extapi.ENVS_EXTENSION_ID });
+        sinon.stub(workspaceApis, 'getWorkspaceFolders').returns(undefined);
+        getConfigurationStub = sinon.stub(workspaceApis, 'getConfiguration');
+        getConfigurationStub.returns({
+            get: () => true,
+            inspect: () => ({ globalValue: false, workspaceValue: true }),
+        });
+    });
+
+    teardown(() => {
+        extapi.EnvExtApiInternalTests.resetState();
+        sinon.restore();
+    });
+
+    test('Returns false when the effective workspace value is true but the global value is false', () => {
+        assert.strictEqual(extapi.useEnvExtension(), false);
+    });
+
+    test('Returns true when the effective value is true and no scope explicitly disables the extension', () => {
+        getConfigurationStub.returns({
+            get: () => true,
+            inspect: () => ({ globalValue: undefined, workspaceValue: true }),
+        });
+
+        assert.strictEqual(extapi.useEnvExtension(), true);
+    });
+});


### PR DESCRIPTION
## Summary

- align `useEnvExtension()` with the Python Environments extension's window-wide explicit-disable rules
- fall back to the legacy environment path when any configuration scope explicitly disables Python Environments
- add regression coverage for conflicting global/workspace values and the enabled path
- isolate the memoized activation decision between tests

Fixes #26068

## Validation

- `./node_modules/.bin/tsc -p ./`
- ESLint on the changed source and test files
- focused affected suites: 32 passing, 3 pending
- full unit suite: 5,170 passing, 36 pending, with 2 unrelated existing Posix Known Path Locator failures