### PR TITLE
Pythonrc: Don't register PyREPL hooks twice

### DIFF
--- a/python_files/pythonrc.py
+++ b/python_files/pythonrc.py
@@ -29,19 +29,17 @@ class REPLHooks:
         self.failure_flag = False
         self.original_excepthook = sys.excepthook
         self.original_displayhook = sys.displayhook
-        sys.excepthook = self.my_excepthook
-        sys.displayhook = self.my_displayhook
+        sys.excepthook = self.vscode_excepthook
+        sys.displayhook = self.vscode_displayhook
 
-    def my_displayhook(self, value):
+    def vscode_displayhook(self, value):
         if value is None:
             self.failure_flag = False
-
         self.original_displayhook(value)
 
-    def my_excepthook(self, type_, value, traceback):
+    def vscode_excepthook(self, type_, value, traceback):
         self.global_exit = value
         self.failure_flag = True
-
         self.original_excepthook(type_, value, traceback)
 
 
@@ -50,15 +48,11 @@ def get_last_command():
     last_command = ""
     if sys.platform != "win32":
         last_command = readline.get_history_item(readline.get_current_history_length())
-
     return last_command
 
 
 class PS1:
     hooks = REPLHooks()
-    sys.excepthook = hooks.my_excepthook
-    sys.displayhook = hooks.my_displayhook
-
     # str will get called for every prompt with exit code to show success/failure
     def __str__(self):
         exit_code = int(bool(self.hooks.failure_flag))
@@ -101,7 +95,6 @@ class PS1:
 if sys.platform != "win32" and (not is_wsl):
     sys.ps1 = PS1()
 
-if sys.platform == "darwin":
-    print("Cmd click to launch VS Code Native REPL (https://aka.ms/python-native-repl)")
-else:
-    print("Ctrl click to launch VS Code Native REPL (https://aka.ms/python-native-repl)")
+ctrl_key = "Cmd" if sys.platform == "darwin" else "Ctrl"
+
+print(f"{ctrl_key} click to launch VS Code Native REPL (https://aka.ms/python-native-repl)")

--- a/python_files/pythonrc.py
+++ b/python_files/pythonrc.py
@@ -53,6 +53,7 @@ def get_last_command():
 
 class PS1:
     hooks = REPLHooks()
+
     # str will get called for every prompt with exit code to show success/failure
     def __str__(self):
         exit_code = int(bool(self.hooks.failure_flag))

--- a/python_files/tests/test_shell_integration.py
+++ b/python_files/tests/test_shell_integration.py
@@ -46,7 +46,7 @@ def test_displayhook_call():
     hooks = pythonrc.REPLHooks()
     hooks.original_displayhook = mock_displayhook
 
-    hooks.my_displayhook("mock_value")
+    hooks.vscode_displayhook("mock_value")
 
     mock_displayhook.assert_called_once_with("mock_value")
 
@@ -59,7 +59,7 @@ def test_excepthook_call():
     hooks = pythonrc.REPLHooks()
     hooks.original_excepthook = mock_excepthook
 
-    hooks.my_excepthook("mock_type", "mock_value", "mock_traceback")
+    hooks.vscode_excepthook("mock_type", "mock_value", "mock_traceback")
     mock_excepthook.assert_called_once_with("mock_type", "mock_value", "mock_traceback")
 
 


### PR DESCRIPTION
This pull request refactors the naming and usage of exception and display hooks in the `pythonrc.py` file to better reflect their association with VS Code integration. It also simplifies the REPL launch message and updates related tests to use the new hook names.  **Refactoring and renaming for clarity:**  * Renamed `my_excepthook` and `my_displayhook` methods in `REPLHooks` to `vscode_excepthook` and `vscode_displayhook`, and updated all references and assignments accordingly in `pythonrc.py`. * Updated test cases in `test_shell_integration.py` to use the new hook method names (`vscode_displayhook` and `vscode_excepthook`). [[1]](diffhunk://#diff-f900183871669133df435002b57b4e9e7b8d57779718d41d65427fccc833172bL49-R49) [[2]](diffhunk://#diff-f900183871669133df435002b57b4e9e7b8d57779718d41d65427fccc833172bL62-R62)  **Prompt message simplification:**  * Simplified the REPL launch message to dynamically use "Cmd" or "Ctrl" based on the platform, reducing duplicated code.

Fixes #26146