### PR TITLE
fix: discover tests during controller activation

### DIFF
--- a/src/client/testing/testController/controller.ts
+++ b/src/client/testing/testController/controller.ts
@@ -265,6 +265,7 @@ export class PythonTestController implements ITestController, IExtensionSingleAc
         // LEGACY MODE: Single WorkspaceTestAdapter per workspace (backward compatibility)
         workspaces.forEach((workspace) => {
             this.activateLegacyWorkspace(workspace);
+            void this.refreshTestData(workspace.uri);
         });
         this.disposables.push(
             this.workspaceService.onDidChangeWorkspaceFolders((evt) => {

--- a/src/test/testing/testController/controller.unit.test.ts
+++ b/src/test/testing/testController/controller.unit.test.ts
@@ -92,8 +92,40 @@ suite('PythonTestController', () => {
             pythonExecFactory,
             debugLauncher,
             envVarsService,
+
+            
         );
     }
+    test('discovers tests for existing workspace during activation', async () => {
+        const workspaceUri = vscode.Uri.file('/workspace');
+        const workspaceFolder = {
+            uri: workspaceUri,
+            name: 'workspace',
+            index: 0,
+        } as vscode.WorkspaceFolder;
+
+        sandbox.stub(envExtApiInternal, 'useEnvExtension').returns(false);
+
+        const discoveryAdapter = {
+            discoverTests: sandbox.stub().resolves(undefined),
+        };
+
+        sandbox.stub(projectUtils, 'createTestAdapters').returns({
+            discoveryAdapter,
+            executionAdapter: {},
+        } as any);
+
+        const controller = createController({
+            workspaceService: {
+                workspaceFolders: [workspaceFolder],
+            },
+        });
+
+        await controller.activate();
+        await new Promise((resolve) => setTimeout(resolve, 350));
+
+        assert.strictEqual(discoveryAdapter.discoverTests.calledOnce, true);
+    });
 
     suite('getTestProvider', () => {
         test('returns unittest when enabled', () => {


### PR DESCRIPTION
## Summary

Fixes initial test discovery for existing workspaces when the Python test controller is activated.

## Changes

- Trigger `refreshTestData()` for each existing workspace during controller activation.
- Add a regression test to verify that test discovery is triggered for an existing workspace.

## Motivation

Previously, existing workspaces were activated but their test data was not refreshed immediately. This could prevent tests from being discovered until another workspace-related event triggered a refresh.

This change ensures test discovery is initiated during activation for existing workspaces.

## Testing

- Added a unit test covering initial test discovery during controller activation.
- Verified the project compiles successfully.

## Related Issue

Closes #26118 