### PR TITLE
Re-enable PyREPL

### DIFF
--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -218,7 +218,7 @@ export namespace Interpreters {
         '{0} environment was successfully activated, even though {1} indicator may not be present in the terminal prompt. [Learn more](https://aka.ms/vscodePythonTerminalActivation).',
     );
     export const shellIntegrationEnvVarCollectionDescription = l10n.t(
-        'Enables `python.terminal.shellIntegration.enabled` by modifying `PYTHONSTARTUP` and `PYTHON_BASIC_REPL`',
+        'Enables `python.terminal.shellIntegration.enabled` by modifying `PYTHONSTARTUP`',
     );
     export const shellIntegrationDisabledEnvVarCollectionDescription = l10n.t(
         'Disables `python.terminal.shellIntegration.enabled` by unsetting `PYTHONSTARTUP` and `PYTHON_BASIC_REPL`',

--- a/src/client/terminals/pythonStartup.ts
+++ b/src/client/terminals/pythonStartup.ts
@@ -22,8 +22,6 @@ async function applyPythonStartupSetting(context: ExtensionContext): Promise<voi
         const sourcePath = path.join(EXTENSION_ROOT_DIR, 'python_files', 'pythonrc.py');
         await copy(Uri.file(sourcePath), destPath, { overwrite: true });
         context.environmentVariableCollection.replace('PYTHONSTARTUP', destPath.fsPath);
-        // When shell integration is enabled, we disable PyREPL from cpython.
-        context.environmentVariableCollection.replace('PYTHON_BASIC_REPL', '1');
         context.environmentVariableCollection.description = new MarkdownString(
             Interpreters.shellIntegrationEnvVarCollectionDescription,
         );

--- a/src/test/terminals/shellIntegration/pythonStartup.test.ts
+++ b/src/test/terminals/shellIntegration/pythonStartup.test.ts
@@ -135,11 +135,24 @@ suite('Terminal - Shell Integration with PYTHONSTARTUP', () => {
         globalEnvironmentVariableCollection.verify((c) => c.delete('PYTHONSTARTUP'), TypeMoq.Times.once());
     });
 
-    test('PYTHON_BASIC_REPL is set when shell integration is enabled', async () => {
+    test('PYTHON_BASIC_REPL is not set when shell integration is enabled', async () => {
         pythonConfig.setup((p) => p.get('terminal.shellIntegration.enabled')).returns(() => true);
+
         await registerPythonStartup(context.object);
+
         globalEnvironmentVariableCollection.verify(
-            (c) => c.replace('PYTHON_BASIC_REPL', '1', TypeMoq.It.isAny()),
+            (c) => c.replace('PYTHON_BASIC_REPL', TypeMoq.It.isAny(), TypeMoq.It.isAny()),
+            TypeMoq.Times.never(),
+        );
+    });
+
+    test('PYTHON_BASIC_REPL is deleted when shell integration is disabled', async () => {
+        pythonConfig.setup((p) => p.get('terminal.shellIntegration.enabled')).returns(() => false);
+
+        await registerPythonStartup(context.object);
+
+        globalEnvironmentVariableCollection.verify(
+            (c) => c.delete('PYTHON_BASIC_REPL'),
             TypeMoq.Times.once(),
         );
     });

--- a/src/test/terminals/shellIntegration/pythonStartup.test.ts
+++ b/src/test/terminals/shellIntegration/pythonStartup.test.ts
@@ -151,10 +151,7 @@ suite('Terminal - Shell Integration with PYTHONSTARTUP', () => {
 
         await registerPythonStartup(context.object);
 
-        globalEnvironmentVariableCollection.verify(
-            (c) => c.delete('PYTHON_BASIC_REPL'),
-            TypeMoq.Times.once(),
-        );
+        globalEnvironmentVariableCollection.verify((c) => c.delete('PYTHON_BASIC_REPL'), TypeMoq.Times.once());
     });
 
     test('Ensure registering terminal link calls registerTerminalLinkProvider', async () => {


### PR DESCRIPTION
Fixes #25577 

<img width="1300" height="485" alt="image" src="https://github.com/user-attachments/assets/11faa8d3-d5ce-4057-acdf-3a70775dc784" />


This pull request makes a small change to the logic that configures the Python startup environment. The setting of the `PYTHON_BASIC_REPL` environment variable has been removed, so the extension will no longer explicitly disable PyREPL from CPython when shell integration is enabled. 

- Removed the line that set the `PYTHON_BASIC_REPL` environment variable in `applyPythonStartupSetting`, which previously disabled PyREPL when shell integration was enabled.