### PR TITLE
Add link to native REPL information

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -74,5 +74,6 @@
     "python.testing.pytestEnabled": true,
     "rust-analyzer.linkedProjects": [
         ".\\python-env-tools\\Cargo.toml"
-    ]
+    ],
+    "python-envs.defaultEnvManager": "ms-python.python:system"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -74,6 +74,5 @@
     "python.testing.pytestEnabled": true,
     "rust-analyzer.linkedProjects": [
         ".\\python-env-tools\\Cargo.toml"
-    ],
-    "python-envs.defaultEnvManager": "ms-python.python:system"
+    ]
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -68,7 +68,7 @@
     "python.poetryPath.description": "Path to the poetry executable.",
     "python.pixiToolPath.description": "Path to the pixi executable.",
     "python.EnableREPLSmartSend.description": "Toggle Smart Send for the Python REPL. Smart Send enables sending the smallest runnable block of code to the REPL on Shift+Enter and moves the cursor accordingly.",
-    "python.REPL.sendToNativeREPL.description": "Toggle to send code to Python REPL instead of the terminal on execution. Turning this on will change the behavior for both Smart Send and Run Selection/Line in the Context Menu.",
+    "python.REPL.sendToNativeREPL.description": "Toggle to send code to [Python REPL](https://aka.ms/python-native-repl) instead of the terminal on execution. Turning this on will change the behavior for both Smart Send and Run Selection/Line in the Context Menu.",
     "python.REPL.provideVariables.description": "Toggle to provide variables for the REPL variable view for the native REPL.",
     "python.tensorBoard.logDirectory.description": "Set this setting to your preferred TensorBoard log directory to skip log directory prompt when starting TensorBoard.",
     "python.tensorBoard.logDirectory.markdownDeprecationMessage": "Tensorboard support has been moved to the extension [Tensorboard extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.tensorboard). Instead use the setting `tensorBoard.logDirectory`.",

--- a/python_files/pythonrc.py
+++ b/python_files/pythonrc.py
@@ -19,6 +19,9 @@ class ShellIntegrationSequence(str, Enum):
     COMMAND_START = "\x1b]633;B\x07"
     TERMINATOR = "\x07"
 
+    def __str__(self):
+        return self.value
+
 
 class REPLHooks:
     def __init__(self):

--- a/python_files/pythonrc.py
+++ b/python_files/pythonrc.py
@@ -1,11 +1,23 @@
 import platform
 import sys
+from enum import Enum
 
 if sys.platform != "win32":
     import readline
 
 original_ps1 = ">>> "
 is_wsl = "microsoft-standard-WSL" in platform.release()
+
+
+class ShellIntegrationSequence(str, Enum):
+    SOH = "\001"
+    STX = "\002"
+    COMMAND_EXECUTED = "\x1b]633;C\x07"
+    COMMAND_LINE = "\x1b]633;E;"
+    COMMAND_FINISHED = "\x1b]633;D;"
+    PROMPT_STARTED = "\x1b]633;A\x07"
+    COMMAND_START = "\x1b]633;B\x07"
+    TERMINATOR = "\x07"
 
 
 class REPLHooks:
@@ -53,25 +65,29 @@ class PS1:
         # For non-windows allow recent_command history.
         if sys.platform != "win32":
             result = "{soh}{command_executed}{command_line}{command_finished}{prompt_started}{stx}{prompt}{soh}{command_start}{stx}".format(
-                soh="\001",
-                stx="\002",
-                command_executed="\x1b]633;C\x07",
-                command_line="\x1b]633;E;" + str(get_last_command()) + "\x07",
-                command_finished="\x1b]633;D;" + str(exit_code) + "\x07",
-                prompt_started="\x1b]633;A\x07",
+                soh=ShellIntegrationSequence.SOH,
+                stx=ShellIntegrationSequence.STX,
+                command_executed=ShellIntegrationSequence.COMMAND_EXECUTED,
+                command_line=ShellIntegrationSequence.COMMAND_LINE
+                + str(get_last_command())
+                + ShellIntegrationSequence.TERMINATOR,
+                command_finished=ShellIntegrationSequence.COMMAND_FINISHED
+                + str(exit_code)
+                + ShellIntegrationSequence.TERMINATOR,
+                prompt_started=ShellIntegrationSequence.PROMPT_STARTED,
                 prompt=original_ps1,
-                command_start="\x1b]633;B\x07",
+                command_start=ShellIntegrationSequence.COMMAND_START,
             )
         else:
             result = "{command_finished}{prompt_started}{prompt}{command_start}{command_executed}".format(
-                command_finished="\x1b]633;D;" + str(exit_code) + "\x07",
-                prompt_started="\x1b]633;A\x07",
+                command_finished=ShellIntegrationSequence.COMMAND_FINISHED
+                + str(exit_code)
+                + ShellIntegrationSequence.TERMINATOR,
+                prompt_started=ShellIntegrationSequence.PROMPT_STARTED,
                 prompt=original_ps1,
-                command_start="\x1b]633;B\x07",
-                command_executed="\x1b]633;C\x07",
+                command_start=ShellIntegrationSequence.COMMAND_START,
+                command_executed=ShellIntegrationSequence.COMMAND_EXECUTED,
             )
-
-        # result = f"{chr(27)}]633;D;{exit_code}{chr(7)}{chr(27)}]633;A{chr(7)}{original_ps1}{chr(27)}]633;B{chr(7)}{chr(27)}]633;C{chr(7)}"
 
         return result
 

--- a/python_files/pythonrc.py
+++ b/python_files/pythonrc.py
@@ -99,6 +99,6 @@ if sys.platform != "win32" and (not is_wsl):
     sys.ps1 = PS1()
 
 if sys.platform == "darwin":
-    print("Cmd click to launch VS Code Native REPL")
+    print("Cmd click to launch VS Code Native REPL (https://aka.ms/python-native-repl)")
 else:
-    print("Ctrl click to launch VS Code Native REPL")
+    print("Ctrl click to launch VS Code Native REPL (https://aka.ms/python-native-repl)")

--- a/python_files/tests/test_shell_integration.py
+++ b/python_files/tests/test_shell_integration.py
@@ -70,7 +70,9 @@ if sys.platform == "darwin":
         with monkeypatch.context() as m:
             m.setattr("builtins.print", Mock())
             importlib.reload(sys.modules["pythonrc"])
-            print.assert_any_call("Cmd click to launch VS Code Native REPL")
+            print.assert_any_call(
+                "Cmd click to launch VS Code Native REPL (https://aka.ms/python-native-repl)"
+            )
 
 
 if sys.platform == "win32":
@@ -80,4 +82,6 @@ if sys.platform == "win32":
         with monkeypatch.context() as m:
             m.setattr("builtins.print", Mock())
             importlib.reload(sys.modules["pythonrc"])
-            print.assert_any_call("Ctrl click to launch VS Code Native REPL")
+            print.assert_any_call(
+                "Ctrl click to launch VS Code Native REPL (https://aka.ms/python-native-repl)"
+            )

--- a/src/client/terminals/pythonStartupLinkProvider.ts
+++ b/src/client/terminals/pythonStartupLinkProvider.ts
@@ -21,13 +21,10 @@ export class CustomTerminalLinkProvider implements TerminalLinkProvider<CustomTe
         _token: CancellationToken,
     ): ProviderResult<CustomTerminalLink[]> {
         const links: CustomTerminalLink[] = [];
-        let expectedNativeLink;
-
-        if (process.platform === 'darwin') {
-            expectedNativeLink = 'Cmd click to launch VS Code Native REPL';
-        } else {
-            expectedNativeLink = 'Ctrl click to launch VS Code Native REPL';
-        }
+        let expectedNativeLink =
+            process.platform === 'darwin'
+                ? 'Cmd click to launch VS Code Native REPL'
+                : 'Ctrl click to launch VS Code Native REPL';
 
         if (context.line.includes(expectedNativeLink)) {
             links.push({

--- a/src/test/terminals/shellIntegration/pythonStartup.test.ts
+++ b/src/test/terminals/shellIntegration/pythonStartup.test.ts
@@ -248,12 +248,14 @@ suite('Terminal - Shell Integration with PYTHONSTARTUP', () => {
                 );
                 assert.equal(
                     links[0].startIndex,
-                    context.line.indexOf('Ctrl click to launch VS Code Native REPL'),
+                    context.line.indexOf(
+                        'Ctrl click to launch VS Code Native REPL (https://aka.ms/python-native-repl)',
+                    ),
                     'start index should match',
                 );
                 assert.equal(
                     links[0].length,
-                    'Ctrl click to launch VS Code Native REPL'.length,
+                    'Ctrl click to launch VS Code Native REPL (https://aka.ms/python-native-repl)'.length,
                     'Match expected Length',
                 );
                 assert.equal(

--- a/src/test/terminals/shellIntegration/pythonStartup.test.ts
+++ b/src/test/terminals/shellIntegration/pythonStartup.test.ts
@@ -182,7 +182,8 @@ suite('Terminal - Shell Integration with PYTHONSTARTUP', () => {
         test('Mac - Verify provideTerminalLinks returns links when context.line contains expectedNativeLink', () => {
             const provider = new CustomTerminalLinkProvider();
             const context: TerminalLinkContext = {
-                line: 'Some random string with Cmd click to launch VS Code Native REPL',
+                line:
+                    'Some random string with Cmd click to launch VS Code Native REPL (https://aka.ms/python-native-repl)',
                 terminal: {} as Terminal,
             };
             const token: CancellationToken = {
@@ -224,7 +225,8 @@ suite('Terminal - Shell Integration with PYTHONSTARTUP', () => {
         test('Windows/Linux - Verify provideTerminalLinks returns links when context.line contains expectedNativeLink', () => {
             const provider = new CustomTerminalLinkProvider();
             const context: TerminalLinkContext = {
-                line: 'Some random string with Ctrl click to launch VS Code Native REPL',
+                line:
+                    'Some random string with Ctrl click to launch VS Code Native REPL (https://aka.ms/python-native-repl)',
                 terminal: {} as Terminal,
             };
             const token: CancellationToken = {

--- a/src/test/terminals/shellIntegration/pythonStartup.test.ts
+++ b/src/test/terminals/shellIntegration/pythonStartup.test.ts
@@ -248,14 +248,12 @@ suite('Terminal - Shell Integration with PYTHONSTARTUP', () => {
                 );
                 assert.equal(
                     links[0].startIndex,
-                    context.line.indexOf(
-                        'Ctrl click to launch VS Code Native REPL (https://aka.ms/python-native-repl)',
-                    ),
+                    context.line.indexOf('Ctrl click to launch VS Code Native REPL'),
                     'start index should match',
                 );
                 assert.equal(
                     links[0].length,
-                    'Ctrl click to launch VS Code Native REPL (https://aka.ms/python-native-repl)'.length,
+                    'Ctrl click to launch VS Code Native REPL'.length,
                     'Match expected Length',
                 );
                 assert.equal(


### PR DESCRIPTION
Fixes #24754

<img width="1466" height="373" alt="image" src="https://github.com/user-attachments/assets/5b683332-c5ff-47fa-937e-60a097b1395c" />


This pull request refactors how shell integration sequences are managed in `python_files/pythonrc.py` by introducing a dedicated `ShellIntegrationSequence` enum, and updates related string formatting to use this enum. It also updates user-facing messages in both the Python startup script and the VS Code terminal link provider to include a documentation URL. These changes improve maintainability, clarity, and user guidance.

**Shell integration refactoring:**
* Introduced the `ShellIntegrationSequence` enum to centralize shell integration control sequences, replacing hard-coded string literals throughout the code. [[1]](diffhunk://#diff-8734bb7310870e747bbb82c387dc848241b398db31918a75ed6bee20bcc491eaR3) [[2]](diffhunk://#diff-8734bb7310870e747bbb82c387dc848241b398db31918a75ed6bee20bcc491eaR12-R22)
* Refactored the `__str__` method in the prompt class to use the new enum values, improving readability and reducing duplication.

**User guidance improvements:**
* Updated the printed startup message in `pythonrc.py` to include a documentation URL, guiding users to more information about the VS Code Native REPL.
* Updated the expected link text in `pythonStartupLinkProvider.ts` to match the new message format (excluding the URL), ensuring the link detection logic remains consistent with the Python script output.