### PR TITLE
fix: dispose orphaned progress notifications on language server shutdown

### DIFF
--- a/src/client/activation/progress.ts
+++ b/src/client/activation/progress.ts
@@ -47,6 +47,11 @@ export class ProgressReporting implements Disposable {
         if (this.statusBarMessage) {
             this.statusBarMessage.dispose();
         }
+        if (this.progressDeferred) {
+            this.progressDeferred.resolve();
+            this.progressDeferred = undefined;
+            this.progress = undefined;
+        }
     }
 
     private beginProgress(): void {


### PR DESCRIPTION
Fixes #16750

When a language server crashed or was restarted, any active progress notifications (started via `python/beginProgress`) would remain orphaned in the UI because the `progressDeferred` promise was never resolved during `dispose()`.

This PR ensures that if the `ProgressReporting` instance is disposed, any pending progress deferred is resolved, closing the orphaned UI notification.