### PR TITLE
Clear default unittestArgs for test discovery and execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -719,13 +719,7 @@
                     "type": "string"
                 },
                 "python.testing.unittestArgs": {
-                    "default": [
-                        "-v",
-                        "-s",
-                        ".",
-                        "-p",
-                        "*test*.py"
-                    ],
+                    "default": [],
                     "description": "%python.testing.unittestArgs.description%",
                     "items": {
                         "type": "string"

--- a/src/test/.vscode/settings.json
+++ b/src/test/.vscode/settings.json
@@ -2,7 +2,7 @@
     "python.linting.pylintEnabled": false,
     "python.linting.flake8Enabled": false,
     "python.testing.pytestArgs": [],
-    "python.testing.unittestArgs": ["-s=./tests", "-p=test_*.py", "-v", "-s", ".", "-p", "*test*.py"],
+    "python.testing.unittestArgs": [],
     "python.linting.lintOnSave": false,
     "python.linting.enabled": true,
     "python.linting.pycodestyleEnabled": false,

--- a/src/test/testing/common/testingAdapter.test.ts
+++ b/src/test/testing/common/testingAdapter.test.ts
@@ -170,7 +170,7 @@ suite('End to End Tests: test adapters', () => {
 
         // set workspace to test workspace folder and set up settings
 
-        configService.getSettings(workspaceUri).testing.unittestArgs = ['-s', '.', '-p', '*test*.py'];
+        configService.getSettings(workspaceUri).testing.unittestArgs = [];
 
         // run unittest discovery
         const discoveryAdapter = new UnittestTestDiscoveryAdapter(configService, resultResolver, envVarsService);
@@ -210,7 +210,7 @@ suite('End to End Tests: test adapters', () => {
 
         // set settings to work for the given workspace
         workspaceUri = Uri.parse(rootPathLargeWorkspace);
-        configService.getSettings(workspaceUri).testing.unittestArgs = ['-s', '.', '-p', '*test*.py'];
+        configService.getSettings(workspaceUri).testing.unittestArgs = [];
         // run discovery
         const discoveryAdapter = new UnittestTestDiscoveryAdapter(configService, resultResolver, envVarsService);
 
@@ -486,7 +486,7 @@ suite('End to End Tests: test adapters', () => {
 
         // set workspace to test workspace folder
         workspaceUri = Uri.parse(rootPathSmallWorkspace);
-        configService.getSettings(workspaceUri).testing.unittestArgs = ['-s', '.', '-p', '*test*.py'];
+        configService.getSettings(workspaceUri).testing.unittestArgs = [];
         // run execution
         const executionAdapter = new UnittestTestExecutionAdapter(configService, resultResolver, envVarsService);
         const testRun = typeMoq.Mock.ofType<TestRun>();
@@ -563,7 +563,7 @@ suite('End to End Tests: test adapters', () => {
 
         // set workspace to test workspace folder
         workspaceUri = Uri.parse(rootPathLargeWorkspace);
-        configService.getSettings(workspaceUri).testing.unittestArgs = ['-s', '.', '-p', '*test*.py'];
+        configService.getSettings(workspaceUri).testing.unittestArgs = [];
 
         // run unittest execution
         const executionAdapter = new UnittestTestExecutionAdapter(configService, resultResolver, envVarsService);
@@ -711,7 +711,7 @@ suite('End to End Tests: test adapters', () => {
 
         // set workspace to test workspace folder
         workspaceUri = Uri.parse(rootPathCoverageWorkspace);
-        configService.getSettings(workspaceUri).testing.unittestArgs = ['-s', '.', '-p', '*test*.py'];
+        configService.getSettings(workspaceUri).testing.unittestArgs = [];
         // run execution
         const executionAdapter = new UnittestTestExecutionAdapter(configService, resultResolver, envVarsService);
         const testRun = typeMoq.Mock.ofType<TestRun>();
@@ -895,7 +895,7 @@ suite('End to End Tests: test adapters', () => {
 
         // set workspace to test workspace folder
         workspaceUri = Uri.parse(rootPathDiscoveryErrorWorkspace);
-        configService.getSettings(workspaceUri).testing.unittestArgs = ['-s', '.', '-p', '*test*.py'];
+        configService.getSettings(workspaceUri).testing.unittestArgs = [];
 
         const discoveryAdapter = new UnittestTestDiscoveryAdapter(configService, resultResolver, envVarsService);
         const testRun = typeMoq.Mock.ofType<TestRun>();

--- a/src/test/testing/testController/testCancellationRunAdapters.unit.test.ts
+++ b/src/test/testing/testController/testCancellationRunAdapters.unit.test.ts
@@ -48,7 +48,7 @@ suite('Execution Flow Run Adapters', () => {
         myTestPath = path.join('/', 'my', 'test', 'path', '/');
         configService = ({
             getSettings: () => ({
-                testing: { pytestArgs: ['.'], unittestArgs: ['-v', '-s', '.', '-p', 'test*'] },
+                testing: { pytestArgs: ['.'], unittestArgs: [] },
             }),
             isTestExecution: () => false,
         } as unknown) as IConfigurationService;

--- a/src/test/testing/testController/unittest/testDiscoveryAdapter.unit.test.ts
+++ b/src/test/testing/testController/unittest/testDiscoveryAdapter.unit.test.ts
@@ -44,7 +44,7 @@ suite('Unittest test discovery adapter', () => {
         expectedPath = path.join('/', 'new', 'cwd');
         configService = ({
             getSettings: () => ({
-                testing: { unittestArgs: ['-v', '-s', '.', '-p', 'test*'] },
+                testing: { unittestArgs: [] },
             }),
         } as unknown) as IConfigurationService;
 
@@ -96,7 +96,7 @@ suite('Unittest test discovery adapter', () => {
         const adapter = new UnittestTestDiscoveryAdapter(configService);
         adapter.discoverTests(uri, execFactory.object);
         const script = path.join(EXTENSION_ROOT_DIR, 'python_files', 'unittestadapter', 'discovery.py');
-        const argsExpected = [script, '--udiscovery', '-v', '-s', '.', '-p', 'test*'];
+        const argsExpected = [script, '--udiscovery'];
 
         // must await until the execObservable is called in order to verify it
         await deferred.promise;
@@ -133,13 +133,13 @@ suite('Unittest test discovery adapter', () => {
         const expectedNewPath = path.join('/', 'new', 'cwd');
         configService = ({
             getSettings: () => ({
-                testing: { unittestArgs: ['-v', '-s', '.', '-p', 'test*'], cwd: expectedNewPath.toString() },
+                testing: { unittestArgs: [], cwd: expectedNewPath.toString() },
             }),
         } as unknown) as IConfigurationService;
         const adapter = new UnittestTestDiscoveryAdapter(configService);
         adapter.discoverTests(uri, execFactory.object);
         const script = path.join(EXTENSION_ROOT_DIR, 'python_files', 'unittestadapter', 'discovery.py');
-        const argsExpected = [script, '--udiscovery', '-v', '-s', '.', '-p', 'test*'];
+        const argsExpected = [script, '--udiscovery'];
 
         // must await until the execObservable is called in order to verify it
         await deferred.promise;
@@ -258,7 +258,7 @@ suite('Unittest test discovery adapter', () => {
         const adapter = new UnittestTestDiscoveryAdapter(configService);
         adapter.discoverTests(uri, execFactory.object, undefined, undefined, mockProject);
         const script = path.join(EXTENSION_ROOT_DIR, 'python_files', 'unittestadapter', 'discovery.py');
-        const argsExpected = [script, '--udiscovery', '-v', '-s', '.', '-p', 'test*'];
+        const argsExpected = [script, '--udiscovery'];
 
         // must await until the execObservable is called in order to verify it
         await deferred.promise;
@@ -301,7 +301,7 @@ suite('Unittest test discovery adapter', () => {
         const adapter = new UnittestTestDiscoveryAdapter(configService);
         adapter.discoverTests(uri, execFactory.object);
         const script = path.join(EXTENSION_ROOT_DIR, 'python_files', 'unittestadapter', 'discovery.py');
-        const argsExpected = [script, '--udiscovery', '-v', '-s', '.', '-p', 'test*'];
+        const argsExpected = [script, '--udiscovery'];
 
         // must await until the execObservable is called in order to verify it
         await deferred.promise;


### PR DESCRIPTION
Resolves microsoft/vscode#327966.